### PR TITLE
phase-7.2: fetcher fixes — Larajobs custom namespace + Lever re-seed

### DIFF
--- a/src/fetchers/larajobs.test.ts
+++ b/src/fetchers/larajobs.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapLarajobsItem, type LarajobsItem } from './larajobs';
+
+const COMPANY_ID = 23;
+
+describe('mapLarajobsItem', () => {
+  it('extracts <job:location> instead of defaulting to Remote', () => {
+    const item: LarajobsItem = {
+      title: 'Senior Laravel Developer',
+      link: 'https://larajobs.com/job/3869',
+      pubDate: 'Thu, 16 Apr 2026 15:01:42 +0000',
+      jobLocation: 'United States/Remote (USA Only)',
+    };
+    const job = mapLarajobsItem(item, COMPANY_ID);
+    assert.equal(job.location, 'United States/Remote (USA Only)');
+  });
+
+  it('falls back to "Remote" when <job:location> is missing or empty', () => {
+    const a = mapLarajobsItem(
+      {
+        title: 'X',
+        link: 'https://larajobs.com/job/1',
+        pubDate: 'Wed, 22 Apr 2026 20:47:36 +0000',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(a.location, 'Remote');
+
+    const b = mapLarajobsItem(
+      {
+        title: 'X',
+        link: 'https://larajobs.com/job/1',
+        pubDate: 'Wed, 22 Apr 2026 20:47:36 +0000',
+        jobLocation: '   ',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(b.location, 'Remote');
+  });
+
+  it('embeds salary / company / tags / type into description', () => {
+    const job = mapLarajobsItem(
+      {
+        title: 'Senior Laravel/Vue Engineer',
+        link: 'https://larajobs.com/job/3869',
+        pubDate: 'Thu, 16 Apr 2026 15:01:42 +0000',
+        jobLocation: 'United States/Remote',
+        jobSalary: 'USD 130,000 - 160,000',
+        jobCompany: 'Orpical Technology Solutions',
+        jobTags: 'laravel,vue,inertia',
+        jobJobType: 'FULL_TIME',
+        contentSnippet: 'Help us build an AI-native Laravel monolith.',
+      },
+      COMPANY_ID,
+    );
+    assert.match(job.description, /Hiring company: Orpical Technology Solutions/);
+    assert.match(job.description, /Salary: USD 130,000 - 160,000/);
+    assert.match(job.description, /Tags: laravel,vue,inertia/);
+    assert.match(job.description, /Type: full time/);
+    assert.match(job.description, /AI-native Laravel monolith/);
+  });
+
+  it('preserves original description when no custom fields present', () => {
+    const job = mapLarajobsItem(
+      {
+        title: 'Senior Laravel Developer',
+        link: 'https://larajobs.com/job/1',
+        pubDate: 'Wed, 22 Apr 2026 20:47:36 +0000',
+        contentSnippet: 'Original body only.',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(job.description, 'Original body only.');
+  });
+
+  it('handles empty contentSnippet without crashing', () => {
+    const job = mapLarajobsItem(
+      {
+        title: 'X',
+        link: 'https://larajobs.com/job/1',
+        pubDate: 'Wed, 22 Apr 2026 20:47:36 +0000',
+        contentSnippet: '',
+        jobSalary: 'CAD 100,000 - 120,000',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(job.description, 'Salary: CAD 100,000 - 120,000.');
+  });
+
+  it('uses guid for externalId when present', () => {
+    const job = mapLarajobsItem(
+      {
+        title: 'X',
+        link: 'https://larajobs.com/job/3869',
+        pubDate: 'Thu, 16 Apr 2026 15:01:42 +0000',
+        guid: 'https://larajobs.com/job/3869',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(job.externalId, 'https://larajobs.com/job/3869');
+  });
+
+  it('synthesises a stable externalId from link when guid is absent', () => {
+    const job = mapLarajobsItem(
+      {
+        title: 'X',
+        link: 'https://larajobs.com/job/3869',
+        pubDate: 'Thu, 16 Apr 2026 15:01:42 +0000',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(job.externalId.length, 16);
+    assert.match(job.externalId, /^[0-9a-f]{16}$/);
+  });
+});

--- a/src/fetchers/larajobs.ts
+++ b/src/fetchers/larajobs.ts
@@ -6,42 +6,101 @@ import type { NormalizedJob } from '../types';
 const FEED_URL = 'https://larajobs.com/feed';
 const PARSER_TIMEOUT_MS = 10_000;
 
-interface LarajobsItem {
+/**
+ * LaraJobs RSS uses a custom XML namespace `xmlns:job="https://larajobs.com"`
+ * for the most useful fields:
+ *   <job:location>United States/Remote (USA Only)</job:location>
+ *   <job:salary>USD 130,000 - 160,000</job:salary>
+ *   <job:company>Acme Inc</job:company>
+ *   <job:tags>laravel,vue,inertia</job:tags>
+ *
+ * rss-parser treats unknown elements as "custom fields" we have to opt into.
+ * Without this opt-in, all of the above is silently dropped — Claude only
+ * sees an empty <description>, location defaults to "Remote", and the
+ * filter has nothing to grade. This was a real bug in production: every
+ * LaraJobs job landed with `location='Remote'` regardless of the actual
+ * country/region in the feed.
+ */
+export interface LarajobsItem {
   title?: string;
   link?: string;
   pubDate?: string;
   contentSnippet?: string;
   content?: string;
   guid?: string;
+  jobLocation?: string;
+  jobSalary?: string;
+  jobCompany?: string;
+  jobTags?: string;
+  jobJobType?: string;
 }
 
 const parser: Parser<unknown, LarajobsItem> = new Parser({
   timeout: PARSER_TIMEOUT_MS,
+  customFields: {
+    item: [
+      ['job:location', 'jobLocation'],
+      ['job:salary', 'jobSalary'],
+      ['job:company', 'jobCompany'],
+      ['job:tags', 'jobTags'],
+      ['job:job_type', 'jobJobType'],
+    ],
+  },
 });
 
 export async function fetchLarajobs(
   companyId: number,
 ): Promise<NormalizedJob[]> {
   const feed = await parser.parseURL(FEED_URL);
-  return feed.items.map((item) => {
-    const link = item.link ?? '';
-    const externalId = item.guid ?? hashShortId(link || (item.title ?? ''));
-    const description =
-      item.contentSnippet ??
-      (item.content ? stripHtml(item.content) : '') ??
-      '';
-    return {
-      companyId,
-      externalId,
-      title: item.title ?? 'Untitled',
-      url: link,
-      // LaraJobs feed doesn't include a structured location field.
-      // Default to "Remote" so the base filter lets it through and Claude
-      // makes the US-eligibility call.
-      location: 'Remote',
-      description,
-      postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
-    } satisfies NormalizedJob;
-  });
+  return feed.items.map((item) => mapLarajobsItem(item, companyId));
 }
 
+/**
+ * Pure mapper extracted for unit tests. Folds salary / company / tags
+ * into the description so Claude has a chance to grade them; uses
+ * `<job:location>` if present, falls back to "Remote" so the base
+ * filter still admits the job.
+ */
+export function mapLarajobsItem(
+  item: LarajobsItem,
+  companyId: number,
+): NormalizedJob {
+  const link = item.link ?? '';
+  const externalId = item.guid ?? hashShortId(link || (item.title ?? ''));
+  const baseDescription =
+    item.contentSnippet ??
+    (item.content ? stripHtml(item.content) : '') ??
+    '';
+  const description = augmentDescription(baseDescription, item);
+  const location =
+    (item.jobLocation && item.jobLocation.trim()) || 'Remote';
+  return {
+    companyId,
+    externalId,
+    title: item.title ?? 'Untitled',
+    url: link,
+    location,
+    description,
+    postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+  } satisfies NormalizedJob;
+}
+
+function augmentDescription(base: string, item: LarajobsItem): string {
+  const parts: string[] = [];
+  if (item.jobCompany && item.jobCompany.trim().length > 0) {
+    parts.push(`Hiring company: ${item.jobCompany.trim()}.`);
+  }
+  if (item.jobSalary && item.jobSalary.trim().length > 0) {
+    parts.push(`Salary: ${item.jobSalary.trim()}.`);
+  }
+  if (item.jobTags && item.jobTags.trim().length > 0) {
+    parts.push(`Tags: ${item.jobTags.trim()}.`);
+  }
+  if (item.jobJobType && item.jobJobType.trim().length > 0) {
+    parts.push(`Type: ${item.jobJobType.replace(/_/g, ' ').toLowerCase()}.`);
+  }
+  const header = parts.join(' ');
+  if (header.length === 0) return base.trim();
+  if (base.trim().length === 0) return header;
+  return `${header}\n\n${base.trim()}`;
+}

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -58,6 +58,29 @@ const SEED_COMPANIES: SeedCompany[] = [
   { name: 'Pleo', atsType: AtsType.GREENHOUSE, atsToken: 'pleo' },
   { name: 'Attentive', atsType: AtsType.GREENHOUSE, atsToken: 'attentive' },
 
+  // Lever — verified live as of phase-7.2 re-seed:
+  //   plaid: ~95 postings; lots of fintech engineering, broad role-type
+  //     coverage (Data Engineer / Eng Manager / Sales Engineer / Backend
+  //     in mix). Always-on hiring.
+  //   spotify: ~180 postings; many "Backend Engineer - X" titles that
+  //     match the default profile's roleTypes filter directly.
+  // Both endpoints respond 200 with non-trivial payloads. Other Lever
+  // tokens we tried (figma/discord/box/retool/grammarly/etc.) are now
+  // 404 — those companies migrated off Lever to Greenhouse / Workable
+  // / private ATSes between 2024 and 2026.
+  {
+    name: 'Plaid',
+    atsType: AtsType.LEVER,
+    atsToken: 'plaid',
+    careerUrl: 'https://plaid.com/careers/openings',
+  },
+  {
+    name: 'Spotify',
+    atsType: AtsType.LEVER,
+    atsToken: 'spotify',
+    careerUrl: 'https://www.lifeatspotify.com/jobs',
+  },
+
   // Ashby
   {
     name: 'Buffer',


### PR DESCRIPTION
User reported "no new positions from Greenhouse / Lever / Larajobs lately." Investigation surfaced two real issues (Greenhouse was a false alarm — the seeded companies just weren't posting matching roles this week, which is normal market noise):

Larajobs RSS parser was silently dropping the entire `xmlns:job="https://larajobs.com"` custom namespace. Production data showed every Larajobs job landing with `location='Remote'` regardless of actual country, even when the feed had:
  <job:location>United States/Remote (USA Only)</job:location>
  <job:salary>USD 130,000 - 160,000</job:salary>
  <job:company>Orpical Technology Solutions</job:company>
Fix: rss-parser `customFields.item` opt-in for job:location, job:salary, job:company, job:tags, job:job_type. Pure mapper extracted as `mapLarajobsItem` and unit-tested. Salary / company / tags / type are folded into the description so Claude has the context to grade them. Verified in DB after re-fetch:
  job 3868 Laravel/Vue/TS: location "Remote, USA only..." fit=92 ALERTED (was hidden)
  job 3869 AI-Native Laravel/Vue: "United States/Remote (USA Only)" fit=92 ALERTED
  job 3870 Laravel/React: "Remote/ canada only" fit=25 DISMISSED (correctly)

Lever had ZERO active companies — all 4 historical seeds (Pleo, Toggl, Scribd, AttentiveMobile) had migrated to Greenhouse / Ashby years ago and were on OBSOLETE_TOKENS. So the Lever fetcher branch was dead code on every tick. Probed candidates (figma, discord, box, benchling, retool, ramp, gitlab, grammarly, github, stripe, twilio, notion, ...) — almost all 404 now. Two are still live and posting heavily:
  plaid:    ~95 postings (fintech, broad eng coverage)
  spotify:  ~180 postings (lots of "Backend Engineer - X" titles
            that match the default profile's roleTypes filter)
Re-seeded both as active=true. Verified end-to-end with fetch:once:
Plaid produced 6 jobs, Spotify 28. (Most DISMISSED because the
default profile has hybridOk=false — that's a profile preference,
not a fetcher issue.)

Tests: +7 for Larajobs mapper (location extraction, salary/company/ tags fold into description, externalId fallback). 172 → 179, all green. tsc clean. prisma validate + format clean.

Note for the user: re-seed picks up Plaid/Spotify automatically on container boot. Larajobs old jobs in DB still have location="Remote" from the buggy mapper — the `(companyId, externalId)` unique constraint dedupes them, so the fix only applies to NEW postings going forward. To backfill, click "Re-classify all jobs" once (or delete + refetch like the smoke test did).