### PR TITLE
phase-7.3: fetcher coverage — pure mappers + tests + HigherLogic seed

### DIFF
--- a/src/fetchers/ashby.test.ts
+++ b/src/fetchers/ashby.test.ts
@@ -1,0 +1,130 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapAshbyJob, type AshbyJob } from './ashby';
+
+const COMPANY_ID = 7;
+
+const baseJob = (overrides: Partial<AshbyJob> = {}): AshbyJob => ({
+  id: 'ashby-uuid-abc',
+  title: 'Senior Backend Engineer',
+  department: 'Engineering',
+  team: 'Platform',
+  employmentType: 'FullTime',
+  location: 'New York',
+  secondaryLocations: [],
+  publishedAt: '2026-04-28T12:00:00Z',
+  isListed: true,
+  isRemote: false,
+  workplaceType: 'Hybrid',
+  jobUrl: 'https://jobs.ashbyhq.com/buffer/ashby-uuid-abc',
+  applyUrl: 'https://jobs.ashbyhq.com/buffer/ashby-uuid-abc/application',
+  descriptionHtml: '<p>Senior Node.js role.</p>',
+  ...overrides,
+});
+
+describe('mapAshbyJob', () => {
+  it('joins primary + secondary locations with " / "', () => {
+    const job = mapAshbyJob(
+      baseJob({
+        location: 'New York',
+        secondaryLocations: [
+          { location: 'San Francisco' },
+          { location: 'Remote — US' },
+        ],
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'New York / San Francisco / Remote — US (Hybrid)');
+  });
+
+  it('appends workplaceType in parens', () => {
+    const job = mapAshbyJob(
+      baseJob({ workplaceType: 'Remote', location: 'Anywhere' }),
+      COMPANY_ID,
+    );
+    assert.match(job.location, /\(Remote\)$/);
+  });
+
+  it('omits workplace suffix when workplaceType is null', () => {
+    const job = mapAshbyJob(
+      baseJob({ workplaceType: null, location: 'Boston' }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'Boston');
+  });
+
+  it('skips empty / null secondary locations', () => {
+    const job = mapAshbyJob(
+      baseJob({
+        location: 'NYC',
+        secondaryLocations: [
+          { location: null },
+          { location: '' },
+          { location: 'Boston' },
+        ],
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'NYC / Boston (Hybrid)');
+  });
+
+  it('returns empty location when both primary and secondary are missing', () => {
+    const job = mapAshbyJob(
+      baseJob({
+        location: null,
+        secondaryLocations: [],
+        workplaceType: null,
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, '');
+  });
+
+  it('preserves Ashby uuid as externalId', () => {
+    const job = mapAshbyJob(baseJob(), COMPANY_ID);
+    assert.equal(job.externalId, 'ashby-uuid-abc');
+  });
+
+  it('strips HTML from descriptionHtml', () => {
+    const job = mapAshbyJob(
+      baseJob({
+        descriptionHtml:
+          '<h2>About the role</h2><p>Senior <em>PHP</em> engineer.</p>',
+      }),
+      COMPANY_ID,
+    );
+    assert.match(job.description, /About the role/);
+    assert.match(job.description, /Senior PHP engineer/);
+    assert.doesNotMatch(job.description, /<\w+>/);
+  });
+
+  it('handles missing descriptionHtml', () => {
+    const a = mapAshbyJob(
+      baseJob({ descriptionHtml: null }),
+      COMPANY_ID,
+    );
+    assert.equal(a.description, '');
+  });
+
+  it('parses ISO publishedAt', () => {
+    const job = mapAshbyJob(
+      baseJob({ publishedAt: '2026-04-28T12:00:00Z' }),
+      COMPANY_ID,
+    );
+    assert.equal(job.postedAt.toISOString(), '2026-04-28T12:00:00.000Z');
+  });
+
+  it('falls back to "now" when publishedAt is unparseable', () => {
+    const before = Date.now();
+    const job = mapAshbyJob(
+      baseJob({ publishedAt: 'totally not a date' }),
+      COMPANY_ID,
+    );
+    assert.ok(job.postedAt.getTime() >= before);
+  });
+
+  it('uses jobUrl (canonical) for url, not applyUrl', () => {
+    const job = mapAshbyJob(baseJob(), COMPANY_ID);
+    assert.equal(job.url, 'https://jobs.ashbyhq.com/buffer/ashby-uuid-abc');
+  });
+});

--- a/src/fetchers/ashby.ts
+++ b/src/fetchers/ashby.ts
@@ -26,6 +26,8 @@ const AshbyJobSchema = z.object({
   descriptionHtml: z.string().nullable().optional(),
 });
 
+export type AshbyJob = z.infer<typeof AshbyJobSchema>;
+
 const AshbyResponseSchema = z.object({
   jobs: z.array(AshbyJobSchema),
 });
@@ -47,27 +49,36 @@ export async function fetchAshby(
       `Ashby schema invalid for "${company.atsToken}": ${parsed.error.message}`,
     );
   }
-
   return parsed.data.jobs
     .filter((j) => j.isListed !== false)
-    .map((j) => {
-      const secondary = j.secondaryLocations
-        .map((s) => s.location ?? '')
-        .filter((s) => s.length > 0);
-      const locationParts = [j.location ?? '', ...secondary].filter(
-        (s) => s.length > 0,
-      );
-      const workplace = j.workplaceType ? ` (${j.workplaceType})` : '';
-      return {
-        companyId: company.id,
-        externalId: j.id,
-        title: j.title,
-        url: j.jobUrl,
-        location: `${locationParts.join(' / ')}${workplace}`.trim(),
-        description: stripHtml(j.descriptionHtml ?? ''),
-        postedAt: parseDate(j.publishedAt),
-      } satisfies NormalizedJob;
-    });
+    .map((j) => mapAshbyJob(j, company.id));
+}
+
+/**
+ * Pure mapper extracted for unit tests. Ashby puts the canonical
+ * location in `location` and any extras in `secondaryLocations[].location`.
+ * We join them with " / " (Ashby's own separator on /careers pages) and
+ * append `workplaceType` in parens so the downstream filter can read
+ * it as part of the location string. Listings with isListed=false are
+ * filtered out earlier in `fetchAshby`.
+ */
+export function mapAshbyJob(j: AshbyJob, companyId: number): NormalizedJob {
+  const secondary = j.secondaryLocations
+    .map((s) => s.location ?? '')
+    .filter((s) => s.length > 0);
+  const locationParts = [j.location ?? '', ...secondary].filter(
+    (s) => s.length > 0,
+  );
+  const workplace = j.workplaceType ? ` (${j.workplaceType})` : '';
+  return {
+    companyId,
+    externalId: j.id,
+    title: j.title,
+    url: j.jobUrl,
+    location: `${locationParts.join(' / ')}${workplace}`.trim(),
+    description: stripHtml(j.descriptionHtml ?? ''),
+    postedAt: parseDate(j.publishedAt),
+  } satisfies NormalizedJob;
 }
 
 function parseDate(s: string): Date {

--- a/src/fetchers/greenhouse.test.ts
+++ b/src/fetchers/greenhouse.test.ts
@@ -1,0 +1,134 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapGreenhouseJob, type GreenhouseJob } from './greenhouse';
+
+const COMPANY_ID = 42;
+
+const baseJob = (overrides: Partial<GreenhouseJob> = {}): GreenhouseJob => ({
+  id: 7658329003,
+  title: 'Sr. Software Engineer (PHP)',
+  location: { name: 'Remote, US' },
+  content: '<p>Join our PHP team.</p>',
+  absolute_url: 'https://job-boards.greenhouse.io/higherlogic/jobs/7658329003',
+  updated_at: '2026-04-28T12:00:00Z',
+  departments: [],
+  offices: [],
+  ...overrides,
+});
+
+describe('mapGreenhouseJob', () => {
+  it('uses location.name when present', () => {
+    const job = mapGreenhouseJob(baseJob(), COMPANY_ID);
+    assert.equal(job.location, 'Remote, US');
+  });
+
+  it('falls back to offices[].location when top-level location is missing', () => {
+    const job = mapGreenhouseJob(
+      baseJob({
+        location: null,
+        offices: [
+          { name: 'NYC', location: 'New York, NY' },
+          { name: 'SF', location: 'San Francisco, CA' },
+        ],
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'New York, NY');
+  });
+
+  it('falls back to offices[].name when offices.location is also missing', () => {
+    const job = mapGreenhouseJob(
+      baseJob({
+        location: null,
+        offices: [{ name: 'Remote — Worldwide' }],
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'Remote — Worldwide');
+  });
+
+  it('uses empty string when no location info at all (Claude decides)', () => {
+    const job = mapGreenhouseJob(
+      baseJob({ location: null, offices: [] }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, '');
+  });
+
+  it('strips HTML from content', () => {
+    const job = mapGreenhouseJob(
+      baseJob({
+        content:
+          '<p>We are <strong>hiring</strong> a Senior <em>PHP</em> Developer.</p>\n<p>Stack: Laravel.</p>',
+      }),
+      COMPANY_ID,
+    );
+    assert.match(job.description, /We are hiring/);
+    assert.match(job.description, /PHP Developer/);
+    assert.match(job.description, /Laravel/);
+    assert.doesNotMatch(job.description, /<\w+>/);
+  });
+
+  it('decodes numeric HTML entities (&#x2F;, &#39;, &amp;)', () => {
+    const job = mapGreenhouseJob(
+      baseJob({
+        content: 'PHP&#x2F;Laravel + JS&#x2F;TS &#39;senior&#39; role &amp; more',
+      }),
+      COMPANY_ID,
+    );
+    assert.match(job.description, /PHP\/Laravel/);
+    assert.match(job.description, /JS\/TS/);
+    assert.match(job.description, /'senior'/);
+    assert.match(job.description, /& more/);
+  });
+
+  it('handles missing content gracefully', () => {
+    const a = mapGreenhouseJob(baseJob({ content: null }), COMPANY_ID);
+    assert.equal(a.description, '');
+    const b = mapGreenhouseJob(baseJob({ content: undefined }), COMPANY_ID);
+    assert.equal(b.description, '');
+  });
+
+  it('coerces numeric job id to string for externalId', () => {
+    const job = mapGreenhouseJob(baseJob({ id: 7658329003 }), COMPANY_ID);
+    assert.equal(job.externalId, '7658329003');
+    assert.equal(typeof job.externalId, 'string');
+  });
+
+  it('preserves the canonical absolute_url for the apply link', () => {
+    const job = mapGreenhouseJob(baseJob(), COMPANY_ID);
+    assert.equal(
+      job.url,
+      'https://job-boards.greenhouse.io/higherlogic/jobs/7658329003',
+    );
+  });
+
+  it('falls back to "now" when updated_at is unparseable', () => {
+    const before = Date.now();
+    const job = mapGreenhouseJob(
+      baseJob({ updated_at: 'not-a-date' }),
+      COMPANY_ID,
+    );
+    assert.ok(job.postedAt.getTime() >= before);
+  });
+
+  it('parses valid ISO timestamp', () => {
+    const job = mapGreenhouseJob(
+      baseJob({ updated_at: '2026-04-28T12:00:00Z' }),
+      COMPANY_ID,
+    );
+    assert.equal(job.postedAt.toISOString(), '2026-04-28T12:00:00.000Z');
+  });
+
+  it('regression: HigherLogic-style "Sr. Software Engineer (PHP)" title is preserved verbatim', () => {
+    // The user found this job on LinkedIn at HigherLogic's Greenhouse
+    // board. Title contains parentheses and a trailing whitespace
+    // pattern that must NOT be stripped — the word "PHP" inside parens
+    // is what makes it pass the user's profile filter.
+    const job = mapGreenhouseJob(
+      baseJob({ title: 'Sr. Software Engineer (PHP) ' }),
+      COMPANY_ID,
+    );
+    assert.equal(job.title, 'Sr. Software Engineer (PHP) ');
+  });
+});

--- a/src/fetchers/greenhouse.ts
+++ b/src/fetchers/greenhouse.ts
@@ -26,6 +26,8 @@ const GreenhouseJobSchema = z.object({
   offices: z.array(GreenhouseOfficeSchema).optional().default([]),
 });
 
+export type GreenhouseJob = z.infer<typeof GreenhouseJobSchema>;
+
 const GreenhouseResponseSchema = z.object({
   jobs: z.array(GreenhouseJobSchema),
 });
@@ -47,23 +49,33 @@ export async function fetchGreenhouse(
       `Greenhouse schema invalid for "${company.atsToken}": ${parsed.error.message}`,
     );
   }
+  return parsed.data.jobs.map((j) => mapGreenhouseJob(j, company.id));
+}
 
-  return parsed.data.jobs.map((j) => {
-    const officeLocations = j.offices
-      .map((o) => o.location ?? o.name ?? '')
-      .filter((s) => s.length > 0);
-    const primaryLocation =
-      j.location?.name ?? officeLocations[0] ?? '';
-    return {
-      companyId: company.id,
-      externalId: String(j.id),
-      title: j.title,
-      url: j.absolute_url,
-      location: primaryLocation,
-      description: stripHtml(j.content ?? ''),
-      postedAt: parseDate(j.updated_at),
-    } satisfies NormalizedJob;
-  });
+/**
+ * Pure mapper extracted for unit tests. Greenhouse returns location
+ * either as a top-level `location.name` (most common) or — when the
+ * recruiter didn't fill that — as one of `offices[i].{location,name}`.
+ * We prefer the structured top-level value, then fall back to the
+ * first non-empty office. Description is HTML and is always stripped.
+ */
+export function mapGreenhouseJob(
+  j: GreenhouseJob,
+  companyId: number,
+): NormalizedJob {
+  const officeLocations = j.offices
+    .map((o) => o.location ?? o.name ?? '')
+    .filter((s) => s.length > 0);
+  const primaryLocation = j.location?.name ?? officeLocations[0] ?? '';
+  return {
+    companyId,
+    externalId: String(j.id),
+    title: j.title,
+    url: j.absolute_url,
+    location: primaryLocation,
+    description: stripHtml(j.content ?? ''),
+    postedAt: parseDate(j.updated_at),
+  } satisfies NormalizedJob;
 }
 
 function parseDate(s: string): Date {

--- a/src/fetchers/lever.test.ts
+++ b/src/fetchers/lever.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapLeverPosting, type LeverPosting } from './lever';
+
+const COMPANY_ID = 99;
+
+const basePosting = (overrides: Partial<LeverPosting> = {}): LeverPosting => ({
+  id: '5e7f6c91-d3a9-4f8e-bcde-1234567890ab',
+  text: 'Senior Software Engineer - Fullstack',
+  categories: { location: 'San Francisco', allLocations: [] },
+  descriptionPlain: 'Build the next generation of Plaid APIs.',
+  hostedUrl: 'https://jobs.lever.co/plaid/abc-def',
+  createdAt: 1714305600000, // 2024-04-28
+  workplaceType: 'hybrid',
+  ...overrides,
+});
+
+describe('mapLeverPosting', () => {
+  it('uses categories.location when present', () => {
+    const job = mapLeverPosting(basePosting(), COMPANY_ID);
+    assert.equal(job.location, 'San Francisco (hybrid)');
+  });
+
+  it('appends workplaceType in parens', () => {
+    const a = mapLeverPosting(
+      basePosting({ workplaceType: 'remote' }),
+      COMPANY_ID,
+    );
+    assert.match(a.location, /\(remote\)$/);
+    const b = mapLeverPosting(
+      basePosting({ workplaceType: 'on-site' }),
+      COMPANY_ID,
+    );
+    assert.match(b.location, /\(on-site\)$/);
+  });
+
+  it('omits workplace suffix when workplaceType is null', () => {
+    const job = mapLeverPosting(
+      basePosting({ workplaceType: null }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'San Francisco');
+  });
+
+  it('falls back to categories.allLocations[0] when location is null', () => {
+    const job = mapLeverPosting(
+      basePosting({
+        categories: {
+          location: null,
+          allLocations: ['Remote — Americas', 'New York, NY'],
+        },
+        workplaceType: null,
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'Remote — Americas');
+  });
+
+  it('returns empty location when both fields are missing (Claude decides)', () => {
+    const job = mapLeverPosting(
+      basePosting({
+        categories: { location: null, allLocations: [] },
+        workplaceType: null,
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, '');
+  });
+
+  it('handles missing categories object entirely', () => {
+    const job = mapLeverPosting(
+      basePosting({ categories: undefined, workplaceType: null }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, '');
+  });
+
+  it('preserves the Lever uuid as externalId', () => {
+    const job = mapLeverPosting(basePosting(), COMPANY_ID);
+    assert.equal(job.externalId, '5e7f6c91-d3a9-4f8e-bcde-1234567890ab');
+  });
+
+  it('parses createdAt epoch ms', () => {
+    const job = mapLeverPosting(
+      basePosting({ createdAt: 1714305600000 }),
+      COMPANY_ID,
+    );
+    assert.equal(job.postedAt.toISOString(), '2024-04-28T12:00:00.000Z');
+  });
+
+  it('handles null descriptionPlain (Workable-style title-only jobs)', () => {
+    const job = mapLeverPosting(
+      basePosting({ descriptionPlain: null }),
+      COMPANY_ID,
+    );
+    assert.equal(job.description, '');
+  });
+
+  it('leaves descriptionPlain unchanged (no HTML to strip)', () => {
+    const job = mapLeverPosting(
+      basePosting({
+        descriptionPlain: 'Senior PHP role.\n\nStack: Laravel + Vue.',
+      }),
+      COMPANY_ID,
+    );
+    assert.match(job.description, /Senior PHP role\./);
+    assert.match(job.description, /Laravel \+ Vue/);
+  });
+});

--- a/src/fetchers/lever.ts
+++ b/src/fetchers/lever.ts
@@ -20,6 +20,8 @@ const LeverPostingSchema = z.object({
   workplaceType: z.string().nullable().optional(),
 });
 
+export type LeverPosting = z.infer<typeof LeverPostingSchema>;
+
 const LeverResponseSchema = z.array(LeverPostingSchema);
 
 export interface LeverCompany {
@@ -39,19 +41,30 @@ export async function fetchLever(
       `Lever schema invalid for "${company.atsToken}": ${parsed.error.message}`,
     );
   }
+  return parsed.data.map((p) => mapLeverPosting(p, company.id));
+}
 
-  return parsed.data.map((p) => {
-    const allLocations = p.categories?.allLocations ?? [];
-    const primary = p.categories?.location ?? allLocations[0] ?? '';
-    const workplace = p.workplaceType ? ` (${p.workplaceType})` : '';
-    return {
-      companyId: company.id,
-      externalId: p.id,
-      title: p.text,
-      url: p.hostedUrl,
-      location: `${primary}${workplace}`.trim(),
-      description: p.descriptionPlain ?? '',
-      postedAt: new Date(p.createdAt),
-    } satisfies NormalizedJob;
-  });
+/**
+ * Pure mapper extracted for unit tests. Lever puts location in
+ * `categories.location` (most reliable) or as the first item of
+ * `categories.allLocations`. `workplaceType` is a separate enum
+ * ("remote"/"on-site"/"hybrid") which we append in parens so the
+ * downstream filter can read it as part of the location string.
+ */
+export function mapLeverPosting(
+  p: LeverPosting,
+  companyId: number,
+): NormalizedJob {
+  const allLocations = p.categories?.allLocations ?? [];
+  const primary = p.categories?.location ?? allLocations[0] ?? '';
+  const workplace = p.workplaceType ? ` (${p.workplaceType})` : '';
+  return {
+    companyId,
+    externalId: p.id,
+    title: p.text,
+    url: p.hostedUrl,
+    location: `${primary}${workplace}`.trim(),
+    description: p.descriptionPlain ?? '',
+    postedAt: new Date(p.createdAt),
+  } satisfies NormalizedJob;
 }

--- a/src/fetchers/workable.test.ts
+++ b/src/fetchers/workable.test.ts
@@ -1,0 +1,182 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapWorkableFeed } from './workable';
+
+const COMPANY_ID = 13;
+const SLUG = 'acme';
+
+describe('mapWorkableFeed', () => {
+  it('returns [] for non-object input', () => {
+    assert.deepEqual(mapWorkableFeed(null, COMPANY_ID, SLUG), []);
+    assert.deepEqual(mapWorkableFeed('not json', COMPANY_ID, SLUG), []);
+    assert.deepEqual(mapWorkableFeed(42, COMPANY_ID, SLUG), []);
+  });
+
+  it('returns [] when results is missing', () => {
+    assert.deepEqual(mapWorkableFeed({}, COMPANY_ID, SLUG), []);
+  });
+
+  it('maps a minimal job entry', () => {
+    const out = mapWorkableFeed(
+      {
+        total: 1,
+        results: [
+          {
+            id: 1,
+            shortcode: 'ABC123',
+            title: 'Senior Backend Engineer',
+            remote: true,
+            published: '2026-04-28T00:00:00Z',
+          },
+        ],
+      },
+      COMPANY_ID,
+      SLUG,
+    );
+    assert.equal(out.length, 1);
+    const job = out[0]!;
+    assert.equal(job.companyId, COMPANY_ID);
+    assert.equal(job.externalId, 'ABC123');
+    assert.equal(job.title, 'Senior Backend Engineer');
+    assert.equal(job.url, 'https://apply.workable.com/acme/j/ABC123/');
+    assert.equal(job.location, 'Remote');
+    assert.equal(job.description, '');
+  });
+
+  it('coerces numeric id to string', () => {
+    const out = mapWorkableFeed(
+      {
+        results: [{ id: 12345, shortcode: 'X', title: 'Y', published: '' }],
+      },
+      COMPANY_ID,
+      SLUG,
+    );
+    assert.equal(out[0]?.externalId, 'X');
+  });
+
+  it('formats location with city/region/country', () => {
+    const out = mapWorkableFeed(
+      {
+        results: [
+          {
+            id: '1',
+            shortcode: 'X',
+            title: 'Engineer',
+            location: {
+              city: 'Austin',
+              region: 'TX',
+              country: 'United States',
+            },
+            published: '',
+          },
+        ],
+      },
+      COMPANY_ID,
+      SLUG,
+    );
+    assert.equal(out[0]?.location, 'Austin, TX, United States');
+  });
+
+  it('combines Remote + city when remote is true and location given', () => {
+    const out = mapWorkableFeed(
+      {
+        results: [
+          {
+            id: '1',
+            shortcode: 'X',
+            title: 'Engineer',
+            remote: true,
+            location: { city: 'Berlin', country: 'Germany' },
+            published: '',
+          },
+        ],
+      },
+      COMPANY_ID,
+      SLUG,
+    );
+    assert.equal(out[0]?.location, 'Remote · Berlin, Germany');
+  });
+
+  it('treats workplace="remote" as remote', () => {
+    const out = mapWorkableFeed(
+      {
+        results: [
+          {
+            id: '1',
+            shortcode: 'X',
+            title: 'Engineer',
+            workplace: 'remote',
+            published: '',
+          },
+        ],
+      },
+      COMPANY_ID,
+      SLUG,
+    );
+    assert.equal(out[0]?.location, 'Remote');
+  });
+
+  it('returns "" location when nothing is set (Claude decides)', () => {
+    const out = mapWorkableFeed(
+      {
+        results: [
+          { id: '1', shortcode: 'X', title: 'Engineer', published: '' },
+        ],
+      },
+      COMPANY_ID,
+      SLUG,
+    );
+    assert.equal(out[0]?.location, '');
+  });
+
+  it('skips malformed entries silently', () => {
+    const out = mapWorkableFeed(
+      {
+        results: [
+          { id: '1', shortcode: 'A', title: 'Good', published: '' },
+          { not: 'a job' },
+          { id: '2', shortcode: 'B', title: 'Also good', published: '' },
+        ],
+      },
+      COMPANY_ID,
+      SLUG,
+    );
+    assert.equal(out.length, 2);
+    assert.deepEqual(
+      out.map((j) => j.externalId),
+      ['A', 'B'],
+    );
+  });
+
+  it('parses published timestamp', () => {
+    const out = mapWorkableFeed(
+      {
+        results: [
+          {
+            id: '1',
+            shortcode: 'X',
+            title: 'Engineer',
+            published: '2026-04-28T12:00:00Z',
+          },
+        ],
+      },
+      COMPANY_ID,
+      SLUG,
+    );
+    assert.equal(out[0]?.postedAt.toISOString(), '2026-04-28T12:00:00.000Z');
+  });
+
+  it('falls back to "now" for unparseable published', () => {
+    const before = Date.now();
+    const out = mapWorkableFeed(
+      {
+        results: [
+          { id: '1', shortcode: 'X', title: 'Engineer', published: 'bad' },
+        ],
+      },
+      COMPANY_ID,
+      SLUG,
+    );
+    assert.ok((out[0]?.postedAt.getTime() ?? 0) >= before);
+  });
+});

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -57,6 +57,18 @@ const SEED_COMPANIES: SeedCompany[] = [
   { name: 'MongoDB', atsType: AtsType.GREENHOUSE, atsToken: 'mongodb' },
   { name: 'Pleo', atsType: AtsType.GREENHOUSE, atsToken: 'pleo' },
   { name: 'Attentive', atsType: AtsType.GREENHOUSE, atsToken: 'attentive' },
+  // HigherLogic — added phase-7.3 after the user found a "Sr. Software
+  // Engineer (PHP)" posting on LinkedIn that wasn't in our DB. This is
+  // exactly the long-tail case the system needs to scale to: companies
+  // that post small numbers of senior PHP roles without crowding the
+  // PHP-aggregator boards. The /companies UI is the proper way to grow
+  // this list; the seed is just a starter set.
+  {
+    name: 'HigherLogic',
+    atsType: AtsType.GREENHOUSE,
+    atsToken: 'higherlogic',
+    careerUrl: 'https://www.higherlogic.com/about/careers/',
+  },
 
   // Lever — verified live as of phase-7.2 re-seed:
   //   plaid: ~95 postings; lots of fintech engineering, broad role-type


### PR DESCRIPTION
User reported finding a "Sr. Software Engineer (PHP)" posting on LinkedIn at HigherLogic that wasn't surfaced by the system. Two issues underneath the complaint, addressed separately here:

(1) HigherLogic wasn't in our seed
    Greenhouse fetcher monitors only the boards we know about
    (15 companies pre-fetch). The /companies form is the proper way
    to grow this list, but HigherLogic is a known PHP shop with
    consistent senior PHP postings — adding to seed so the next
    fresh deploy finds it without manual setup. End-to-end verified:

      Sr. Software Engineer (PHP)  | US-Remote  | fit=92 ALERTED
      priorityRulesApplied: {PHP remote-US}

(2) Greenhouse / Lever / Ashby / Workable mappers were inline +
    untested.
    Audit of /jobs/:id surfaces, schema-changes, and edge-case
    location handling all touched these mappers without any safety
    net. Extracted to exported pure helpers:

      mapGreenhouseJob   (12 tests)
      mapLeverPosting    (10 tests)
      mapAshbyJob        (11 tests)
      mapWorkableFeed    (11 tests, was exported, no test before)

    Coverage for: location fallback chain (location → offices →
    secondaryLocations → empty), workplaceType-in-parens, HTML
    strip + numeric-entity decode, missing/null fields, malformed
    list entries (zod-skip), externalId coercion, postedAt ISO
    parse + "now" fallback. Also a regression test that the
    HigherLogic-style title `"Sr. Software Engineer (PHP) "` is
    preserved verbatim — that title was a useful sanity check
    because parens + trailing whitespace are common ways title
    extraction can silently mangle data.

Test count: 179 → 223 (+44). tsc --noEmit clean, prisma validate clean, npm test green.

Note on the original "0 new jobs in 20h" complaint: this is partly expected — the fetch run stats show that we DO fetch ~1225 jobs/tick from the active sources, but ~1179 are filter-rejected and the rest are duplicates of jobs already in DB. New postings from PHP-friendly companies are intermittent. The remedy is broader company coverage (via /companies UI as users encounter postings on LinkedIn) plus the priority-rules feature from phase-7.1 which now ensures bare PHP roles like the HigherLogic one don't get scored low and dismissed.

Investigated but skipped: universal ATS-URL discovery from aggregator job descriptions. RemoteOK / Remotive / WeWorkRemotely / Larajobs URLs and descriptions in our DB do NOT contain Greenhouse / Lever / Ashby URLs (verified via SQL: 0 matches). Those aggregators redirect through their own domains. The HN parser already harvests ATS URLs from comments where they DO appear.