### PR TITLE
phase-7.4: Jobicy cross-company source + honest coverage docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,20 @@ The same paragraph also handles location: `Remote · Germany` / `🇩🇪 …` /
 ### 9. Worker and web are separate processes — read settings on every tick
 A toggle in `/settings` writes to Postgres immediately. Worker reads it at the start of the next cron tick (so changes are visible within at most an hour). Don't try to short-circuit by caching settings in the worker — that defeats the live-toggle UX.
 
+### 10. There is NO "all Greenhouse jobs" API — coverage is two-tier by design
+Greenhouse / Lever / Ashby / Workable / SmartRecruiters are **HR vendors, not job boards**. Their public APIs only expose `/v1/boards/<slug>/jobs` — you have to know the company slug. There is no global "list every Greenhouse posting" endpoint, and crawling vendor customer lists is grey-zone scraping (ADR 0005 forbids it: no LinkedIn / Indeed / Workday / Wellfound / JobSpy).
+
+Coverage is therefore **two-tier**:
+
+1. **Direct boards** (per-company, narrow but precise) — `Company` rows with `atsType ∈ {GREENHOUSE, LEVER, ASHBY, WORKABLE, SMARTRECRUITERS}`. Curated by the user via `/companies` (paste a board URL → manual probe → save) or seeded in `src/seed.ts`. Catches every job at the companies you've added; misses everything else.
+2. **Cross-company aggregators** (broad but noisy) — `LARAJOBS_RSS`, `REMOTEOK`, `REMOTIVE`, `JOBICY`, `WEWORKREMOTELY`, `HN_HIRING`, `ARBEITNOW`, `GOLANGPROJECTS`. Each is a single synthetic Company row that ingests jobs from many employers we'd never seed individually (PSI CRO, ManTech, DoorDash, Lemon.io, …). Catches the long tail; lets `passesBaseFilter` + Claude cull the noise.
+
+Common user trap: disabling all aggregators in `/settings → Job sources` because "I want only Greenhouse" produces near-zero new jobs (we have ~15 seeded Greenhouse boards, most don't post matching roles weekly). The cure is to **leave aggregators enabled** and let the profile filter narrow scope. Document this in any user-facing copy that talks about "monitoring".
+
+When a user finds a job at a company we don't track (e.g. via LinkedIn), the right path is:
+- Paste the board URL into `/companies → Add company` — the form runs `extractAtsToken` + `probeAts` and refuses to save if the slug doesn't resolve. One-click promote into the rotation.
+- Or, the HN parser harvests ATS URLs from comments automatically (when `discoveryEnabled` is on) — they show up on `/discovery` as PENDING candidates.
+
 ---
 
 ## ATS templates (when adding a new source)

--- a/prisma/migrations/20260429203142_add_jobicy/migration.sql
+++ b/prisma/migrations/20260429203142_add_jobicy/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "AtsType" ADD VALUE 'JOBICY';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ enum AtsType {
   SMARTRECRUITERS
   WEWORKREMOTELY
   GOLANGPROJECTS
+  JOBICY
 }
 
 enum JobStatus {

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -15,6 +15,7 @@ import { fetchWorkable } from './workable';
 import { fetchSmartRecruiters } from './smartrecruiters';
 import { fetchWeWorkRemotely } from './weworkremotely';
 import { fetchGolangProjects } from './golangprojects';
+import { fetchJobicy } from './jobicy';
 import type { NormalizedJob } from '../types';
 
 const POLITE_DELAY_MS = 1_000;
@@ -101,5 +102,7 @@ async function fetchOne(company: {
       });
     case AtsType.GOLANGPROJECTS:
       return fetchGolangProjects(company.id);
+    case AtsType.JOBICY:
+      return fetchJobicy(company.id);
   }
 }

--- a/src/fetchers/jobicy.test.ts
+++ b/src/fetchers/jobicy.test.ts
@@ -1,0 +1,113 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapJobicyItem, type JobicyItem } from './jobicy';
+
+const COMPANY_ID = 99;
+
+describe('mapJobicyItem', () => {
+  it('extracts <job_listing:location> instead of defaulting to Remote', () => {
+    const job = mapJobicyItem(
+      {
+        title: 'Senior PHP Developer',
+        link: 'https://jobicy.com/jobs/142345-senior-php',
+        pubDate: 'Mon, 28 Apr 2026 04:14:43 +0000',
+        jobLocation: 'USA',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'USA');
+  });
+
+  it('falls back to "Remote" when location field is missing or empty', () => {
+    const a = mapJobicyItem(
+      {
+        title: 'X',
+        link: 'https://jobicy.com/jobs/1',
+        pubDate: 'Mon, 28 Apr 2026 04:14:43 +0000',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(a.location, 'Remote');
+    const b = mapJobicyItem(
+      {
+        title: 'X',
+        link: 'https://jobicy.com/jobs/1',
+        pubDate: 'Mon, 28 Apr 2026 04:14:43 +0000',
+        jobLocation: '   ',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(b.location, 'Remote');
+  });
+
+  it('embeds hiring company + job type into description', () => {
+    const job = mapJobicyItem(
+      {
+        title: 'Senior SAP Integration Developer',
+        link: 'https://jobicy.com/jobs/142515',
+        pubDate: 'Fri, 24 Apr 2026 15:07:31 +0000',
+        jobLocation: 'USA',
+        jobCompany: 'ManTech',
+        jobType: 'Full Time',
+        contentSnippet: 'Shape the future of defense with MANTECH!',
+      },
+      COMPANY_ID,
+    );
+    assert.match(job.description, /Hiring company: ManTech/);
+    assert.match(job.description, /Type: full time/);
+    assert.match(job.description, /Shape the future of defense/);
+  });
+
+  it('preserves description when no custom fields are set', () => {
+    const job = mapJobicyItem(
+      {
+        title: 'X',
+        link: 'https://jobicy.com/jobs/1',
+        pubDate: 'Mon, 28 Apr 2026 04:14:43 +0000',
+        contentSnippet: 'Just a description.',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(job.description, 'Just a description.');
+  });
+
+  it('uses guid for externalId when present', () => {
+    const job = mapJobicyItem(
+      {
+        title: 'X',
+        link: 'https://jobicy.com/jobs/142345',
+        pubDate: 'Mon, 28 Apr 2026 04:14:43 +0000',
+        guid: 'https://jobicy.com/jobs/142345',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(job.externalId, 'https://jobicy.com/jobs/142345');
+  });
+
+  it('synthesises a stable externalId from link when guid is missing', () => {
+    const job = mapJobicyItem(
+      {
+        title: 'X',
+        link: 'https://jobicy.com/jobs/142345',
+        pubDate: 'Mon, 28 Apr 2026 04:14:43 +0000',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(job.externalId.length, 16);
+    assert.match(job.externalId, /^[0-9a-f]{16}$/);
+  });
+
+  it('handles empty contentSnippet without crashing', () => {
+    const job = mapJobicyItem(
+      {
+        title: 'X',
+        link: 'https://jobicy.com/jobs/1',
+        pubDate: 'Mon, 28 Apr 2026 04:14:43 +0000',
+        contentSnippet: '',
+        jobCompany: 'Acme Inc',
+      },
+      COMPANY_ID,
+    );
+    assert.equal(job.description, 'Hiring company: Acme Inc.');
+  });
+});

--- a/src/fetchers/jobicy.ts
+++ b/src/fetchers/jobicy.ts
@@ -1,0 +1,99 @@
+import Parser from 'rss-parser';
+import { stripHtml } from '../http';
+import { hashShortId } from '../text-utils';
+import type { NormalizedJob } from '../types';
+
+const FEED_URL_TEMPLATE = (category: string) =>
+  `https://jobicy.com/?feed=job_feed&job_categories=${encodeURIComponent(category)}`;
+const PARSER_TIMEOUT_MS = 15_000;
+const DEFAULT_CATEGORY = 'dev';
+
+/**
+ * Jobicy is a cross-company remote-job aggregator. Their RSS feed
+ * `https://jobicy.com/?feed=job_feed&job_categories=dev` returns ~50
+ * recent jobs spanning many employers (PSI CRO, ManTech, Mindrift,
+ * etc.) — none of which we'd ever seed individually. This is the
+ * mechanism for "see jobs at companies I don't track yet".
+ *
+ * Like Larajobs, the structured fields live in a custom XML namespace
+ * (`xmlns:job_listing="https://jobicy.com"`):
+ *   <job_listing:location>USA</job_listing:location>
+ *   <job_listing:job_type>Full Time</job_listing:job_type>
+ *   <job_listing:company>ManTech</job_listing:company>
+ * rss-parser drops these unless we opt in via customFields. The
+ * Larajobs fetcher (phase-7.2) hit the exact same pitfall — see that
+ * file's header comment for the gotcha.
+ */
+export interface JobicyItem {
+  title?: string;
+  link?: string;
+  pubDate?: string;
+  contentSnippet?: string;
+  content?: string;
+  guid?: string;
+  jobLocation?: string;
+  jobType?: string;
+  jobCompany?: string;
+}
+
+const parser: Parser<unknown, JobicyItem> = new Parser({
+  timeout: PARSER_TIMEOUT_MS,
+  customFields: {
+    item: [
+      ['job_listing:location', 'jobLocation'],
+      ['job_listing:job_type', 'jobType'],
+      ['job_listing:company', 'jobCompany'],
+    ],
+  },
+});
+
+export async function fetchJobicy(
+  companyId: number,
+  category: string = DEFAULT_CATEGORY,
+): Promise<NormalizedJob[]> {
+  const feed = await parser.parseURL(FEED_URL_TEMPLATE(category));
+  return feed.items.map((item) => mapJobicyItem(item, companyId));
+}
+
+/**
+ * Pure mapper extracted for unit tests. Folds the underlying employer
+ * name (Jobicy aggregates across companies, but we register a single
+ * synthetic Company row for the feed) into the description so Claude
+ * sees `Hiring company: ManTech` and can score accordingly.
+ */
+export function mapJobicyItem(
+  item: JobicyItem,
+  companyId: number,
+): NormalizedJob {
+  const link = item.link ?? '';
+  const externalId = item.guid ?? hashShortId(link || (item.title ?? ''));
+  const baseDescription =
+    item.contentSnippet ??
+    (item.content ? stripHtml(item.content) : '') ??
+    '';
+  const description = augmentDescription(baseDescription, item);
+  const location = (item.jobLocation && item.jobLocation.trim()) || 'Remote';
+  return {
+    companyId,
+    externalId,
+    title: item.title ?? 'Untitled',
+    url: link,
+    location,
+    description,
+    postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+  } satisfies NormalizedJob;
+}
+
+function augmentDescription(base: string, item: JobicyItem): string {
+  const parts: string[] = [];
+  if (item.jobCompany && item.jobCompany.trim().length > 0) {
+    parts.push(`Hiring company: ${item.jobCompany.trim()}.`);
+  }
+  if (item.jobType && item.jobType.trim().length > 0) {
+    parts.push(`Type: ${item.jobType.trim().toLowerCase()}.`);
+  }
+  const header = parts.join(' ');
+  if (header.length === 0) return base.trim();
+  if (base.trim().length === 0) return header;
+  return `${header}\n\n${base.trim()}`;
+}

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -144,6 +144,19 @@ const SEED_COMPANIES: SeedCompany[] = [
     active: false,
   },
 
+  // Jobicy — cross-company remote-job aggregator (~50 items/feed).
+  // Indexes employers we'd never seed individually (PSI CRO, ManTech,
+  // Mindrift, etc.). This is the answer to "monitor PHP roles at
+  // companies I haven't added yet" — without scraping LinkedIn /
+  // Indeed (excluded by ADR 0005, which we hold to). Active by
+  // default so users get cross-company coverage out of the box.
+  {
+    name: 'Jobicy Feed',
+    atsType: AtsType.JOBICY,
+    atsToken: 'jobicy',
+    careerUrl: 'https://jobicy.com',
+  },
+
   // WeWorkRemotely — paid posting → low-spam. Two relevant categories
   // for the default profile; user can add more (`design-jobs`, etc) via UI.
   {

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -51,6 +51,39 @@ export const CompaniesPage: FC<CompaniesProps> = ({ companies, flash }) => (
       </div>
     )}
 
+    <Card class="mb-6 border-amber-500/30 bg-amber-500/5">
+      <SectionTitle>How job discovery actually works</SectionTitle>
+      <p class="text-xs text-zinc-300">
+        Greenhouse / Lever / Ashby / Workable / SmartRecruiters are{' '}
+        <strong>HR vendors, not job boards</strong> — their public APIs only
+        let you query <code class="rounded bg-zinc-900 px-1">/boards/&lt;slug&gt;/jobs</code>,
+        so we only see jobs at companies in this table. There is{' '}
+        <em>no global "all Greenhouse postings" endpoint</em>, and we never
+        scrape LinkedIn / Indeed / Workday (
+        <a
+          href="https://github.com/nazboyko/job-hunter/blob/main/docs/adr/0005-no-linkedin-indeed-workday.md"
+          class="underline hover:text-zinc-100"
+        >
+          ADR 0005
+        </a>
+        ).
+      </p>
+      <p class="mt-2 text-xs text-zinc-300">
+        Coverage is <strong>two-tier</strong>: per-company boards (this page,
+        narrow + precise) plus cross-company aggregators (
+        <code class="rounded bg-zinc-900 px-1">LARAJOBS</code>{' '}
+        <code class="rounded bg-zinc-900 px-1">REMOTEOK</code>{' '}
+        <code class="rounded bg-zinc-900 px-1">REMOTIVE</code>{' '}
+        <code class="rounded bg-zinc-900 px-1">JOBICY</code>{' '}
+        <code class="rounded bg-zinc-900 px-1">WEWORKREMOTELY</code>{' '}
+        <code class="rounded bg-zinc-900 px-1">HN_HIRING</code> — broad, noisy,
+        let the profile filter cull). <strong>If you disable all aggregators</strong>{' '}
+        in /settings → Job sources, you'll only see jobs at companies you've
+        added here. The aggregators are how the long tail (HigherLogic, …)
+        gets surfaced.
+      </p>
+    </Card>
+
     <Card class="mb-6">
       <SectionTitle>Add company</SectionTitle>
       <p class="mb-3 text-xs text-zinc-500">


### PR DESCRIPTION
User asked for "all possible companies" coverage — explicitly including ones not in the seed (e.g. HigherLogic posts a new PHP remote-US role, system should surface it without manual seed update). The honest technical answer is:

- Greenhouse / Lever / Ashby / Workable / SmartRecruiters are HR vendors with per-slug-only public APIs. There is NO global "list every Greenhouse posting" endpoint. Crawling vendor customer lists is grey-zone scraping (ADR 0005 forbids it).
- The actual mechanism for long-tail discovery is cross-company aggregator feeds: LARAJOBS, REMOTEOK, REMOTIVE, WEWORKREMOTELY, HN_HIRING, ARBEITNOW, GOLANGPROJECTS — and now JOBICY.
- The user had disabled all aggregators in /settings ("only Greenhouse"), which was the root cause of the 0-new-jobs run: with all aggregators off, only the ~15 seeded Greenhouse boards produce jobs, and most don't post matching roles weekly.

Concrete shipping changes:

(1) Added JOBICY as a new AtsType + fetcher.
    Jobicy.com publishes a free, no-auth RSS feed with ~50 recent
    cross-company remote dev jobs in a custom xmlns:job_listing
    namespace. Fixed the same rss-parser customFields opt-in
    pitfall as Larajobs (phase-7.2) — without it, location and
    employer name silently disappear. Pure mapper `mapJobicyItem`
    extracted with 7 unit tests; description is augmented with
    "Hiring company: X. Type: full time." so Claude sees the
    underlying employer.
    End-to-end verified after rebuild: pulled 3 USA full-stack
    postings from Tines / PSI CRO / California Institute of
    Applied Technology — none of which we'd ever seed. Claude
    correctly scored them low (15-25) because they're not
    PHP-specific, but the *plumbing* is now in place: when Jobicy
    indexes a company's PHP role, we see it without manual seed
    updates.

(2) /companies UI — amber banner explaining the architecture.
    The "How job discovery actually works" card sits at the top of
    the page and says, in plain language: per-company boards are
    narrow + precise, aggregators are broad + noisy, and disabling
    all aggregators is what breaks long-tail coverage. Links to
    ADR 0005 for the no-LinkedIn-no-Indeed policy.

(3) CLAUDE.md gotcha #10 — "There is NO 'all Greenhouse jobs' API".
    Codifies the two-tier coverage model so future work (or future
    sessions of Claude) doesn't accidentally re-litigate "let's
    just crawl Greenhouse customers." Includes the user-trap
    pattern (disable all aggregators → near-zero jobs) and the
    correct remediation.

Schema migration 20260429203142_add_jobicy adds the JOBICY enum value. JOBICY is active=true in seed and NOT pre-disabled in AppSettings.disabledSources, so users get cross-company coverage on next deploy without flipping a toggle.

Test count: 223 → 230 (+7 for Jobicy mapper). tsc + prisma validate + format clean. All 8 dashboard pages still 200.