### PR TITLE
phase-7.5: HN /jobs fetcher + universal ATS-URL discovery harvest

### DIFF
--- a/prisma/migrations/20260429220551_add_hn_jobs/migration.sql
+++ b/prisma/migrations/20260429220551_add_hn_jobs/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "AtsType" ADD VALUE 'HN_JOBS';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ enum AtsType {
   WEWORKREMOTELY
   GOLANGPROJECTS
   JOBICY
+  HN_JOBS
 }
 
 enum JobStatus {

--- a/src/fetchers/hn-jobs.test.ts
+++ b/src/fetchers/hn-jobs.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapHnJobHit, type HnJobHit } from './hn-jobs';
+
+const COMPANY_ID = 11;
+
+const baseHit = (overrides: Partial<HnJobHit> = {}): HnJobHit => ({
+  objectID: '40000000',
+  title: 'Acme Is Hiring a Founding Engineer (SF or Remote)',
+  url: 'https://acme.example.com/careers',
+  job_text: '<p>Help us build the future.</p>',
+  story_text: null,
+  created_at: '2026-04-29T12:00:00Z',
+  created_at_i: 1745928000,
+  ...overrides,
+});
+
+describe('mapHnJobHit', () => {
+  it('uses objectID with hn-job- prefix as externalId', () => {
+    const job = mapHnJobHit(baseHit({ objectID: '12345' }), COMPANY_ID);
+    assert.equal(job.externalId, 'hn-job-12345');
+  });
+
+  it('preserves the company-supplied URL verbatim', () => {
+    const job = mapHnJobHit(
+      baseHit({
+        url: 'https://jobs.ashbyhq.com/infisical/782b9da8-20e1-48b2-919e-6c5430c58628',
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(
+      job.url,
+      'https://jobs.ashbyhq.com/infisical/782b9da8-20e1-48b2-919e-6c5430c58628',
+    );
+  });
+
+  it('falls back to news.ycombinator.com URL when hit.url is null', () => {
+    const job = mapHnJobHit(
+      baseHit({ objectID: '12345', url: null }),
+      COMPANY_ID,
+    );
+    assert.equal(job.url, 'https://news.ycombinator.com/item?id=12345');
+  });
+
+  it('extracts trailing parens as location', () => {
+    const job = mapHnJobHit(
+      baseHit({ title: 'Acme Is Hiring (Remote US)' }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'Remote US');
+  });
+
+  it('skips YC batch markers when extracting location', () => {
+    const job = mapHnJobHit(
+      baseHit({
+        title: 'Infisical (YC W23) Is Hiring Full Stack Software Engineers (Remote)',
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, 'Remote');
+  });
+
+  it('returns "" location when title has no parens', () => {
+    const job = mapHnJobHit(
+      baseHit({ title: 'Stardex Is Hiring a Founding Engineer' }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, '');
+  });
+
+  it('returns "" location when only YC batch is present', () => {
+    const job = mapHnJobHit(
+      baseHit({ title: 'Acme (YC S22) Is Hiring' }),
+      COMPANY_ID,
+    );
+    assert.equal(job.location, '');
+  });
+
+  it('strips HTML entities from job_text', () => {
+    const job = mapHnJobHit(
+      baseHit({
+        job_text: '<p>We&#x27;re hiring &amp; growing fast.</p>',
+      }),
+      COMPANY_ID,
+    );
+    assert.match(job.description, /We're hiring & growing fast/);
+    assert.doesNotMatch(job.description, /<\w+>/);
+  });
+
+  it('falls back to story_text when job_text is missing', () => {
+    const job = mapHnJobHit(
+      baseHit({ job_text: null, story_text: 'Story body content here.' }),
+      COMPANY_ID,
+    );
+    assert.equal(job.description, 'Story body content here.');
+  });
+
+  it('handles empty title gracefully', () => {
+    const job = mapHnJobHit(baseHit({ title: '' }), COMPANY_ID);
+    assert.equal(job.title, 'Untitled HN job');
+  });
+
+  it('parses created_at_i as epoch seconds', () => {
+    const job = mapHnJobHit(
+      baseHit({ created_at_i: 1745928000, created_at: null }),
+      COMPANY_ID,
+    );
+    assert.equal(job.postedAt.toISOString(), '2025-04-29T12:00:00.000Z');
+  });
+
+  it('falls back to ISO created_at when created_at_i is missing', () => {
+    const job = mapHnJobHit(
+      baseHit({ created_at_i: null, created_at: '2026-04-29T12:00:00Z' }),
+      COMPANY_ID,
+    );
+    assert.equal(job.postedAt.toISOString(), '2026-04-29T12:00:00.000Z');
+  });
+
+  it('regression: Infisical YC W23 job preserves Ashby URL for discovery', () => {
+    // Real example pulled from HN /jobs Algolia API. The URL is exactly
+    // the kind of thing extractAtsToken should pick up: a Greenhouse /
+    // Lever / Ashby ATS link → CompanyCandidate. We just need the URL
+    // here to flow through verbatim.
+    const job = mapHnJobHit(
+      baseHit({
+        objectID: '40892341',
+        title: 'Infisical (YC W23) Is Hiring Full Stack Software Engineers (Remote)',
+        url: 'https://jobs.ashbyhq.com/infisical/782b9da8-20e1-48b2-919e-6c5430c58628',
+      }),
+      COMPANY_ID,
+    );
+    assert.equal(
+      job.url,
+      'https://jobs.ashbyhq.com/infisical/782b9da8-20e1-48b2-919e-6c5430c58628',
+    );
+    assert.match(job.title, /Infisical/);
+    assert.equal(job.location, 'Remote');
+  });
+});

--- a/src/fetchers/hn-jobs.ts
+++ b/src/fetchers/hn-jobs.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+import { fetchWithRetry, stripHtml } from '../http';
+import type { NormalizedJob } from '../types';
+
+const ALGOLIA_BASE = 'https://hn.algolia.com/api/v1';
+const FRESH_WINDOW_DAYS = 14;
+const HITS_PER_PAGE = 100;
+
+/**
+ * HN /jobs feed — separate from the monthly Who-is-Hiring thread.
+ * Algolia indexes individual YC-job posts under tags=job; these post
+ * continuously (each a few hours apart, typically YC-portfolio
+ * companies). The post URL almost always points directly to the
+ * company's ATS (Greenhouse / Lever / Ashby / Workable), which lets
+ * the discovery pipeline harvest CompanyCandidate rows for free —
+ * essentially "auto-seed" for any new YC-funded employer.
+ *
+ * We restrict to the last 14 days because HN /jobs has 17K+ historical
+ * entries from 2009 onward; old posts are already filled and re-fetching
+ * them on every tick wastes Anthropic budget on stale data.
+ */
+const HnJobHitSchema = z
+  .object({
+    objectID: z.string(),
+    title: z.string().nullable().optional(),
+    url: z.string().nullable().optional(),
+    job_text: z.string().nullable().optional(),
+    story_text: z.string().nullable().optional(),
+    created_at: z.string().nullable().optional(),
+    created_at_i: z.number().nullable().optional(),
+  })
+  .passthrough();
+
+export type HnJobHit = z.infer<typeof HnJobHitSchema>;
+
+const HnJobSearchResultSchema = z
+  .object({
+    hits: z.array(HnJobHitSchema),
+    nbHits: z.number().optional(),
+  })
+  .passthrough();
+
+export async function fetchHnJobs(
+  companyId: number,
+  now: Date = new Date(),
+): Promise<NormalizedJob[]> {
+  const since = Math.floor(now.getTime() / 1000) - FRESH_WINDOW_DAYS * 86_400;
+  const url = `${ALGOLIA_BASE}/search_by_date?tags=job&hitsPerPage=${HITS_PER_PAGE}&numericFilters=created_at_i>${since}`;
+  const resp = await fetchWithRetry(url);
+  const raw: unknown = await resp.json();
+  const parsed = HnJobSearchResultSchema.safeParse(raw);
+  if (!parsed.success) return [];
+  return parsed.data.hits.map((h) => mapHnJobHit(h, companyId));
+}
+
+/**
+ * Pure mapper extracted for unit tests.
+ *
+ * - HN /jobs entries don't carry a structured location field. We
+ *   parse common patterns ("(Remote)", "(US-Remote)", "(SF or Remote)")
+ *   out of the title, defaulting to empty so Claude decides.
+ * - `job_text` is the body when present; otherwise `story_text`. Both
+ *   are HTML-encoded HN snippets; stripHtml decodes entities.
+ * - The url field, when present, is THE company's ATS link (e.g.
+ *   `jobs.ashbyhq.com/infisical/<id>`) — kept verbatim so the
+ *   discovery pipeline can run extractAtsToken on it later.
+ */
+export function mapHnJobHit(
+  hit: HnJobHit,
+  companyId: number,
+): NormalizedJob {
+  const title = (hit.title ?? '').trim() || 'Untitled HN job';
+  const link = hit.url ?? `https://news.ycombinator.com/item?id=${hit.objectID}`;
+  const bodyRaw = hit.job_text ?? hit.story_text ?? '';
+  const description = stripHtml(bodyRaw);
+  return {
+    companyId,
+    externalId: `hn-job-${hit.objectID}`,
+    title,
+    url: link,
+    location: extractLocationFromTitle(title),
+    description,
+    postedAt: hit.created_at_i
+      ? new Date(hit.created_at_i * 1000)
+      : hit.created_at
+        ? new Date(hit.created_at)
+        : new Date(),
+  } satisfies NormalizedJob;
+}
+
+const TITLE_LOCATION_RE = /\(([^)]+)\)\s*$/;
+
+/**
+ * HN job titles often look like:
+ *   "Infisical (YC W23) Is Hiring Full Stack Software Engineers (Remote)"
+ *   "Acme Is Hiring a Founding Engineer (SF or NYC)"
+ *   "Stardex Is Hiring a Founding Customer Success Lead"
+ * The trailing parens tend to hold location. YC batch markers like
+ * "(YC W23)" are NOT location — we filter those out by token.
+ */
+function extractLocationFromTitle(title: string): string {
+  const matches = [...title.matchAll(/\(([^)]+)\)/g)];
+  if (matches.length === 0) return '';
+  // Take the last paren group that is NOT a YC batch marker.
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const candidate = matches[i]?.[1]?.trim() ?? '';
+    if (candidate.length === 0) continue;
+    if (/^YC\s+[SWFA]\d{2,4}$/i.test(candidate)) continue;
+    return candidate;
+  }
+  return '';
+}
+
+// Re-export helper for caller-side discovery URL extraction.
+export { TITLE_LOCATION_RE };

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -16,6 +16,7 @@ import { fetchSmartRecruiters } from './smartrecruiters';
 import { fetchWeWorkRemotely } from './weworkremotely';
 import { fetchGolangProjects } from './golangprojects';
 import { fetchJobicy } from './jobicy';
+import { fetchHnJobs } from './hn-jobs';
 import type { NormalizedJob } from '../types';
 
 const POLITE_DELAY_MS = 1_000;
@@ -104,5 +105,7 @@ async function fetchOne(company: {
       return fetchGolangProjects(company.id);
     case AtsType.JOBICY:
       return fetchJobicy(company.id);
+    case AtsType.HN_JOBS:
+      return fetchHnJobs(company.id);
   }
 }

--- a/src/jobs/fetch-job.ts
+++ b/src/jobs/fetch-job.ts
@@ -2,6 +2,7 @@ import { logger } from '../logger';
 import { runAllFetchers } from '../fetchers';
 import { getActiveProfile } from '../profiles';
 import { getSettings } from '../settings';
+import { recordCandidatesFromText } from '../discovery';
 import { processNormalizedJobs, type ProcessStats } from './process-jobs';
 import type { CronStats } from './cron-run';
 
@@ -16,7 +17,8 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     );
     return { stats: { aborted: 1, reason: 'no-active-profile' } };
   }
-  const { classifierMode } = await getSettings();
+  const settings = await getSettings();
+  const { classifierMode } = settings;
   logger.info(
     { profile: profile.name, minFitScore: profile.minFitScore, classifierMode },
     'fetch-job: using active profile',
@@ -24,6 +26,31 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
 
   const fetched = await runAllFetchers();
   logger.info({ count: fetched.length }, 'fetch-job: total fetched');
+
+  // Phase 7.5 — universal ATS-URL discovery from any fetched job's URL
+  // and description. The HN /jobs feed is the primary source: each
+  // hit's URL points directly at jobs.ashbyhq.com / boards.greenhouse.io
+  // / etc., so extractAtsToken (called inside recordCandidatesFromText)
+  // automatically registers a CompanyCandidate row for the underlying
+  // employer. Other aggregators (Larajobs, Jobicy, RemoteOK, …) almost
+  // never include direct ATS links, so this is a near-noop for them.
+  // Idempotent on (atsType, atsToken), so cheap to re-run.
+  let candidates = 0;
+  if (settings.discoveryEnabled) {
+    const sourceTag = `fetch-${new Date().toISOString().slice(0, 7)}`;
+    for (const { job, companyName } of fetched) {
+      const text = `${job.url}\n${job.description}`;
+      const recorded = await recordCandidatesFromText(text, sourceTag, {
+        name: null,
+        sourceUrl: job.url,
+        signal: `Found in ${companyName} feed: ${job.title.slice(0, 80)}`,
+      });
+      candidates += recorded;
+    }
+    if (candidates > 0) {
+      logger.info({ candidates }, 'fetch-job: discovery harvested candidates');
+    }
+  }
 
   const inner: ProcessStats = {
     filterRejected: 0,
@@ -44,6 +71,7 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     profile: profile.name,
     classifierMode,
     fetched: fetched.length,
+    candidatesRecorded: candidates,
     ...inner,
     durationMs,
   };

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -144,6 +144,21 @@ const SEED_COMPANIES: SeedCompany[] = [
     active: false,
   },
 
+  // HN /jobs — individual YC-job posts indexed by Algolia under
+  // tags=job (separate from the monthly Who-is-hiring thread). Each
+  // hit is a YC-portfolio company hiring continuously, with the post
+  // URL pointing directly at the company's ATS — so the discovery
+  // pipeline gets free CompanyCandidate harvest as a side-effect of
+  // running this fetcher. Highest-ROI cross-company source for the
+  // PHP / JS / full-stack / backend profile because YC companies skew
+  // remote-friendly and US-eligible.
+  {
+    name: 'HN /jobs Feed',
+    atsType: AtsType.HN_JOBS,
+    atsToken: 'hn-jobs',
+    careerUrl: 'https://news.ycombinator.com/jobs',
+  },
+
   // Jobicy — cross-company remote-job aggregator (~50 items/feed).
   // Indexes employers we'd never seed individually (PSI CRO, ManTech,
   // Mindrift, etc.). This is the answer to "monitor PHP roles at


### PR DESCRIPTION
Direct response to "I want jobs at companies I haven't seeded". Two complementary changes that compound:

**(1) New AtsType.HN_JOBS — Algolia tags=job feed.** Algolia's HN index publishes individual YC-job posts under `tags=job`, separate from the monthly Who-is-hiring thread. They post continuously, are heavily US/remote, and almost every post URL points directly at the company's ATS. Fetcher restricts to last 14 days (FRESH_WINDOW_DAYS). Pure mapper `mapHnJobHit` extracted with 13 unit tests (YC batch marker filtering, trailing-paren location extraction, HTML entity decode, story_text fallback, ISO/epoch postedAt parsing).

**(2) Universal candidate harvest from job.url + description.** In fetch-job.ts (gated by `AppSettings.discoveryEnabled`): for every job in every fetch tick, `recordCandidatesFromText` runs on the URL + description and yields CompanyCandidate rows for any Greenhouse / Lever / Ashby / Workable / SmartRecruiters URL found. Idempotent on (atsType, atsToken). First tick harvested 106 candidate URLs → 10+ new PENDING rows on /discovery (Anduril, Verkada, Infisical, Squint, Oneleet, …).

CI green on branch; 243/243 tests pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)