### PR TITLE
phase-7.7: pause toggle for job fetching + Node 20 → 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
       DATABASE_URL: postgresql://ci:ci@localhost:5432/ci
       ANTHROPIC_API_KEY: sk-ci-dummy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 ## Two-process layout
 
-The whole system is two Node 20 processes plus a Postgres container,
+The whole system is two Node 24 processes plus a Postgres container,
 all in the same `docker-compose.yml`:
 
 ```mermaid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ When the question is **"how does the user toggle / configure X?"**:
 
 | What | Page |
 | --- | --- |
+| Pause / resume all new-job fetching | `/settings` → "Job fetching" card (top) |
 | Add / remove tracked company | `/companies` (with manual probe before save) |
 | Disable whole ATS family (e.g. all Workable) | `/settings` → "Job sources" card |
 | Enable two-stage classifier (cheaper, less precise) | `/settings` → "Classifier mode" |
@@ -210,3 +211,4 @@ Always:
 | Migrate after a schema change | `DATABASE_URL=… npx prisma migrate dev --name <name>` |
 | Re-classify everything against the active profile | UI: `/settings` → "Re-classify all jobs" |
 | Pause all alerts temporarily | UI: `/settings` → "Telegram alerts" → Disable |
+| Pause new-job fetching entirely (no docker) | UI: `/settings` → "Job fetching" → Pause |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 > [ARCHITECTURE.md](./ARCHITECTURE.md) (data flow + file map).
 
 ## Stack
-- TypeScript strict mode, Node 20
+- TypeScript strict mode, Node 24 (runtime image; engines allow >=22)
 - Prisma + Postgres 16 (already in docker-compose)
 - Native fetch (no axios). Use AbortController for timeouts (10s default via `fetchWithRetry`).
 - pino for logs (never console.log in production code)
@@ -55,7 +55,7 @@
 
 ## Docker
 - Multi-stage Dockerfile: `deps → build → runtime`.
-- Runtime image: `node:20-alpine`.
+- Runtime image: `node:24-alpine`.
 - `init.ts` runs `prisma migrate deploy` if `prisma/migrations/` exists,
   else falls back to `prisma db push`. Real migrations exist from
   `phase-3.0` onward.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json* ./
 COPY prisma ./prisma
 ENV PRISMA_SKIP_POSTINSTALL_GENERATE=1
 RUN npm install --ignore-scripts && npx prisma generate
 
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npx prisma generate && npx tsc
 
-FROM node:20-alpine AS runtime
+FROM node:24-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 RUN apk add --no-cache tini

--- a/SPEC.md
+++ b/SPEC.md
@@ -121,6 +121,7 @@ clause at the start of the affected job/handler.
 | `staleApplicationsDigestEnabled` | true     | Daily nudge job exits early                  |
 | `hnParserEnabled`                | false    | Monthly HN cron + manual run skip            |
 | `discoveryEnabled`               | false    | HN parser does not record CompanyCandidates  |
+| `fetchingEnabled`                | true     | Master pause: hourly fetch + monthly HN pull exit early (`fetching-paused`); digest/cleanup/discovery/dashboard unaffected |
 | `disabledSources` (String[])     | `[]`     | Skip whole AtsType families in runAllFetchers |
 
 ## Discovery

--- a/SPEC.md
+++ b/SPEC.md
@@ -19,7 +19,7 @@ postgres ←─ worker (cron, fetchers, classifier, notifier)
 postgres ←─ web    (Hono dashboard, read-mostly + settings writes)
 ```
 
-Two separate Node 20 processes inside the same docker-compose stack.
+Two separate Node 24 processes inside the same docker-compose stack.
 Both share the database and the Prisma client. The dashboard never
 runs an HTTP server inside the worker; the worker never opens a web
 port.
@@ -144,7 +144,7 @@ marking 4xx-returning slugs as DEAD.
 
 ## Tech stack (locked)
 
-- TypeScript strict, Node 20, pino, zod, native fetch with `fetchWithRetry` + `AbortController`
+- TypeScript strict, Node 24 (runtime image; >=22 locally), pino, zod, native fetch with `fetchWithRetry` + `AbortController`
 - Prisma 6 + Postgres 16 (real migrations from `phase-3.0` baseline onward)
 - node-cron for scheduling, no Redis / BullMQ
 - Hono 4 for the dashboard, JSX SSR with `hono/jsx`, htmx + Tailwind via CDN (no build pipeline)

--- a/SPEC.md
+++ b/SPEC.md
@@ -121,7 +121,7 @@ clause at the start of the affected job/handler.
 | `staleApplicationsDigestEnabled` | true     | Daily nudge job exits early                  |
 | `hnParserEnabled`                | false    | Monthly HN cron + manual run skip            |
 | `discoveryEnabled`               | false    | HN parser does not record CompanyCandidates  |
-| `fetchingEnabled`                | true     | Master pause: hourly fetch + monthly HN pull exit early (`fetching-paused`); digest/cleanup/discovery/dashboard unaffected |
+| `fetchingEnabled`                | false    | Master pause: hourly fetch + monthly HN pull exit early (`fetching-paused`); digest/cleanup/discovery/dashboard unaffected. Deployments start PAUSED — enable via `/settings` → "Job fetching" |
 | `disabledSources` (String[])     | `[]`     | Skip whole AtsType families in runAllFetchers |
 
 ## Discovery

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Local Docker worker that monitors Greenhouse / Lever / LaraJobs for senior remote-US PHP/Laravel roles and alerts via Telegram.",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc",

--- a/prisma/migrations/20260827122249_add_fetching_enabled/migration.sql
+++ b/prisma/migrations/20260827122249_add_fetching_enabled/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "AppSettings" ADD COLUMN     "fetchingEnabled" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "AppSettings" ADD COLUMN     "fetchingEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20260827122249_add_fetching_enabled/migration.sql
+++ b/prisma/migrations/20260827122249_add_fetching_enabled/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AppSettings" ADD COLUMN     "fetchingEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,6 +134,12 @@ model AppSettings {
   // Phase 4.2: discovery toggle (gates auto-creation of CompanyCandidate
   // rows from HN comments and the weekly probe job).
   discoveryEnabled               Boolean  @default(false)
+  // Phase 7.7: master pause for new-job ingestion. When false, the hourly
+  // fetch tick and the monthly HN pull exit early ("fetching-paused" in
+  // /runs). Digest, stale nudge, cleanup, discovery probe, and the
+  // dashboard keep running — this is the "stop the pipeline without
+  // touching docker" switch.
+  fetchingEnabled                Boolean  @default(true)
   updatedAt                      DateTime @updatedAt
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,8 +138,10 @@ model AppSettings {
   // fetch tick and the monthly HN pull exit early ("fetching-paused" in
   // /runs). Digest, stale nudge, cleanup, discovery probe, and the
   // dashboard keep running — this is the "stop the pipeline without
-  // touching docker" switch.
-  fetchingEnabled                Boolean  @default(true)
+  // touching docker" switch. Default FALSE by user choice: deployments
+  // (and the existing row, backfilled by the migration) start paused;
+  // enable from /settings → "Job fetching" when ready.
+  fetchingEnabled                Boolean  @default(false)
   updatedAt                      DateTime @updatedAt
 }
 

--- a/src/jobs/fetch-job.ts
+++ b/src/jobs/fetch-job.ts
@@ -10,6 +10,12 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
   const started = Date.now();
   logger.info('fetch-job: start');
 
+  const settings = await getSettings();
+  if (!settings.fetchingEnabled) {
+    logger.info('fetch-job: skipped (fetching paused in settings)');
+    return { stats: { skipped: 1, reason: 'fetching-paused' } };
+  }
+
   const profile = await getActiveProfile();
   if (!profile) {
     logger.warn(
@@ -17,7 +23,6 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     );
     return { stats: { aborted: 1, reason: 'no-active-profile' } };
   }
-  const settings = await getSettings();
   const { classifierMode } = settings;
   logger.info(
     { profile: profile.name, minFitScore: profile.minFitScore, classifierMode },

--- a/src/jobs/hn-hiring-job.ts
+++ b/src/jobs/hn-hiring-job.ts
@@ -22,6 +22,10 @@ export async function runHnHiringJob(): Promise<{ stats: CronStats }> {
   logger.info('hn-hiring: start');
 
   const settings = await getSettings();
+  if (!settings.fetchingEnabled) {
+    logger.info('hn-hiring: skipped (fetching paused in settings)');
+    return { stats: { skipped: 1, reason: 'fetching-paused' } };
+  }
   if (!settings.hnParserEnabled) {
     logger.info('hn-hiring: skipped (parser disabled in settings)');
     return { stats: { skipped: 1, reason: 'parser-disabled' } };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export interface AppSettingsView {
   hnParserEnabled: boolean;
   disabledSources: string[];
   discoveryEnabled: boolean;
+  fetchingEnabled: boolean;
   updatedAt: Date;
 }
 
@@ -36,6 +37,7 @@ export async function getSettings(): Promise<AppSettingsView> {
     hnParserEnabled: row.hnParserEnabled,
     disabledSources: row.disabledSources,
     discoveryEnabled: row.discoveryEnabled,
+    fetchingEnabled: row.fetchingEnabled,
     updatedAt: row.updatedAt,
   };
 }
@@ -98,6 +100,15 @@ export async function setDiscoveryEnabled(enabled: boolean): Promise<void> {
     update: { discoveryEnabled: enabled },
     create: { id: SETTINGS_ID, discoveryEnabled: enabled },
   });
+}
+
+export async function setFetchingEnabled(enabled: boolean): Promise<void> {
+  await prisma.appSettings.upsert({
+    where: { id: SETTINGS_ID },
+    update: { fetchingEnabled: enabled },
+    create: { id: SETTINGS_ID, fetchingEnabled: enabled },
+  });
+  logger.info({ enabled }, enabled ? 'settings: job fetching resumed' : 'settings: job fetching paused');
 }
 
 function normaliseClassifierMode(raw: string): ClassifierMode {

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -103,10 +103,11 @@ export const SettingsPage: FC<SettingsProps> = ({
           </div>
           <p class="mt-1 text-xs text-zinc-500">
             Master switch for new-job ingestion — the hourly fetch tick and
-            the monthly HN pull. Pause it to stop new jobs and alerts
-            without touching Docker; the dashboard, digest, cleanup, and
-            discovery probe keep working. Takes effect on the next cron
-            tick (within the hour).
+            the monthly HN pull. Off by default: nothing is fetched until
+            you press Resume. Pausing stops new jobs and alerts without
+            touching Docker; the dashboard, digest, cleanup, and discovery
+            probe keep working. Takes effect on the next cron tick (within
+            the hour).
           </p>
         </div>
         <form method="post" action="/settings/fetching-toggle">

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -44,6 +44,7 @@ export interface SettingsProps {
   disabledSources: string[];
   allSources: string[];
   discoveryEnabled: boolean;
+  fetchingEnabled: boolean;
   targets: MaskedTarget[];
   profiles: ProfileListItem[];
   activeProfile: Profile | null;
@@ -60,6 +61,7 @@ export const SettingsPage: FC<SettingsProps> = ({
   disabledSources,
   allSources,
   discoveryEnabled,
+  fetchingEnabled,
   targets,
   profiles,
   activeProfile,
@@ -86,6 +88,41 @@ export const SettingsPage: FC<SettingsProps> = ({
         {flash.text}
       </div>
     )}
+
+    <Card class="mb-6">
+      <SectionTitle>Job fetching</SectionTitle>
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <div class="text-sm text-zinc-300">
+            Status:{' '}
+            {fetchingEnabled ? (
+              <Tag tone="green">Running</Tag>
+            ) : (
+              <Tag tone="red">Paused</Tag>
+            )}
+          </div>
+          <p class="mt-1 text-xs text-zinc-500">
+            Master switch for new-job ingestion — the hourly fetch tick and
+            the monthly HN pull. Pause it to stop new jobs and alerts
+            without touching Docker; the dashboard, digest, cleanup, and
+            discovery probe keep working. Takes effect on the next cron
+            tick (within the hour).
+          </p>
+        </div>
+        <form method="post" action="/settings/fetching-toggle">
+          <button
+            type="submit"
+            class={`rounded-md px-4 py-2 text-sm font-medium text-white ${
+              fetchingEnabled
+                ? 'bg-amber-600 hover:bg-amber-500'
+                : 'bg-emerald-600 hover:bg-emerald-500'
+            }`}
+          >
+            {fetchingEnabled ? 'Pause' : 'Resume'}
+          </button>
+        </form>
+      </div>
+    </Card>
 
     <Card class="mb-6">
       <SectionTitle>Active profile</SectionTitle>

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -13,6 +13,7 @@ import {
   setClassifierMode,
   setDisabledSources,
   setDiscoveryEnabled,
+  setFetchingEnabled,
   setHnParserEnabled,
   setStaleApplicationsDigestEnabled,
   setTelegramEnabled,
@@ -89,6 +90,7 @@ settingsRoute.get('/settings', async (c) => {
       disabledSources={settings.disabledSources}
       allSources={Object.values(AtsType)}
       discoveryEnabled={settings.discoveryEnabled}
+      fetchingEnabled={settings.fetchingEnabled}
       targets={targets.map((t) => ({
         id: t.id,
         name: t.name,
@@ -116,6 +118,20 @@ settingsRoute.get('/settings', async (c) => {
     />,
     200,
     { 'Set-Cookie': clearFlashCookie() },
+  );
+});
+
+// --- Fetching pause / resume -----------------------------------------------
+
+settingsRoute.post('/settings/fetching-toggle', async (c) => {
+  const settings = await getSettings();
+  await setFetchingEnabled(!settings.fetchingEnabled);
+  return redirectWithFlash(
+    c,
+    'ok',
+    settings.fetchingEnabled
+      ? 'Job fetching paused — no new jobs or alerts until you resume.'
+      : 'Job fetching resumed — next hourly tick will pull new jobs.',
   );
 });
 


### PR DESCRIPTION
Two commits:

**(a) Node 20 → 24.** Node 20 hit EOL on 2026-04-30 and GH Actions warns about it. Runtime image → `node:24-alpine` (active LTS), CI → `node-version: 24` + `checkout@v5` / `setup-node@v5`, engines → `>=22`. No code changes needed — Prisma 6 / Hono 4 / node:test all run on 24.

**(b) `AppSettings.fetchingEnabled` — pause new-job ingestion from the UI.** Until now the only way to stop the pipeline was `docker compose down`. New master switch (**default `false`** — deployments start paused until enabled from the UI), wired along the documented toggle path (schema → settings.ts → jobs guards → UI card → POST route):

- `runFetchJob` and `runHnHiringJob` exit early with `reason: 'fetching-paused'` — both new-job ingestion paths covered, including manual `fetch:once` runs (consistent with how `hnParserEnabled` gates manual runs).
- Digest, stale nudge, cleanup, discovery probe, and the dashboard keep working — pausing fetch doesn't blind the rest of the app.
- Worker re-reads settings every tick (gotcha-9), so Pause/Resume takes effect within the hour with no restart.
- `/settings` gets a "Job fetching" card at the very top: Running/Paused status tag, amber **Pause** / emerald **Resume** button.

Migration is hand-written (`ALTER TABLE ADD COLUMN … DEFAULT true`) per the gotcha-7 baseline procedure (host `prisma migrate dev` still P1010s) and applies on next container boot via `init.ts → migrate deploy`. 262/262 tests, tsc clean, `prisma validate` + `format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
