### PR TITLE
Classify jobs concurrently

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ ANTHROPIC_API_KEY=
 CLAUDE_MODEL=claude-haiku-4-5-20251001
 # Path to the Claude Code CLI (only for AI_PROVIDER=claude_code).
 CLAUDE_CODE_BIN=claude
+# Jobs classified at the same time (1-8). With claude_code each one is a
+# separate CLI process; with anthropic_api it is a concurrent request.
+AI_CONCURRENCY=3
 # Subscription token for headless use inside Docker: run `claude setup-token`
 # on the host (browser login) and paste the result here. macOS keeps the
 # interactive login in Keychain, so a ~/.claude volume mount does NOT work.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,7 +91,12 @@ Two things to remember while reading this:
 
 1. **`processNormalizedJobs` is the single source of truth for the
    filter → dedupe → classify → persist → alert sequence.** It's
-   shared by `runFetchJob` and `runHnHiringJob`.
+   shared by `runFetchJob` and `runHnHiringJob`. Filter and dedupe run
+   first; classification then runs `AI_CONCURRENCY` jobs at a time
+   (`src/concurrency.ts`), while persist + alert consume the results in
+   the original order — so the DB and Telegram see the same sequence a
+   serial loop would produce. `runReclassifyAll` does the same per batch
+   of 50.
 2. **All toggles read from the DB at the start of the tick.** Flipping
    a toggle in the UI takes effect on the next cron tick — no restart.
 
@@ -164,6 +169,7 @@ src/
   filter.ts                    ← passesBaseFilter (pure, profile-aware)
   ai-provider.ts               ← AiProvider seam: AnthropicApiProvider | ClaudeCodeProvider
   ai-provider-parse.ts         ← pure parser for `claude -p` JSON output (tested)
+  concurrency.ts               ← createLimiter(max), pure
   classifier.ts                ← classifyJob wrapper + classifyWithClaude (full prompt)
   classifier-prefilter.ts      ← preClassify (short prompt)
   notifier.ts                  ← Telegram MarkdownV2 send, multi-target broadcast

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Where to add a new toggle | `prisma/schema.prisma:AppSettings` (column) → `src/settings.ts` (getter/setter) → `src/web/pages/settings.tsx` (UI) → `src/web/routes/settings.tsx` (POST) |
 | The Claude system prompt | `src/classifier.ts:buildSystemPrompt` |
 | Which backend runs Claude (API key vs subscription CLI) | `src/ai-provider.ts:getAiProvider`, `AI_PROVIDER` in `.env` |
+| How many jobs are classified at once | `AI_CONCURRENCY` in `.env` (default 3); limiter in `src/concurrency.ts`, used by `jobs/process-jobs.ts` and `jobs/reclassify-job.ts` |
 | The two-stage prefilter prompt | `src/classifier-prefilter.ts:buildPrefilterPrompt` |
 | Per-job filter rules (pre-Claude) | `src/filter.ts:passesBaseFilter` |
 | Telegram MarkdownV2 escape | `src/notifier.ts:escapeMarkdownV2` |

--- a/README.md
+++ b/README.md
@@ -233,8 +233,10 @@ backend with `AI_PROVIDER`:
   The Docker image installs the CLI; mount your credentials with the
   `~/.claude` volume line in `docker-compose.yml`.
 - Every call carries Claude Code's own system prompt (~5k tokens) and
-  starts a new process — expect a few seconds per job instead of
-  sub-second. Fine for an hourly tick, noticeable on "Re-classify all".
+  starts a new process — ~7 s per job on a laptop, 15–30 s inside Docker.
+  `AI_CONCURRENCY` (default 3) runs that many CLI processes at once, so
+  wall-clock for a tick or "Re-classify all" divides by roughly that
+  number; budget ~130 MB RAM per process.
 - The subscription has a rolling usage window. When it is exhausted the
   provider logs `claude-code rate-limited`, the job counts as
   `classifyFailed` for this tick, and it is retried on the next tick.
@@ -253,7 +255,8 @@ classifier mode and how many sources are active:
 - Discovery harvest doesn't call Claude (only HN parsing → ATS-URL
   detection).
 - Anthropic prompt caching gives ~90% read discount on the system
-  prompt within the 5-minute window.
+  prompt within the 5-minute window. `AI_CONCURRENCY` requests run at
+  once, so the first few of a tick may each pay the cache write.
 
 Postgres + Telegram + GitHub Actions are all free. The whole stack
 runs on a $5/month VPS or your laptop.

--- a/SPEC.md
+++ b/SPEC.md
@@ -149,7 +149,7 @@ marking 4xx-returning slugs as DEAD.
 - Prisma 6 + Postgres 16 (real migrations from `phase-3.0` baseline onward)
 - node-cron for scheduling, no Redis / BullMQ
 - Hono 4 for the dashboard, JSX SSR with `hono/jsx`, htmx + Tailwind via CDN (no build pipeline)
-- `src/ai-provider.ts` seam: `anthropic_api` (SDK, per-token) or `claude_code` (headless CLI, subscription); Claude Haiku 4.5 for both classifier stages
+- `src/ai-provider.ts` seam: `anthropic_api` (SDK, per-token) or `claude_code` (headless CLI, subscription); Claude Haiku 4.5 for both classifier stages; `AI_CONCURRENCY` jobs classified at once (default 3)
 - node:test runner (`npm test`), no jest
 
 ## Project layout

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -60,7 +60,18 @@ as API-key only).
   caveat in README.
 - [x] Unit test for the CLI-output parser (pure).
 
-### 1.3 Cheaper API path (no grey zone — do this regardless)
+### 1.3 Concurrency (done 2026-08-27, PR "parallel-classifier")
+- [x] `AI_CONCURRENCY` (default 3, 1–8) in `config.ts`; pure
+  `src/concurrency.ts:createLimiter` + unit test.
+- [x] `process-jobs.ts`: filter + dedupe first (with in-batch dedupe),
+  classify through the limiter, persist + alert in original order.
+- [x] `reclassify-job.ts`: same per batch of 50. `classifyJob` never
+  rejects (queued promises would otherwise crash on unhandled rejection).
+- [x] Verified in Docker with `claude_code`: 3 CLI processes in `ps`,
+  web container ~460 MB, per-call latency unchanged (bench: 16 s serial,
+  11–14 s each with 3 in flight) → throughput ×3.
+
+### 1.4 Cheaper API path (no grey zone — do this regardless)
 - [ ] Batch API mode for `AnthropicApiProvider` (−50 % on tokens). Deferred:
   `process-jobs.ts` classifies one job at a time inside the persist loop, so
   batching needs a collect → submit → poll → persist restructure. Do it as its
@@ -122,6 +133,10 @@ reviewed:
 ## 3. Housekeeping candidates (pick up when convenient)
 - [x] `@anthropic-ai/sdk` bumped `^0.39.0` → `^0.121.0`; tests + live smoke OK.
 - [x] Model id → `CLAUDE_MODEL` env in `config.ts`.
+- [ ] `CronRun` rows stay `RUNNING` forever when a container restarts
+  mid-run (seen for `fetch` and `reclassify-all`). On boot, mark stale
+  `RUNNING` rows as `FAILED` with `errorMessage='interrupted'`; the web
+  `reclassifyInFlight` flag resets anyway.
 
 ---
 

--- a/docs/adr/0007-ai-provider-seam.md
+++ b/docs/adr/0007-ai-provider-seam.md
@@ -36,7 +36,7 @@ Two implementations, selected by `AI_PROVIDER` in `.env`:
 | `AI_PROVIDER` | Implementation | Billing |
 | --- | --- | --- |
 | `anthropic_api` (default) | SDK `messages.create`, cached system prompt, one 429 retry | per token |
-| `claude_code` | `execFile(claude, ['--print', '--output-format', 'json', '--model', …, '--system-prompt', …, '--tools', '', '--no-session-persistence', user])`, 90 s timeout, one retry on rate limit | subscription |
+| `claude_code` | `execFile(claude, ['--print', '--output-format', 'json', '--model', …, '--system-prompt', …, '--tools', '', '--no-session-persistence', user])`, 180 s timeout, one retry on rate limit | subscription |
 
 `classifier.ts` and `classifier-prefilter.ts` keep building prompts and
 validating JSON with zod; they no longer import the SDK. `ANTHROPIC_API_KEY`

--- a/docs/adr/0007-ai-provider-seam.md
+++ b/docs/adr/0007-ai-provider-seam.md
@@ -54,8 +54,13 @@ one is active.
 ✅ Docker runtime image ships the Claude Code CLI; mount `~/.claude` to use
 the subscription inside the container.
 
-❌ `claude_code` is slow: "Re-classify all jobs" on ~700 jobs takes over an
-hour. Acceptable for the hourly tick.
+❌ `claude_code` is slow: ~7 s per job on the host, 15–30 s in Docker. Since
+2026-08-27 `process-jobs` and `reclassify-job` classify `AI_CONCURRENCY`
+jobs at once (default 3, `src/concurrency.ts`) and persist in the original
+order. Measured in Docker: per-call latency is unchanged with three
+concurrent `claude` processes (16 s serial vs 11–14 s each in parallel),
+~460 MB for the web container, throughput ×3. "Re-classify all" on ~750
+jobs still takes over an hour.
 ❌ Subscription usage window can leave a tick partially classified. Jobs are
 retried next tick, but alerts for them arrive late.
 ❌ No prompt cache on the CLI path — the ~5k-token CLI system prompt is

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -33,7 +33,9 @@ export interface AiProvider {
 
 const RATE_LIMIT_RETRY_DELAY_MS = 2_000;
 const MAX_ATTEMPTS = 2;
-const CLAUDE_CODE_TIMEOUT_MS = 90_000;
+// Calls normally finish in 15-30 s inside Docker, but with AI_CONCURRENCY
+// in flight a few strayed past 90 s and lost their work to the timeout.
+const CLAUDE_CODE_TIMEOUT_MS = 180_000;
 const CLAUDE_CODE_MAX_BUFFER = 1024 * 1024;
 
 const execFileAsync = promisify(execFile);

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -42,6 +42,21 @@ export async function classifyJob(
   profile: Profile,
   mode: ClassifierMode,
 ): Promise<ClassifyOutcome> {
+  try {
+    return await runStages(input, profile, mode);
+  } catch (err) {
+    // Callers queue several classifications and await them in order, so a
+    // rejection here would become an unhandled rejection in the meantime.
+    logger.error({ err, title: input.title }, 'classifier: unexpected failure');
+    return { result: null, preFiltered: false };
+  }
+}
+
+async function runStages(
+  input: ClassifyInput,
+  profile: Profile,
+  mode: ClassifierMode,
+): Promise<ClassifyOutcome> {
   if (mode === 'two_stage') {
     const pre = await preClassify(input, profile);
     if (pre && pre.relevant === false) {

--- a/src/concurrency.test.ts
+++ b/src/concurrency.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createLimiter } from './concurrency';
+
+const tick = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+test('createLimiter never runs more than max tasks at once', async () => {
+  const limit = createLimiter(2);
+  let active = 0;
+  let peak = 0;
+  const task = async (): Promise<void> => {
+    active++;
+    peak = Math.max(peak, active);
+    await tick();
+    await tick();
+    active--;
+  };
+  await Promise.all(Array.from({ length: 6 }, () => limit(task)));
+  assert.equal(peak, 2);
+  assert.equal(active, 0);
+});
+
+test('createLimiter starts tasks in call order and keeps results in order', async () => {
+  const limit = createLimiter(3);
+  const started: number[] = [];
+  const results = await Promise.all(
+    [0, 1, 2, 3, 4].map((i) =>
+      limit(async () => {
+        started.push(i);
+        // Later tasks finish first; order of results must not depend on it.
+        for (let n = 4 - i; n > 0; n--) await tick();
+        return i * 10;
+      }),
+    ),
+  );
+  assert.deepEqual(started, [0, 1, 2, 3, 4]);
+  assert.deepEqual(results, [0, 10, 20, 30, 40]);
+});
+
+test('createLimiter frees the slot when a task rejects', async () => {
+  const limit = createLimiter(1);
+  await assert.rejects(limit(async () => { throw new Error('boom'); }), /boom/);
+  assert.equal(await limit(async () => 'ok'), 'ok');
+});
+
+test('createLimiter rejects a non-positive max', () => {
+  assert.throws(() => createLimiter(0), RangeError);
+});

--- a/src/concurrency.test.ts
+++ b/src/concurrency.test.ts
@@ -37,10 +37,13 @@ test('createLimiter starts tasks in call order and keeps results in order', asyn
   assert.deepEqual(results, [0, 10, 20, 30, 40]);
 });
 
-test('createLimiter frees the slot when a task rejects', async () => {
+test('createLimiter frees the slot when a task rejects or throws', async () => {
   const limit = createLimiter(1);
   await assert.rejects(limit(async () => { throw new Error('boom'); }), /boom/);
-  assert.equal(await limit(async () => 'ok'), 'ok');
+  const queued = limit(async () => 'ok');
+  await assert.rejects(limit(() => { throw new Error('sync'); }), /sync/);
+  assert.equal(await queued, 'ok');
+  assert.equal(await limit(async () => 'still ok'), 'still ok');
 });
 
 test('createLimiter rejects a non-positive max', () => {

--- a/src/concurrency.ts
+++ b/src/concurrency.ts
@@ -1,0 +1,28 @@
+/**
+ * Minimal concurrency limiter: `limit(fn)` runs `fn` as soon as fewer than
+ * `max` tasks are in flight, otherwise queues it. Tasks start in call order.
+ */
+export type Limiter = <T>(fn: () => Promise<T>) => Promise<T>;
+
+export function createLimiter(max: number): Limiter {
+  if (!Number.isInteger(max) || max < 1) {
+    throw new RangeError(`createLimiter: max must be a positive integer, got ${max}`);
+  }
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  const next = (): void => {
+    active--;
+    queue.shift()?.();
+  };
+
+  return <T>(fn: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const run = (): void => {
+        active++;
+        fn().then(resolve, reject).finally(next);
+      };
+      if (active < max) run();
+      else queue.push(run);
+    });
+}

--- a/src/concurrency.ts
+++ b/src/concurrency.ts
@@ -20,7 +20,8 @@ export function createLimiter(max: number): Limiter {
     new Promise<T>((resolve, reject) => {
       const run = (): void => {
         active++;
-        fn().then(resolve, reject).finally(next);
+        // `new Promise` turns a synchronous throw in fn into a rejection.
+        new Promise<T>((r) => r(fn())).then(resolve, reject).finally(next);
       };
       if (active < max) run();
       else queue.push(run);

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,8 @@ const ConfigSchema = z.object({
   CLAUDE_MODEL: z.string().default('claude-haiku-4-5-20251001'),
   // Path to the Claude Code CLI when AI_PROVIDER=claude_code.
   CLAUDE_CODE_BIN: z.string().default('claude'),
+  // How many jobs are classified at the same time (both providers).
+  AI_CONCURRENCY: z.coerce.number().int().min(1).max(8).default(3),
   TELEGRAM_BOT_TOKEN: z.string().optional(),
   TELEGRAM_CHAT_ID: z.string().optional(),
   LOG_LEVEL: z

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -1,6 +1,8 @@
 import { JobStatus, type Prisma, type Profile } from '@prisma/client';
 import { prisma } from '../db';
+import { config } from '../config';
 import { logger } from '../logger';
+import { createLimiter } from '../concurrency';
 import { passesBaseFilter } from '../filter';
 import { classifyJob } from '../classifier';
 import { sendTelegramAlert } from '../notifier';
@@ -44,36 +46,46 @@ export async function processNormalizedJobs(
 ): Promise<void> {
   const priorityRules = parsePriorityRules(profile.priorityRules);
 
-  for (const { job, companyName } of items) {
-    if (!passesBaseFilter(job, profile)) {
+  // `seen` catches the same posting twice in one fetch: the sequential loop
+  // used to see it in the DB, now both copies would be classified together.
+  const candidates: FetchResult[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (!passesBaseFilter(item.job, profile)) {
       stats.filterRejected++;
       continue;
     }
-
-    const existing = await prisma.job.findUnique({
-      where: {
-        companyId_externalId: {
-          companyId: job.companyId,
-          externalId: job.externalId,
-        },
-      },
-      select: { id: true },
-    });
-    if (existing) {
+    const key = `${item.job.companyId}:${item.job.externalId}`;
+    if (seen.has(key) || (await isPersisted(item.job))) {
       stats.duplicate++;
       continue;
     }
+    seen.add(key);
+    candidates.push(item);
+  }
 
-    const outcome = await classifyJob(
-      buildClassifyInput(job, companyName),
-      profile,
-      classifierMode,
+  // Classify up to AI_CONCURRENCY jobs at once; results are consumed in the
+  // original order, so persisting and alerting stay sequential and ordered.
+  const limit = createLimiter(config.AI_CONCURRENCY);
+  const pending = candidates.map((item) => ({
+    ...item,
+    outcome: limit(() =>
+      classifyJob(buildClassifyInput(item.job, item.companyName), profile, classifierMode),
+    ),
+  }));
+  if (pending.length > 0) {
+    logger.info(
+      { jobs: pending.length, concurrency: config.AI_CONCURRENCY },
+      'process-jobs: classifying',
     );
-    if (outcome.preFiltered) {
+  }
+
+  for (const { job, companyName, outcome } of pending) {
+    const { result: classification, preFiltered } = await outcome;
+    if (preFiltered) {
       stats.preFiltered++;
       continue;
     }
-    const classification = outcome.result;
     if (!classification) {
       stats.classifyFailed++;
       continue;
@@ -155,6 +167,19 @@ export async function processNormalizedJobs(
       );
     }
   }
+}
+
+async function isPersisted(job: NormalizedJob): Promise<boolean> {
+  const existing = await prisma.job.findUnique({
+    where: {
+      companyId_externalId: {
+        companyId: job.companyId,
+        externalId: job.externalId,
+      },
+    },
+    select: { id: true },
+  });
+  return existing !== null;
 }
 
 function buildClassifyInput(

--- a/src/jobs/reclassify-job.ts
+++ b/src/jobs/reclassify-job.ts
@@ -1,6 +1,8 @@
 import { JobStatus } from '@prisma/client';
 import { prisma } from '../db';
+import { config } from '../config';
 import { logger } from '../logger';
+import { createLimiter } from '../concurrency';
 import { classifyJob } from '../classifier';
 import { passesBaseFilter } from '../filter';
 import { getActiveProfile } from '../profiles';
@@ -27,7 +29,12 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
   const { classifierMode } = await getSettings();
   const priorityRules = parsePriorityRules(profile.priorityRules);
   logger.info(
-    { profile: profile.name, classifierMode, priorityRules: priorityRules.length },
+    {
+      profile: profile.name,
+      classifierMode,
+      priorityRules: priorityRules.length,
+      concurrency: config.AI_CONCURRENCY,
+    },
     'reclassify-all: start',
   );
 
@@ -41,6 +48,7 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
   let filterRejected = 0;
   let priorityBoosted = 0;
 
+  const limit = createLimiter(config.AI_CONCURRENCY);
   let lastId = 0;
   while (true) {
     const batch = await prisma.job.findMany({
@@ -55,12 +63,32 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
     if (batch.length === 0) break;
     lastId = batch[batch.length - 1]?.id ?? lastId;
 
-    for (const j of batch) {
+    // Jobs that fail the current profile's base filter skip Claude entirely;
+    // the rest are classified AI_CONCURRENCY at a time and persisted in
+    // id order as their results come in.
+    const pending = batch.map((j) => ({
+      job: j,
+      outcome: passesBaseFilter(j, profile)
+        ? limit(() =>
+            classifyJob(
+              {
+                title: j.title,
+                companyName: j.company.name,
+                location: j.location,
+                description: j.description,
+                postedAt: j.postedAt,
+              },
+              profile,
+              classifierMode,
+            ),
+          )
+        : null,
+    }));
+
+    for (const { job: j, outcome } of pending) {
       scanned++;
 
-      // Apply current profile's base filter — if the job no longer passes it,
-      // mark DISMISSED and skip Claude (saves API cost).
-      if (!passesBaseFilter(j, profile)) {
+      if (outcome === null) {
         if (j.status !== JobStatus.DISMISSED) {
           await prisma.job.update({
             where: { id: j.id },
@@ -72,18 +100,8 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
         continue;
       }
 
-      const outcome = await classifyJob(
-        {
-          title: j.title,
-          companyName: j.company.name,
-          location: j.location,
-          description: j.description,
-          postedAt: j.postedAt,
-        },
-        profile,
-        classifierMode,
-      );
-      if (outcome.preFiltered) {
+      const { result: c0, preFiltered: wasPreFiltered } = await outcome;
+      if (wasPreFiltered) {
         preFiltered++;
         // Reclassify treats pre-filtered jobs the same as base-filter rejects:
         // demote to DISMISSED so they leave the inbox.
@@ -96,7 +114,6 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
         }
         continue;
       }
-      const c0 = outcome.result;
       if (!c0) {
         failed++;
         continue;
@@ -150,6 +167,7 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
   const stats: CronStats = {
     profile: profile.name,
     classifierMode,
+    concurrency: config.AI_CONCURRENCY,
     scanned,
     reclassified,
     preFiltered,


### PR DESCRIPTION
## What

Classify `AI_CONCURRENCY` jobs at a time (default 3, range 1–8) instead of one after another. Applies to the hourly fetch, the HN run and "Re-classify all".

- `src/concurrency.ts` — small `createLimiter(max)`, unit-tested (order, cap, rejects, sync throws).
- `process-jobs.ts` — filter + dedupe first (in-batch dedupe added, since two copies of one posting would now be classified together), classification goes through the limiter, persist + alert consume results in the original order. DB and Telegram see the same sequence as before.
- `reclassify-job.ts` — same shape per batch of 50.
- `classifyJob` never rejects: queued promises are awaited later, so a rejection in the meantime would have been an unhandled rejection.
- Docs: README, ADR 0007 amendment, ARCHITECTURE, SPEC, CLAUDE.md, `.env.example`, TASKS.

## Verified

- `npm run lint:types && npm test` (271 tests).
- Docker, `AI_PROVIDER=claude_code`: "Re-classify all" from /settings shows three `claude --print` processes in `ps` for the whole sampling window; web container ~450–465 MB (vs ~67 MB idle). Bench inside the container with the real provider: 16.5 s for one call, 11–14 s each with three in flight — latency flat, throughput ×3. Two of the first ~12 calls hit the 90 s timeout, hence the raise to 180 s (not yet in the running containers).
- Fetch path (`processNormalizedJobs`) shares the limiter code but was not exercised live — fetching is paused in /settings.
