### PR TITLE
AI engine chain, settings tabs, profile fill (v0.2.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,12 +48,13 @@ TELEGRAM_CHAT_ID=
 # Logging level: fatal | error | warn | info | debug | trace | silent
 LOG_LEVEL=info
 
-# Cron timezone (used by node-cron). America/Chicago covers MN/TX.
-TZ=America/Chicago
+# Cron timezone (used by node-cron) — set to your local timezone.
+TZ=UTC
 
-# Filter thresholds.
+# Filter thresholds (bootstrap-only; edit on /settings → Profile after first boot).
 MIN_FIT_SCORE=70
-MIN_SALARY_USD=120000
+# 0 = no salary filter.
+MIN_SALARY_USD=0
 
 # --- Dashboard (web service) -----------------------------------------------
 # Port the Hono server listens on (inside the container).

--- a/.env.example
+++ b/.env.example
@@ -2,28 +2,37 @@
 # Inside docker-compose this is overridden to point at the postgres service.
 DATABASE_URL=postgresql://jobhunter:jobhunter@localhost:5432/jobhunter
 
-# --- AI backend ------------------------------------------------------------
-# Defaults only — /settings → "AI engine" overrides provider + models at
-# runtime (stored in Postgres, no restart). See ADR 0013.
-# anthropic_api  — Messages API, pay per token (needs ANTHROPIC_API_KEY).
-# claude_code    — headless `claude -p`, billed to the Claude.ai subscription
-#                  the CLI is logged into. Slower, subject to the
-#                  subscription's usage window; see README "AI backend".
-# gemini_cli     — headless `gemini -p`, billed to the Google account the CLI
-#                  is logged into (or GEMINI_API_KEY).
+# --- AI engines ------------------------------------------------------------
+# Full setup guide (local + Docker, every engine): docs/ai-engines.md.
+# Priority order + per-engine models live on /settings → "AI engine"
+# (stored in Postgres, no restart). AI_PROVIDER only seeds the default:
+# anthropic_api | claude_code | gemini_cli | openai_api | codex_cli
 AI_PROVIDER=anthropic_api
+
+# Anthropic API (pay per token).
 ANTHROPIC_API_KEY=
-# Model id for both classifier stages (Haiku 4.5 by default).
+# Claude model for both classifier stages (Haiku 4.5 by default).
 CLAUDE_MODEL=claude-haiku-4-5-20251001
-# Model for resume scan + resume-vs-job comparison (a few calls a day).
+# Claude model for resume scan + comparison (a few calls a day).
 CLAUDE_MODEL_RESUME=claude-opus-5
-# Path to the Claude Code CLI (only for AI_PROVIDER=claude_code).
+
+# Claude Code CLI (Claude.ai subscription).
 CLAUDE_CODE_BIN=claude
-# Path to the Gemini CLI (only for the gemini_cli engine).
+
+# Gemini CLI (Google account or API key from https://aistudio.google.com/apikey).
 GEMINI_CLI_BIN=gemini
-# Gemini auth for headless/Docker use — an API key from AI Studio. Leave
-# empty when the CLI is logged in interactively (~/.gemini holds the creds).
 GEMINI_API_KEY=
+
+# OpenAI-compatible API — works with OpenAI, OpenRouter, Groq, DeepSeek and
+# local servers (LM Studio / Ollama): set the base URL accordingly.
+OPENAI_API_KEY=
+OPENAI_BASE_URL=https://api.openai.com/v1
+# Default model for the openai_api engine when the /settings slot is empty.
+OPENAI_MODEL=gpt-5-mini
+
+# Codex CLI (ChatGPT subscription): `codex login` once; in Docker mount
+# ~/.codex (see docker-compose.yml).
+CODEX_CLI_BIN=codex
 # Jobs classified at the same time (1-8). With claude_code each one is a
 # separate CLI process; with anthropic_api it is a concurrent request.
 AI_CONCURRENCY=3

--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,14 @@
 DATABASE_URL=postgresql://jobhunter:jobhunter@localhost:5432/jobhunter
 
 # --- AI backend ------------------------------------------------------------
+# Defaults only — /settings → "AI engine" overrides provider + models at
+# runtime (stored in Postgres, no restart). See ADR 0013.
 # anthropic_api  — Messages API, pay per token (needs ANTHROPIC_API_KEY).
 # claude_code    — headless `claude -p`, billed to the Claude.ai subscription
 #                  the CLI is logged into. Slower, subject to the
 #                  subscription's usage window; see README "AI backend".
+# gemini_cli     — headless `gemini -p`, billed to the Google account the CLI
+#                  is logged into (or GEMINI_API_KEY).
 AI_PROVIDER=anthropic_api
 ANTHROPIC_API_KEY=
 # Model id for both classifier stages (Haiku 4.5 by default).
@@ -15,6 +19,11 @@ CLAUDE_MODEL=claude-haiku-4-5-20251001
 CLAUDE_MODEL_RESUME=claude-opus-5
 # Path to the Claude Code CLI (only for AI_PROVIDER=claude_code).
 CLAUDE_CODE_BIN=claude
+# Path to the Gemini CLI (only for the gemini_cli engine).
+GEMINI_CLI_BIN=gemini
+# Gemini auth for headless/Docker use — an API key from AI Studio. Leave
+# empty when the CLI is logged in interactively (~/.gemini holds the creds).
+GEMINI_API_KEY=
 # Jobs classified at the same time (1-8). With claude_code each one is a
 # separate CLI process; with anthropic_api it is a concurrent request.
 AI_CONCURRENCY=3

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -185,6 +185,7 @@ src/
     pdf-text.ts                ← PDF → plain text via unpdf (ADR 0011), tested
     resume-text.ts             ← upload dispatch by extension, pure
     prompts.ts                 ← scan + match prompts, zod schemas, Json readers, pure
+    profile-draft.ts           ← resume scan → profile-editor draft (ADR 0015), pure
     score.ts                   ← deterministic match score + breakdown (ADR 0012), pure
     facts.ts                   ← apply CandidateFacts / cross-resume hints to keywords, pure
     diff.ts                    ← version delta from two matches (gained/lost, components), pure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,63 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-08-30
+
+### Added
+- **AI engine chain (ADR 0013/0014).** Five interchangeable backends behind
+  one seam — Anthropic API, Claude Code CLI, Gemini CLI, Codex CLI, and any
+  OpenAI-compatible `/chat/completions` endpoint (OpenAI, OpenRouter, Groq,
+  local LM Studio/Ollama via `OPENAI_BASE_URL`). Enable the ones you own on
+  `/settings` → AI engine, order them with ↑ Priority, and every call is
+  served by engine #1 with automatic per-call failover to the next on
+  errors, rate limits or exhausted quota — control returns as soon as the
+  primary recovers. Per-engine classifier/resume model slots use
+  family-locked dropdowns (a wrong-family id cannot be saved); each card has
+  an availability probe (binary + auth detection) and a live **Test** button
+  that runs one real call and reports the response time.
+- **Engine-chain hardening.** CLI child processes get an env allowlist —
+  only their own auth variables, so a stray `ANTHROPIC_API_KEY` can no
+  longer silently switch the Claude subscription engine to API billing, and
+  no AI process ever sees the database URL or Telegram token. Failing
+  engines go into a short cooldown (3 consecutive misses → 60 s skip)
+  instead of stalling bulk runs, and one logical call is capped at three
+  engines inside a hard deadline.
+- **Honest cost surface.** Metered engines carry a "pay per token" badge and
+  a warning when enabled behind subscription engines; reports produced by a
+  fallback engine are marked `· fallback`; a "Last 7 days" line counts runs
+  per engine (stored in `AppSettings.aiUsage`, trimmed to 60 days by the
+  cleanup cron).
+- **Settings tabs.** `/settings` is now five link-based tabs — General ·
+  Profile · AI engine · Notifications · Sources — and every save returns to
+  the tab it came from.
+- **Fill profile from a resume (ADR 0015).** One click maps a scanned
+  resume onto the profile fields (stack, role types, seniority) and shows a
+  reviewable draft — nothing is saved until you confirm. Resume scans now
+  extract primary skills to power it.
+- **Cross-engine bench.** `npm run bench:resume -- --engine <id>|all` runs
+  the gold fixtures through any usable engine; `--list-engines` shows who is
+  ready without spending a call.
+- **Setup guide.** `docs/ai-engines.md` — step-by-step setup for every
+  engine, local and Docker, plus a pipeline pause/resume control on the
+  Overview page.
+
+### Changed
+- Settings & discovery refactor: human source names (LARAJOBS_RSS → "Laravel
+  Jobs"), a `warn` flash variant for pausing states, confirm on
+  "Save & re-classify", discovery/HN toggles moved to `/discovery`, the
+  resumes card deduplicated to a list + link, bot tokens masked to the last
+  4 characters, and a jargon-free copy pass.
+- First boot is stack-neutral: a blank starter profile, `TZ` defaults to
+  UTC, no salary floor, and fetching starts paused until the profile is
+  filled.
+- README rewritten around the actual first-run path (engines → profile →
+  resume → alerts).
+
+### Fixed
+- Saving job sources no longer re-adds the internal MANUAL type to the
+  disabled list on every save.
+- Personal data removed from test fixtures and UI copy.
+
 ## [0.1.1] — 2026-08-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,8 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Which AI engines run (priority chain + per-engine models, auto-failover) | `src/ai-runtime.ts:getAiRuntime().complete({role})` + pure chain merge in `src/ai-engine.ts` (ADR 0013/0014); UI on `/settings` → "AI engine" tab |
 | Adding a new AI backend | `src/ai-provider.ts` (`CliProvider` spec or fetch class) + `AI_PROVIDER_IDS`/labels/options in `src/ai-engine.ts` + probe in `src/ai-runtime.ts` |
 | How users set up each engine (local + Docker) | `docs/ai-engines.md` |
+| AI usage counters (runs per engine × role) | `AppSettings.aiUsage` — incremented in `ai-runtime.ts:recordUsage`, 7-day summary on `/settings` AI tab, 60-day trim in `cleanup-job.ts` |
+| What a CLI child process may see in env | `ai-provider-parse.ts:CLI_PROVIDER_ENV_KEYS` (allowlist; ANTHROPIC_API_KEY never reaches claude_code) |
 | How many jobs are classified at once | `AI_CONCURRENCY` in `.env` (default 3); limiter in `src/concurrency.ts`, used by `jobs/process-jobs.ts` and `jobs/reclassify-job.ts` |
 | The two-stage prefilter prompt | `src/classifier-prefilter.ts:buildPrefilterPrompt` |
 | Per-job filter rules (pre-Claude) | `src/filter.ts:passesBaseFilter` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,9 @@
 - Each fetcher returns `NormalizedJob[]` — never writes to DB directly.
 - `filter.ts` is pure — no I/O.
 - `classifier.ts` (and `classifier-prefilter.ts`) build prompts and parse
-  replies; the only thing that talks to Claude is `ai-provider.ts` — no DB.
+  replies; the only thing that talks to the AI is `ai-provider.ts` — no DB.
+  Engine choice (provider + models) resolves per call via `ai-runtime.ts`
+  (DB row → `.env` fallback, pure merge in `ai-engine.ts` — ADR 0013).
 - `jobs/process-jobs.ts` is the single source of truth for the inner
   filter → dedupe → classify → persist → alert sequence. Reused by
   `runFetchJob` and `runHnHiringJob`.
@@ -114,7 +116,8 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Where to register a new ATS | `src/fetchers/index.ts:fetchOne` switch + `prisma/schema.prisma:AtsType` enum |
 | Where to add a new toggle | `prisma/schema.prisma:AppSettings` (column) → `src/settings.ts` (getter/setter) → `src/web/pages/settings.tsx` (UI) → `src/web/routes/settings.tsx` (POST) |
 | The Claude system prompt | `src/classifier.ts:buildSystemPrompt` |
-| Which backend runs Claude (API key vs subscription CLI) | `src/ai-provider.ts:getAiProvider`, `AI_PROVIDER` in `.env` |
+| Which AI engine runs (provider + models, DB override → .env fallback) | `src/ai-runtime.ts:getAiRuntime` + pure merge in `src/ai-engine.ts` (ADR 0013); UI on `/settings` → "AI engine" |
+| Adding a new AI backend | `src/ai-provider.ts` (`CliProvider` spec) + `AI_PROVIDER_IDS` in `src/ai-engine.ts` + probe in `src/ai-runtime.ts` |
 | How many jobs are classified at once | `AI_CONCURRENCY` in `.env` (default 3); limiter in `src/concurrency.ts`, used by `jobs/process-jobs.ts` and `jobs/reclassify-job.ts` |
 | The two-stage prefilter prompt | `src/classifier-prefilter.ts:buildPrefilterPrompt` |
 | Per-job filter rules (pre-Claude) | `src/filter.ts:passesBaseFilter` |
@@ -135,7 +138,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Live smoke bench of the match prompt (3 gold fixtures) | `npm run bench:resume` — `src/scripts/resume-bench-once.ts` |
 | Compare-run progress pages (async classify/scan/match) | `src/web/target-runs.ts` (in-memory registry) + `src/web/pages/target-run.tsx`; started by `/target`, `/jobs/:id/match`, `/jobs/:id/target/reupload` |
 | Which resume a job page preselects | `src/resume/pick.ts:pickResumeForJob` (skill-tag overlap) |
-| Model for resume calls | `CLAUDE_MODEL_RESUME` in `.env` (default `claude-opus-5`), passed via `AiRequest.model` |
+| Model for resume calls | `/settings` → "AI engine" resume model; falls back to `CLAUDE_MODEL_RESUME` in `.env` (default `claude-opus-5`) |
 | Ghost-job checklist prompt + verdict schema | `src/verification/prompts.ts` |
 | Letting a call use web search (API server tools / CLI WebSearch) | `AiRequest.webTools` in `src/ai-provider.ts`, args in `ai-provider-parse.ts:buildClaudeCodeArgs` |
 | Classify one stored job (Re-classify button, pasted jobs) | `src/jobs/classify-existing.ts` |
@@ -148,6 +151,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | What | Page |
 | --- | --- |
 | Pause / resume all new-job fetching | `/settings` → "Job fetching" card (top) |
+| Pick the AI provider / models | `/settings` → "AI engine" (availability-probed radios + two model slots) |
 | Add / remove tracked company | `/companies` (with manual probe before save) |
 | Disable whole ATS family (e.g. all Workable) | `/settings` → "Job sources" card |
 | Enable two-stage classifier (cheaper, less precise) | `/settings` → "Classifier mode" |
@@ -158,7 +162,8 @@ When the question is **"how does the user toggle / configure X?"**:
 | Add Telegram bot or chat | `/settings` → "Add target" (validates with getMe + sendMessage) |
 | Pipeline stage on a job | `/jobs/:id` → "Application tracking" card |
 | Review newly discovered companies | `/discovery` (sorted by jobsSeen DESC) |
-| Upload / scan a resume | `/settings` → "Resumes" card, or `/resumes` |
+| Toggle auto-discovery / HN parser | `/discovery` (card at the top; moved off `/settings` 2026-08-29) |
+| Upload / scan a resume | `/resumes` (the Settings card only lists + links) |
 | Compare a resume with a posting | `/jobs/:id` → "Resume match" card (Compare) |
 | Paste a posting the fetchers don't see | `/jobs` → "+ Paste a job" (`/jobs/new`) |
 | Compare a pasted posting with any resume in one step | menu → Target (`/target`): paste posting, pick / upload / paste resume, Compare |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@
   returns `[]`, `/companies` and the source toggles hide them.
 - `src/resume/` is the resume module: `zip.ts`, `docx-text.ts`, `pdf-text.ts`
   (unpdf, ADR 0011), `resume-text.ts`, `prompts.ts`, `pick.ts`, `score.ts`
-  (ADR 0012), `facts.ts`, `diff.ts`, `parse-warnings.ts` are pure (tested);
+  (ADR 0012), `facts.ts`, `diff.ts`, `parse-warnings.ts`,
+  `profile-draft.ts` (ADR 0015) are pure (tested);
   `scan.ts` / `match.ts` call the AI provider; `store.ts` is the only file
   that touches Prisma. Web-only — the worker never imports it (ADR 0008).
 - `src/web/public/score.mjs` mirrors `src/resume/score.ts` line for line —
@@ -139,6 +140,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Live smoke bench of the match prompt (3 gold fixtures) | `npm run bench:resume` — `src/scripts/resume-bench-once.ts` |
 | Compare-run progress pages (async classify/scan/match) | `src/web/target-runs.ts` (in-memory registry) + `src/web/pages/target-run.tsx`; started by `/target`, `/jobs/:id/match`, `/jobs/:id/target/reupload` |
 | Which resume a job page preselects | `src/resume/pick.ts:pickResumeForJob` (skill-tag overlap) |
+| Prefill the profile from a resume scan | `src/resume/profile-draft.ts:buildProfileDraft` (pure) + `POST /settings/profiles/:id/fill-from-resume` (renders a draft, saves nothing — ADR 0015) |
 | Model for resume calls | per-engine "Resume model" on `/settings` → AI engine; Claude engines fall back to `CLAUDE_MODEL_RESUME` in `.env` (default `claude-opus-5`) |
 | Ghost-job checklist prompt + verdict schema | `src/verification/prompts.ts` |
 | Letting a call use web search (API server tools / CLI WebSearch) | `AiRequest.webTools` in `src/ai-provider.ts`, args in `ai-provider-parse.ts:buildClaudeCodeArgs` |
@@ -156,7 +158,8 @@ When the question is **"how does the user toggle / configure X?"**:
 | Add / remove tracked company | `/companies` (with manual probe before save) |
 | Disable whole ATS family (e.g. all Workable) | `/settings` Sources tab |
 | Enable two-stage classifier (cheaper, less precise) | `/settings` AI engine tab → "Classifier" |
-| Edit profile (stack, role types, regions, fit threshold) | `/settings` Profile tab |
+| Edit profile (stack, role types, regions, fit threshold) | `/settings` Profile tab (excludes, notes, priority rules, thresholds live in its "Advanced" block) |
+| Fill the profile from a resume (AI draft, review before save) | `/settings` Profile tab → "Fill from a resume" |
 | Switch between profiles | `/settings` Profile tab → dropdown + Activate |
 | Re-classify all jobs against new profile | `/settings` Profile tab → "Re-classify all jobs" (async, watch /runs) |
 | Telegram on/off | `/settings` Notifications tab |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,8 +116,9 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Where to register a new ATS | `src/fetchers/index.ts:fetchOne` switch + `prisma/schema.prisma:AtsType` enum |
 | Where to add a new toggle | `prisma/schema.prisma:AppSettings` (column) → `src/settings.ts` (getter/setter) → `src/web/pages/settings.tsx` (UI) → `src/web/routes/settings.tsx` (POST) |
 | The Claude system prompt | `src/classifier.ts:buildSystemPrompt` |
-| Which AI engine runs (provider + models, DB override → .env fallback) | `src/ai-runtime.ts:getAiRuntime` + pure merge in `src/ai-engine.ts` (ADR 0013); UI on `/settings` → "AI engine" |
-| Adding a new AI backend | `src/ai-provider.ts` (`CliProvider` spec) + `AI_PROVIDER_IDS` in `src/ai-engine.ts` + probe in `src/ai-runtime.ts` |
+| Which AI engines run (priority chain + per-engine models, auto-failover) | `src/ai-runtime.ts:getAiRuntime().complete({role})` + pure chain merge in `src/ai-engine.ts` (ADR 0013/0014); UI on `/settings` → "AI engine" tab |
+| Adding a new AI backend | `src/ai-provider.ts` (`CliProvider` spec or fetch class) + `AI_PROVIDER_IDS`/labels/options in `src/ai-engine.ts` + probe in `src/ai-runtime.ts` |
+| How users set up each engine (local + Docker) | `docs/ai-engines.md` |
 | How many jobs are classified at once | `AI_CONCURRENCY` in `.env` (default 3); limiter in `src/concurrency.ts`, used by `jobs/process-jobs.ts` and `jobs/reclassify-job.ts` |
 | The two-stage prefilter prompt | `src/classifier-prefilter.ts:buildPrefilterPrompt` |
 | Per-job filter rules (pre-Claude) | `src/filter.ts:passesBaseFilter` |
@@ -138,7 +139,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Live smoke bench of the match prompt (3 gold fixtures) | `npm run bench:resume` — `src/scripts/resume-bench-once.ts` |
 | Compare-run progress pages (async classify/scan/match) | `src/web/target-runs.ts` (in-memory registry) + `src/web/pages/target-run.tsx`; started by `/target`, `/jobs/:id/match`, `/jobs/:id/target/reupload` |
 | Which resume a job page preselects | `src/resume/pick.ts:pickResumeForJob` (skill-tag overlap) |
-| Model for resume calls | `/settings` → "AI engine" resume model; falls back to `CLAUDE_MODEL_RESUME` in `.env` (default `claude-opus-5`) |
+| Model for resume calls | per-engine "Resume model" on `/settings` → AI engine; Claude engines fall back to `CLAUDE_MODEL_RESUME` in `.env` (default `claude-opus-5`) |
 | Ghost-job checklist prompt + verdict schema | `src/verification/prompts.ts` |
 | Letting a call use web search (API server tools / CLI WebSearch) | `AiRequest.webTools` in `src/ai-provider.ts`, args in `ai-provider-parse.ts:buildClaudeCodeArgs` |
 | Classify one stored job (Re-classify button, pasted jobs) | `src/jobs/classify-existing.ts` |
@@ -151,7 +152,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | What | Page |
 | --- | --- |
 | Pause / resume all new-job fetching | `/settings` General tab → "Job fetching" |
-| Pick the AI provider / models | `/settings` AI engine tab (availability-probed radios + two model slots) |
+| Pick / order AI engines + models, test them | `/settings` AI engine tab (per-engine cards: Enable, ↑ priority, model selects, Test) |
 | Add / remove tracked company | `/companies` (with manual probe before save) |
 | Disable whole ATS family (e.g. all Workable) | `/settings` Sources tab |
 | Enable two-stage classifier (cheaper, less precise) | `/settings` AI engine tab → "Classifier" |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,16 +150,16 @@ When the question is **"how does the user toggle / configure X?"**:
 
 | What | Page |
 | --- | --- |
-| Pause / resume all new-job fetching | `/settings` → "Job fetching" card (top) |
-| Pick the AI provider / models | `/settings` → "AI engine" (availability-probed radios + two model slots) |
+| Pause / resume all new-job fetching | `/settings` General tab → "Job fetching" |
+| Pick the AI provider / models | `/settings` AI engine tab (availability-probed radios + two model slots) |
 | Add / remove tracked company | `/companies` (with manual probe before save) |
-| Disable whole ATS family (e.g. all Workable) | `/settings` → "Job sources" card |
-| Enable two-stage classifier (cheaper, less precise) | `/settings` → "Classifier mode" |
-| Edit profile (stack, role types, regions, fit threshold) | `/settings` → "Active profile" |
-| Switch between profiles | `/settings` → dropdown + Activate |
-| Re-classify all jobs against new profile | `/settings` → "Re-classify all jobs" (async, watch /runs) |
-| Telegram on/off | `/settings` → "Telegram alerts" |
-| Add Telegram bot or chat | `/settings` → "Add target" (validates with getMe + sendMessage) |
+| Disable whole ATS family (e.g. all Workable) | `/settings` Sources tab |
+| Enable two-stage classifier (cheaper, less precise) | `/settings` AI engine tab → "Classifier" |
+| Edit profile (stack, role types, regions, fit threshold) | `/settings` Profile tab |
+| Switch between profiles | `/settings` Profile tab → dropdown + Activate |
+| Re-classify all jobs against new profile | `/settings` Profile tab → "Re-classify all jobs" (async, watch /runs) |
+| Telegram on/off | `/settings` Notifications tab |
+| Add Telegram bot or chat | `/settings` Notifications tab → "Add target" (validates with getMe + sendMessage) |
 | Pipeline stage on a job | `/jobs/:id` → "Application tracking" card |
 | Review newly discovered companies | `/discovery` (sorted by jobsSeen DESC) |
 | Toggle auto-discovery / HN parser | `/discovery` (card at the top; moved off `/settings` 2026-08-29) |

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM node:24-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 RUN apk add --no-cache tini \
- && npm install -g @anthropic-ai/claude-code
+ && npm install -g @anthropic-ai/claude-code @google/gemini-cli
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 # Static assets served by the dashboard (keyword matcher for /jobs/:id/target).

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM node:24-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 RUN apk add --no-cache tini \
- && npm install -g @anthropic-ai/claude-code @google/gemini-cli
+ && npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 # Static assets served by the dashboard (keyword matcher for /jobs/:id/target).

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -14,7 +14,7 @@ tune the profile, manage sources, compare resumes against postings.
 
 ## Audience and scene
 
-- One user: Nazar, a senior full-stack engineer running his own job search.
+- One user: the self-hosting engineer running their own job search.
 - Checked briefly a few times a day, mostly on a desktop browser at 1440–1920px,
   occasionally on a phone. Daylight, indoor work light — a light theme suits the scene.
 - The user is technical; density and precision beat hand-holding.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ Three containers come up:
 
 1. **postgres** — Postgres 16 with persistent volume.
 2. **app** — cron worker. Runs `prisma migrate deploy`, seeds companies
-   + default profile, registers 6 cron jobs, idles.
+   + a blank starter profile, registers 6 cron jobs, idles. Fetching
+   starts **paused**: fill the profile (fastest: upload a resume and use
+   "Fill from a resume" on `/settings` → Profile), then hit Resume on
+   the Overview page or `/settings` → General.
 3. **web** — Hono dashboard at <http://localhost:4747> (bound to
    `127.0.0.1`, never exposed publicly by default).
 
@@ -178,7 +181,9 @@ Bound to `127.0.0.1:4747`. Optional `WEB_BASIC_AUTH=user:password` in
 
 ### Profiles
 
-`/settings` → "Active profile" lets you edit:
+`/settings` → "Active profile" lets you edit (or prefill in one click with
+**"Fill from a resume"** — AI maps your scanned resume onto the fields and
+shows a draft to review before saving):
 
 - **Tech stack required** — actual technologies (e.g. `php`, `laravel`, `javascript`, `go`)
 - **Role types** — title hints (`full-stack`, `backend`, `frontend`)

--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ that understands the difference between "Senior Rails engineer" and
   proposes new companies to track.
 - **Clean sourcing** — official public APIs and RSS only. No LinkedIn /
   Indeed / Workday scraping ([ADR 0005](./docs/adr/0005-no-linkedin-indeed-workday.md)).
-- **Two AI backends** — Anthropic API (pay per token, ~$2–10/month) or the
-  Claude Code CLI on an existing subscription.
+- **Five AI engines, one chain** — Anthropic API, Claude Code CLI, Gemini
+  CLI, any OpenAI-compatible API (OpenAI / OpenRouter / Groq / local), Codex
+  CLI. Enable what you own, set the priority, and calls fail over
+  automatically when an engine errors or rate-limits
+  ([setup guide](./docs/ai-engines.md)).
 
 > **Docs map:** [SPEC.md](./SPEC.md) — current state.
 > [ARCHITECTURE.md](./ARCHITECTURE.md) — diagrams + file map.
@@ -55,9 +58,11 @@ git clone https://github.com/nazboyko/job-hunter.git
 cd job-hunter
 
 cp .env.example .env
-# Required (one of):
-#   ANTHROPIC_API_KEY=sk-ant-...        (AI_PROVIDER=anthropic_api, default)
-#   AI_PROVIDER=claude_code             (uses your Claude.ai subscription, see below)
+# Pick at least one AI engine (all five in docs/ai-engines.md), e.g.:
+#   ANTHROPIC_API_KEY=sk-ant-...        (Anthropic API, pay per token)
+#   AI_PROVIDER=claude_code + CLAUDE_CODE_OAUTH_TOKEN=...  (Claude.ai subscription)
+#   GEMINI_API_KEY=... / OPENAI_API_KEY=...
+# The rest is configured later on /settings → AI engine (priority + models).
 # Optional (bootstrap-only — managed in /settings after first boot):
 #   TELEGRAM_BOT_TOKEN=...
 #   TELEGRAM_CHAT_ID=...
@@ -139,7 +144,7 @@ Workday, Wellfound, JobSpy. See
 **Easiest:** the manual form on `/companies` runs a live probe of the
 ATS endpoint and refuses to save if the slug doesn't resolve.
 
-**Discovery:** if you turn on Auto-discovery + HN parser in `/settings`,
+**Discovery:** if you turn on Auto-discovery + HN parser on `/discovery`,
 the system auto-finds candidate companies from URLs in HN comments.
 Review on `/discovery` and click **Promote** to start tracking.
 
@@ -309,46 +314,43 @@ descriptions, plus Mermaid diagrams of the data flow.
 
 ## AI backend
 
-Every AI call goes through one seam, `src/ai-provider.ts`. The default
-backend comes from `AI_PROVIDER` in `.env`; **`/settings` → "AI engine"
-overrides the backend and both models at runtime** (stored in Postgres — the
-dashboard switches immediately, the worker on its next tick; ADR 0013).
+Every AI call goes through one seam, `src/ai-provider.ts`. On
+**`/settings` → "AI engine"** you enable the engines you own, put them in
+priority order, and pick per-engine models. **Engine #1 serves every call;
+on an error or rate limit the next enabled engine takes over automatically**
+and control returns as soon as #1 recovers (ADR 0013/0014). `AI_PROVIDER`
+in `.env` only seeds the default before you configure anything.
 
-| Value | How it runs | Billing |
+| Engine | How it runs | Billing |
 | --- | --- | --- |
-| `anthropic_api` (default) | `@anthropic-ai/sdk` → Messages API, system prompt cached | per token, `ANTHROPIC_API_KEY` required |
-| `claude_code` | spawns `claude -p --output-format json` per job | your Claude.ai Pro/Max subscription |
-| `gemini_cli` | spawns `gemini -p --output-format json` per job | your Google account (Gemini CLI login) or `GEMINI_API_KEY` |
+| `anthropic_api` | `@anthropic-ai/sdk` → Messages API, system prompt cached | per token, `ANTHROPIC_API_KEY` |
+| `claude_code` | spawns `claude -p` per job | Claude.ai Pro/Max subscription |
+| `gemini_cli` | spawns `gemini -p` per job | Google account or `GEMINI_API_KEY` |
+| `openai_api` | `POST /chat/completions` via fetch | OpenAI / OpenRouter / Groq key, or a free local server (`OPENAI_BASE_URL`) |
+| `codex_cli` | spawns `codex exec` per job | ChatGPT Plus/Pro subscription |
 
-Two model slots, both overridable on `/settings`: the **classifier model**
-(`CLAUDE_MODEL`, Haiku 4.5 — cheap, runs on every fetched job) and the
-**resume model** (`CLAUDE_MODEL_RESUME`, Opus 5 — resume scan, match and job
-verification, a few calls a day where judgment matters more than cost). With
-the Gemini engine the slots default to `gemini-2.5-flash` / `gemini-2.5-pro`.
+Each engine has two model slots — the **classifier model** (cheap, runs on
+every fetched job; Haiku 4.5 for the Claude engines) and the **resume
+model** (resume scan / match / verification; Opus 5 for the Claude
+engines). Closed families are dropdowns, so a wrong-family id cannot be
+saved; every card has a **Test** button that runs one live call end-to-end.
 
-`gemini_cli` notes: install with `npm i -g @google/gemini-cli` (the Docker
-image ships it), then either run `gemini` once to log in or set
-`GEMINI_API_KEY` in `.env`. The prompts are tuned against Claude — expect
-somewhat different scoring behaviour.
+**Setup for every engine — local (no Docker) and Docker, step by step:
+[docs/ai-engines.md](./docs/ai-engines.md).**
 
-`claude_code` notes:
+CLI engine notes (claude_code / gemini_cli / codex_cli):
 
-- Requires the Claude Code CLI on the host running the worker
-  (`npm i -g @anthropic-ai/claude-code`, then `claude` once to log in).
-  The Docker image installs the CLI; uncomment the `~/.claude` volume
-  lines in `docker-compose.yml` (both `app` and `web`) to mount your
-  credentials into the containers.
-- Every call carries Claude Code's own system prompt (~5k tokens) and
-  starts a new process — ~7 s per job on a laptop, 15–30 s inside Docker.
-  `AI_CONCURRENCY` (default 3) runs that many CLI processes at once, so
-  wall-clock for a tick or "Re-classify all" divides by roughly that
-  number; budget ~130 MB RAM per process.
-- The subscription has a rolling usage window. When it is exhausted the
-  provider logs `claude-code rate-limited`, the job counts as
-  `classifyFailed` for this tick, and it is retried on the next tick.
+- Every call starts a process and carries the CLI's own system prompt —
+  ~7 s per job on a laptop, 15–30 s inside Docker. `AI_CONCURRENCY`
+  (default 3) runs that many processes at once; budget ~130 MB RAM each.
+- A subscription has a rolling usage window. When it is exhausted the call
+  fails over to the next engine (or, with a one-engine chain, the job is
+  retried next tick).
 - Running a background service on a consumer subscription is not something
-  Anthropic's consumer terms explicitly cover. Check them before making it
-  your default.
+  the vendors' consumer terms explicitly cover. Check them before making
+  one your primary.
+- The prompts are tuned against Claude (see CLAUDE.md gotchas 8 and 11) —
+  expect somewhat different scoring from Gemini / GPT engines.
 
 ## Costs
 

--- a/README.md
+++ b/README.md
@@ -309,17 +309,27 @@ descriptions, plus Mermaid diagrams of the data flow.
 
 ## AI backend
 
-Both classifier stages go through one seam, `src/ai-provider.ts`. Pick the
-backend with `AI_PROVIDER`:
+Every AI call goes through one seam, `src/ai-provider.ts`. The default
+backend comes from `AI_PROVIDER` in `.env`; **`/settings` → "AI engine"
+overrides the backend and both models at runtime** (stored in Postgres — the
+dashboard switches immediately, the worker on its next tick; ADR 0013).
 
 | Value | How it runs | Billing |
 | --- | --- | --- |
 | `anthropic_api` (default) | `@anthropic-ai/sdk` → Messages API, system prompt cached | per token, `ANTHROPIC_API_KEY` required |
 | `claude_code` | spawns `claude -p --output-format json` per job | your Claude.ai Pro/Max subscription |
+| `gemini_cli` | spawns `gemini -p --output-format json` per job | your Google account (Gemini CLI login) or `GEMINI_API_KEY` |
 
-`CLAUDE_MODEL` (Haiku 4.5) runs the classifier; `CLAUDE_MODEL_RESUME`
-(Opus 5 by default) runs the resume scan and resume-vs-job comparison —
-a few calls a day where judgment matters more than cost.
+Two model slots, both overridable on `/settings`: the **classifier model**
+(`CLAUDE_MODEL`, Haiku 4.5 — cheap, runs on every fetched job) and the
+**resume model** (`CLAUDE_MODEL_RESUME`, Opus 5 — resume scan, match and job
+verification, a few calls a day where judgment matters more than cost). With
+the Gemini engine the slots default to `gemini-2.5-flash` / `gemini-2.5-pro`.
+
+`gemini_cli` notes: install with `npm i -g @google/gemini-cli` (the Docker
+image ships it), then either run `gemini` once to log in or set
+`GEMINI_API_KEY` in `.env`. The prompts are tuned against Claude — expect
+somewhat different scoring behaviour.
 
 `claude_code` notes:
 

--- a/README.md
+++ b/README.md
@@ -6,378 +6,309 @@
 [![TypeScript strict](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](./tsconfig.json)
 [![Release](https://img.shields.io/github/v/release/nazboyko/job-hunter?display_name=tag)](./CHANGELOG.md)
 
-**Self-hosted AI job hunter.** Watches 16 ATS / aggregator sources, scores
-every posting with Claude against *your* profile, tells you whether a
-posting is a ghost job, compares your resume with it, and pings Telegram
-when something is worth applying to. Runs on your laptop or a $5 VPS with
-`docker compose up`.
+**A self-hosted AI job hunter.** It watches 16 job sources around the clock,
+reads every posting the way you would, and only interrupts you when
+something is actually worth applying to. Then it helps you apply well:
+it checks whether the job is real, scores your resume against the posting,
+and tells you exactly what to change.
 
-Built for people who are tired of scrolling job boards and want a filter
-that understands the difference between "Senior Rails engineer" and
-"Senior PHP engineer".
+Built for one specific kind of tired: you know what you're looking for,
+the boards keep showing you everything else, and every "Senior Engineer"
+listing needs three minutes of reading to discover it's the wrong stack,
+the wrong country, or a ghost. This tool does that reading for you.
+
+Everything runs on your machine — your resume, your profile, and every AI
+report stay in your own Postgres. `docker compose up` on a laptop or a $5
+VPS is all it takes.
 
 ![Job Hunter — Overview: status counters with 24h deltas, recent alerts, cron health](docs/screenshots/overview.png)
 
-## Highlights
+## How it works
 
-- **Profile, not keywords** — stack, role types, seniority, regions, salary
-  floor, fit threshold. Claude reads each posting against the profile with
-  explicit tech-stack and country-lock rules.
-- **Two-stage classifier** — a short, cached prefilter prompt drops obvious
-  misses; the full prompt only runs on survivors. Same model, 30–40 % fewer
-  tokens.
-- **Is this job real?** — ghost-job checklist run with web search: careers
-  page, company footprint, posting age, named humans, scam flags. Verdict +
-  evidence URLs.
-- **Resume match** — upload your resume, compare it with any posting: match
-  score, red flags, prioritised edits, keyword coverage. Then edit it in a
-  side-by-side **targeted view** with a live score.
-- **Application tracking** — kanban from *applied* to *offer*, plus a daily
-  nudge for applications that went quiet.
-- **Discovery** — harvests ATS URLs from HN "Who is hiring" threads and
-  proposes new companies to track.
-- **Clean sourcing** — official public APIs and RSS only. No LinkedIn /
-  Indeed / Workday scraping ([ADR 0005](./docs/adr/0005-no-linkedin-indeed-workday.md)).
-- **Five AI engines, one chain** — Anthropic API, Claude Code CLI, Gemini
-  CLI, any OpenAI-compatible API (OpenAI / OpenRouter / Groq / local), Codex
-  CLI. Enable what you own, set the priority, and calls fail over
-  automatically when an engine errors or rate-limits
-  ([setup guide](./docs/ai-engines.md)).
+Once an hour, the worker pulls fresh postings from every enabled source.
+Cheap deterministic filters drop the obvious misses first (excluded words in
+the title, dead locations). Everything that survives goes to an AI
+classifier that reads the full description against **your profile** — the
+stack you actually use, the role types you accept, seniority, regions,
+salary floor — with strict rules about what counts as a match: `full-stack`
+in a title is not a tech match, and "Remote · Germany" is not a US-remote
+job. Postings that clear your fit threshold land in the dashboard and, if
+you want, in your Telegram.
 
-> **Docs map:** [SPEC.md](./SPEC.md) — current state.
-> [ARCHITECTURE.md](./ARCHITECTURE.md) — diagrams + file map.
-> [CLAUDE.md](./CLAUDE.md) — conventions + gotchas + where-to-look.
-> [docs/adr/](./docs/adr/) — non-trivial decisions.
-> [CHANGELOG.md](./CHANGELOG.md) — releases.
-> [SPEC-phase1.md](./SPEC-phase1.md) — historical Phase 1 spec.
+From there the toolkit takes over:
 
-## Quick start
+- **"Is this job real?"** runs a ghost-job checklist with live web search —
+  careers page, company footprint, posting age, named humans, scam flags —
+  and returns a verdict (`legit` / `suspicious` / `fake`) with the evidence
+  URLs it used. Built for postings you paste in from LinkedIn or email.
+- **Resume match** compares any resume against any posting: a score with a
+  fixed rubric, keyword coverage (present / missing / can't honestly claim),
+  red flags, prioritised edits — and what to *remove*. The score itself is
+  computed by application code from facts the model marks, not invented by
+  the model, so a Laravel resume cannot sweet-talk its way to 85 against a
+  Node.js posting, and v2 is genuinely comparable to v1.
+- **The targeted editor** puts the posting and your resume side by side with
+  every keyword highlighted, lets you edit the resume in place, and recomputes
+  keyword coverage live in the browser as you type. One click sends the
+  draft back to the AI for the full rubric score; another saves it as a new
+  version.
+- **Application tracking** keeps a small kanban from *applied* to *offer*
+  and nudges you about applications that went quiet for two weeks.
+- **Discovery** harvests company ATS boards from Hacker News "Who is
+  hiring" threads and proposes them as new sources to track.
+
+Sourcing is deliberately clean: official public APIs and RSS feeds only,
+never scraping. LinkedIn, Indeed, Glassdoor, Workday and Wellfound are
+permanently out of scope ([ADR 0005](./docs/adr/0005-no-linkedin-indeed-workday.md)).
+
+## Bring your own AI — all of it
+
+This is the part that makes the tool practical to run all day. Instead of
+one hard-coded API key, job-hunter speaks to **five AI backends**, and you
+can attach every subscription and key you own:
+
+| Engine | What it is | Billing |
+| --- | --- | --- |
+| Claude Code CLI | headless `claude -p` | your Claude.ai Pro/Max subscription |
+| Gemini CLI | headless `gemini -p` | your Google account (free tier is generous) or an AI Studio key |
+| Codex CLI | headless `codex exec` | your ChatGPT Plus/Pro subscription |
+| Anthropic API | Messages API, prompt-cached | per token |
+| OpenAI-compatible API | `POST /chat/completions` to any base URL | OpenAI, OpenRouter, Groq, DeepSeek — or a free local model via LM Studio / Ollama |
+
+On **Settings → AI engine** each backend is a card: enable the ones you
+have, arrange them with ↑ Priority, and pick models per engine from
+dropdowns that only offer that family's models (a wrong id is impossible to
+save). Engine **#1 serves every call. If it errors, hits a rate limit, or
+runs out of quota, the next engine takes over automatically for that call —
+and #1 is back in charge the moment it recovers.** An engine that fails
+repeatedly is put on a short cooldown instead of slowing every job down.
+
+The dashboard never guesses about your setup. Every card shows whether the
+engine is actually usable on this machine ("available" vs "not detected",
+with the exact missing step), metered engines carry a "pay per token" badge
+and a warning when you place one behind subscriptions as a paid fallback,
+and a **Test** button runs one real end-to-end call and reports the response
+time. A "Last 7 days" line counts who actually served your calls, and any
+report produced by a fallback engine is marked as such.
+
+Two model slots per engine keep costs sane: a cheap **classifier model**
+that reads every fetched job (Haiku 4.5 on the Claude engines) and a strong
+**resume model** for the handful of judgment calls a day — resume scans,
+matches, verification (Opus 5 on the Claude engines).
+
+Setup for every engine, both with and without Docker, lives in
+**[docs/ai-engines.md](./docs/ai-engines.md)** — including details like
+using a Gemini API key with zero extra code through the OpenAI-compatible
+engine, and why a Claude subscription needs `claude setup-token` inside
+Docker on macOS.
+
+One honest note: running a background service on a consumer AI subscription
+is not something the vendors' terms explicitly cover — read yours before
+making a subscription your primary engine. The prompts are tuned against
+Claude, so expect somewhat different scoring from Gemini or GPT engines
+(there's a bench for exactly that: `npm run bench:resume -- --engine all`).
+
+## Quick start (Docker)
 
 ```bash
 git clone https://github.com/nazboyko/job-hunter.git
 cd job-hunter
 
 cp .env.example .env
-# Pick at least one AI engine (all five in docs/ai-engines.md), e.g.:
-#   ANTHROPIC_API_KEY=sk-ant-...        (Anthropic API, pay per token)
-#   AI_PROVIDER=claude_code + CLAUDE_CODE_OAUTH_TOKEN=...  (Claude.ai subscription)
-#   GEMINI_API_KEY=... / OPENAI_API_KEY=...
-# The rest is configured later on /settings → AI engine (priority + models).
-# Optional (bootstrap-only — managed in /settings after first boot):
-#   TELEGRAM_BOT_TOKEN=...
-#   TELEGRAM_CHAT_ID=...
+# Give it at least one AI engine — any of these works:
+#   ANTHROPIC_API_KEY=sk-ant-...                          (Anthropic API)
+#   AI_PROVIDER=claude_code + CLAUDE_CODE_OAUTH_TOKEN=... (Claude.ai subscription)
+#   GEMINI_API_KEY=...                                    (Gemini, free tier)
+#   OPENAI_API_KEY=... (+ OPENAI_BASE_URL for OpenRouter/Groq/local)
+# Everything else is configured later in the dashboard.
 
 docker compose up -d
-docker compose logs -f app    # worker
-docker compose logs -f web    # dashboard
 ```
 
-Three containers come up:
+Three containers come up: **postgres** (16, persistent volume), **app**
+(the cron worker — applies migrations, seeds sources and a blank starter
+profile, registers six cron jobs) and **web** (the dashboard at
+<http://localhost:4747>, bound to `127.0.0.1` so it is never exposed to the
+network by default; add `WEB_BASIC_AUTH=user:password` to `.env` if you
+want a login prompt anyway).
 
-1. **postgres** — Postgres 16 with persistent volume.
-2. **app** — cron worker. Runs `prisma migrate deploy`, seeds companies
-   + a blank starter profile, registers 6 cron jobs, idles. Fetching
-   starts **paused**: fill the profile (fastest: upload a resume and use
-   "Fill from a resume" on `/settings` → Profile), then hit Resume on
-   the Overview page or `/settings` → General.
-3. **web** — Hono dashboard at <http://localhost:4747> (bound to
-   `127.0.0.1`, never exposed publicly by default).
+### Your first fifteen minutes
 
-The dashboard is read-mostly with limited writes (status changes,
-profile / settings edits, candidate promote, company add).
+Fetching starts **paused** on a fresh install — on purpose. A blank profile
+would classify everything as a miss and waste your AI quota. The path:
 
-## Cron schedule (TZ = `America/Chicago` by default)
+1. Open <http://localhost:4747/settings?tab=ai>. Your engines from `.env`
+   are already detected — press **Test** on each and watch it reply.
+   Enable more engines, order them, adjust models if you care.
+2. Go to the **Profile** tab. Fill in your stack and preferences by hand —
+   or upload your resume on `/resumes` first and press **"Fill from a
+   resume"**: the AI maps your scanned resume onto the profile fields and
+   shows you a draft to review before anything is saved.
+3. (Optional) **Notifications** tab: add a Telegram bot so alerts reach
+   your phone. The form validates the token by actually sending you a
+   message before it saves. To create a bot: [@BotFather](https://t.me/BotFather);
+   your chat id comes from `https://api.telegram.org/bot<TOKEN>/getUpdates`
+   after you message the bot once.
+4. Back to **General** → press **Resume** on the "Job fetching" switch.
+   The next hourly tick pulls, classifies and (if warranted) alerts. Too
+   impatient to wait for the tick:
 
-| Cron expr   | Job                | What it does                                        |
-| ----------- | ------------------ | --------------------------------------------------- |
-| `5 * * * *` | fetch              | Pull all sources, filter, classify, alert.          |
-| `0 9 * * *` | digest             | Telegram digest of NEW/ALERTED jobs from last 24h.  |
-| `0 8 * * *` | stale-applications | Nudge for `applied >14d ago, no recruiter contact`. |
-| `0 3 * * 0` | cleanup            | Delete DISMISSED jobs older than 30 days.           |
-| `0 4 * * 0` | discovery          | Re-probe pending CompanyCandidates.                 |
-| `0 6 1 * *` | hn-hiring          | Pull latest HN Who-is-hiring + harvest candidates.  |
+   ```bash
+   docker compose exec app node dist/scripts/fetch-once.js
+   ```
 
-## Manual one-shot runs
+From then on it runs itself. Every settings change saves to Postgres the
+moment you click — no restarts, no `.env` edits; the worker picks changes
+up within the hour, dashboard actions use them immediately.
+
+## Running without Docker
+
+The stack is plain Node + Postgres, so a local setup is first-class — you
+only need a database:
 
 ```bash
-# Inside Docker (recommended):
-docker compose exec app node dist/scripts/fetch-once.js
-docker compose exec app node dist/scripts/digest-once.js
-docker compose exec app node dist/scripts/cleanup-once.js
-docker compose exec app node dist/scripts/stale-once.js
-docker compose exec app node dist/scripts/hn-once.js
-docker compose exec app node dist/scripts/discovery-once.js
-
-# Locally (requires Postgres running, DATABASE_URL pointing at it):
+docker compose up -d postgres   # or any Postgres 16 you already have
+cp .env.example .env            # DATABASE_URL=postgresql://jobhunter:jobhunter@localhost:5432/jobhunter
 npm install
-npm run fetch:once
-npm run digest:once
-# … etc
+npx prisma migrate deploy
+npm run seed
+
+npm run dev                     # the cron worker
+npm run dev:web                 # the dashboard → http://localhost:4747
 ```
 
-## Sources
+CLI engines (claude / gemini / codex) are even simpler locally: install
+them globally, log in once in your terminal, and the probe on the AI tab
+turns green — no tokens or mounts needed. Details per engine in
+[docs/ai-engines.md](./docs/ai-engines.md).
 
-16 source types, all on official public APIs / RSS — no scraping.
+> `dev:web` compiles with `tsc` and reloads with Node's `--watch` rather
+> than `tsx` — a deliberate workaround, see gotcha #2 in
+> [CLAUDE.md](./CLAUDE.md#gotchas).
 
-| Type            | Shape         | Notes                                              |
-| --------------- | ------------- | -------------------------------------------------- |
-| GREENHOUSE      | per-company   | Add via /companies                                 |
-| LEVER           | per-company   | Add via /companies                                 |
-| ASHBY           | per-company   | Add via /companies                                 |
-| WORKABLE        | per-company   | Add via /companies. Title-only classification.     |
-| SMARTRECRUITERS | per-company   | Add via /companies. List + per-job detail.         |
-| LARAJOBS_RSS    | aggregator    | Single seeded feed.                                |
-| REMOTEOK        | aggregator    | Single seeded feed.                                |
-| REMOTIVE        | aggregator    | Single seeded feed (?category=software-dev).       |
-| ARBEITNOW       | aggregator    | EU-skewed; **disabled** by default.                |
-| HN_HIRING       | aggregator    | Monthly HN Who-is-hiring thread (Algolia API).     |
-| WEWORKREMOTELY  | per-category  | atsToken = category slug. Two seeded.              |
-| GOLANGPROJECTS  | aggregator    | Go-only feed; **disabled** by default.             |
-| JOBICY          | aggregator    | Single seeded feed (?job_categories=dev).          |
-| HN_JOBS         | aggregator    | HN /jobs firehose (Algolia tags=job, 14-day window). |
-| WORKINGNOMADS   | aggregator    | Free JSON API, ~30 most recent cross-company jobs. |
-| HIMALAYAS       | aggregator    | Free JSON API, 20 newest jobs/call, all categories. |
+## Day to day
 
-**Hard exclusions** (never adding): LinkedIn, Indeed, Glassdoor,
-Workday, Wellfound, JobSpy. See
-[ADR 0005](./docs/adr/0005-no-linkedin-indeed-workday.md).
-
-## Adding companies
-
-**Easiest:** the manual form on `/companies` runs a live probe of the
-ATS endpoint and refuses to save if the slug doesn't resolve.
-
-**Discovery:** if you turn on Auto-discovery + HN parser on `/discovery`,
-the system auto-finds candidate companies from URLs in HN comments.
-Review on `/discovery` and click **Promote** to start tracking.
-
-**Seed (rare):** edit `src/seed.ts` and run `docker compose exec app
-node dist/seed.js`. Idempotent on `(atsType, atsToken)`. Disabling a
-company through the UI persists across reseeds.
-
-## Dashboard
-
-Bound to `127.0.0.1:4747`. Optional `WEB_BASIC_AUTH=user:password` in
-`.env` to enable HTTP Basic Auth.
+| Page | URL | What it's for |
+| --- | --- | --- |
+| Overview | `/` | Counters by status, recent alerts, cron health, pause/resume |
+| Jobs | `/jobs` | Filterable, sortable list of everything fetched |
+| Paste a job | `/jobs/new` | Save a posting by hand (LinkedIn, email, referral) — it gets classified like any other |
+| Job detail | `/jobs/:id` | Full description, AI verdict, status actions, verification, resume match, tracking |
+| Targeted editor | `/jobs/:id/target` | Posting ↔ resume side by side, live keyword score, edit in place |
+| Target | `/target` | One-shot comparison: paste any posting, pick/upload/paste any resume — without touching your saved resumes |
+| Applications | `/applications` | Kanban: applied → screen → tech → onsite → offer / rejected / ghosted |
+| Resumes | `/resumes` | Upload `.pdf` / `.docx` / `.md` / `.txt`, AI scan, version history |
+| Companies | `/companies` | Tracked boards; add new ones with a live probe that refuses bad slugs |
+| Discovery | `/discovery` | Board candidates harvested from HN, with the discovery toggles |
+| Runs | `/runs` | The last 100 cron runs with stats and errors |
+| Settings | `/settings` | Five tabs: General · Profile · AI engine · Notifications · Sources |
 
 ![Job Hunter — Jobs: full-width table with fit scores, status filters and sticky header](docs/screenshots/jobs.png)
 
-| Page         | URL              | What it shows                                                        |
-| ------------ | ---------------- | -------------------------------------------------------------------- |
-| Overview     | `/`              | Counters by status, recent alerts, cron health                       |
-| Jobs         | `/jobs`          | Filterable + sortable + paginated list                               |
-| Paste a job  | `/jobs/new`      | Save a posting by hand (LinkedIn, email, referral) — classified like any other |
-| Job detail   | `/jobs/:id`      | Full description, Claude output, status actions, **is this job real?**, **resume match**, application tracking, re-classify |
-| Targeted     | `/jobs/:id/target` | Posting ↔ resume side by side, keyword highlights, in-place editing with live coverage score, AI re-analysis of the draft |
-| Target       | `/target`        | Pure comparison: paste a posting, pick / upload / paste a resume — a live progress page runs classify → AI match and opens the targeted view. Uploads here never land in your Resumes |
-| Applications | `/applications`  | Kanban (applied → screen → tech → onsite → offer / rejected / ghosted) |
-| Resumes      | `/resumes`       | Upload `.pdf` / `.docx` / `.md` / `.txt`, AI scan (headline, skills, issues), comparison history |
-| Resume       | `/resumes/:id`   | Scan result, job-agnostic issues, comparisons, extracted text, download |
-| Companies    | `/companies`     | Sources list, manual add (with probe), per-row toggle / delete       |
-| Discovery    | `/discovery`     | Pending / Promoted / Ignored / Dead candidates harvested by HN parser |
-| Runs         | `/runs`          | Last 100 cron runs with stats / errors                               |
-| Settings     | `/settings`      | Active profile editor, resumes, 8 toggles, telegram targets, source family on/off |
-| Health       | `/health`        | JSON liveness for external monitoring                                |
+The worker's schedule (`TZ` from `.env`, UTC by default):
 
-### Profiles
-
-`/settings` → "Active profile" lets you edit (or prefill in one click with
-**"Fill from a resume"** — AI maps your scanned resume onto the fields and
-shows a draft to review before saving):
-
-- **Tech stack required** — actual technologies (e.g. `php`, `laravel`, `javascript`, `go`)
-- **Role types** — title hints (`full-stack`, `backend`, `frontend`)
-- **Nice-to-have** — boost only
-- **Exclude** — auto-reject in title (`junior`, `intern`, `wordpress`)
-- **Notes** — free-form context appended to the Claude prompt
-- **Seniority, location, regions, on-site cities, hybrid OK**
-- **Min salary**, **min fit score**
-- **Telegram target** — route alerts to a specific bot (or broadcast)
-
-Multiple profiles can coexist; one is active. Switch via dropdown,
-then click **Re-classify all jobs** to rescore existing rows under
-the new profile.
-
-### Resumes
-
-Upload the resumes you actually send (`/settings` → "Resumes" or
-`/resumes`). Each upload is scanned once by `CLAUDE_MODEL_RESUME`
-(headline, seniority, skill tags, job-agnostic ATS issues). On any job
-page, "Resume match" → **Compare** runs one comparison and stores a report:
-match score, what already sells you, red flags, a to-do list (section →
-where → what → why, with priority) and keyword coverage
-(`present` / `add` / `can't claim` — the last one is what the resume
-cannot honestly claim), and **what to remove** so the resume reads
-cleaner. Recruiter reality is baked into the prompt: the title, summary and
-most recent role get the edits; older roles get trims.
-
-Then iterate: edit the resume, **Upload a new version** on its page, hit
-Compare again — the score uses a fixed rubric, so the card shows
-"▲ +16 vs v1". Files and reports stay in your Postgres.
-
-### Targeted view
-
-The **Target** page in the menu (`/target`) starts this flow from scratch:
-paste a posting, then pick an uploaded resume, upload a file or paste plain
-text — a progress page shows each step (classify → AI match, ~1-2 min) and
-opens the result. Target is a *pure comparison*: an uploaded or pasted
-resume lives on one hidden scratch slot, every new upload replaces the
-previous analysis, and nothing is added to your Resumes. The match score uses a
-primary-stack gate — a posting's core language/framework missing from the
-resume caps the score hard, so a Laravel resume cannot score 80+ against a
-Node.js posting. Otherwise, "Open targeted view →" on any comparison (`/jobs/:id/target`) puts the
-posting and your resume side by side, Resume Worded style: every keyword
-highlighted in the posting (found / missing / can't claim), keywords and
-suggested removals highlighted in the resume, and the resume **editable in
-place**. A live **keyword coverage** score recomputes as you type (in the
-browser, no AI call — see ADR 0010); "Re-analyze with AI" sends the draft to
-the resume model for the full rubric score; "Save as vN" stores the draft as
-a text version; "Re-upload resume" does version + scan + compare in one go.
-Drafts live in the browser tab until you save.
-
-### Is this job real?
-
-Any job page → **Verify**. The model gets web search (server tools on the
-API, `WebSearch`/`WebFetch` on the Claude Code CLI) and runs the ghost-job
-checklist: company careers page, LinkedIn footprint, reputation, posting
-age, salary, named humans, hard scam flags. Result: `legit` / `suspicious`
-/ `fake`, a recommendation (apply / caution / skip), confidence, and
-evidence rows with the URLs it used. Takes 2-4 minutes. Pasted jobs
-(`/jobs/new`) are the main use — LinkedIn postings you'd otherwise have to
-judge by eye.
-
-### Toggles
-
-Every feature can be disabled in `/settings`:
-
-| Toggle                        | Effect when off                                |
-| ----------------------------- | ---------------------------------------------- |
-| Job fetching (master switch)  | No new jobs or alerts; dashboard, digest, cleanup and discovery keep running |
-| Telegram alerts               | Notifier no-ops with log preview               |
-| Classifier mode               | `single` (full Haiku 4.5) vs `two_stage` (cheap prefilter + full) |
-| Application tracking          | Hides per-job tracking card, no auto-set on APPLIED |
-| Stale-applications digest     | Daily nudge cron exits early                   |
-| HN parser                     | Monthly HN cron + manual run skip              |
-| Auto-discovery                | HN parser doesn't write CompanyCandidates      |
-| Disabled sources (multi)      | Skip whole AtsType families in fetch tick      |
-
-## Local dev
-
-```bash
-docker compose up -d postgres        # just the database
-cp .env.example .env                  # set DATABASE_URL=postgresql://jobhunter:jobhunter@localhost:5432/jobhunter
-npm install
-npx prisma migrate deploy             # apply real migrations
-npm run seed
-npm run fetch:once
-
-# Dashboard locally:
-npm run dev:web                       # tsc + node --watch
-# then open http://localhost:4747
-```
-
-Note: the dashboard's dev script compiles via `tsc` and reloads via
-Node's `--watch`. We don't use `tsx` for the web service because of
-[a known issue with jsxImportSource](./CLAUDE.md#gotchas) — see
-gotcha #2 in CLAUDE.md.
-
-## Tests + CI
-
-```bash
-npm run lint:types     # tsc --noEmit
-npm test               # node --test via tsx, ~300 tests
-```
-
-GitHub Actions runs both on every push and PR — see
-`.github/workflows/test.yml`. Tests cover **pure modules only**:
-filter, text-utils, http, hn-parser, notifier helpers, fetcher
-mappers, prefilter parser, stale-applications formatter. Modules that
-touch Prisma or the Anthropic SDK are verified via smoke runs and
-dashboard integration testing instead.
-
-## Telegram
-
-Two paths:
-
-**Bootstrap from .env:** set `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`,
-boot the stack, `init.ts` imports them as a `TelegramTarget` row and
-turns alerts on. After this, `.env` is no longer consulted at runtime.
-
-**Manage in dashboard:** `/settings` → "Add target". The form runs
-`getMe` + `sendMessage` against your bot and refuses to save if either
-fails. Add multiple targets if you want parallel delivery; route a
-profile to one specific target via `Profile.telegramTargetId`.
-
-To create a bot: [@BotFather](https://t.me/BotFather) → copy token.
-To find your chat id: send any message to your bot, then visit
-`https://api.telegram.org/bot<TOKEN>/getUpdates` and grab `chat.id`.
-
-## Project layout
-
-See [ARCHITECTURE.md](./ARCHITECTURE.md) — full file map with
-descriptions, plus Mermaid diagrams of the data flow.
-
-## AI backend
-
-Every AI call goes through one seam, `src/ai-provider.ts`. On
-**`/settings` → "AI engine"** you enable the engines you own, put them in
-priority order, and pick per-engine models. **Engine #1 serves every call;
-on an error or rate limit the next enabled engine takes over automatically**
-and control returns as soon as #1 recovers (ADR 0013/0014). `AI_PROVIDER`
-in `.env` only seeds the default before you configure anything.
-
-| Engine | How it runs | Billing |
+| Cron | Job | What it does |
 | --- | --- | --- |
-| `anthropic_api` | `@anthropic-ai/sdk` → Messages API, system prompt cached | per token, `ANTHROPIC_API_KEY` |
-| `claude_code` | spawns `claude -p` per job | Claude.ai Pro/Max subscription |
-| `gemini_cli` | spawns `gemini -p` per job | Google account or `GEMINI_API_KEY` |
-| `openai_api` | `POST /chat/completions` via fetch | OpenAI / OpenRouter / Groq key, or a free local server (`OPENAI_BASE_URL`) |
-| `codex_cli` | spawns `codex exec` per job | ChatGPT Plus/Pro subscription |
+| `5 * * * *` | fetch | Pull all sources → filter → classify → alert |
+| `0 9 * * *` | digest | Telegram digest of the last 24h of new/alerted jobs |
+| `0 8 * * *` | stale-applications | Nudge for applications quiet for 14+ days |
+| `0 3 * * 0` | cleanup | Drop dismissed jobs older than 30 days, trim usage counters |
+| `0 4 * * 0` | discovery | Re-probe pending company candidates |
+| `0 6 1 * *` | hn-hiring | Pull the monthly HN "Who is hiring" thread |
 
-Each engine has two model slots — the **classifier model** (cheap, runs on
-every fetched job; Haiku 4.5 for the Claude engines) and the **resume
-model** (resume scan / match / verification; Opus 5 for the Claude
-engines). Closed families are dropdowns, so a wrong-family id cannot be
-saved; every card has a **Test** button that runs one live call end-to-end.
+Every cron has a matching one-shot script for manual runs
+(`docker compose exec app node dist/scripts/<name>-once.js`, or
+`npm run <name>:once` locally).
 
-**Setup for every engine — local (no Docker) and Docker, step by step:
-[docs/ai-engines.md](./docs/ai-engines.md).**
+## Where the jobs come from
 
-CLI engine notes (claude_code / gemini_cli / codex_cli):
+Coverage is two-tier by design, because the big HR vendors have no "all
+jobs" API — only per-company endpoints:
 
-- Every call starts a process and carries the CLI's own system prompt —
-  ~7 s per job on a laptop, 15–30 s inside Docker. `AI_CONCURRENCY`
-  (default 3) runs that many processes at once; budget ~130 MB RAM each.
-- A subscription has a rolling usage window. When it is exhausted the call
-  fails over to the next engine (or, with a one-engine chain, the job is
-  retried next tick).
-- Running a background service on a consumer subscription is not something
-  the vendors' consumer terms explicitly cover. Check them before making
-  one your primary.
-- The prompts are tuned against Claude (see CLAUDE.md gotchas 8 and 11) —
-  expect somewhat different scoring from Gemini / GPT engines.
+- **Direct boards** — Greenhouse, Lever, Ashby, Workable, SmartRecruiters
+  boards for companies *you* choose to track. Precise, but only as broad as
+  your list. Add one by pasting its board URL on `/companies`; the form
+  probes the API live and refuses slugs that don't resolve.
+- **Aggregators** — RemoteOK, Remotive, We Work Remotely, Jobicy, Working
+  Nomads, Himalayas, Laravel Jobs, Golang Projects, Arbeitnow, the HN jobs
+  feed and the monthly HN "Who is hiring" thread. Broad and noisy — which
+  is fine, because the filters and the classifier do the narrowing.
 
-## Costs
+Leave the aggregators on. Turning them off to "only watch real boards"
+sounds tidy and reliably produces near-zero new jobs — a dozen tracked
+companies simply don't post matching roles every week. The long tail comes
+from the aggregators; your profile keeps it quiet.
 
-With `AI_PROVIDER=anthropic_api`, roughly **$2-10/month** depending on
-classifier mode and how many sources are active:
+When you spot a company elsewhere, paste its board URL on `/companies` —
+or let **Discovery** do it: the HN parser spots Greenhouse/Lever/Ashby URLs
+in comments and queues them on `/discovery` for a one-click promote.
 
-- Single-stage classifier mode (default): ~$0.001 per classified job, ~5-10 jobs/day = ~$5/month.
-- Two-stage classifier mode: ~30-40% reduction in token spend on a
-  typical day where most fetched jobs are off-target.
-- Discovery harvest doesn't call Claude (only HN parsing → ATS-URL
-  detection).
-- Anthropic prompt caching gives ~90% read discount on the system
-  prompt within the 5-minute window. `AI_CONCURRENCY` requests run at
-  once, so the first few of a tick may each pay the cache write.
+## The resume toolkit, in practice
 
-Postgres + Telegram + GitHub Actions are all free. The whole stack
-runs on a $5/month VPS or your laptop.
+Upload the resumes you actually send on `/resumes`. Each gets one AI scan
+(headline, seniority, skill tags, job-agnostic ATS issues — including a
+"what the ATS sees" text check). Then, on any job page, **Compare** runs
+the match and stores the report; on the targeted editor you fix the resume
+right there, watching keyword coverage update on every keystroke without
+spending a single AI call. When the draft feels right, "Re-analyze with
+AI" gives the honest rubric score, and "Save as vN" keeps the version —
+the next report shows "▲ +16 vs v1", and the delta is real because the
+scoring is deterministic.
+
+The **Target** page runs the same flow for things outside your pipeline: a
+posting from anywhere, a resume from anywhere (even pasted plain text — say,
+a friend's), one progress page, full report. Nothing from it lands in your
+saved resumes.
+
+## What it costs
+
+The realistic setups:
+
+- **Subscriptions you already pay for** (Claude.ai, ChatGPT, Google) —
+  $0 extra. The CLI engines ride the subscription's usage window; when it
+  runs dry mid-day, the chain fails over to your next engine and comes
+  back on its own.
+- **Anthropic API only** — roughly **$2–10/month**: about $0.001 per
+  classified job at 5–10 matching jobs a day, with prompt caching covering
+  ~90% of the system-prompt tokens. The two-stage classifier mode (Settings
+  → AI engine) cuts another 30–40% by letting a short prefilter drop
+  obvious misses before the full prompt runs.
+- **Free tier** — Gemini CLI's free quota comfortably covers the
+  classifier for a typical day; a local model via LM Studio/Ollama through
+  the OpenAI-compatible engine costs nothing at all.
+
+Postgres, Telegram and GitHub Actions are free. The "Last 7 days" counter
+on the AI tab shows exactly which engine your calls went to.
+
+## Under the hood
+
+TypeScript strict, Node 24, Prisma + Postgres 16, Hono for the dashboard
+(server-side JSX, no build step), node-cron for scheduling — deliberately
+no Redis, no queues, no framework sprawl. Every external byte (env vars,
+API responses, AI output) passes through zod before it's trusted. The
+worker and the dashboard are separate processes sharing one database, so a
+toggle flipped in the UI reaches the worker on its next tick.
+
+```bash
+npm run lint:types   # tsc --noEmit
+npm test             # node --test, 400+ unit tests on the pure modules
+```
+
+CI runs both on every push. AI- and DB-touching modules are verified by
+smoke runs and the dashboard instead of mocks — the philosophy is written
+down in [CLAUDE.md](./CLAUDE.md).
+
+> **Docs map:** [SPEC.md](./SPEC.md) — current behaviour, phase by phase ·
+> [ARCHITECTURE.md](./ARCHITECTURE.md) — data-flow diagrams + file map ·
+> [CLAUDE.md](./CLAUDE.md) — conventions, gotchas, where-to-look tables ·
+> [docs/ai-engines.md](./docs/ai-engines.md) — AI setup, local + Docker ·
+> [docs/adr/](./docs/adr/) — every non-obvious decision, with reasons ·
+> [CHANGELOG.md](./CHANGELOG.md) — releases.
 
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md). Bug reports and new-source PRs
-are welcome; the ATS templates in CLAUDE.md make a new fetcher a
+are welcome — the ATS templates in CLAUDE.md make a new fetcher close to a
 one-file change.
 
 ## License

--- a/SPEC.md
+++ b/SPEC.md
@@ -138,7 +138,7 @@ marking 4xx-returning slugs as DEAD.
 
 `Resume` rows hold an uploaded file (`original` bytes, `.docx` / `.md` /
 `.txt`) and its plain-text extraction (`text`). On upload the web process
-runs one AI call (`CLAUDE_MODEL_RESUME`) that fills headline, seniority,
+runs one AI call (the resume model, `CLAUDE_MODEL_RESUME` by default) that fills headline, seniority,
 years, skill tags, role types and job-agnostic `issues`. The first upload
 becomes the default.
 
@@ -193,7 +193,7 @@ skip, confidence, evidence rows with URLs, red flags, company snapshot.
 - Prisma 6 + Postgres 16 (real migrations from `phase-3.0` baseline onward)
 - node-cron for scheduling, no Redis / BullMQ
 - Hono 4 for the dashboard, JSX SSR with `hono/jsx`, Tailwind via CDN over semantic CSS-variable tokens (no build pipeline; light SaaS theme, see DESIGN.md)
-- `src/ai-provider.ts` seam: `anthropic_api` (SDK, per-token) or `claude_code` (headless CLI, subscription); Claude Haiku 4.5 for both classifier stages;  `CLAUDE_MODEL_RESUME` (Opus 5) for resume scan / match; `AI_CONCURRENCY` jobs classified at once (default 3)
+- `src/ai-provider.ts` seam: `anthropic_api` (SDK, per-token), `claude_code` (headless CLI, subscription) or `gemini_cli` (headless CLI, Google account); provider + classifier/resume models overridable at runtime from `/settings` → "AI engine" (AppSettings, ADR 0013), `.env` as fallback (Haiku 4.5 classifier, Opus 5 resume); `AI_CONCURRENCY` jobs classified at once (default 3)
 - node:test runner (`npm test`), no jest
 
 ## Project layout

--- a/SPEC.md
+++ b/SPEC.md
@@ -193,7 +193,7 @@ skip, confidence, evidence rows with URLs, red flags, company snapshot.
 - Prisma 6 + Postgres 16 (real migrations from `phase-3.0` baseline onward)
 - node-cron for scheduling, no Redis / BullMQ
 - Hono 4 for the dashboard, JSX SSR with `hono/jsx`, Tailwind via CDN over semantic CSS-variable tokens (no build pipeline; light SaaS theme, see DESIGN.md)
-- `src/ai-provider.ts` seam: `anthropic_api` (SDK, per-token), `claude_code` (headless CLI, subscription) or `gemini_cli` (headless CLI, Google account); provider + classifier/resume models overridable at runtime from `/settings` → "AI engine" (AppSettings, ADR 0013), `.env` as fallback (Haiku 4.5 classifier, Opus 5 resume); `AI_CONCURRENCY` jobs classified at once (default 3)
+- `src/ai-provider.ts` seam, five engines: `anthropic_api` (SDK, per-token), `claude_code` (headless CLI, subscription), `gemini_cli` (headless CLI, Google account), `openai_api` (fetch → any /chat/completions endpoint via OPENAI_BASE_URL), `codex_cli` (headless CLI, ChatGPT subscription). `/settings` → "AI engine" stores an ordered chain + per-engine classifier/resume models (AppSettings.aiEngine JSON, ADR 0013/0014); calls fail over down the chain automatically; `.env` seeds the default (Haiku 4.5 classifier, Opus 5 resume); `AI_CONCURRENCY` jobs classified at once (default 3)
 - node:test runner (`npm test`), no jest
 
 ## Project layout

--- a/SPEC.md
+++ b/SPEC.md
@@ -108,6 +108,17 @@ Profile fields that drive matching:
 - `notes` — free-form prose appended to the Claude prompt
 - `telegramTargetId` — optional: route alerts to a specific bot (else broadcast)
 
+The editor shows the essentials (stack, role types, seniority, location);
+excludes, notes, on-site cities, priority rules, thresholds and Telegram
+routing sit in a collapsed "Advanced" block that opens itself when any of
+them is customised.
+
+**Fill from a resume** (ADR 0015): the Profile tab can prefill
+`stackRequired` (from `Resume.primarySkills`), `stackNiceToHave` (remaining
+scanned skills), `roleTypes` and `seniority` from any scanned resume —
+rendered as an unsaved draft in the editor; nothing persists until Save.
+Resumes scanned before `primarySkills` existed are re-scanned on demand.
+
 ## Toggles in `/settings`
 
 All gating is in `AppSettings` (singleton row). Each toggle has a guard

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,10 +27,12 @@ services:
     environment:
       DATABASE_URL: postgresql://jobhunter:jobhunter@postgres:5432/jobhunter
       NODE_ENV: production
-    # For AI_PROVIDER=claude_code: mount your Claude CLI credentials
-    # (the image runs as user "node").
+    # For the claude_code / gemini_cli engines: mount the CLI credentials
+    # (the image runs as user "node"), or use CLAUDE_CODE_OAUTH_TOKEN /
+    # GEMINI_API_KEY in .env instead.
     # volumes:
     #   - ~/.claude:/home/node/.claude
+    #   - ~/.gemini:/home/node/.gemini
     restart: unless-stopped
 
   web:
@@ -50,10 +52,12 @@ services:
     ports:
       # Bind to localhost only — never expose dashboard publicly.
       - "127.0.0.1:4747:4747"
-    # For AI_PROVIDER=claude_code (resume scan / match / verify run in this
-    # service too): mount your Claude CLI credentials.
+    # For the claude_code / gemini_cli engines (resume scan / match / verify
+    # run in this service too): mount the CLI credentials, or use
+    # CLAUDE_CODE_OAUTH_TOKEN / GEMINI_API_KEY in .env instead.
     # volumes:
     #   - ~/.claude:/home/node/.claude
+    #   - ~/.gemini:/home/node/.gemini
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,13 @@ services:
     environment:
       DATABASE_URL: postgresql://jobhunter:jobhunter@postgres:5432/jobhunter
       NODE_ENV: production
-    # For the claude_code / gemini_cli engines: mount the CLI credentials
-    # (the image runs as user "node"), or use CLAUDE_CODE_OAUTH_TOKEN /
-    # GEMINI_API_KEY in .env instead.
+    # For the CLI engines (claude_code / gemini_cli / codex_cli): mount the
+    # credentials (the image runs as user "node"), or use
+    # CLAUDE_CODE_OAUTH_TOKEN / GEMINI_API_KEY in .env instead.
     # volumes:
     #   - ~/.claude:/home/node/.claude
     #   - ~/.gemini:/home/node/.gemini
+    #   - ~/.codex:/home/node/.codex
     restart: unless-stopped
 
   web:
@@ -52,12 +53,13 @@ services:
     ports:
       # Bind to localhost only — never expose dashboard publicly.
       - "127.0.0.1:4747:4747"
-    # For the claude_code / gemini_cli engines (resume scan / match / verify
+    # For the CLI engines (resume scan / match / verify
     # run in this service too): mount the CLI credentials, or use
     # CLAUDE_CODE_OAUTH_TOKEN / GEMINI_API_KEY in .env instead.
     # volumes:
     #   - ~/.claude:/home/node/.claude
     #   - ~/.gemini:/home/node/.gemini
+    #   - ~/.codex:/home/node/.codex
     restart: unless-stopped
 
 volumes:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -325,6 +325,12 @@ removing the violet accent.
       (+classifier mode) / Notifications / Sources. Single route kept, every
       POST redirects back to its tab; the audit's full route split stays
       rejected
+- [x] AI engine improvements P1–P2 integrated (2026-08-30): CLI child-process
+      env allowlist (ANTHROPIC_API_KEY precedence trap), per-engine cooldown +
+      chain deadline, "pay per token" badges + paid-fallback warn, cross-engine
+      bench flags, `model · fallback` marker on match/verify, aiUsage counters
+      (7-day summary on the AI tab, 60-day trim in cleanup), classifier prompt
+      version stamp. Status ticks in docs/ai-engine-improvements.md
 - [x] AI engine CHAIN (2026-08-30, ADR 0014):
       ordered multi-engine config in `AppSettings.aiEngine` (JSON), automatic
       per-call failover, + `openai_api` (base-URL compatible: OpenAI /

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -325,6 +325,12 @@ removing the violet accent.
       (+classifier mode) / Notifications / Sources. Single route kept, every
       POST redirects back to its tab; the audit's full route split stays
       rejected
+- [x] AI engine CHAIN (2026-08-30, ADR 0014):
+      ordered multi-engine config in `AppSettings.aiEngine` (JSON), automatic
+      per-call failover, + `openai_api` (base-URL compatible: OpenAI /
+      OpenRouter / Groq / local) and `codex_cli` (ChatGPT subscription)
+      backends, per-engine model dropdowns (no wrong-family saves), per-engine
+      live Test buttons, setup guide docs/ai-engines.md (local + Docker)
 
 ### 6.4 Later (P2)
 - [ ] Apply-suggestion buttons on action cards — do together with 5.15

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -46,9 +46,11 @@ as API-key only).
 - [x] `config.ts`: `AI_PROVIDER: z.enum(['anthropic_api','claude_code']).default('anthropic_api')`;
   `ANTHROPIC_API_KEY` becomes optional, validated as required only when
   `AI_PROVIDER=anthropic_api`.
-- [ ] Optional: expose the choice as an `AppSettings` toggle on `/settings`
+- [x] Optional: expose the choice as an `AppSettings` toggle on `/settings`
   (schema → settings.ts → settings.tsx → routes/settings.tsx) so it is
-  switchable at runtime. Worker reads it per tick (gotcha 9).
+  switchable at runtime. Worker reads it per tick (gotcha 9). Done
+  2026-08-29 as the "AI engine" card — provider + both models, with a
+  `gemini_cli` backend (ADR 0013), branch `ai-engine-settings`.
 
 ### 1.2 `claude_code` provider (subscription)
 - [x] `ClaudeCodeProvider`: `execFile('claude', ['-p', prompt, '--output-format', 'json', '--model', 'haiku'])`
@@ -302,19 +304,22 @@ removing the violet accent.
       Dropdown panels are in-flow on phones (an absolute panel overflowed 375px)
 - [x] Meta reads "analyzed Nh ago"
 
-### 6.3 Settings + shell (SEPARATE BRANCH — pairs with multi-AI-provider settings)
-- [ ] AtsType display-name map (LARAJOBS_RSS → Laravel Jobs) on /settings + /discovery
-- [ ] Flash `warn` variant; the paused state stops using success green
-- [ ] `confirm()` on "Save & re-classify" (the sibling button already has one)
-- [ ] Copy pass: getMe+sendMessage / cron / Docker out of primary UI (keep the
-      gotcha-10 aggregator explanation)
-- [ ] De-duplicate: Settings resumes card → list + link (drop the second upload
-      form); discovery toggles move to /discovery
-- [ ] Section order General → Notifications → Advanced; flash texts match option labels
-- [ ] /settings/sources: stop re-adding MANUAL to disabledSources on every save
-- [ ] `maskToken` → last-4 only
-- [ ] AI provider selection UI (§1.1 leftover) extended to other AI subscriptions —
-      the reason this block is its own branch
+### 6.3 Settings + shell (branch `ai-engine-settings`, done 2026-08-29)
+- [x] AtsType display-name map (LARAJOBS_RSS → Laravel Jobs) on /settings + /discovery
+      (`src/web/source-names.ts`, unit-tested)
+- [x] Flash `warn` variant; the paused state stops using success green
+- [x] `confirm()` on "Save & re-classify" (the sibling button already has one)
+- [x] Copy pass: getMe+sendMessage / cron / Docker out of primary UI (keep the
+      gotcha-10 aggregator explanation — now a hint under the sources pills)
+- [x] De-duplicate: Settings resumes card → list + link (drop the second upload
+      form); discovery toggles move to /discovery (routes moved too:
+      POST /discovery/toggle, /discovery/hn-parser-toggle, /discovery/hn-run)
+- [x] Section order General → Notifications → Advanced; flash texts match option labels
+- [x] /settings/sources: stop re-adding MANUAL to disabledSources on every save
+- [x] `maskToken` → last-4 only
+- [x] AI provider selection UI (§1.1 leftover) extended to other AI subscriptions —
+      "AI engine" card: anthropic_api / claude_code / gemini_cli radios with
+      availability probe, classifier + resume model slots (ADR 0013)
 
 ### 6.4 Later (P2)
 - [ ] Apply-suggestion buttons on action cards — do together with 5.15

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -320,6 +320,11 @@ removing the violet accent.
 - [x] AI provider selection UI (§1.1 leftover) extended to other AI subscriptions —
       "AI engine" card: anthropic_api / claude_code / gemini_cli radios with
       availability probe, classifier + resume model slots (ADR 0013)
+- [x] Tabs on /settings (user request, later same day): link-based `?tab=`
+      sub-nav — General (fetching, tracking, resumes) / Profile / AI engine
+      (+classifier mode) / Notifications / Sources. Single route kept, every
+      POST redirects back to its tab; the audit's full route split stays
+      rejected
 
 ### 6.4 Later (P2)
 - [ ] Apply-suggestion buttons on action cards — do together with 5.15

--- a/docs/adr/0008-resume-module-in-web.md
+++ b/docs/adr/0008-resume-module-in-web.md
@@ -34,7 +34,7 @@ Constraints that shaped the decision:
   (`src/resume/prompts.ts:MATCH_SYSTEM`) that returns JSON: keywords with
   `present | add | cannot_claim`, an `actions` list (section, where, what,
   why, priority), strengths, red flags, score. `cannot_claim` replaces the
-  skill's "ask Nazar mid-run" — the truthfulness rule is enforced by the
+  skill's "ask the user mid-run" — the truthfulness rule is enforced by the
   schema, and the user sees what was not claimed.
 - **Model:** `CLAUDE_MODEL_RESUME` (default `claude-opus-5`), passed per
   request through a new optional `AiRequest.model`. The classifier keeps

--- a/docs/adr/0013-runtime-ai-engine.md
+++ b/docs/adr/0013-runtime-ai-engine.md
@@ -1,0 +1,53 @@
+# 0013 — AI engine is chosen at runtime from AppSettings, with a Gemini CLI backend
+
+**Status:** Accepted (2026-08-29). Extends 0007 — the seam is unchanged, the
+selection mechanism moves from `.env`-only to DB-with-`.env`-fallback.
+
+## Context
+
+ADR 0007's seam was selected once per process by `AI_PROVIDER` in `.env`, so
+changing the engine or a model id meant editing `.env` and restarting
+containers — against the dashboard rule that toggles live in Postgres and
+apply on the next tick (CLAUDE.md gotcha 9). The owner also wants non-Claude
+subscriptions selectable. The Gemini CLI is the same headless pattern as
+Claude Code: JSON on stdout, one process per call, billed to a Google
+subscription or `GEMINI_API_KEY`. Model needs differ per task: cheap,
+frequent classifier calls vs a few judgment-heavy resume calls.
+
+## Decision
+
+- Three nullable `AppSettings` columns: `aiProvider`, `aiModelClassifier`,
+  `aiModelResume`. NULL = follow `.env` (`AI_PROVIDER`, `CLAUDE_MODEL`,
+  `CLAUDE_MODEL_RESUME`).
+- `src/ai-engine.ts:resolveAiEngine` merges row + env, pure and unit-tested:
+  unknown provider, blank/wrong-family model, or `anthropic_api` without a
+  key fall back — a stale row can never leave the pipeline engineless.
+- `src/ai-runtime.ts:getAiRuntime` reads the row per call and hands callers
+  `{ provider, classifierModel, resumeModel }`. Worker follows on the next
+  tick; dashboard actions immediately.
+- `gemini_cli` joins as a third backend via a generic `CliProvider`:
+  `gemini --output-format json -m <model> -p "<system>\n\n<user>"`, cwd set
+  to tmpdir so it cannot ingest workspace context, tools denied by default,
+  `--allowed-tools google_web_search web_fetch` only when `webTools`.
+- `/settings → AI engine`: provider radios gated by
+  `probeAiProviders()` (API key present / CLI on PATH / gemini auth
+  configured), two model inputs with suggestions; the POST re-validates
+  availability and model family before saving.
+
+## Consequences
+
+✅ Engine and model switch without restarts; resolution is one indexed read
+per call against multi-second AI calls.
+✅ A future backend is one `CliProvider` spec + enum value + probe entry
+(e.g. the Batch API from TASKS §1.4, or Codex CLI).
+❌ Prompts are tuned against Claude (gotchas 8 and 11); another engine may
+score or parse worse. Zod validation + one retry contain that, not prevent it.
+❌ Gemini's success path is not yet live-verified here (CLI installed but
+never logged in); its error path is verified against the real binary.
+❌ Runtime image grows by the Gemini CLI install.
+
+## When to revisit
+
+- Batch API path lands → fourth implementation behind the same seam.
+- A third per-task model split (e.g. a dedicated verification model) →
+  another column, not another env var.

--- a/docs/adr/0013-runtime-ai-engine.md
+++ b/docs/adr/0013-runtime-ai-engine.md
@@ -29,10 +29,12 @@ frequent classifier calls vs a few judgment-heavy resume calls.
   `gemini --output-format json -m <model> -p "<system>\n\n<user>"`, cwd set
   to tmpdir so it cannot ingest workspace context, tools denied by default,
   `--allowed-tools google_web_search web_fetch` only when `webTools`.
-- `/settings → AI engine`: provider radios gated by
+- `/settings → AI engine`: provider radios with availability badges from
   `probeAiProviders()` (API key present / CLI on PATH / gemini auth
-  configured), two model inputs with suggestions; the POST re-validates
-  availability and model family before saving.
+  configured), two model inputs with suggestions. The POST validates the
+  model family; a not-yet-usable engine still saves (warn flash + card
+  banner) — `resolveAiEngine` keeps the pipeline on a usable fallback and
+  switches over the moment auth appears.
 
 ## Consequences
 

--- a/docs/adr/0014-ai-engine-chain.md
+++ b/docs/adr/0014-ai-engine-chain.md
@@ -1,0 +1,55 @@
+# 0014 — AI engines form a priority chain with automatic failover
+
+**Status:** Accepted (2026-08-30). Extends 0013 (runtime selection stays in
+AppSettings; a single choice becomes an ordered chain).
+
+## Context
+
+One selected engine (0013) means one subscription's rate limit or outage
+stalls the pipeline until someone flips a switch. The owner has several
+subscriptions and wants all of them attached, ordered, and switched
+automatically. GPT access was missing entirely, in both its forms
+(ChatGPT subscription via Codex CLI, API key via chat completions). The
+0013 UI also allowed typing a wrong-family model id and rejected the save —
+a dead end the UI itself created.
+
+## Decision
+
+- `AppSettings.aiEngine` (JSONB): `{ order: [provider ids], models:
+  { <id>: { classifier, resume } } }`, replacing the three 0013 columns
+  (migration backfills). NULL = one-engine chain seeded from `AI_PROVIDER`.
+- Five backends behind the same `AiProvider` seam: + `openai_api`
+  (native-fetch `POST /chat/completions` against `OPENAI_BASE_URL` — covers
+  OpenAI, OpenRouter, Groq, local servers; no SDK) and + `codex_cli`
+  (`codex exec --json`, JSONL parsed defensively).
+- `src/ai-runtime.ts:getAiRuntime()` returns a chain runner:
+  `complete({role, ...})` tries usable engines in order, picks the
+  per-engine model for the role, and moves to the next on any null
+  (error / quota / rate limit), logging each hop. Callers get
+  `{text, providerId, model}`. Recovery is per call — the primary serves
+  again as soon as it works. `webTools` calls prefer engines that have web
+  tools (all but `openai_api`).
+- Per-engine UI cards on `/settings → AI engine`: Enable/Disable, ↑
+  priority, per-family model dropdowns (wrong ids unpickable; `openai_api`
+  stays free-text for base-URL setups) and a live **Test** button per
+  engine. Unusable-but-enabled engines are shown as "skipped".
+- Setup documented per engine × (local, Docker) in `docs/ai-engines.md`.
+
+## Consequences
+
+✅ One dead subscription no longer stalls classification — the next engine
+takes over mid-tick, automatically, and hands back when the primary recovers.
+✅ Any OpenAI-compatible endpoint works without new code (base URL + key).
+❌ `codex_cli` and `openai_api` could not be live-verified on this machine
+(no ChatGPT login, no key) — parsers are unit-tested against documented
+shapes and the per-engine Test button verifies a real setup end-to-end.
+❌ Mixed-engine scoring is less comparable (prompts tuned on Claude,
+gotchas 8/11); fit scores from a fallback engine may drift.
+❌ One chain for both roles — a per-role order (classifier on X, resume on
+Y) was deliberately left out to keep failover semantics simple.
+
+## When to revisit
+
+- If per-role chains are actually wanted → second `order` list, same shape.
+- If a sixth backend appears (Batch API from TASKS §1.4) → one `CliSpec` /
+  provider class + enum entry + probe, per 0013's extension path.

--- a/docs/adr/0015-profile-draft-from-resume-scan.md
+++ b/docs/adr/0015-profile-draft-from-resume-scan.md
@@ -1,0 +1,47 @@
+# 0015 — The profile is drafted from the resume scan, never written by AI
+
+**Status:** Accepted (2026-08-29)
+
+## Context
+
+The `/settings` Profile tab asks for ~14 fields, but only `stackRequired` /
+`roleTypes` (the base-filter title gate) and the location block genuinely
+need user input — an empty gate admits every fetched job to the classifier
+and burns AI credit. Users don't fill long forms, yet almost everything the
+form needs is already extracted by the resume scan (`skills`, `role_types`,
+`seniority`, `title`) and stored on the `Resume` row. What the scan lacked
+was the required-vs-nice-to-have split.
+
+Alternatives considered: (a) auto-update the profile whenever a resume is
+uploaded — rejected: users keep several stack-specific resumes (PHP vs JS),
+so the latest upload would silently thrash the classifier's behaviour;
+(b) a dedicated "scan resume → profile" AI call — rejected: a second call
+that re-reads the same text for facts the scan already extracts.
+
+## Decision
+
+- The scan prompt marks `primary_skills` — the 2-5 core languages/frameworks
+  of recent day-to-day work, same definition as the match prompt's primary
+  stack — stored as `Resume.primarySkills`.
+- `src/resume/profile-draft.ts` (pure) maps a scan onto a profile:
+  primary → `stackRequired`, remaining skills → `stackNiceToHave`, plus
+  `roleTypes` / `seniority`; location, thresholds, rules and routing are
+  never touched — a resume cannot know them.
+- `POST /settings/profiles/:id/fill-from-resume` renders the draft into the
+  profile editor (re-scanning the resume first when `primarySkills` is
+  empty). **It persists nothing** — the user reviews and presses Save;
+  auto-apply on upload stays out.
+
+## Consequences
+
+✅ Onboarding is upload resume → Fill from resume → tick regions → Save.
+✅ Old resumes keep working — the fill route back-fills the scan on demand.
+❌ One extra scan call the first time an old resume is used for filling.
+❌ The draft lives only in the rendered page: a refresh re-posts, navigation
+   away discards it. Accepted — matches the "review before save" intent.
+
+## When to revisit
+
+If profiles grow per-resume (one profile per resume variant), or if users
+ask for the fill to run automatically after every upload, revisit (a) with
+an explicit opt-in toggle.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0010 — Two scores: live keyword coverage in the browser, AI match on demand](./0010-two-scores-live-keywords-vs-ai-match.md)
 - [0011 — PDF resume text comes from unpdf, not a hand-rolled parser](./0011-pdf-extraction-via-unpdf.md)
 - [0012 — The resume-match score is computed by application code, not by the model](./0012-deterministic-match-score.md)
+- [0013 — AI engine is chosen at runtime from AppSettings, with a Gemini CLI backend](./0013-runtime-ai-engine.md)
 
 ## When to write a new one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0011 — PDF resume text comes from unpdf, not a hand-rolled parser](./0011-pdf-extraction-via-unpdf.md)
 - [0012 — The resume-match score is computed by application code, not by the model](./0012-deterministic-match-score.md)
 - [0013 — AI engine is chosen at runtime from AppSettings, with a Gemini CLI backend](./0013-runtime-ai-engine.md)
+- [0014 — AI engines form a priority chain with automatic failover](./0014-ai-engine-chain.md)
 
 ## When to write a new one
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0012 — The resume-match score is computed by application code, not by the model](./0012-deterministic-match-score.md)
 - [0013 — AI engine is chosen at runtime from AppSettings, with a Gemini CLI backend](./0013-runtime-ai-engine.md)
 - [0014 — AI engines form a priority chain with automatic failover](./0014-ai-engine-chain.md)
+- [0015 — The profile is drafted from the resume scan, never written by AI](./0015-profile-draft-from-resume-scan.md)
 
 ## When to write a new one
 

--- a/docs/ai-engine-improvements.md
+++ b/docs/ai-engine-improvements.md
@@ -1,0 +1,121 @@
+# AI engine — future improvements (backlog, not scheduled)
+
+> Distilled 2026-08-30 from the multi-provider research doc
+> ([job-hunter-multi-provider-ai-architecture.md](./job-hunter-multi-provider-ai-architecture.md),
+> § numbers below refer to it) reviewed against what ADR 0013/0014 already
+> shipped. ~70% of that doc is implemented; this file keeps only the delta
+> worth doing — and the explicitly rejected parts, so future sessions don't
+> re-adopt them. **Nothing here is scheduled** — pick items into
+> [TASKS.md](./TASKS.md) when their trigger fires.
+
+## Already covered — do not rebuild
+
+DB-backed engine config with `.env` as seed (§3–5) · adapter seam + probe
+(§10–14) · ordered fallback on operational failures only (§30, §39) ·
+CLI-owned subscription credentials, no OAuth copying (§9, §166) · argument
+arrays, never shell strings (§90) · zod-validated structured output (§49–50)
+· deterministic scoring — model marks facts, code computes the number
+(§161–162 = ADR 0012) · tool-less CLI runs in tmp workspaces (§128–129) ·
+Codex-subscription vs OpenAI-API separation (§17–18) · empty slot = engine
+default model (§46) · cheap classifier / strong resume model split (§113) ·
+per-engine live Test buttons (§76).
+
+---
+
+## P1 — real gaps, cheap fixes
+
+### 1. Env allowlist for CLI child processes (§16, §91)
+
+Claude Code documents that `ANTHROPIC_API_KEY` **takes precedence over
+subscription login**. The moment that key lands in `.env` (for the
+`anthropic_api` engine), the `claude_code` engine starts silently billing
+the API while the user believes the subscription is working. CLI children
+also inherit the whole process env today — a gemini process does not need
+`TELEGRAM_BOT_TOKEN` or `DATABASE_URL`.
+
+*Apply:* `CliProvider` passes an explicit `env` to `execFile`: `PATH`,
+`HOME`, locale + only the variables of its own provider; strip
+`ANTHROPIC_API_KEY` from the `claude_code` child (keep
+`CLAUDE_CODE_OAUTH_TOKEN`), keep `GEMINI_API_KEY` only for `gemini_cli`,
+OpenAI vars only for `codex_cli`. One spec field + unit test.
+**Trigger:** before the Anthropic API key is ever added to `.env`.
+
+### 2. Cooldown / circuit breaker per engine (§41–43)
+
+Failover is resolved per call with no memory: during a 750-job
+re-classify, a dead engine #1 burns its retries + timeout on **every job**
+before yielding. Add an in-process map `engineId → cooldownUntil` — after
+N consecutive failures, skip the engine for ~60 s (log once). Plus an
+overall deadline per logical call: verify's 10-min timeout across a 3-CLI
+chain is a potential 30-minute wait today (`maxSwitches` /
+`overallDeadlineMs` in the chain runner).
+**Trigger:** first bulk run on a chain with a flaky primary.
+
+### 3. Honest "paid" marking in the chain UI (§31–32)
+
+API engines (`anthropic_api`, `openai_api`) look identical to subscription
+engines in the chain. Minimum: a "pay per token" badge on their cards and a
+`warn` flash when one is enabled *behind* subscription engines ("fallback
+will spend money"). Daily/monthly API budget caps (§66–67) only once real
+keys exist — start with the badge, not the accounting.
+**Trigger:** first API key in `.env`.
+
+---
+
+## P2 — useful, moderate effort
+
+### 4. Cross-engine bench (§116, §164)
+
+`npm run bench:resume` already has gold fixtures — loop it over every
+enabled engine and print accuracy / schema-validity / latency per task.
+This turns "can the Gemini classifier be trusted?" (ADR 0014 warns about
+drift but doesn't measure it) into a table instead of an impression.
+**Trigger:** the first non-Claude engine goes live.
+
+### 5. Fallback visible to the user, not only in logs (§122–123)
+
+Every call already returns `providerId` — surface it: a line on the
+match/verify card like "completed by Gemini — Claude was unavailable", and
+a clearer all-engines-failed flash (§157). Builds trust, speeds diagnosis.
+
+### 6. Lightweight usage counters (§98–100, light)
+
+Runs per engine × role per day — no prices, no new tables (`CronRun.stats`
+or a tiny JSON on AppSettings). Full cost tracking with versioned pricing
+snapshots (§56–57) is deliberately deferred until API keys are in use —
+and if built later: integer micro-USD, never floats (§150).
+
+---
+
+## P3 — later / conditional
+
+- **Gemini API key without the CLI — zero code** (§22): Gemini API exposes
+  an OpenAI-compatible endpoint
+  (`https://generativelanguage.googleapis.com/v1beta/openai/`), so the
+  existing `openai_api` engine already covers it via `OPENAI_BASE_URL`.
+  Document in [ai-engines.md](./ai-engines.md) when someone needs it.
+- **Model discovery** (§45): populate the `openai_api` free-text slot from
+  the endpoint's `/models`; cached, manual refresh.
+- **Per-provider prompt overrides** (§48): only if the bench (item 4)
+  shows real scoring drift — small, tested deltas on top of the shared
+  prompt, never a fork.
+- **PII in warn logs** (§102): parse-failure logs include
+  `raw.slice(0, 500)` of model output, which can carry resume content.
+  Acceptable for a local single-user install; mask if the deployment story
+  ever changes.
+- **Classifier prompt version stamp** (§119): resume module has
+  `PROMPT_VERSION`, the classifier doesn't — add one before any
+  cross-engine quality comparison of classification.
+
+---
+
+## Rejected — with reasons (do not re-adopt without a new decision)
+
+| Doc proposal | Why not here |
+| --- | --- |
+| Secret store / keychain / API keys entered in UI (§8, §140) | CLAUDE.md: secrets live in `.env` only; the UI never touches them. For a localhost single-user tool this is stricter *and* simpler than the doc's assumption. |
+| 6+ new tables: `ai_connections`, `ai_routing_policies`, `ai_task_routes`, `ai_pricing_snapshots`, `ai_runs`, `ai_attempts` (§7, §53–57, §110–111) | The `aiEngine` JSON column delivers ~80% of the value at ~5% of the schema — ADR 0003's "minimum moving parts" ethos. |
+| Host-side Local AI Runner daemon (§86–89) | Justified for SaaS / multi-user; we are localhost single-user and official env tokens already solve Docker auth. Revisit only if the deployment model changes. |
+| Per-task routing across 7+ task types (§26–27, §80) | Two roles (classifier / resume) *are* the real cost split for one user; finer routing is config for config's sake. ADR 0014 records this as a deliberate simplification (revisit = second `order` list, same shape). |
+| Playwright / e2e suite (§179) | Already rejected in the §6 audits — testing philosophy is units + smoke runs + screenshots. |
+| Compare / parallel mode now (§34–38) | The doc itself says Phase 4. If ever built: explicit opt-in, never average scores across engines, side effects committed once. |

--- a/docs/ai-engine-improvements.md
+++ b/docs/ai-engine-improvements.md
@@ -5,8 +5,9 @@
 > § numbers below refer to it) reviewed against what ADR 0013/0014 already
 > shipped. ~70% of that doc is implemented; this file keeps only the delta
 > worth doing — and the explicitly rejected parts, so future sessions don't
-> re-adopt them. **Nothing here is scheduled** — pick items into
-> [TASKS.md](./TASKS.md) when their trigger fires.
+> re-adopt them. **Status 2026-08-30:** items 1–6 plus two P3 notes are
+> integrated (commits `add cli env allowlist` … `update docs for integrated
+> improvements`); what remains open is marked below.
 
 ## Already covered — do not rebuild
 
@@ -24,7 +25,9 @@ per-engine live Test buttons (§76).
 
 ## P1 — real gaps, cheap fixes
 
-### 1. Env allowlist for CLI child processes (§16, §91)
+### 1. Env allowlist for CLI child processes (§16, §91) — ✅ done 2026-08-30
+
+> `buildCliEnv` + `CLI_PROVIDER_ENV_KEYS` in `ai-provider-parse.ts` (unit-tested), wired into `CliProvider`.
 
 Claude Code documents that `ANTHROPIC_API_KEY` **takes precedence over
 subscription login**. The moment that key lands in `.env` (for the
@@ -40,7 +43,9 @@ also inherit the whole process env today — a gemini process does not need
 OpenAI vars only for `codex_cli`. One spec field + unit test.
 **Trigger:** before the Anthropic API key is ever added to `.env`.
 
-### 2. Cooldown / circuit breaker per engine (§41–43)
+### 2. Cooldown / circuit breaker per engine (§41–43) — ✅ done 2026-08-30
+
+> `src/ai-cooldown.ts` (3 fails → 60 s skip, unit-tested) + `MAX_ENGINE_SWITCHES`/deadline in the chain runner.
 
 Failover is resolved per call with no memory: during a 750-job
 re-classify, a dead engine #1 burns its retries + timeout on **every job**
@@ -51,7 +56,9 @@ chain is a potential 30-minute wait today (`maxSwitches` /
 `overallDeadlineMs` in the chain runner).
 **Trigger:** first bulk run on a chain with a flaky primary.
 
-### 3. Honest "paid" marking in the chain UI (§31–32)
+### 3. Honest "paid" marking in the chain UI (§31–32) — ✅ done 2026-08-30 (badge + enable-warn; budget caps still open)
+
+> `PROVIDER_PAID`, "pay per token" badge, warn flash when a paid engine is enabled behind subscriptions.
 
 API engines (`anthropic_api`, `openai_api`) look identical to subscription
 engines in the chain. Minimum: a "pay per token" badge on their cards and a
@@ -64,7 +71,9 @@ keys exist — start with the badge, not the accounting.
 
 ## P2 — useful, moderate effort
 
-### 4. Cross-engine bench (§116, §164)
+### 4. Cross-engine bench (§116, §164) — ✅ done 2026-08-30
+
+> `npm run bench:resume -- --engine <id>|all` and `--list-engines`.
 
 `npm run bench:resume` already has gold fixtures — loop it over every
 enabled engine and print accuracy / schema-validity / latency per task.
@@ -72,13 +81,17 @@ This turns "can the Gemini classifier be trusted?" (ADR 0014 warns about
 drift but doesn't measure it) into a table instead of an impression.
 **Trigger:** the first non-Claude engine goes live.
 
-### 5. Fallback visible to the user, not only in logs (§122–123)
+### 5. Fallback visible to the user, not only in logs (§122–123) — ✅ done 2026-08-30
+
+> `viaFallback` on every call; match/verification store and show `model · fallback`.
 
 Every call already returns `providerId` — surface it: a line on the
 match/verify card like "completed by Gemini — Claude was unavailable", and
 a clearer all-engines-failed flash (§157). Builds trust, speeds diagnosis.
 
-### 6. Lightweight usage counters (§98–100, light)
+### 6. Lightweight usage counters (§98–100, light) — ✅ done 2026-08-30
+
+> `AppSettings.aiUsage` (atomic jsonb increment per call), 60-day trim in cleanup, 7-day summary on the AI tab.
 
 Runs per engine × role per day — no prices, no new tables (`CronRun.stats`
 or a tiny JSON on AppSettings). Full cost tracking with versioned pricing
@@ -89,11 +102,9 @@ and if built later: integer micro-USD, never floats (§150).
 
 ## P3 — later / conditional
 
-- **Gemini API key without the CLI — zero code** (§22): Gemini API exposes
-  an OpenAI-compatible endpoint
-  (`https://generativelanguage.googleapis.com/v1beta/openai/`), so the
-  existing `openai_api` engine already covers it via `OPENAI_BASE_URL`.
-  Document in [ai-engines.md](./ai-engines.md) when someone needs it.
+- **Gemini API key without the CLI — zero code** (§22): ✅ documented in
+  [ai-engines.md](./ai-engines.md) (2026-08-30) — the `openai_api` engine
+  covers it via `OPENAI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai`.
 - **Model discovery** (§45): populate the `openai_api` free-text slot from
   the endpoint's `/models`; cached, manual refresh.
 - **Per-provider prompt overrides** (§48): only if the bench (item 4)
@@ -103,9 +114,8 @@ and if built later: integer micro-USD, never floats (§150).
   `raw.slice(0, 500)` of model output, which can carry resume content.
   Acceptable for a local single-user install; mask if the deployment story
   ever changes.
-- **Classifier prompt version stamp** (§119): resume module has
-  `PROMPT_VERSION`, the classifier doesn't — add one before any
-  cross-engine quality comparison of classification.
+- **Classifier prompt version stamp** (§119): ✅ done 2026-08-30 —
+  `CLASSIFIER_PROMPT_VERSION` in `classifier.ts`, logged on schema misses.
 
 ---
 

--- a/docs/ai-engines.md
+++ b/docs/ai-engines.md
@@ -1,0 +1,156 @@
+# AI engines — setup guide
+
+The pipeline can run on any mix of five AI backends. You enable the ones you
+have, put them in priority order on **`/settings` → AI engine**, and the app
+does the rest:
+
+- **Engine #1 serves every call** (job classification, resume analysis,
+  verification).
+- If it errors, runs out of quota, or hits a rate limit, the call
+  **automatically retries on engine #2**, then #3, and so on.
+- The switch is per call — as soon as #1 recovers, it serves again. No
+  restarts, no manual flipping.
+- An enabled engine that is not set up yet (no key / not logged in) is
+  simply **skipped** and joins the chain the moment its auth appears.
+
+Every engine card has a **Test** button — it sends one tiny live request
+through that engine and reports success or the exact failure. Use it after
+every setup step below.
+
+| Engine | What it is | Billing | Needs |
+| --- | --- | --- | --- |
+| Anthropic API | Messages API via SDK | per token | `ANTHROPIC_API_KEY` |
+| Claude Code CLI | headless `claude -p` | Claude.ai Pro/Max subscription | `claude` binary + login |
+| Gemini CLI | headless `gemini -p` | Google account (free tier) or API key | `gemini` binary + login/key |
+| OpenAI-compatible API | `POST /chat/completions` | per token (or free if local) | `OPENAI_API_KEY` (+ optional base URL) |
+| Codex CLI | headless `codex exec` | ChatGPT Plus/Pro subscription | `codex` binary + login |
+
+Two model slots per engine: the **classifier model** (cheap, runs on every
+fetched job) and the **resume model** (a few calls a day where judgment
+matters). Closed families are dropdowns — you cannot pick a wrong-family id.
+"Default" means the engine's own default (for CLIs, whatever the CLI is
+configured to use).
+
+---
+
+## Anthropic API
+
+Pay-per-token Messages API. Fastest option (no process spawn, prompt cache).
+
+**Local:**
+1. Get a key at <https://console.anthropic.com/settings/keys>.
+2. Add to `.env`:
+   ```
+   ANTHROPIC_API_KEY=sk-ant-...
+   ```
+3. Restart the app (`npm run dev` / your process manager). Enable the engine
+   on `/settings` → AI engine and press **Test**.
+
+**Docker:** same `.env` line — both containers read `.env` via `env_file`.
+Recreate them so the new variable lands:
+```
+docker compose up -d
+```
+
+## Claude Code CLI (Claude.ai subscription)
+
+Runs `claude -p` per call on the subscription the CLI is logged into. Slower
+(~7 s per call locally, 15–30 s in Docker), no per-token bill.
+
+**Local:**
+1. `npm install -g @anthropic-ai/claude-code`
+2. Run `claude` once and log in with your Claude.ai account.
+3. Enable + **Test** on `/settings`.
+
+**Docker:** the image already ships the CLI. macOS keeps the interactive
+login in the Keychain, so mounting `~/.claude` does **not** carry auth into
+the container. Instead:
+1. On the host: `claude setup-token` (opens a browser login, prints a token).
+2. Add to `.env`: `CLAUDE_CODE_OAUTH_TOKEN=...`
+3. `docker compose up -d`
+
+## Gemini CLI (Google account or API key)
+
+Runs `gemini -p` per call. The free Google-account tier is generous enough
+for the classifier.
+
+**Local — choose one:**
+- *Subscription/free tier:* `npm install -g @google/gemini-cli`, run
+  `gemini` once, pick "Login with Google".
+- *API key:* get one at <https://aistudio.google.com/apikey> and add
+  `GEMINI_API_KEY=...` to `.env`. No login needed.
+
+**Docker:** the image ships the CLI. Either:
+- add `GEMINI_API_KEY=...` to `.env` and `docker compose up -d` (simplest), or
+- log in locally first, then mount the credentials — uncomment in
+  `docker-compose.yml` under both `app` and `web`:
+  ```yaml
+  volumes:
+    - ~/.gemini:/home/node/.gemini
+  ```
+
+## OpenAI-compatible API (OpenAI, OpenRouter, Groq, local models)
+
+One engine covers every server that speaks `POST /chat/completions`:
+
+| Target | `.env` |
+| --- | --- |
+| OpenAI | `OPENAI_API_KEY=sk-...` (base URL default is `https://api.openai.com/v1`) |
+| OpenRouter | `OPENAI_API_KEY=sk-or-...`, `OPENAI_BASE_URL=https://openrouter.ai/api/v1` |
+| Groq | `OPENAI_API_KEY=gsk_...`, `OPENAI_BASE_URL=https://api.groq.com/openai/v1` |
+| Local (LM Studio / Ollama) | `OPENAI_API_KEY=local`, `OPENAI_BASE_URL=http://localhost:1234/v1` |
+
+The model slots here are free text — type whatever id your endpoint serves
+(`gpt-5-mini`, `meta-llama/llama-3.3-70b-instruct`, …). `OPENAI_MODEL` in
+`.env` sets the default for empty slots.
+
+**Local:** add the lines, restart, **Test**.
+**Docker:** add the lines, `docker compose up -d`. For a local model server,
+use `http://host.docker.internal:1234/v1` as the base URL so the container
+can reach your host.
+
+## Codex CLI (ChatGPT subscription)
+
+Runs `codex exec` per call on a ChatGPT Plus/Pro subscription.
+
+**Local:**
+1. `npm install -g @openai/codex`
+2. `codex login` (browser sign-in with your ChatGPT account).
+3. Enable + **Test**.
+
+**Docker:** the image ships the CLI. Log in locally first, then mount the
+credentials — uncomment in `docker-compose.yml` under both services:
+```yaml
+volumes:
+  - ~/.codex:/home/node/.codex
+```
+(Codex stores auth in `~/.codex/auth.json` — a plain file, so the mount
+works on macOS too.)
+
+---
+
+## Checking the whole setup
+
+1. `/settings` → AI engine: every engine you own shows **available**.
+2. Press **Test** on each — a green flash with the response time means the
+   full path works (binary, auth, model id, network).
+3. The "Active now" line at the top shows who serves calls and in which
+   order the rest stand by.
+4. Worker side: `docker compose logs -f app` (or your local worker output) —
+   on failover you will see `ai: engine failed, trying next` followed by
+   `ai: served by fallback engine`.
+
+## Troubleshooting
+
+- **"not detected" badge** — the hint in the card says exactly what is
+  missing (key line, login command, or mount). Fix it and reload; the probe
+  refreshes within a minute.
+- **Enabled but "skipped"** — the engine is in your chain but this host
+  cannot run it yet. The banner lists them; the pipeline keeps working on
+  the next usable engine.
+- **Test fails after N seconds** — the exact error is in the web logs:
+  `docker compose logs web | grep "ai:"` (Docker) or the terminal running
+  the server (local).
+- **Every engine failed** — the log line `ai: every engine in the chain
+  failed` lists the chain that was tried. Jobs are retried on the next
+  cron tick; nothing is lost.

--- a/docs/ai-engines.md
+++ b/docs/ai-engines.md
@@ -98,6 +98,7 @@ One engine covers every server that speaks `POST /chat/completions`:
 | OpenAI | `OPENAI_API_KEY=sk-...` (base URL default is `https://api.openai.com/v1`) |
 | OpenRouter | `OPENAI_API_KEY=sk-or-...`, `OPENAI_BASE_URL=https://openrouter.ai/api/v1` |
 | Groq | `OPENAI_API_KEY=gsk_...`, `OPENAI_BASE_URL=https://api.groq.com/openai/v1` |
+| Gemini API key, no CLI | `OPENAI_API_KEY=<AI Studio key>`, `OPENAI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai` |
 | Local (LM Studio / Ollama) | `OPENAI_API_KEY=local`, `OPENAI_BASE_URL=http://localhost:1234/v1` |
 
 The model slots here are free text — type whatever id your endpoint serves

--- a/docs/job-hunter-resume-match-ux-refactor.md
+++ b/docs/job-hunter-resume-match-ux-refactor.md
@@ -694,7 +694,7 @@ Example:
 HIGH IMPACT
 
 Add troubleshooting evidence
-V Shred · Experience
+Acme Corp · Experience
 
 WHY
 The job explicitly requires troubleshooting existing applications.
@@ -1047,7 +1047,7 @@ Instead, create a semantic preview.
 Example:
 
 ```text
-Nazar Boyko
+Alex Doe
 Senior Full Stack Software Engineer
 
 Professional Summary
@@ -1064,7 +1064,7 @@ AI / LLM
 Professional Experience
 ────────────────────────────────
 
-V Shred
+Acme Corp
 Senior Full Stack Software Engineer
 Dec 2024 – Present
 
@@ -1357,7 +1357,7 @@ Needs attention
 
 HIGH IMPACT
 Troubleshooting evidence
-Evidence already exists in your V Shred experience.
+Evidence already exists in your Acme Corp experience.
 [Review suggestion]
 
 MEDIUM IMPACT
@@ -1385,7 +1385,7 @@ Suggestions
 HIGH IMPACT
 ──────────────────────────────────────────────────────────
 Add troubleshooting evidence
-V Shred · Experience
+Acme Corp · Experience
 
 Why
 The job explicitly requires troubleshooting existing apps.
@@ -1403,7 +1403,7 @@ Suggested edit
 MEDIUM IMPACT
 ──────────────────────────────────────────────────────────
 Make Azure explicit
-V Shred · Experience
+Acme Corp · Experience
 
 Evidence found
 Azure appears in your skills and recent stack.

--- a/docs/job-hunter-ui-ux-refactor-plan.md
+++ b/docs/job-hunter-ui-ux-refactor-plan.md
@@ -759,8 +759,8 @@ Recommended Settings/Target summary at most:
 ```text
 Default resume
 
-Senior Backend PHP
-Nazar Boyko Senior Software Engineer Resume
+Senior Backend
+Alex Doe Senior Software Engineer Resume
 
 [Manage resumes]
 ```

--- a/docs/resume-ats-blueprint.md
+++ b/docs/resume-ats-blueprint.md
@@ -1964,7 +1964,7 @@ This should become the center of the page.
 
 | Requirement | Priority | Status | Evidence | Confidence |
 |---|---|---|---|---:|
-| TypeScript | Must | Strong | V Shred bullet 2 | 0.98 |
+| TypeScript | Must | Strong | Acme Corp bullet 2 | 0.98 |
 | Node.js | Must | Strong | Projects 1, 3 | 0.96 |
 | Azure | Must | Related only | AWS evidence | 0.91 |
 | Developer utilities | Preferred | Partial | Internal tooling | 0.86 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-hunter",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-hunter",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-hunter",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "Self-hosted AI job hunter: monitors 16 ATS / aggregator sources, classifies postings with Claude against your profile, verifies ghost jobs, matches your resume, alerts via Telegram.",
   "license": "MIT",

--- a/prisma/migrations/20260829213000_add_ai_engine/migration.sql
+++ b/prisma/migrations/20260829213000_add_ai_engine/migration.sql
@@ -1,0 +1,4 @@
+-- AI engine override (ADR 0013). NULL = follow .env defaults.
+ALTER TABLE "AppSettings" ADD COLUMN "aiProvider" TEXT;
+ALTER TABLE "AppSettings" ADD COLUMN "aiModelClassifier" TEXT;
+ALTER TABLE "AppSettings" ADD COLUMN "aiModelResume" TEXT;

--- a/prisma/migrations/20260830120000_add_ai_engine_chain/migration.sql
+++ b/prisma/migrations/20260830120000_add_ai_engine_chain/migration.sql
@@ -1,0 +1,19 @@
+-- AI engine chain (ADR 0014): ordered providers + per-provider models in one
+-- JSON column. Backfills the single-provider columns from ADR 0013.
+ALTER TABLE "AppSettings" ADD COLUMN "aiEngine" JSONB;
+
+UPDATE "AppSettings"
+SET "aiEngine" = jsonb_build_object(
+  'order', jsonb_build_array("aiProvider"),
+  'models', jsonb_build_object(
+    "aiProvider", jsonb_build_object(
+      'classifier', "aiModelClassifier",
+      'resume', "aiModelResume"
+    )
+  )
+)
+WHERE "aiProvider" IS NOT NULL;
+
+ALTER TABLE "AppSettings" DROP COLUMN "aiProvider";
+ALTER TABLE "AppSettings" DROP COLUMN "aiModelClassifier";
+ALTER TABLE "AppSettings" DROP COLUMN "aiModelResume";

--- a/prisma/migrations/20260830160000_add_ai_usage/migration.sql
+++ b/prisma/migrations/20260830160000_add_ai_usage/migration.sql
@@ -1,0 +1,2 @@
+-- Lightweight AI usage counters (docs/ai-engine-improvements.md item 6).
+ALTER TABLE "AppSettings" ADD COLUMN "aiUsage" JSONB;

--- a/prisma/migrations/20260831120000_add_resume_primary_skills/migration.sql
+++ b/prisma/migrations/20260831120000_add_resume_primary_skills/migration.sql
@@ -1,0 +1,2 @@
+-- Resume scan now marks the candidate's primary stack (subset of skills).
+ALTER TABLE "Resume" ADD COLUMN "primarySkills" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,6 +148,12 @@ model AppSettings {
   // (and the existing row, backfilled by the migration) start paused;
   // enable from /settings → "Job fetching" when ready.
   fetchingEnabled                Boolean  @default(false)
+  // AI engine override (ADR 0013). NULL = follow .env (AI_PROVIDER /
+  // CLAUDE_MODEL / CLAUDE_MODEL_RESUME). Provider: anthropic_api |
+  // claude_code | gemini_cli. Models fall back per provider family.
+  aiProvider                     String?
+  aiModelClassifier              String?
+  aiModelResume                  String?
   updatedAt                      DateTime @updatedAt
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,12 +148,11 @@ model AppSettings {
   // (and the existing row, backfilled by the migration) start paused;
   // enable from /settings → "Job fetching" when ready.
   fetchingEnabled                Boolean  @default(false)
-  // AI engine override (ADR 0013). NULL = follow .env (AI_PROVIDER /
-  // CLAUDE_MODEL / CLAUDE_MODEL_RESUME). Provider: anthropic_api |
-  // claude_code | gemini_cli. Models fall back per provider family.
-  aiProvider                     String?
-  aiModelClassifier              String?
-  aiModelResume                  String?
+  // AI engine chain (ADR 0013/0014): { order: [provider ids by priority],
+  // models: { <id>: { classifier, resume } } }. The first usable engine
+  // serves each call; the rest are automatic fallbacks. NULL = follow .env
+  // (AI_PROVIDER seeds a one-engine chain).
+  aiEngine                       Json?
   updatedAt                      DateTime @updatedAt
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,6 +153,11 @@ model AppSettings {
   // serves each call; the rest are automatic fallbacks. NULL = follow .env
   // (AI_PROVIDER seeds a one-engine chain).
   aiEngine                       Json?
+  // Lightweight AI usage counters: { "YYYY-MM-DD": { <provider>: {
+  // classifier: n, resume: n } } }. Incremented atomically per successful
+  // call (ai-runtime.ts:recordUsage), trimmed to 60 days by the cleanup
+  // cron, summarized on /settings → AI engine.
+  aiUsage                        Json?
   updatedAt                      DateTime @updatedAt
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -255,6 +255,9 @@ model Resume {
   seniority       String?
   yearsExperience Int?
   skills          String[]      @default([])
+  // Subset of skills: the 2-5 core languages/frameworks of the candidate's
+  // day-to-day work. Feeds Profile.stackRequired via "Fill from resume".
+  primarySkills   String[]      @default([])
   roleTypes       String[]      @default([])
   summary         String?       @db.Text
   // [{ section, issue, fix }] — job-agnostic ATS / recruiter problems.

--- a/src/ai-cooldown.test.ts
+++ b/src/ai-cooldown.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCooldownTracker } from './ai-cooldown';
+
+describe('createCooldownTracker', () => {
+  it('blocks only after the failure threshold', () => {
+    let clock = 1_000;
+    const t = createCooldownTracker({ threshold: 3, cooldownMs: 60_000, now: () => clock });
+    t.failure('claude_code');
+    t.failure('claude_code');
+    assert.equal(t.blockedUntil('claude_code'), null);
+    t.failure('claude_code');
+    assert.equal(t.blockedUntil('claude_code'), 61_000);
+    clock = 61_001;
+    assert.equal(t.blockedUntil('claude_code'), null);
+  });
+
+  it('a success resets the consecutive-failure count', () => {
+    const t = createCooldownTracker({ threshold: 2, cooldownMs: 60_000, now: () => 0 });
+    t.failure('gemini_cli');
+    t.success('gemini_cli');
+    t.failure('gemini_cli');
+    assert.equal(t.blockedUntil('gemini_cli'), null);
+  });
+
+  it('tracks engines independently', () => {
+    const t = createCooldownTracker({ threshold: 1, cooldownMs: 10, now: () => 5 });
+    t.failure('openai_api');
+    assert.equal(t.blockedUntil('openai_api'), 15);
+    assert.equal(t.blockedUntil('claude_code'), null);
+  });
+
+  it('extends the block while failures keep coming', () => {
+    let clock = 0;
+    const t = createCooldownTracker({ threshold: 1, cooldownMs: 100, now: () => clock });
+    t.failure('codex_cli');
+    clock = 50;
+    t.failure('codex_cli');
+    assert.equal(t.blockedUntil('codex_cli'), 150);
+  });
+});

--- a/src/ai-cooldown.ts
+++ b/src/ai-cooldown.ts
@@ -1,0 +1,43 @@
+/*
+ * In-process cooldown for AI engines (docs/ai-engine-improvements.md item 2).
+ * Without it, a dead primary engine burns its retries + timeout on EVERY job
+ * of a bulk run before the chain falls over. After `threshold` consecutive
+ * failures an engine is skipped for `cooldownMs`; one success resets it.
+ * Pure factory with an injectable clock — unit-tested.
+ */
+
+export interface CooldownTracker {
+  failure(id: string): void;
+  success(id: string): void;
+  /** Epoch ms until which the engine should be skipped, or null. */
+  blockedUntil(id: string): number | null;
+}
+
+export const COOLDOWN_FAILURE_THRESHOLD = 3;
+export const COOLDOWN_MS = 60_000;
+
+export function createCooldownTracker(
+  opts: { threshold?: number; cooldownMs?: number; now?: () => number } = {},
+): CooldownTracker {
+  const threshold = opts.threshold ?? COOLDOWN_FAILURE_THRESHOLD;
+  const cooldownMs = opts.cooldownMs ?? COOLDOWN_MS;
+  const now = opts.now ?? Date.now;
+  const state = new Map<string, { failures: number; until: number }>();
+
+  return {
+    failure(id) {
+      const s = state.get(id) ?? { failures: 0, until: 0 };
+      s.failures += 1;
+      if (s.failures >= threshold) s.until = now() + cooldownMs;
+      state.set(id, s);
+    },
+    success(id) {
+      state.delete(id);
+    },
+    blockedUntil(id) {
+      const s = state.get(id);
+      if (!s || s.until <= now()) return null;
+      return s.until;
+    },
+  };
+}

--- a/src/ai-engine.test.ts
+++ b/src/ai-engine.test.ts
@@ -12,6 +12,7 @@ import {
 const ENV: AiEngineEnv = {
   provider: 'claude_code',
   hasAnthropicKey: false,
+  geminiUsable: true,
   classifierModel: 'claude-haiku-4-5-20251001',
   resumeModel: 'claude-opus-5',
 };
@@ -67,6 +68,26 @@ describe('resolveAiEngine', () => {
     const out = resolveAiEngine(
       { aiProvider: 'anthropic_api', aiModelClassifier: null, aiModelResume: null },
       ENV,
+    );
+    assert.equal(out.providerId, 'claude_code');
+  });
+
+  it('gemini_cli without auth falls back and keeps claude models', () => {
+    const out = resolveAiEngine(
+      { aiProvider: 'gemini_cli', aiModelClassifier: null, aiModelResume: null },
+      { ...ENV, geminiUsable: false },
+    );
+    assert.deepEqual(out, {
+      providerId: 'claude_code',
+      classifierModel: ENV.classifierModel,
+      resumeModel: ENV.resumeModel,
+    });
+  });
+
+  it('falls back to claude_code when the .env provider is unusable too', () => {
+    const out = resolveAiEngine(
+      { aiProvider: 'anthropic_api', aiModelClassifier: null, aiModelResume: null },
+      { ...ENV, provider: 'gemini_cli', geminiUsable: false },
     );
     assert.equal(out.providerId, 'claude_code');
   });

--- a/src/ai-engine.test.ts
+++ b/src/ai-engine.test.ts
@@ -1,0 +1,117 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  GEMINI_DEFAULT_CLASSIFIER_MODEL,
+  GEMINI_DEFAULT_RESUME_MODEL,
+  isAiProviderId,
+  modelFitsProvider,
+  resolveAiEngine,
+  type AiEngineEnv,
+} from './ai-engine';
+
+const ENV: AiEngineEnv = {
+  provider: 'claude_code',
+  hasAnthropicKey: false,
+  classifierModel: 'claude-haiku-4-5-20251001',
+  resumeModel: 'claude-opus-5',
+};
+
+describe('resolveAiEngine', () => {
+  it('follows .env when there is no stored row', () => {
+    assert.deepEqual(resolveAiEngine(null, ENV), {
+      providerId: 'claude_code',
+      classifierModel: ENV.classifierModel,
+      resumeModel: ENV.resumeModel,
+    });
+  });
+
+  it('stored provider overrides .env and switches model family defaults', () => {
+    const out = resolveAiEngine(
+      { aiProvider: 'gemini_cli', aiModelClassifier: null, aiModelResume: null },
+      ENV,
+    );
+    assert.deepEqual(out, {
+      providerId: 'gemini_cli',
+      classifierModel: GEMINI_DEFAULT_CLASSIFIER_MODEL,
+      resumeModel: GEMINI_DEFAULT_RESUME_MODEL,
+    });
+  });
+
+  it('keeps stored models that fit the provider', () => {
+    const out = resolveAiEngine(
+      {
+        aiProvider: 'claude_code',
+        aiModelClassifier: 'claude-sonnet-5',
+        aiModelResume: 'opus',
+      },
+      ENV,
+    );
+    assert.equal(out.classifierModel, 'claude-sonnet-5');
+    assert.equal(out.resumeModel, 'opus');
+  });
+
+  it('drops a stored model from the wrong family', () => {
+    const out = resolveAiEngine(
+      {
+        aiProvider: 'gemini_cli',
+        aiModelClassifier: 'claude-haiku-4-5-20251001',
+        aiModelResume: 'gemini-2.5-pro',
+      },
+      ENV,
+    );
+    assert.equal(out.classifierModel, GEMINI_DEFAULT_CLASSIFIER_MODEL);
+    assert.equal(out.resumeModel, 'gemini-2.5-pro');
+  });
+
+  it('anthropic_api without a key falls back to the .env provider', () => {
+    const out = resolveAiEngine(
+      { aiProvider: 'anthropic_api', aiModelClassifier: null, aiModelResume: null },
+      ENV,
+    );
+    assert.equal(out.providerId, 'claude_code');
+  });
+
+  it('anthropic_api with a key is honoured', () => {
+    const out = resolveAiEngine(
+      { aiProvider: 'anthropic_api', aiModelClassifier: null, aiModelResume: null },
+      { ...ENV, hasAnthropicKey: true },
+    );
+    assert.equal(out.providerId, 'anthropic_api');
+  });
+
+  it('ignores unknown provider strings and blank models', () => {
+    const out = resolveAiEngine(
+      { aiProvider: 'openai', aiModelClassifier: '  ', aiModelResume: '' },
+      ENV,
+    );
+    assert.deepEqual(out, {
+      providerId: 'claude_code',
+      classifierModel: ENV.classifierModel,
+      resumeModel: ENV.resumeModel,
+    });
+  });
+});
+
+describe('modelFitsProvider', () => {
+  it('gemini models only fit gemini_cli', () => {
+    assert.equal(modelFitsProvider('gemini-2.5-flash', 'gemini_cli'), true);
+    assert.equal(modelFitsProvider('gemini-2.5-flash', 'claude_code'), false);
+    assert.equal(modelFitsProvider('claude-opus-5', 'gemini_cli'), false);
+  });
+
+  it('claude aliases fit claude_code but not the Messages API', () => {
+    assert.equal(modelFitsProvider('haiku', 'claude_code'), true);
+    assert.equal(modelFitsProvider('haiku', 'anthropic_api'), false);
+    assert.equal(modelFitsProvider('claude-opus-5', 'anthropic_api'), true);
+  });
+});
+
+describe('isAiProviderId', () => {
+  it('accepts the three known ids and nothing else', () => {
+    assert.equal(isAiProviderId('gemini_cli'), true);
+    assert.equal(isAiProviderId('anthropic_api'), true);
+    assert.equal(isAiProviderId('claude_code'), true);
+    assert.equal(isAiProviderId('openai'), false);
+    assert.equal(isAiProviderId(null), false);
+  });
+});

--- a/src/ai-engine.test.ts
+++ b/src/ai-engine.test.ts
@@ -6,6 +6,7 @@ import {
   parseAiEngineConfig,
   providerUnusable,
   resolveAiEngine,
+  summarizeAiUsage,
   type AiEngineEnv,
 } from './ai-engine';
 
@@ -116,6 +117,30 @@ describe('modelFitsProvider', () => {
   it('openai_api accepts any non-empty id (base-URL providers)', () => {
     assert.equal(modelFitsProvider('meta-llama/llama-3.3-70b-instruct', 'openai_api'), true);
     assert.equal(modelFitsProvider('', 'openai_api'), false);
+  });
+});
+
+describe('summarizeAiUsage', () => {
+  const today = new Date('2026-08-30T12:00:00Z');
+
+  it('sums the window, drops old days and unknown providers', () => {
+    const raw = {
+      '2026-08-30': { claude_code: { classifier: 5, resume: 1 } },
+      '2026-08-28': { claude_code: { classifier: 2 }, gemini_cli: { resume: 3 } },
+      '2026-08-01': { claude_code: { classifier: 99 } },
+      '2026-08-29': { openai: { classifier: 7 } },
+    };
+    const rows = summarizeAiUsage(raw, 7, today);
+    assert.deepEqual(rows, [
+      { id: 'claude_code', classifier: 7, resume: 1 },
+      { id: 'gemini_cli', classifier: 0, resume: 3 },
+    ]);
+  });
+
+  it('is tolerant of garbage and empty input', () => {
+    assert.deepEqual(summarizeAiUsage(null, 7, today), []);
+    assert.deepEqual(summarizeAiUsage('nope', 7, today), []);
+    assert.deepEqual(summarizeAiUsage({ '2026-08-30': { claude_code: {} } }, 7, today), []);
   });
 });
 

--- a/src/ai-engine.test.ts
+++ b/src/ai-engine.test.ts
@@ -1,10 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  GEMINI_DEFAULT_CLASSIFIER_MODEL,
-  GEMINI_DEFAULT_RESUME_MODEL,
   isAiProviderId,
   modelFitsProvider,
+  parseAiEngineConfig,
+  providerUnusable,
   resolveAiEngine,
   type AiEngineEnv,
 } from './ai-engine';
@@ -12,126 +12,125 @@ import {
 const ENV: AiEngineEnv = {
   provider: 'claude_code',
   hasAnthropicKey: false,
+  hasOpenAiKey: false,
   geminiUsable: true,
+  codexUsable: false,
   classifierModel: 'claude-haiku-4-5-20251001',
   resumeModel: 'claude-opus-5',
+  openAiModel: '',
 };
 
 describe('resolveAiEngine', () => {
-  it('follows .env when there is no stored row', () => {
-    assert.deepEqual(resolveAiEngine(null, ENV), {
-      providerId: 'claude_code',
-      classifierModel: ENV.classifierModel,
-      resumeModel: ENV.resumeModel,
-    });
+  it('seeds a one-engine chain from .env when nothing is stored', () => {
+    const out = resolveAiEngine(null, ENV);
+    assert.deepEqual(out.chain, ['claude_code']);
+    assert.deepEqual(out.skipped, []);
+    assert.equal(out.modelFor('claude_code', 'classifier'), ENV.classifierModel);
+    assert.equal(out.modelFor('claude_code', 'resume'), ENV.resumeModel);
   });
 
-  it('stored provider overrides .env and switches model family defaults', () => {
-    const out = resolveAiEngine(
-      { aiProvider: 'gemini_cli', aiModelClassifier: null, aiModelResume: null },
-      ENV,
-    );
-    assert.deepEqual(out, {
-      providerId: 'gemini_cli',
-      classifierModel: GEMINI_DEFAULT_CLASSIFIER_MODEL,
-      resumeModel: GEMINI_DEFAULT_RESUME_MODEL,
-    });
+  it('keeps the stored priority order', () => {
+    const out = resolveAiEngine({ order: ['gemini_cli', 'claude_code'], models: {} }, ENV);
+    assert.deepEqual(out.chain, ['gemini_cli', 'claude_code']);
+    assert.equal(out.modelFor('gemini_cli', 'classifier'), 'gemini-2.5-flash');
+    assert.equal(out.modelFor('gemini_cli', 'resume'), 'gemini-2.5-pro');
   });
 
-  it('keeps stored models that fit the provider', () => {
+  it('honours stored per-engine models and drops wrong-family ones', () => {
     const out = resolveAiEngine(
       {
-        aiProvider: 'claude_code',
-        aiModelClassifier: 'claude-sonnet-5',
-        aiModelResume: 'opus',
+        order: ['gemini_cli'],
+        models: {
+          gemini_cli: { classifier: 'gemini-2.5-pro', resume: 'claude-opus-5' },
+        },
       },
       ENV,
     );
-    assert.equal(out.classifierModel, 'claude-sonnet-5');
-    assert.equal(out.resumeModel, 'opus');
+    assert.equal(out.modelFor('gemini_cli', 'classifier'), 'gemini-2.5-pro');
+    assert.equal(out.modelFor('gemini_cli', 'resume'), 'gemini-2.5-pro');
   });
 
-  it('drops a stored model from the wrong family', () => {
+  it('skips engines the host cannot run and reports them', () => {
     const out = resolveAiEngine(
-      {
-        aiProvider: 'gemini_cli',
-        aiModelClassifier: 'claude-haiku-4-5-20251001',
-        aiModelResume: 'gemini-2.5-pro',
-      },
+      { order: ['anthropic_api', 'openai_api', 'claude_code'], models: {} },
       ENV,
     );
-    assert.equal(out.classifierModel, GEMINI_DEFAULT_CLASSIFIER_MODEL);
-    assert.equal(out.resumeModel, 'gemini-2.5-pro');
+    assert.deepEqual(out.chain, ['claude_code']);
+    assert.deepEqual(out.skipped, ['anthropic_api', 'openai_api']);
   });
 
-  it('anthropic_api without a key falls back to the .env provider', () => {
+  it('falls back to claude_code when everything is unusable', () => {
     const out = resolveAiEngine(
-      { aiProvider: 'anthropic_api', aiModelClassifier: null, aiModelResume: null },
-      ENV,
-    );
-    assert.equal(out.providerId, 'claude_code');
-  });
-
-  it('gemini_cli without auth falls back and keeps claude models', () => {
-    const out = resolveAiEngine(
-      { aiProvider: 'gemini_cli', aiModelClassifier: null, aiModelResume: null },
-      { ...ENV, geminiUsable: false },
-    );
-    assert.deepEqual(out, {
-      providerId: 'claude_code',
-      classifierModel: ENV.classifierModel,
-      resumeModel: ENV.resumeModel,
-    });
-  });
-
-  it('falls back to claude_code when the .env provider is unusable too', () => {
-    const out = resolveAiEngine(
-      { aiProvider: 'anthropic_api', aiModelClassifier: null, aiModelResume: null },
+      { order: ['openai_api'], models: {} },
       { ...ENV, provider: 'gemini_cli', geminiUsable: false },
     );
-    assert.equal(out.providerId, 'claude_code');
+    assert.deepEqual(out.chain, ['claude_code']);
   });
 
-  it('anthropic_api with a key is honoured', () => {
+  it('codex defaults to the CLI-configured model (empty id)', () => {
     const out = resolveAiEngine(
-      { aiProvider: 'anthropic_api', aiModelClassifier: null, aiModelResume: null },
-      { ...ENV, hasAnthropicKey: true },
+      { order: ['codex_cli'], models: {} },
+      { ...ENV, codexUsable: true },
     );
-    assert.equal(out.providerId, 'anthropic_api');
+    assert.equal(out.modelFor('codex_cli', 'classifier'), '');
   });
 
-  it('ignores unknown provider strings and blank models', () => {
+  it('openai model comes from OPENAI_MODEL when the slot is empty', () => {
     const out = resolveAiEngine(
-      { aiProvider: 'openai', aiModelClassifier: '  ', aiModelResume: '' },
-      ENV,
+      { order: ['openai_api'], models: {} },
+      { ...ENV, hasOpenAiKey: true, openAiModel: 'llama-3.3-70b' },
     );
-    assert.deepEqual(out, {
-      providerId: 'claude_code',
-      classifierModel: ENV.classifierModel,
-      resumeModel: ENV.resumeModel,
+    assert.deepEqual(out.chain, ['openai_api']);
+    assert.equal(out.modelFor('openai_api', 'resume'), 'llama-3.3-70b');
+  });
+});
+
+describe('parseAiEngineConfig', () => {
+  it('drops unknown ids and de-duplicates the order', () => {
+    const out = parseAiEngineConfig({
+      order: ['claude_code', 'openai', 'claude_code', 'gemini_cli'],
+      models: { openai: { classifier: 'x' }, gemini_cli: { classifier: 'gemini-2.5-pro' } },
     });
+    assert.deepEqual(out.order, ['claude_code', 'gemini_cli']);
+    assert.deepEqual(Object.keys(out.models), ['gemini_cli']);
+  });
+
+  it('never throws on garbage', () => {
+    assert.deepEqual(parseAiEngineConfig('nope'), { order: [], models: {} });
+    assert.deepEqual(parseAiEngineConfig(null), { order: [], models: {} });
+    assert.deepEqual(parseAiEngineConfig({ order: 42 }), { order: [], models: {} });
   });
 });
 
 describe('modelFitsProvider', () => {
-  it('gemini models only fit gemini_cli', () => {
+  it('checks family prefixes per provider', () => {
     assert.equal(modelFitsProvider('gemini-2.5-flash', 'gemini_cli'), true);
-    assert.equal(modelFitsProvider('gemini-2.5-flash', 'claude_code'), false);
     assert.equal(modelFitsProvider('claude-opus-5', 'gemini_cli'), false);
-  });
-
-  it('claude aliases fit claude_code but not the Messages API', () => {
     assert.equal(modelFitsProvider('haiku', 'claude_code'), true);
     assert.equal(modelFitsProvider('haiku', 'anthropic_api'), false);
-    assert.equal(modelFitsProvider('claude-opus-5', 'anthropic_api'), true);
+    assert.equal(modelFitsProvider('gpt-5.1', 'codex_cli'), true);
+    assert.equal(modelFitsProvider('o3', 'codex_cli'), true);
+    assert.equal(modelFitsProvider('claude-opus-5', 'codex_cli'), false);
+  });
+
+  it('openai_api accepts any non-empty id (base-URL providers)', () => {
+    assert.equal(modelFitsProvider('meta-llama/llama-3.3-70b-instruct', 'openai_api'), true);
+    assert.equal(modelFitsProvider('', 'openai_api'), false);
   });
 });
 
-describe('isAiProviderId', () => {
-  it('accepts the three known ids and nothing else', () => {
-    assert.equal(isAiProviderId('gemini_cli'), true);
-    assert.equal(isAiProviderId('anthropic_api'), true);
-    assert.equal(isAiProviderId('claude_code'), true);
+describe('providerUnusable / isAiProviderId', () => {
+  it('flags key-less APIs and unauthenticated CLIs', () => {
+    assert.equal(providerUnusable('anthropic_api', ENV), true);
+    assert.equal(providerUnusable('openai_api', ENV), true);
+    assert.equal(providerUnusable('gemini_cli', ENV), false);
+    assert.equal(providerUnusable('codex_cli', ENV), true);
+    assert.equal(providerUnusable('claude_code', ENV), false);
+  });
+
+  it('accepts the five known ids and nothing else', () => {
+    assert.equal(isAiProviderId('codex_cli'), true);
+    assert.equal(isAiProviderId('openai_api'), true);
     assert.equal(isAiProviderId('openai'), false);
     assert.equal(isAiProviderId(null), false);
   });

--- a/src/ai-engine.ts
+++ b/src/ai-engine.ts
@@ -1,20 +1,53 @@
+import { z } from 'zod';
+
 /*
- * Pure AI-engine resolution: which backend runs the AI calls and which model
- * ids to use. The dashboard stores an override in AppSettings (NULL = follow
- * .env); this module merges the two. No I/O — unit-tested (ai-engine.test.ts).
+ * Pure AI-engine resolution (ADR 0013 / 0014): which backends run the AI
+ * calls, in which priority order, and with which model per backend per role.
+ * The dashboard stores an ordered chain in AppSettings.aiEngine (JSON);
+ * .env only seeds the default. No I/O — unit-tested (ai-engine.test.ts).
  */
 
-export const AI_PROVIDER_IDS = ['anthropic_api', 'claude_code', 'gemini_cli'] as const;
+export const AI_PROVIDER_IDS = [
+  'anthropic_api',
+  'claude_code',
+  'gemini_cli',
+  'openai_api',
+  'codex_cli',
+] as const;
 export type AiProviderId = (typeof AI_PROVIDER_IDS)[number];
 
 export const AI_PROVIDER_LABELS: Record<AiProviderId, string> = {
   anthropic_api: 'Anthropic API',
   claude_code: 'Claude Code CLI',
   gemini_cli: 'Gemini CLI',
+  openai_api: 'OpenAI-compatible API',
+  codex_cli: 'Codex CLI',
 };
 
-export const GEMINI_DEFAULT_CLASSIFIER_MODEL = 'gemini-2.5-flash';
-export const GEMINI_DEFAULT_RESUME_MODEL = 'gemini-2.5-pro';
+/** Which backends can research the web (verification calls ask for it). */
+export const PROVIDER_WEB_TOOLS: Record<AiProviderId, boolean> = {
+  anthropic_api: true,
+  claude_code: true,
+  gemini_cli: true,
+  openai_api: false,
+  codex_cli: true,
+};
+
+export type AiRole = 'classifier' | 'resume';
+
+/**
+ * Curated per-family model ids for the dashboard selects. The empty string
+ * means "the engine's own default" (CLI-configured model, or the built-in
+ * default below). openai_api is free-text in the UI — with a custom base URL
+ * (OpenRouter, Groq, local servers) any model id is legal.
+ */
+export const PROVIDER_MODEL_OPTIONS: Record<AiProviderId, string[]> = {
+  anthropic_api: ['claude-haiku-4-5-20251001', 'claude-sonnet-5', 'claude-opus-5'],
+  claude_code: ['claude-haiku-4-5-20251001', 'claude-sonnet-5', 'claude-opus-5'],
+  gemini_cli: ['gemini-2.5-flash', 'gemini-2.5-pro'],
+  openai_api: [],
+  codex_cli: ['gpt-5.1', 'gpt-5-mini'],
+};
 
 // Claude Code resolves these aliases in --model; the Messages API does not.
 const CLAUDE_CODE_MODEL_ALIASES = new Set(['haiku', 'sonnet', 'opus']);
@@ -25,77 +58,128 @@ export function isAiProviderId(value: unknown): value is AiProviderId {
 
 /** True when the model id plausibly belongs to the provider's family. */
 export function modelFitsProvider(model: string, provider: AiProviderId): boolean {
-  if (provider === 'gemini_cli') return model.startsWith('gemini');
-  if (model.startsWith('claude')) return true;
-  return provider === 'claude_code' && CLAUDE_CODE_MODEL_ALIASES.has(model);
+  switch (provider) {
+    case 'gemini_cli':
+      return model.startsWith('gemini');
+    case 'openai_api':
+      // Base-URL providers (OpenRouter, Groq, local) use arbitrary ids.
+      return model.length > 0;
+    case 'codex_cli':
+      return /^(gpt-|o\d|codex)/.test(model);
+    case 'claude_code':
+      return model.startsWith('claude') || CLAUDE_CODE_MODEL_ALIASES.has(model);
+    case 'anthropic_api':
+      return model.startsWith('claude');
+  }
 }
 
-/** The AppSettings columns this module reads (all NULL = follow .env). */
-export interface AiEngineRow {
-  aiProvider: string | null;
-  aiModelClassifier: string | null;
-  aiModelResume: string | null;
+/** Stored shape of AppSettings.aiEngine — tolerant, unknowns dropped. */
+const StoredEngineSchema = z.object({
+  order: z.array(z.string()).default([]),
+  models: z
+    .record(
+      z.string(),
+      z.object({
+        classifier: z.string().nullable().optional(),
+        resume: z.string().nullable().optional(),
+      }),
+    )
+    .default({}),
+});
+
+export interface AiEngineConfig {
+  order: AiProviderId[];
+  models: Partial<Record<AiProviderId, { classifier?: string | null; resume?: string | null }>>;
+}
+
+/** Parses the raw JSON column; never throws, unknown ids are dropped. */
+export function parseAiEngineConfig(raw: unknown): AiEngineConfig {
+  const parsed = StoredEngineSchema.safeParse(raw ?? {});
+  if (!parsed.success) return { order: [], models: {} };
+  const order = parsed.data.order.filter(isAiProviderId);
+  const models: AiEngineConfig['models'] = {};
+  for (const [id, m] of Object.entries(parsed.data.models)) {
+    if (isAiProviderId(id)) models[id] = m;
+  }
+  return { order: [...new Set(order)], models };
 }
 
 export interface AiEngineEnv {
   provider: AiProviderId;
   hasAnthropicKey: boolean;
-  /** Gemini auth is file/env detectable — false means calls cannot work yet. */
+  hasOpenAiKey: boolean;
+  /** CLI auth is file/env detectable — false means calls cannot work yet. */
   geminiUsable: boolean;
+  codexUsable: boolean;
   classifierModel: string;
   resumeModel: string;
+  /** OPENAI_MODEL from .env, used when the openai_api slot is empty. */
+  openAiModel: string;
 }
 
-export interface AiEngineChoice {
-  providerId: AiProviderId;
-  classifierModel: string;
-  resumeModel: string;
+/** Engines that certainly cannot complete a call on this host right now. */
+export function providerUnusable(id: AiProviderId, env: AiEngineEnv): boolean {
+  switch (id) {
+    case 'anthropic_api':
+      return !env.hasAnthropicKey;
+    case 'openai_api':
+      return !env.hasOpenAiKey;
+    case 'gemini_cli':
+      return !env.geminiUsable;
+    case 'codex_cli':
+      return !env.codexUsable;
+    case 'claude_code':
+      return false; // keychain auth is not detectable — let the call decide
+  }
 }
 
 /**
- * Merges the stored override with the .env defaults. Unknown provider values,
- * blank models and models from the wrong family fall back; anthropic_api
- * without an API key and gemini_cli without auth fall back to the .env
- * provider (claude_code as the last resort) — a saved-but-not-yet-usable
- * preference never leaves the pipeline without a runnable engine.
+ * Default model per backend per role when the slot is empty. '' means "let
+ * the CLI use its own configured default" (the arg builders omit --model).
  */
-export function resolveAiEngine(
-  row: AiEngineRow | null | undefined,
-  env: AiEngineEnv,
-): AiEngineChoice {
-  let providerId =
-    row?.aiProvider && isAiProviderId(row.aiProvider) ? row.aiProvider : env.provider;
-  const unusable = (id: AiProviderId): boolean =>
-    (id === 'anthropic_api' && !env.hasAnthropicKey) ||
-    (id === 'gemini_cli' && !env.geminiUsable);
-  if (unusable(providerId)) {
-    providerId = unusable(env.provider) ? 'claude_code' : env.provider;
+export function defaultModelFor(id: AiProviderId, role: AiRole, env: AiEngineEnv): string {
+  switch (id) {
+    case 'anthropic_api':
+    case 'claude_code':
+      return role === 'classifier' ? env.classifierModel : env.resumeModel;
+    case 'gemini_cli':
+      return role === 'classifier' ? 'gemini-2.5-flash' : 'gemini-2.5-pro';
+    case 'openai_api':
+      return env.openAiModel;
+    case 'codex_cli':
+      return '';
   }
-  return {
-    providerId,
-    classifierModel: pickModel(
-      row?.aiModelClassifier,
-      providerId,
-      env.classifierModel,
-      GEMINI_DEFAULT_CLASSIFIER_MODEL,
-    ),
-    resumeModel: pickModel(
-      row?.aiModelResume,
-      providerId,
-      env.resumeModel,
-      GEMINI_DEFAULT_RESUME_MODEL,
-    ),
-  };
 }
 
-function pickModel(
-  stored: string | null | undefined,
-  provider: AiProviderId,
-  claudeDefault: string,
-  geminiDefault: string,
-): string {
-  const fallback = provider === 'gemini_cli' ? geminiDefault : claudeDefault;
-  const model = stored?.trim();
-  if (!model) return fallback;
-  return modelFitsProvider(model, provider) ? model : fallback;
+export interface ResolvedAiEngine {
+  /** Usable engines in priority order — never empty. */
+  chain: AiProviderId[];
+  /** Engines the user enabled but this host cannot run yet. */
+  skipped: AiProviderId[];
+  modelFor(id: AiProviderId, role: AiRole): string;
+}
+
+/**
+ * Merges the stored chain with the .env defaults. Unusable engines are
+ * skipped (reported, so the UI can explain); an empty result falls back to
+ * the .env provider and finally claude_code — the pipeline always has a
+ * chain to try. Models outside the backend's family fall back per role.
+ */
+export function resolveAiEngine(raw: unknown, env: AiEngineEnv): ResolvedAiEngine {
+  const config = parseAiEngineConfig(raw);
+  const wanted = config.order.length > 0 ? config.order : [env.provider];
+  const chain = wanted.filter((id) => !providerUnusable(id, env));
+  const skipped = wanted.filter((id) => providerUnusable(id, env));
+  if (chain.length === 0) {
+    chain.push(providerUnusable(env.provider, env) ? 'claude_code' : env.provider);
+  }
+  return {
+    chain,
+    skipped,
+    modelFor(id, role) {
+      const stored = config.models[id]?.[role]?.trim();
+      if (stored && modelFitsProvider(stored, id)) return stored;
+      return defaultModelFor(id, role, env);
+    },
+  };
 }

--- a/src/ai-engine.ts
+++ b/src/ai-engine.ts
@@ -1,0 +1,95 @@
+/*
+ * Pure AI-engine resolution: which backend runs the AI calls and which model
+ * ids to use. The dashboard stores an override in AppSettings (NULL = follow
+ * .env); this module merges the two. No I/O — unit-tested (ai-engine.test.ts).
+ */
+
+export const AI_PROVIDER_IDS = ['anthropic_api', 'claude_code', 'gemini_cli'] as const;
+export type AiProviderId = (typeof AI_PROVIDER_IDS)[number];
+
+export const AI_PROVIDER_LABELS: Record<AiProviderId, string> = {
+  anthropic_api: 'Anthropic API',
+  claude_code: 'Claude Code CLI',
+  gemini_cli: 'Gemini CLI',
+};
+
+export const GEMINI_DEFAULT_CLASSIFIER_MODEL = 'gemini-2.5-flash';
+export const GEMINI_DEFAULT_RESUME_MODEL = 'gemini-2.5-pro';
+
+// Claude Code resolves these aliases in --model; the Messages API does not.
+const CLAUDE_CODE_MODEL_ALIASES = new Set(['haiku', 'sonnet', 'opus']);
+
+export function isAiProviderId(value: unknown): value is AiProviderId {
+  return typeof value === 'string' && (AI_PROVIDER_IDS as readonly string[]).includes(value);
+}
+
+/** True when the model id plausibly belongs to the provider's family. */
+export function modelFitsProvider(model: string, provider: AiProviderId): boolean {
+  if (provider === 'gemini_cli') return model.startsWith('gemini');
+  if (model.startsWith('claude')) return true;
+  return provider === 'claude_code' && CLAUDE_CODE_MODEL_ALIASES.has(model);
+}
+
+/** The AppSettings columns this module reads (all NULL = follow .env). */
+export interface AiEngineRow {
+  aiProvider: string | null;
+  aiModelClassifier: string | null;
+  aiModelResume: string | null;
+}
+
+export interface AiEngineEnv {
+  provider: AiProviderId;
+  hasAnthropicKey: boolean;
+  classifierModel: string;
+  resumeModel: string;
+}
+
+export interface AiEngineChoice {
+  providerId: AiProviderId;
+  classifierModel: string;
+  resumeModel: string;
+}
+
+/**
+ * Merges the stored override with the .env defaults. Unknown provider values,
+ * blank models and models from the wrong family fall back, and anthropic_api
+ * without an API key falls back to the .env provider — a stale DB row can
+ * never leave the pipeline without a runnable engine.
+ */
+export function resolveAiEngine(
+  row: AiEngineRow | null | undefined,
+  env: AiEngineEnv,
+): AiEngineChoice {
+  let providerId =
+    row?.aiProvider && isAiProviderId(row.aiProvider) ? row.aiProvider : env.provider;
+  if (providerId === 'anthropic_api' && !env.hasAnthropicKey) {
+    providerId = env.provider === 'anthropic_api' ? 'claude_code' : env.provider;
+  }
+  return {
+    providerId,
+    classifierModel: pickModel(
+      row?.aiModelClassifier,
+      providerId,
+      env.classifierModel,
+      GEMINI_DEFAULT_CLASSIFIER_MODEL,
+    ),
+    resumeModel: pickModel(
+      row?.aiModelResume,
+      providerId,
+      env.resumeModel,
+      GEMINI_DEFAULT_RESUME_MODEL,
+    ),
+  };
+}
+
+function pickModel(
+  stored: string | null | undefined,
+  provider: AiProviderId,
+  claudeDefault: string,
+  geminiDefault: string,
+): string {
+  const fallback = provider === 'gemini_cli' ? geminiDefault : claudeDefault;
+  const model = stored?.trim();
+  if (!model) return fallback;
+  return modelFitsProvider(model, provider) ? model : fallback;
+}

--- a/src/ai-engine.ts
+++ b/src/ai-engine.ts
@@ -33,6 +33,15 @@ export const PROVIDER_WEB_TOOLS: Record<AiProviderId, boolean> = {
   codex_cli: true,
 };
 
+/** Metered billing — every call spends money (vs a flat subscription). */
+export const PROVIDER_PAID: Record<AiProviderId, boolean> = {
+  anthropic_api: true,
+  claude_code: false,
+  gemini_cli: false,
+  openai_api: true,
+  codex_cli: false,
+};
+
 export type AiRole = 'classifier' | 'resume';
 
 /**
@@ -165,6 +174,43 @@ export interface ResolvedAiEngine {
  * the .env provider and finally claude_code — the pipeline always has a
  * chain to try. Models outside the backend's family fall back per role.
  */
+/** Shape of AppSettings.aiUsage: { "YYYY-MM-DD": { provider: { role: n } } }. */
+const StoredUsageSchema = z.record(
+  z.string(),
+  z.record(z.string(), z.record(z.string(), z.number())),
+);
+
+export interface AiUsageRow {
+  id: AiProviderId;
+  classifier: number;
+  resume: number;
+}
+
+/** Sums the per-day counters over the last `days` days; busiest first. */
+export function summarizeAiUsage(raw: unknown, days: number, today: Date): AiUsageRow[] {
+  const parsed = StoredUsageSchema.safeParse(raw ?? {});
+  if (!parsed.success) return [];
+  const window = new Set<string>();
+  for (let i = 0; i < days; i++) {
+    window.add(new Date(today.getTime() - i * 86_400_000).toISOString().slice(0, 10));
+  }
+  const totals = new Map<AiProviderId, { classifier: number; resume: number }>();
+  for (const [day, providers] of Object.entries(parsed.data)) {
+    if (!window.has(day)) continue;
+    for (const [id, roles] of Object.entries(providers)) {
+      if (!isAiProviderId(id)) continue;
+      const row = totals.get(id) ?? { classifier: 0, resume: 0 };
+      row.classifier += roles.classifier ?? 0;
+      row.resume += roles.resume ?? 0;
+      totals.set(id, row);
+    }
+  }
+  return [...totals.entries()]
+    .map(([id, r]) => ({ id, ...r }))
+    .filter((r) => r.classifier + r.resume > 0)
+    .sort((a, b) => b.classifier + b.resume - (a.classifier + a.resume));
+}
+
 export function resolveAiEngine(raw: unknown, env: AiEngineEnv): ResolvedAiEngine {
   const config = parseAiEngineConfig(raw);
   const wanted = config.order.length > 0 ? config.order : [env.provider];

--- a/src/ai-engine.ts
+++ b/src/ai-engine.ts
@@ -40,6 +40,8 @@ export interface AiEngineRow {
 export interface AiEngineEnv {
   provider: AiProviderId;
   hasAnthropicKey: boolean;
+  /** Gemini auth is file/env detectable — false means calls cannot work yet. */
+  geminiUsable: boolean;
   classifierModel: string;
   resumeModel: string;
 }
@@ -52,9 +54,10 @@ export interface AiEngineChoice {
 
 /**
  * Merges the stored override with the .env defaults. Unknown provider values,
- * blank models and models from the wrong family fall back, and anthropic_api
- * without an API key falls back to the .env provider — a stale DB row can
- * never leave the pipeline without a runnable engine.
+ * blank models and models from the wrong family fall back; anthropic_api
+ * without an API key and gemini_cli without auth fall back to the .env
+ * provider (claude_code as the last resort) — a saved-but-not-yet-usable
+ * preference never leaves the pipeline without a runnable engine.
  */
 export function resolveAiEngine(
   row: AiEngineRow | null | undefined,
@@ -62,8 +65,11 @@ export function resolveAiEngine(
 ): AiEngineChoice {
   let providerId =
     row?.aiProvider && isAiProviderId(row.aiProvider) ? row.aiProvider : env.provider;
-  if (providerId === 'anthropic_api' && !env.hasAnthropicKey) {
-    providerId = env.provider === 'anthropic_api' ? 'claude_code' : env.provider;
+  const unusable = (id: AiProviderId): boolean =>
+    (id === 'anthropic_api' && !env.hasAnthropicKey) ||
+    (id === 'gemini_cli' && !env.geminiUsable);
+  if (unusable(providerId)) {
+    providerId = unusable(env.provider) ? 'claude_code' : env.provider;
   }
   return {
     providerId,

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -1,6 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildClaudeCodeArgs, parseClaudeCodeOutput } from './ai-provider-parse';
+import {
+  buildClaudeCodeArgs,
+  buildGeminiCliArgs,
+  parseClaudeCodeOutput,
+  parseGeminiCliOutput,
+} from './ai-provider-parse';
 
 const ok = (result: string) =>
   JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result });
@@ -52,6 +57,51 @@ test('other errors are not rate-limited', () => {
   const out = parseClaudeCodeOutput(raw);
   assert.equal(out.rateLimited, false);
   assert.match(out.error ?? '', /max turns/);
+});
+
+test('gemini success returns the response text', () => {
+  const out = parseGeminiCliOutput(
+    JSON.stringify({ response: '{"relevant": true}', stats: { models: {} } }),
+  );
+  assert.equal(out.error, null);
+  assert.equal(out.rateLimited, false);
+  assert.match(out.text ?? '', /"relevant": true/);
+});
+
+test('gemini error object is surfaced, quota flagged rateLimited', () => {
+  const quota = parseGeminiCliOutput(
+    JSON.stringify({ error: { type: 'ApiError', message: 'RESOURCE_EXHAUSTED: quota', code: 429 } }),
+  );
+  assert.equal(quota.text, null);
+  assert.equal(quota.rateLimited, true);
+  assert.match(quota.error ?? '', /RESOURCE_EXHAUSTED/);
+
+  const other = parseGeminiCliOutput(
+    JSON.stringify({ error: { message: 'model not found' } }),
+  );
+  assert.equal(other.rateLimited, false);
+  assert.match(other.error ?? '', /model not found/);
+});
+
+test('gemini non-JSON and shape misses are errors, not rate-limited', () => {
+  assert.match(parseGeminiCliOutput('boom').error ?? '', /not JSON/);
+  const empty = parseGeminiCliOutput(JSON.stringify({ stats: {} }));
+  assert.equal(empty.text, null);
+  assert.equal(empty.rateLimited, false);
+});
+
+test('buildGeminiCliArgs prepends system text and gates web tools', () => {
+  const base = { system: 'S', user: 'U', model: 'gemini-2.5-flash' };
+  const plain = buildGeminiCliArgs(base);
+  assert.deepEqual(plain, [
+    '--output-format', 'json',
+    '--model', 'gemini-2.5-flash',
+    '--prompt', 'S\n\nU',
+  ]);
+
+  const web = buildGeminiCliArgs({ ...base, webTools: true });
+  assert.ok(web.includes('google_web_search') && web.includes('web_fetch'));
+  assert.equal(web[web.length - 1], 'S\n\nU');
 });
 
 test('buildClaudeCodeArgs disables tools by default and allow-lists web tools on request', () => {

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -2,9 +2,12 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildClaudeCodeArgs,
+  buildCodexCliArgs,
   buildGeminiCliArgs,
   parseClaudeCodeOutput,
+  parseCodexCliOutput,
   parseGeminiCliOutput,
+  parseOpenAiChatResponse,
 } from './ai-provider-parse';
 
 const ok = (result: string) =>
@@ -102,6 +105,67 @@ test('buildGeminiCliArgs prepends system text and gates web tools', () => {
   const web = buildGeminiCliArgs({ ...base, webTools: true });
   assert.ok(web.includes('google_web_search') && web.includes('web_fetch'));
   assert.equal(web[web.length - 1], 'S\n\nU');
+});
+
+test('codex JSONL: last agent message wins, both event shapes covered', () => {
+  const modern = [
+    '{"type":"thread.started","thread_id":"t1"}',
+    'non-json noise',
+    '{"type":"item.completed","item":{"id":"i1","type":"reasoning","text":"thinking"}}',
+    '{"type":"item.completed","item":{"id":"i2","type":"agent_message","text":"draft"}}',
+    '{"type":"item.completed","item":{"id":"i3","type":"agent_message","text":"{\\"ok\\":true}"}}',
+    '{"type":"turn.completed","usage":{"input_tokens":10}}',
+  ].join('\n');
+  const out = parseCodexCliOutput(modern);
+  assert.equal(out.error, null);
+  assert.match(out.text ?? '', /"ok":true/);
+
+  const legacy = '{"id":"0","msg":{"type":"agent_message","message":"hi"}}';
+  assert.equal(parseCodexCliOutput(legacy).text, 'hi');
+});
+
+test('codex errors surface and rate limits are flagged', () => {
+  const limited = parseCodexCliOutput('{"type":"error","message":"You have hit your usage limit."}');
+  assert.equal(limited.text, null);
+  assert.equal(limited.rateLimited, true);
+
+  const plain = parseCodexCliOutput('{"type":"turn.failed","message":"model not found"}');
+  assert.equal(plain.rateLimited, false);
+  assert.match(plain.error ?? '', /model not found/);
+
+  assert.match(parseCodexCliOutput('garbage only').error ?? '', /no agent message/);
+});
+
+test('buildCodexCliArgs: read-only sandbox, optional model and search', () => {
+  const base = { system: 'S', user: 'U', model: '' };
+  const plain = buildCodexCliArgs(base);
+  assert.deepEqual(plain, [
+    'exec', '--json', '--skip-git-repo-check', '--sandbox', 'read-only', 'S\n\nU',
+  ]);
+  const full = buildCodexCliArgs({ ...base, model: 'gpt-5.1', webTools: true });
+  assert.ok(full.includes('--model') && full.includes('gpt-5.1') && full.includes('--search'));
+});
+
+test('openai chat response: content, error envelope, rate limit', () => {
+  const ok = parseOpenAiChatResponse(
+    JSON.stringify({ choices: [{ message: { content: '{"relevant":true}' } }] }),
+  );
+  assert.match(ok.text ?? '', /"relevant":true/);
+
+  const quota = parseOpenAiChatResponse(
+    JSON.stringify({ error: { message: 'Rate limit reached for gpt-5-mini' } }),
+  );
+  assert.equal(quota.text, null);
+  assert.equal(quota.rateLimited, true);
+
+  const empty = parseOpenAiChatResponse(JSON.stringify({ choices: [{ message: { content: null } }] }));
+  assert.match(empty.error ?? '', /empty completion/);
+  assert.match(parseOpenAiChatResponse('<html>').error ?? '', /not JSON/);
+});
+
+test('gemini args omit --model when empty (CLI default)', () => {
+  const args = buildGeminiCliArgs({ system: 'S', user: 'U', model: '' });
+  assert.ok(!args.includes('--model'));
 });
 
 test('buildClaudeCodeArgs disables tools by default and allow-lists web tools on request', () => {

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -2,8 +2,10 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildClaudeCodeArgs,
+  buildCliEnv,
   buildCodexCliArgs,
   buildGeminiCliArgs,
+  CLI_PROVIDER_ENV_KEYS,
   parseClaudeCodeOutput,
   parseCodexCliOutput,
   parseGeminiCliOutput,
@@ -161,6 +163,42 @@ test('openai chat response: content, error envelope, rate limit', () => {
   const empty = parseOpenAiChatResponse(JSON.stringify({ choices: [{ message: { content: null } }] }));
   assert.match(empty.error ?? '', /empty completion/);
   assert.match(parseOpenAiChatResponse('<html>').error ?? '', /not JSON/);
+});
+
+test('buildCliEnv: base keys + own provider vars only', () => {
+  const source = {
+    PATH: '/usr/bin',
+    HOME: '/Users/x',
+    DATABASE_URL: 'postgres://secret',
+    TELEGRAM_BOT_TOKEN: 'tg-secret',
+    ANTHROPIC_API_KEY: 'sk-ant-secret',
+    CLAUDE_CODE_OAUTH_TOKEN: 'oauth-token',
+    GEMINI_API_KEY: 'gm-key',
+    OPENAI_API_KEY: 'sk-openai',
+  };
+  const claude = buildCliEnv(CLI_PROVIDER_ENV_KEYS.claude_code ?? [], source);
+  assert.equal(claude.PATH, '/usr/bin');
+  assert.equal(claude.CLAUDE_CODE_OAUTH_TOKEN, 'oauth-token');
+  // Precedence trap: the key must NEVER reach the claude_code child, or the
+  // CLI silently bills the API instead of the subscription.
+  assert.equal(claude.ANTHROPIC_API_KEY, undefined);
+  assert.equal(claude.DATABASE_URL, undefined);
+  assert.equal(claude.TELEGRAM_BOT_TOKEN, undefined);
+  assert.equal(claude.GEMINI_API_KEY, undefined);
+
+  const gemini = buildCliEnv(CLI_PROVIDER_ENV_KEYS.gemini_cli ?? [], source);
+  assert.equal(gemini.GEMINI_API_KEY, 'gm-key');
+  assert.equal(gemini.OPENAI_API_KEY, undefined);
+  assert.equal(gemini.CLAUDE_CODE_OAUTH_TOKEN, undefined);
+
+  const codex = buildCliEnv(CLI_PROVIDER_ENV_KEYS.codex_cli ?? [], source);
+  assert.equal(codex.OPENAI_API_KEY, 'sk-openai');
+  assert.equal(codex.GEMINI_API_KEY, undefined);
+});
+
+test('buildCliEnv skips unset keys instead of writing undefined', () => {
+  const env = buildCliEnv(['GEMINI_API_KEY'], { PATH: '/bin' });
+  assert.deepEqual(Object.keys(env), ['PATH']);
 });
 
 test('gemini args omit --model when empty (CLI default)', () => {

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { AiProviderId } from './ai-engine';
 
 /**
  * Shape of `claude -p --output-format json`. Only the fields we act on are
@@ -42,6 +43,43 @@ export function parseClaudeCodeOutput(raw: string): CliOutcome {
     return { text: null, rateLimited, error: `claude-code: ${message}` };
   }
   return { text: r.result ?? '', rateLimited: false, error: null };
+}
+
+/**
+ * Env allowlist for CLI child processes. A provider child gets the base
+ * process keys plus ONLY its own auth variables — never the database URL,
+ * Telegram token, or another provider's key. Load-bearing case: Claude Code
+ * documents that ANTHROPIC_API_KEY takes precedence over subscription
+ * login, so leaking it into the claude_code child would silently bill the
+ * API while the user believes the subscription is working.
+ */
+const CLI_BASE_ENV_KEYS = [
+  'PATH', 'HOME', 'SHELL', 'TERM', 'USER', 'LOGNAME', 'TMPDIR', 'LANG', 'LC_ALL', 'TZ',
+] as const;
+
+export const CLI_PROVIDER_ENV_KEYS: Partial<Record<AiProviderId, readonly string[]>> = {
+  claude_code: ['CLAUDE_CODE_OAUTH_TOKEN', 'CLAUDE_CONFIG_DIR'],
+  gemini_cli: [
+    'GEMINI_API_KEY',
+    'GOOGLE_GENAI_USE_VERTEXAI',
+    'GOOGLE_GENAI_USE_GCA',
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'GOOGLE_CLOUD_PROJECT',
+    'GOOGLE_CLOUD_LOCATION',
+  ],
+  codex_cli: ['OPENAI_API_KEY', 'CODEX_HOME'],
+};
+
+export function buildCliEnv(
+  providerKeys: readonly string[],
+  source: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of [...CLI_BASE_ENV_KEYS, ...providerKeys]) {
+    const value = source[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
 }
 
 const CLAUDE_CODE_WEB_TOOLS = 'WebSearch,WebFetch';

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -13,17 +13,17 @@ const ClaudeCodeResultSchema = z.object({
   api_error_status: z.number().nullable().optional(),
 });
 
-export interface ClaudeCodeOutcome {
+export interface CliOutcome {
   text: string | null;
-  /** True for 429 / overloaded — the caller may retry later. */
+  /** True for 429 / overloaded / quota — the caller may retry later. */
   rateLimited: boolean;
   error: string | null;
 }
 
 const RATE_LIMIT_STATUS = 429;
-const RATE_LIMIT_PATTERN = /rate.?limit|usage limit|overloaded/i;
+const RATE_LIMIT_PATTERN = /rate.?limit|usage limit|overloaded|resource.?exhausted|quota/i;
 
-export function parseClaudeCodeOutput(raw: string): ClaudeCodeOutcome {
+export function parseClaudeCodeOutput(raw: string): CliOutcome {
   let json: unknown;
   try {
     json = JSON.parse(raw);
@@ -68,5 +68,65 @@ export function buildClaudeCodeArgs(req: {
     ...tools,
     '--no-session-persistence',
     req.user,
+  ];
+}
+
+/**
+ * Shape of `gemini -p --output-format json`: success carries `response`,
+ * failures an `error` object. Stats pass through untouched.
+ */
+const GeminiCliResultSchema = z.object({
+  response: z.string().optional(),
+  error: z
+    .object({
+      type: z.string().optional(),
+      message: z.string(),
+      code: z.union([z.number(), z.string()]).nullable().optional(),
+    })
+    .optional(),
+});
+
+export function parseGeminiCliOutput(raw: string): CliOutcome {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return { text: null, rateLimited: false, error: 'gemini-cli: output is not JSON' };
+  }
+  const parsed = GeminiCliResultSchema.safeParse(json);
+  if (!parsed.success) {
+    return { text: null, rateLimited: false, error: 'gemini-cli: unexpected result shape' };
+  }
+  const r = parsed.data;
+  if (r.error) {
+    const rateLimited =
+      r.error.code === RATE_LIMIT_STATUS || RATE_LIMIT_PATTERN.test(r.error.message);
+    return { text: null, rateLimited, error: `gemini-cli: ${r.error.message}` };
+  }
+  if (typeof r.response === 'string') {
+    return { text: r.response, rateLimited: false, error: null };
+  }
+  return { text: null, rateLimited: false, error: 'gemini-cli: no response field' };
+}
+
+/**
+ * Argument list for `gemini -p`. The CLI has no system-prompt flag, so the
+ * system text is prepended to the prompt. Headless default approval mode
+ * denies every tool; webTools pre-approves only the two web tools.
+ */
+export function buildGeminiCliArgs(req: {
+  system: string;
+  user: string;
+  model: string;
+  webTools?: boolean;
+}): string[] {
+  const tools = req.webTools
+    ? ['--allowed-tools', 'google_web_search', '--allowed-tools', 'web_fetch']
+    : [];
+  return [
+    '--output-format', 'json',
+    '--model', req.model,
+    ...tools,
+    '--prompt', `${req.system}\n\n${req.user}`,
   ];
 }

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -112,7 +112,8 @@ export function parseGeminiCliOutput(raw: string): CliOutcome {
 /**
  * Argument list for `gemini -p`. The CLI has no system-prompt flag, so the
  * system text is prepended to the prompt. Headless default approval mode
- * denies every tool; webTools pre-approves only the two web tools.
+ * denies every tool; webTools pre-approves only the two web tools. An empty
+ * model means "use the CLI's configured default".
  */
 export function buildGeminiCliArgs(req: {
   system: string;
@@ -125,8 +126,104 @@ export function buildGeminiCliArgs(req: {
     : [];
   return [
     '--output-format', 'json',
-    '--model', req.model,
+    ...(req.model ? ['--model', req.model] : []),
     ...tools,
     '--prompt', `${req.system}\n\n${req.user}`,
   ];
+}
+
+/**
+ * Argument list for `codex exec` (headless, ChatGPT subscription or
+ * OPENAI_API_KEY). No system-prompt flag — the system text is prepended.
+ * read-only sandbox keeps the agent away from the filesystem; --search
+ * enables its web tools only when the request asks. Empty model = the CLI's
+ * configured default.
+ */
+export function buildCodexCliArgs(req: {
+  system: string;
+  user: string;
+  model: string;
+  webTools?: boolean;
+}): string[] {
+  return [
+    'exec',
+    '--json',
+    '--skip-git-repo-check',
+    '--sandbox', 'read-only',
+    ...(req.model ? ['--model', req.model] : []),
+    ...(req.webTools ? ['--search'] : []),
+    `${req.system}\n\n${req.user}`,
+  ];
+}
+
+/**
+ * `codex exec --json` emits JSONL events. The reply is the last
+ * agent-message event; error events carry a message. Two event shapes are
+ * covered — `{item:{type:'agent_message',text}}` (current) and
+ * `{msg:{type:'agent_message',message}}` (older builds) — parsed
+ * defensively line by line.
+ */
+export function parseCodexCliOutput(raw: string): CliOutcome {
+  let text: string | null = null;
+  let error: string | null = null;
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    let event: unknown;
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const e = event as {
+      type?: string;
+      message?: string;
+      error?: { message?: string };
+      item?: { type?: string; text?: string };
+      msg?: { type?: string; message?: string };
+    };
+    if (e.item?.type === 'agent_message' && typeof e.item.text === 'string') {
+      text = e.item.text;
+    } else if (e.msg?.type === 'agent_message' && typeof e.msg.message === 'string') {
+      text = e.msg.message;
+    } else if (e.type === 'error' || e.type === 'turn.failed') {
+      error = e.message ?? e.error?.message ?? 'unknown error';
+    }
+  }
+  if (text !== null) return { text, rateLimited: false, error: null };
+  if (error !== null) {
+    return { text: null, rateLimited: RATE_LIMIT_PATTERN.test(error), error: `codex: ${error}` };
+  }
+  return { text: null, rateLimited: false, error: 'codex: no agent message in output' };
+}
+
+/**
+ * Response of an OpenAI-compatible POST /chat/completions (OpenAI,
+ * OpenRouter, Groq, local servers). Error shape is the OpenAI envelope.
+ */
+const OpenAiChatResponseSchema = z.object({
+  choices: z
+    .array(z.object({ message: z.object({ content: z.string().nullable() }) }))
+    .optional(),
+  error: z.object({ message: z.string() }).optional(),
+});
+
+export function parseOpenAiChatResponse(raw: string): CliOutcome {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return { text: null, rateLimited: false, error: 'openai: response is not JSON' };
+  }
+  const parsed = OpenAiChatResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    return { text: null, rateLimited: false, error: 'openai: unexpected response shape' };
+  }
+  if (parsed.data.error) {
+    const message = parsed.data.error.message;
+    return { text: null, rateLimited: RATE_LIMIT_PATTERN.test(message), error: `openai: ${message}` };
+  }
+  const content = parsed.data.choices?.[0]?.message.content;
+  if (typeof content === 'string') return { text: content, rateLimited: false, error: null };
+  return { text: null, rateLimited: false, error: 'openai: empty completion' };
 }

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -7,8 +7,10 @@ import { logger } from './logger';
 import { sleep } from './http';
 import {
   buildClaudeCodeArgs,
+  buildCliEnv,
   buildCodexCliArgs,
   buildGeminiCliArgs,
+  CLI_PROVIDER_ENV_KEYS,
   parseClaudeCodeOutput,
   parseCodexCliOutput,
   parseGeminiCliOutput,
@@ -200,6 +202,8 @@ interface CliSpec {
   buildArgs(req: { system: string; user: string; model: string; webTools?: boolean }): string[];
   parse(raw: string): CliOutcome;
   defaultModel: string;
+  /** Auth variables this provider's child may see (buildCliEnv allowlist). */
+  envKeys: readonly string[];
   /** Working directory — set to keep the CLI away from workspace context. */
   cwd?: string;
 }
@@ -226,6 +230,7 @@ class CliProvider implements AiProvider {
           timeout: req.timeoutMs ?? CLI_TIMEOUT_MS,
           maxBuffer: CLI_MAX_BUFFER,
           cwd: this.spec.cwd,
+          env: buildCliEnv(this.spec.envKeys),
         }));
       } catch (err) {
         logger.error({ err, label: req.label, provider: this.name }, 'ai: cli process failed');
@@ -271,6 +276,7 @@ export function getAiProviderById(id: AiProviderId): AiProvider {
         buildArgs: buildClaudeCodeArgs,
         parse: parseClaudeCodeOutput,
         defaultModel: config.CLAUDE_MODEL,
+        envKeys: CLI_PROVIDER_ENV_KEYS.claude_code ?? [],
       });
       break;
     case 'gemini_cli':
@@ -278,6 +284,7 @@ export function getAiProviderById(id: AiProviderId): AiProvider {
         buildArgs: buildGeminiCliArgs,
         parse: parseGeminiCliOutput,
         defaultModel: 'gemini-2.5-flash',
+        envKeys: CLI_PROVIDER_ENV_KEYS.gemini_cli ?? [],
         // gemini has no --tools '' switch; an empty cwd keeps it from
         // ingesting workspace files (GEMINI.md, sources) as context.
         cwd: tmpdir(),
@@ -296,6 +303,7 @@ export function getAiProviderById(id: AiProviderId): AiProvider {
         parse: parseCodexCliOutput,
         // '' = let the CLI use its configured default model.
         defaultModel: '',
+        envKeys: CLI_PROVIDER_ENV_KEYS.codex_cli ?? [],
         cwd: tmpdir(),
       });
       break;

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -7,15 +7,18 @@ import { logger } from './logger';
 import { sleep } from './http';
 import {
   buildClaudeCodeArgs,
+  buildCodexCliArgs,
   buildGeminiCliArgs,
   parseClaudeCodeOutput,
+  parseCodexCliOutput,
   parseGeminiCliOutput,
+  parseOpenAiChatResponse,
   type CliOutcome,
 } from './ai-provider-parse';
-import { GEMINI_DEFAULT_CLASSIFIER_MODEL, type AiProviderId } from './ai-engine';
+import type { AiProviderId } from './ai-engine';
 
 /**
- * The single seam between the callers and whatever runs the AI (ADR 0013).
+ * The single seam between the callers and whatever runs the AI (ADR 0013/0014).
  *
  * - `anthropic_api`: Messages API via the SDK (pay per token, prompt cache).
  * - `claude_code`:   headless `claude -p` — uses the Claude.ai subscription
@@ -24,6 +27,11 @@ import { GEMINI_DEFAULT_CLASSIFIER_MODEL, type AiProviderId } from './ai-engine'
  *                    subject to the subscription's rolling usage window.
  * - `gemini_cli`:    headless `gemini -p` — Google account subscription or
  *                    GEMINI_API_KEY. Same process-per-call trade-offs.
+ * - `openai_api`:    OpenAI-compatible POST /chat/completions via fetch —
+ *                    covers OpenAI, OpenRouter, Groq, DeepSeek and local
+ *                    servers through OPENAI_BASE_URL.
+ * - `codex_cli`:     headless `codex exec` — ChatGPT subscription login or
+ *                    OPENAI_API_KEY.
  *
  * All return the raw text; callers own JSON extraction + zod validation.
  */
@@ -59,6 +67,11 @@ const WEB_SEARCH_MAX_USES = 10;
 const WEB_FETCH_MAX_USES = 6;
 const CLI_TIMEOUT_MS = 180_000;
 const CLI_MAX_BUFFER = 1024 * 1024;
+// gpt-5 / o-series burn completion tokens on reasoning before any output;
+// low effort + headroom keeps small-maxTokens JSON calls from truncating.
+const OPENAI_REASONING_MODEL = /^(gpt-5|o\d)/;
+const OPENAI_REASONING_HEADROOM_TOKENS = 2_048;
+const OPENAI_FALLBACK_MODEL = 'gpt-5-mini';
 
 const execFileAsync = promisify(execFile);
 
@@ -113,6 +126,73 @@ class AnthropicApiProvider implements AiProvider {
         .map((b) => b.text)
         .join('');
     }
+  }
+}
+
+/** OpenAI-compatible chat completions over fetch — no SDK dependency. */
+class OpenAiApiProvider implements AiProvider {
+  readonly name = 'openai_api';
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly baseUrl: string,
+  ) {}
+
+  async complete(req: AiRequest): Promise<string | null> {
+    const model = req.model || config.OPENAI_MODEL || OPENAI_FALLBACK_MODEL;
+    // api.openai.com rejects max_tokens for reasoning models; most
+    // compatible servers (OpenRouter, Groq, local) only know max_tokens.
+    const isOpenAi = this.baseUrl.includes('api.openai.com');
+    const reasoning = isOpenAi && OPENAI_REASONING_MODEL.test(model);
+    const body = JSON.stringify({
+      model,
+      messages: [
+        { role: 'system', content: req.system },
+        { role: 'user', content: req.user },
+      ],
+      ...(isOpenAi
+        ? {
+            max_completion_tokens:
+              req.maxTokens + (reasoning ? OPENAI_REASONING_HEADROOM_TOKENS : 0),
+          }
+        : { max_tokens: req.maxTokens }),
+      ...(reasoning ? { reasoning_effort: 'low' } : {}),
+    });
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), req.timeoutMs ?? CLI_TIMEOUT_MS);
+      try {
+        const resp = await fetch(`${this.baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body,
+          signal: ctrl.signal,
+        });
+        const raw = await resp.text();
+        const out = parseOpenAiChatResponse(raw);
+        if (out.text !== null) return out.text;
+        const rateLimited = out.rateLimited || resp.status === 429;
+        if (rateLimited && attempt < MAX_ATTEMPTS - 1) {
+          logger.warn({ label: req.label }, 'ai: openai rate-limited, retrying');
+          await sleep(RATE_LIMIT_RETRY_DELAY_MS);
+          continue;
+        }
+        logger.error(
+          { label: req.label, status: resp.status, error: out.error, model },
+          'ai: openai request failed',
+        );
+        return null;
+      } catch (err) {
+        logger.error({ err, label: req.label, model }, 'ai: openai request failed');
+        return null;
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    return null;
   }
 }
 
@@ -197,9 +277,25 @@ export function getAiProviderById(id: AiProviderId): AiProvider {
       provider = new CliProvider('gemini_cli', config.GEMINI_CLI_BIN, {
         buildArgs: buildGeminiCliArgs,
         parse: parseGeminiCliOutput,
-        defaultModel: GEMINI_DEFAULT_CLASSIFIER_MODEL,
+        defaultModel: 'gemini-2.5-flash',
         // gemini has no --tools '' switch; an empty cwd keeps it from
         // ingesting workspace files (GEMINI.md, sources) as context.
+        cwd: tmpdir(),
+      });
+      break;
+    case 'openai_api': {
+      if (!config.OPENAI_API_KEY) {
+        throw new Error('OPENAI_API_KEY is required for the openai_api provider');
+      }
+      provider = new OpenAiApiProvider(config.OPENAI_API_KEY, config.OPENAI_BASE_URL);
+      break;
+    }
+    case 'codex_cli':
+      provider = new CliProvider('codex_cli', config.CODEX_CLI_BIN, {
+        buildArgs: buildCodexCliArgs,
+        parse: parseCodexCliOutput,
+        // '' = let the CLI use its configured default model.
+        defaultModel: '',
         cwd: tmpdir(),
       });
       break;

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -1,21 +1,31 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { execFile } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { promisify } from 'node:util';
 import { config } from './config';
 import { logger } from './logger';
 import { sleep } from './http';
-import { buildClaudeCodeArgs, parseClaudeCodeOutput } from './ai-provider-parse';
+import {
+  buildClaudeCodeArgs,
+  buildGeminiCliArgs,
+  parseClaudeCodeOutput,
+  parseGeminiCliOutput,
+  type CliOutcome,
+} from './ai-provider-parse';
+import { GEMINI_DEFAULT_CLASSIFIER_MODEL, type AiProviderId } from './ai-engine';
 
 /**
- * The single seam between the classifiers and whatever runs Claude.
+ * The single seam between the callers and whatever runs the AI (ADR 0013).
  *
  * - `anthropic_api`: Messages API via the SDK (pay per token, prompt cache).
  * - `claude_code`:   headless `claude -p` — uses the Claude.ai subscription
  *                    that the CLI is logged into. Slower (one process per
  *                    call, ~5k tokens of CLI system prompt per call) and
  *                    subject to the subscription's rolling usage window.
+ * - `gemini_cli`:    headless `gemini -p` — Google account subscription or
+ *                    GEMINI_API_KEY. Same process-per-call trade-offs.
  *
- * Both return the raw text; callers own JSON extraction + zod validation.
+ * All return the raw text; callers own JSON extraction + zod validation.
  */
 export interface AiRequest {
   system: string;
@@ -23,9 +33,9 @@ export interface AiRequest {
   maxTokens: number;
   /** Short tag for log lines, e.g. 'classifier' / 'prefilter'. */
   label: string;
-  /** Model id; defaults to CLAUDE_MODEL. */
+  /** Model id; callers pass the resolved engine model (src/ai-runtime.ts). */
   model?: string;
-  /** Per-call ceiling for the claude_code process (default CLAUDE_CODE_TIMEOUT_MS). */
+  /** Per-call ceiling for a CLI process (default CLI_TIMEOUT_MS). */
   timeoutMs?: number;
   /**
    * Let the model search and fetch the web before answering (server tools on
@@ -47,8 +57,8 @@ const MAX_ATTEMPTS = 2;
 const MAX_PAUSE_TURN_RESUMES = 5;
 const WEB_SEARCH_MAX_USES = 10;
 const WEB_FETCH_MAX_USES = 6;
-const CLAUDE_CODE_TIMEOUT_MS = 180_000;
-const CLAUDE_CODE_MAX_BUFFER = 1024 * 1024;
+const CLI_TIMEOUT_MS = 180_000;
+const CLI_MAX_BUFFER = 1024 * 1024;
 
 const execFileAsync = promisify(execFile);
 
@@ -106,39 +116,51 @@ class AnthropicApiProvider implements AiProvider {
   }
 }
 
-class ClaudeCodeProvider implements AiProvider {
-  readonly name = 'claude_code';
+interface CliSpec {
+  buildArgs(req: { system: string; user: string; model: string; webTools?: boolean }): string[];
+  parse(raw: string): CliOutcome;
+  defaultModel: string;
+  /** Working directory — set to keep the CLI away from workspace context. */
+  cwd?: string;
+}
 
-  constructor(private readonly bin: string) {}
+/** Headless-CLI backend: spawn, parse JSON stdout, one retry on rate limit. */
+class CliProvider implements AiProvider {
+  constructor(
+    readonly name: string,
+    private readonly bin: string,
+    private readonly spec: CliSpec,
+  ) {}
 
   async complete(req: AiRequest): Promise<string | null> {
-    const args = buildClaudeCodeArgs({
+    const args = this.spec.buildArgs({
       system: req.system,
       user: req.user,
-      model: req.model ?? config.CLAUDE_MODEL,
+      model: req.model ?? this.spec.defaultModel,
       webTools: req.webTools,
     });
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       let stdout: string;
       try {
         ({ stdout } = await execFileAsync(this.bin, args, {
-          timeout: req.timeoutMs ?? CLAUDE_CODE_TIMEOUT_MS,
-          maxBuffer: CLAUDE_CODE_MAX_BUFFER,
+          timeout: req.timeoutMs ?? CLI_TIMEOUT_MS,
+          maxBuffer: CLI_MAX_BUFFER,
+          cwd: this.spec.cwd,
         }));
       } catch (err) {
-        logger.error({ err, label: req.label }, 'ai: claude-code process failed');
+        logger.error({ err, label: req.label, provider: this.name }, 'ai: cli process failed');
         return null;
       }
-      const out = parseClaudeCodeOutput(stdout);
+      const out = this.spec.parse(stdout);
       if (out.text !== null) return out.text;
       if (out.rateLimited && attempt < MAX_ATTEMPTS - 1) {
-        logger.warn({ label: req.label }, 'ai: claude-code rate-limited, retrying');
+        logger.warn({ label: req.label, provider: this.name }, 'ai: cli rate-limited, retrying');
         await sleep(RATE_LIMIT_RETRY_DELAY_MS);
         continue;
       }
       logger.error(
-        { label: req.label, error: out.error, rateLimited: out.rateLimited },
-        'ai: claude-code returned an error',
+        { label: req.label, provider: this.name, error: out.error, rateLimited: out.rateLimited },
+        'ai: cli returned an error',
       );
       return null;
     }
@@ -146,16 +168,48 @@ class ClaudeCodeProvider implements AiProvider {
   }
 }
 
-let provider: AiProvider | null = null;
+const providers = new Map<AiProviderId, AiProvider>();
 
-export function getAiProvider(): AiProvider {
-  if (provider) return provider;
-  if (config.AI_PROVIDER === 'claude_code') {
-    provider = new ClaudeCodeProvider(config.CLAUDE_CODE_BIN);
-  } else {
-    // config.ts guarantees the key is present in this branch.
-    provider = new AnthropicApiProvider(config.ANTHROPIC_API_KEY as string);
+/**
+ * Lazily constructs and caches the backend. Throws for anthropic_api without
+ * an API key — ai-runtime's resolution never selects it in that case.
+ */
+export function getAiProviderById(id: AiProviderId): AiProvider {
+  const cached = providers.get(id);
+  if (cached) return cached;
+  let provider: AiProvider;
+  switch (id) {
+    case 'anthropic_api': {
+      if (!config.ANTHROPIC_API_KEY) {
+        throw new Error('ANTHROPIC_API_KEY is required for the anthropic_api provider');
+      }
+      provider = new AnthropicApiProvider(config.ANTHROPIC_API_KEY);
+      break;
+    }
+    case 'claude_code':
+      provider = new CliProvider('claude_code', config.CLAUDE_CODE_BIN, {
+        buildArgs: buildClaudeCodeArgs,
+        parse: parseClaudeCodeOutput,
+        defaultModel: config.CLAUDE_MODEL,
+      });
+      break;
+    case 'gemini_cli':
+      provider = new CliProvider('gemini_cli', config.GEMINI_CLI_BIN, {
+        buildArgs: buildGeminiCliArgs,
+        parse: parseGeminiCliOutput,
+        defaultModel: GEMINI_DEFAULT_CLASSIFIER_MODEL,
+        // gemini has no --tools '' switch; an empty cwd keeps it from
+        // ingesting workspace files (GEMINI.md, sources) as context.
+        cwd: tmpdir(),
+      });
+      break;
   }
-  logger.info({ provider: provider.name, model: config.CLAUDE_MODEL }, 'ai: provider ready');
+  providers.set(id, provider);
+  logger.info({ provider: id }, 'ai: provider ready');
   return provider;
+}
+
+/** The .env-configured backend (scripts; runtime code uses getAiRuntime). */
+export function getAiProvider(): AiProvider {
+  return getAiProviderById(config.AI_PROVIDER);
 }

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -8,6 +8,7 @@ import { logger } from './logger';
 import { prisma } from './db';
 import { getAiProviderById, type AiProvider } from './ai-provider';
 import { SETTINGS_ID } from './settings';
+import { createCooldownTracker } from './ai-cooldown';
 import {
   PROVIDER_WEB_TOOLS,
   resolveAiEngine,
@@ -18,6 +19,17 @@ import {
 } from './ai-engine';
 
 const execFileAsync = promisify(execFile);
+
+// Chain guards (docs/ai-engine-improvements.md item 2): at most this many
+// engines per logical call, inside a deadline of FACTOR × the per-attempt
+// timeout — a 3-CLI verify chain must not become a 30-minute wait.
+const MAX_ENGINE_SWITCHES = 3;
+const CHAIN_DEADLINE_FACTOR = 2;
+const MIN_REMAINING_MS = 5_000;
+// Mirrors the provider-internal CLI default timeout.
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 180_000;
+
+const cooldowns = createCooldownTracker();
 
 /**
  * The .env side of the engine merge — computed per call: CLI auth can appear
@@ -54,6 +66,8 @@ export interface AiCallResult {
   providerId: AiProviderId;
   /** Model actually used; '' means the CLI's own default. */
   model: string;
+  /** True when an engine other than the configured #1 served the call. */
+  viaFallback: boolean;
 }
 
 export interface AiRuntime {
@@ -101,8 +115,24 @@ async function completeWithFailover(
     ? engine.chain.filter((id) => PROVIDER_WEB_TOOLS[id])
     : engine.chain;
   const chain = capable.length > 0 ? capable : engine.chain;
-  for (let i = 0; i < chain.length; i++) {
-    const id = chain[i]!;
+  // Engines in cooldown are skipped — unless that would leave nothing to try.
+  const hot = chain.filter((id) => cooldowns.blockedUntil(id) === null);
+  if (hot.length > 0 && hot.length < chain.length) {
+    logger.debug(
+      { cooling: chain.filter((id) => !hot.includes(id)), label: req.label },
+      'ai: engines in cooldown, skipped',
+    );
+  }
+  const tryList = (hot.length > 0 ? hot : chain).slice(0, MAX_ENGINE_SWITCHES);
+  const perAttemptMs = req.timeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS;
+  const deadline = Date.now() + perAttemptMs * CHAIN_DEADLINE_FACTOR;
+  for (let i = 0; i < tryList.length; i++) {
+    const id = tryList[i]!;
+    const remainingMs = deadline - Date.now();
+    if (i > 0 && remainingMs < MIN_REMAINING_MS) {
+      logger.warn({ tried: tryList.slice(0, i), label: req.label }, 'ai: chain deadline reached');
+      break;
+    }
     let provider: AiProvider;
     try {
       provider = getAiProviderById(id);
@@ -117,24 +147,53 @@ async function completeWithFailover(
       maxTokens: req.maxTokens,
       label: req.label,
       model,
-      timeoutMs: req.timeoutMs,
+      timeoutMs: Math.min(perAttemptMs, remainingMs),
       webTools: req.webTools,
     });
     if (text !== null) {
-      if (i > 0) {
+      cooldowns.success(id);
+      void recordUsage(id, req.role);
+      const viaFallback = id !== engine.chain[0];
+      if (viaFallback) {
         logger.warn(
-          { served: id, tried: chain.slice(0, i), label: req.label },
+          { served: id, primary: engine.chain[0], label: req.label },
           'ai: served by fallback engine',
         );
       }
-      return { text, providerId: id, model };
+      return { text, providerId: id, model, viaFallback };
     }
-    if (i < chain.length - 1) {
-      logger.warn({ failed: id, next: chain[i + 1], label: req.label }, 'ai: engine failed, trying next');
+    cooldowns.failure(id);
+    if (i < tryList.length - 1) {
+      logger.warn({ failed: id, next: tryList[i + 1], label: req.label }, 'ai: engine failed, trying next');
     }
   }
-  logger.error({ chain, label: req.label }, 'ai: every engine in the chain failed');
+  logger.error({ chain: tryList, label: req.label }, 'ai: every engine in the chain failed');
   return null;
+}
+
+/**
+ * Lightweight usage counters (docs/ai-engine-improvements.md item 6):
+ * runs per day × engine × role in AppSettings.aiUsage. One atomic jsonb
+ * update, fire-and-forget — a counter must never fail an AI call. All the
+ * COALESCE reads see the pre-update value, so nested paths self-create.
+ */
+async function recordUsage(id: AiProviderId, role: AiRole): Promise<void> {
+  const day = new Date().toISOString().slice(0, 10);
+  try {
+    await prisma.$executeRaw`
+      UPDATE "AppSettings" SET "aiUsage" =
+        jsonb_set(
+          jsonb_set(
+            jsonb_set(
+              COALESCE("aiUsage", '{}'::jsonb),
+              ARRAY[${day}], COALESCE("aiUsage"->${day}, '{}'::jsonb), true),
+            ARRAY[${day}, ${id}], COALESCE("aiUsage"->${day}->${id}, '{}'::jsonb), true),
+          ARRAY[${day}, ${id}, ${role}],
+          to_jsonb(COALESCE(("aiUsage"->${day}->${id}->>${role})::int, 0) + 1), true)
+      WHERE id = ${SETTINGS_ID}`;
+  } catch (err) {
+    logger.debug({ err }, 'ai: usage counter update failed');
+  }
 }
 
 export interface AiProviderStatus {

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -17,7 +17,8 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-const ENGINE_ENV: AiEngineEnv = {
+/** The .env side of the engine merge — exported for the settings page. */
+export const AI_ENGINE_ENV: AiEngineEnv = {
   provider: config.AI_PROVIDER,
   hasAnthropicKey: Boolean(config.ANTHROPIC_API_KEY),
   classifierModel: config.CLAUDE_MODEL,
@@ -43,7 +44,7 @@ export async function getAiRuntime(): Promise<AiRuntime> {
   } catch (err) {
     logger.warn({ err }, 'ai: settings read failed, using .env engine');
   }
-  const choice = resolveAiEngine(row, ENGINE_ENV);
+  const choice = resolveAiEngine(row, AI_ENGINE_ENV);
   return { ...choice, provider: getAiProviderById(choice.providerId) };
 }
 

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -1,0 +1,123 @@
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { config } from './config';
+import { logger } from './logger';
+import { prisma } from './db';
+import { getAiProviderById, type AiProvider } from './ai-provider';
+import { SETTINGS_ID } from './settings';
+import {
+  resolveAiEngine,
+  type AiEngineChoice,
+  type AiEngineEnv,
+  type AiProviderId,
+} from './ai-engine';
+
+const execFileAsync = promisify(execFile);
+
+const ENGINE_ENV: AiEngineEnv = {
+  provider: config.AI_PROVIDER,
+  hasAnthropicKey: Boolean(config.ANTHROPIC_API_KEY),
+  classifierModel: config.CLAUDE_MODEL,
+  resumeModel: config.CLAUDE_MODEL_RESUME,
+};
+
+export interface AiRuntime extends AiEngineChoice {
+  provider: AiProvider;
+}
+
+/**
+ * Effective AI engine for one call: the AppSettings override merged with the
+ * .env defaults. Read per call so a dashboard change applies on the next
+ * cron tick (CLAUDE.md gotcha 9) without restarting either process.
+ */
+export async function getAiRuntime(): Promise<AiRuntime> {
+  let row = null;
+  try {
+    row = await prisma.appSettings.findUnique({
+      where: { id: SETTINGS_ID },
+      select: { aiProvider: true, aiModelClassifier: true, aiModelResume: true },
+    });
+  } catch (err) {
+    logger.warn({ err }, 'ai: settings read failed, using .env engine');
+  }
+  const choice = resolveAiEngine(row, ENGINE_ENV);
+  return { ...choice, provider: getAiProviderById(choice.providerId) };
+}
+
+export interface AiProviderStatus {
+  ok: boolean;
+  detail: string;
+}
+
+const PROBE_TIMEOUT_MS = 5_000;
+const PROBE_TTL_MS = 60_000;
+
+let probeCache: { at: number; statuses: Record<AiProviderId, AiProviderStatus> } | null = null;
+
+/**
+ * Which backends this host can actually run: key present for the API,
+ * binary on PATH for the CLIs. Cached briefly — the settings page calls it
+ * on every render. Detects installation, not login state.
+ */
+export async function probeAiProviders(): Promise<Record<AiProviderId, AiProviderStatus>> {
+  if (probeCache && Date.now() - probeCache.at < PROBE_TTL_MS) return probeCache.statuses;
+  const [claude, gemini] = await Promise.all([
+    probeCliBin(config.CLAUDE_CODE_BIN),
+    probeCliBin(config.GEMINI_CLI_BIN),
+  ]);
+  const statuses: Record<AiProviderId, AiProviderStatus> = {
+    anthropic_api: config.ANTHROPIC_API_KEY
+      ? { ok: true, detail: 'API key set' }
+      : { ok: false, detail: 'set ANTHROPIC_API_KEY in .env' },
+    claude_code: claude,
+    gemini_cli: withGeminiAuth(gemini),
+  };
+  probeCache = { at: Date.now(), statuses };
+  return statuses;
+}
+
+async function probeCliBin(bin: string): Promise<AiProviderStatus> {
+  try {
+    const { stdout } = await execFileAsync(bin, ['--version'], { timeout: PROBE_TIMEOUT_MS });
+    return { ok: true, detail: stdout.trim().split('\n')[0] ?? '' };
+  } catch {
+    return { ok: false, detail: `${bin} not found on PATH` };
+  }
+}
+
+/**
+ * A fresh gemini install exits with "Please set an Auth method" in headless
+ * mode, so an installed binary alone is not usable. Auth is file/env
+ * detectable (unlike Claude Code's keychain), so surface it here.
+ */
+function withGeminiAuth(bin: AiProviderStatus): AiProviderStatus {
+  if (!bin.ok || geminiAuthConfigured()) return bin;
+  return {
+    ok: false,
+    detail: `${bin.detail} installed — run \`gemini\` once to log in, or set GEMINI_API_KEY in .env`,
+  };
+}
+
+function geminiAuthConfigured(): boolean {
+  if (
+    process.env.GEMINI_API_KEY ||
+    process.env.GOOGLE_GENAI_USE_VERTEXAI ||
+    process.env.GOOGLE_GENAI_USE_GCA
+  ) {
+    return true;
+  }
+  const dir = join(homedir(), '.gemini');
+  if (existsSync(join(dir, 'oauth_creds.json'))) return true;
+  try {
+    const s = JSON.parse(readFileSync(join(dir, 'settings.json'), 'utf8')) as {
+      selectedAuthType?: string;
+      security?: { auth?: { selectedType?: string } };
+    };
+    return Boolean(s.selectedAuthType || s.security?.auth?.selectedType);
+  } catch {
+    return false;
+  }
+}

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -9,59 +9,132 @@ import { prisma } from './db';
 import { getAiProviderById, type AiProvider } from './ai-provider';
 import { SETTINGS_ID } from './settings';
 import {
+  PROVIDER_WEB_TOOLS,
   resolveAiEngine,
-  type AiEngineChoice,
   type AiEngineEnv,
   type AiProviderId,
+  type AiRole,
+  type ResolvedAiEngine,
 } from './ai-engine';
 
 const execFileAsync = promisify(execFile);
 
 /**
- * The .env side of the engine merge — exported for the settings page.
- * Computed per call: gemini auth can appear while the process runs
- * (login / mounted creds), and the resolver should see it immediately.
+ * The .env side of the engine merge — computed per call: CLI auth can appear
+ * while the process runs (login / mounted creds), and the resolver should
+ * see it immediately.
  */
 export function getAiEngineEnv(): AiEngineEnv {
   return {
     provider: config.AI_PROVIDER,
     hasAnthropicKey: Boolean(config.ANTHROPIC_API_KEY),
+    hasOpenAiKey: Boolean(config.OPENAI_API_KEY),
     geminiUsable: geminiAuthConfigured(),
+    codexUsable: codexAuthConfigured(),
     classifierModel: config.CLAUDE_MODEL,
     resumeModel: config.CLAUDE_MODEL_RESUME,
+    openAiModel: config.OPENAI_MODEL,
   };
 }
 
-export interface AiRuntime extends AiEngineChoice {
-  provider: AiProvider;
+export interface AiCallRequest {
+  system: string;
+  user: string;
+  maxTokens: number;
+  /** Short tag for log lines, e.g. 'classifier' / 'resume-match'. */
+  label: string;
+  /** Picks the per-engine model slot (classifier vs resume calls). */
+  role: AiRole;
+  timeoutMs?: number;
+  webTools?: boolean;
+}
+
+export interface AiCallResult {
+  text: string;
+  providerId: AiProviderId;
+  /** Model actually used; '' means the CLI's own default. */
+  model: string;
+}
+
+export interface AiRuntime {
+  /** Usable engines in priority order — the first one serves the call. */
+  chain: AiProviderId[];
+  /** Enabled engines this host cannot run yet (no key / not logged in). */
+  skipped: AiProviderId[];
+  modelFor(id: AiProviderId, role: AiRole): string;
+  /** Runs the chain: first engine that answers wins; null when all fail. */
+  complete(req: AiCallRequest): Promise<AiCallResult | null>;
 }
 
 /**
- * Effective AI engine for one call: the AppSettings override merged with the
- * .env defaults. Read per call so a dashboard change applies on the next
+ * Effective AI engine chain for one call: the AppSettings config merged with
+ * the .env defaults. Read per call so a dashboard change applies on the next
  * cron tick (CLAUDE.md gotcha 9) without restarting either process.
  */
-let warnedFallback = false;
-
 export async function getAiRuntime(): Promise<AiRuntime> {
-  let row = null;
+  let raw: unknown = null;
   try {
-    row = await prisma.appSettings.findUnique({
+    const row = await prisma.appSettings.findUnique({
       where: { id: SETTINGS_ID },
-      select: { aiProvider: true, aiModelClassifier: true, aiModelResume: true },
+      select: { aiEngine: true },
     });
+    raw = row?.aiEngine ?? null;
   } catch (err) {
     logger.warn({ err }, 'ai: settings read failed, using .env engine');
   }
-  const choice = resolveAiEngine(row, getAiEngineEnv());
-  if (row?.aiProvider && row.aiProvider !== choice.providerId && !warnedFallback) {
-    warnedFallback = true;
-    logger.warn(
-      { saved: row.aiProvider, running: choice.providerId },
-      'ai: saved engine not usable yet, falling back',
-    );
+  const resolved = resolveAiEngine(raw, getAiEngineEnv());
+  return {
+    chain: resolved.chain,
+    skipped: resolved.skipped,
+    modelFor: resolved.modelFor,
+    complete: (req) => completeWithFailover(resolved, req),
+  };
+}
+
+async function completeWithFailover(
+  engine: ResolvedAiEngine,
+  req: AiCallRequest,
+): Promise<AiCallResult | null> {
+  // Verification asks for web tools — prefer engines that have them, but a
+  // tool-less engine is still better than no answer at all.
+  const capable = req.webTools
+    ? engine.chain.filter((id) => PROVIDER_WEB_TOOLS[id])
+    : engine.chain;
+  const chain = capable.length > 0 ? capable : engine.chain;
+  for (let i = 0; i < chain.length; i++) {
+    const id = chain[i]!;
+    let provider: AiProvider;
+    try {
+      provider = getAiProviderById(id);
+    } catch (err) {
+      logger.warn({ err, provider: id }, 'ai: engine not constructible, skipping');
+      continue;
+    }
+    const model = engine.modelFor(id, req.role);
+    const text = await provider.complete({
+      system: req.system,
+      user: req.user,
+      maxTokens: req.maxTokens,
+      label: req.label,
+      model,
+      timeoutMs: req.timeoutMs,
+      webTools: req.webTools,
+    });
+    if (text !== null) {
+      if (i > 0) {
+        logger.warn(
+          { served: id, tried: chain.slice(0, i), label: req.label },
+          'ai: served by fallback engine',
+        );
+      }
+      return { text, providerId: id, model };
+    }
+    if (i < chain.length - 1) {
+      logger.warn({ failed: id, next: chain[i + 1], label: req.label }, 'ai: engine failed, trying next');
+    }
   }
-  return { ...choice, provider: getAiProviderById(choice.providerId) };
+  logger.error({ chain, label: req.label }, 'ai: every engine in the chain failed');
+  return null;
 }
 
 export interface AiProviderStatus {
@@ -75,15 +148,16 @@ const PROBE_TTL_MS = 60_000;
 let probeCache: { at: number; statuses: Record<AiProviderId, AiProviderStatus> } | null = null;
 
 /**
- * Which backends this host can actually run: key present for the API,
- * binary on PATH for the CLIs. Cached briefly — the settings page calls it
- * on every render. Detects installation, not login state.
+ * Which backends this host can actually run: key present for the APIs,
+ * binary on PATH + detectable auth for the CLIs. Cached briefly — the
+ * settings page calls it on every render.
  */
 export async function probeAiProviders(): Promise<Record<AiProviderId, AiProviderStatus>> {
   if (probeCache && Date.now() - probeCache.at < PROBE_TTL_MS) return probeCache.statuses;
-  const [claude, gemini] = await Promise.all([
+  const [claude, gemini, codex] = await Promise.all([
     probeCliBin(config.CLAUDE_CODE_BIN),
     probeCliBin(config.GEMINI_CLI_BIN),
+    probeCliBin(config.CODEX_CLI_BIN),
   ]);
   const statuses: Record<AiProviderId, AiProviderStatus> = {
     anthropic_api: config.ANTHROPIC_API_KEY
@@ -91,9 +165,21 @@ export async function probeAiProviders(): Promise<Record<AiProviderId, AiProvide
       : { ok: false, detail: 'set ANTHROPIC_API_KEY in .env' },
     claude_code: claude,
     gemini_cli: withGeminiAuth(gemini),
+    openai_api: config.OPENAI_API_KEY
+      ? { ok: true, detail: `API key set · ${baseUrlHost()}` }
+      : { ok: false, detail: `set OPENAI_API_KEY in .env (endpoint: ${baseUrlHost()})` },
+    codex_cli: withCodexAuth(codex),
   };
   probeCache = { at: Date.now(), statuses };
   return statuses;
+}
+
+function baseUrlHost(): string {
+  try {
+    return new URL(config.OPENAI_BASE_URL).host;
+  } catch {
+    return config.OPENAI_BASE_URL;
+  }
 }
 
 async function probeCliBin(bin: string): Promise<AiProviderStatus> {
@@ -137,4 +223,16 @@ function geminiAuthConfigured(): boolean {
   } catch {
     return false;
   }
+}
+
+function withCodexAuth(bin: AiProviderStatus): AiProviderStatus {
+  if (!bin.ok || codexAuthConfigured()) return bin;
+  return {
+    ok: false,
+    detail: `${bin.detail} installed — run \`codex login\` once (mount ~/.codex in Docker)`,
+  };
+}
+
+function codexAuthConfigured(): boolean {
+  return existsSync(join(homedir(), '.codex', 'auth.json'));
 }

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -17,13 +17,20 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-/** The .env side of the engine merge — exported for the settings page. */
-export const AI_ENGINE_ENV: AiEngineEnv = {
-  provider: config.AI_PROVIDER,
-  hasAnthropicKey: Boolean(config.ANTHROPIC_API_KEY),
-  classifierModel: config.CLAUDE_MODEL,
-  resumeModel: config.CLAUDE_MODEL_RESUME,
-};
+/**
+ * The .env side of the engine merge — exported for the settings page.
+ * Computed per call: gemini auth can appear while the process runs
+ * (login / mounted creds), and the resolver should see it immediately.
+ */
+export function getAiEngineEnv(): AiEngineEnv {
+  return {
+    provider: config.AI_PROVIDER,
+    hasAnthropicKey: Boolean(config.ANTHROPIC_API_KEY),
+    geminiUsable: geminiAuthConfigured(),
+    classifierModel: config.CLAUDE_MODEL,
+    resumeModel: config.CLAUDE_MODEL_RESUME,
+  };
+}
 
 export interface AiRuntime extends AiEngineChoice {
   provider: AiProvider;
@@ -34,6 +41,8 @@ export interface AiRuntime extends AiEngineChoice {
  * .env defaults. Read per call so a dashboard change applies on the next
  * cron tick (CLAUDE.md gotcha 9) without restarting either process.
  */
+let warnedFallback = false;
+
 export async function getAiRuntime(): Promise<AiRuntime> {
   let row = null;
   try {
@@ -44,7 +53,14 @@ export async function getAiRuntime(): Promise<AiRuntime> {
   } catch (err) {
     logger.warn({ err }, 'ai: settings read failed, using .env engine');
   }
-  const choice = resolveAiEngine(row, AI_ENGINE_ENV);
+  const choice = resolveAiEngine(row, getAiEngineEnv());
+  if (row?.aiProvider && row.aiProvider !== choice.providerId && !warnedFallback) {
+    warnedFallback = true;
+    logger.warn(
+      { saved: row.aiProvider, running: choice.providerId },
+      'ai: saved engine not usable yet, falling back',
+    );
+  }
   return { ...choice, provider: getAiProviderById(choice.providerId) };
 }
 
@@ -98,7 +114,7 @@ function withGeminiAuth(bin: AiProviderStatus): AiProviderStatus {
   if (!bin.ok || geminiAuthConfigured()) return bin;
   return {
     ok: false,
-    detail: `${bin.detail} installed — run \`gemini\` once to log in, or set GEMINI_API_KEY in .env`,
+    detail: `${bin.detail} installed — set GEMINI_API_KEY in .env, or log in once with \`gemini\` (mount ~/.gemini in Docker)`,
   };
 }
 

--- a/src/classifier-prefilter.ts
+++ b/src/classifier-prefilter.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { Profile } from '@prisma/client';
 import { logger } from './logger';
 import { extractJson } from './text-utils';
-import { getAiProvider } from './ai-provider';
+import { getAiRuntime } from './ai-runtime';
 import type { ClassifyInput } from './types';
 
 // Stage 1 uses the same model as stage 2; the saving comes from the much
@@ -33,11 +33,13 @@ export async function preClassify(
     'Return raw JSON only.',
   ].join('\n');
 
-  const text = await getAiProvider().complete({
+  const ai = await getAiRuntime();
+  const text = await ai.provider.complete({
     system: systemPrompt,
     user: userText,
     maxTokens: MAX_TOKENS,
     label: 'prefilter',
+    model: ai.classifierModel,
   });
   if (text === null) return null;
 

--- a/src/classifier-prefilter.ts
+++ b/src/classifier-prefilter.ts
@@ -34,18 +34,18 @@ export async function preClassify(
   ].join('\n');
 
   const ai = await getAiRuntime();
-  const text = await ai.provider.complete({
+  const out = await ai.complete({
     system: systemPrompt,
     user: userText,
     maxTokens: MAX_TOKENS,
     label: 'prefilter',
-    model: ai.classifierModel,
+    role: 'classifier',
   });
-  if (text === null) return null;
+  if (out === null) return null;
 
-  const parsed = parsePrefilterResponse(text);
+  const parsed = parsePrefilterResponse(out.text);
   if (parsed) return parsed;
-  logger.warn({ raw: text.slice(0, 300), title: input.title }, 'prefilter: response did not match schema');
+  logger.warn({ raw: out.text.slice(0, 300), title: input.title }, 'prefilter: response did not match schema');
   return null;
 }
 

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { Profile } from '@prisma/client';
 import { logger } from './logger';
 import { extractJson } from './text-utils';
-import { getAiProvider } from './ai-provider';
+import { getAiRuntime } from './ai-runtime';
 import { preClassify } from './classifier-prefilter';
 import type { ClassifyInput, ClaudeClassification } from './types';
 
@@ -98,14 +98,15 @@ export async function classifyWithClaude(
     'Return raw JSON only.',
   ].join('\n');
 
-  const provider = getAiProvider();
+  const ai = await getAiRuntime();
   // One retry on a malformed reply: Haiku occasionally wraps or truncates JSON.
   for (let attempt = 0; attempt < 2; attempt++) {
-    const text = await provider.complete({
+    const text = await ai.provider.complete({
       system: systemPrompt,
       user: userText,
       maxTokens: MAX_TOKENS,
       label: 'classifier',
+      model: ai.classifierModel,
     });
     if (text === null) return null;
 

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -99,23 +99,23 @@ export async function classifyWithClaude(
   ].join('\n');
 
   const ai = await getAiRuntime();
-  // One retry on a malformed reply: Haiku occasionally wraps or truncates JSON.
+  // One retry on a malformed reply: small models occasionally wrap or truncate JSON.
   for (let attempt = 0; attempt < 2; attempt++) {
-    const text = await ai.provider.complete({
+    const out = await ai.complete({
       system: systemPrompt,
       user: userText,
       maxTokens: MAX_TOKENS,
       label: 'classifier',
-      model: ai.classifierModel,
+      role: 'classifier',
     });
-    if (text === null) return null;
+    if (out === null) return null;
 
-    const json = extractJson(text);
+    const json = extractJson(out.text);
     const parsed = json === null ? null : ClassificationSchema.safeParse(json);
     if (parsed?.success) return parsed.data;
     logger.warn(
       {
-        raw: text.slice(0, 500),
+        raw: out.text.slice(0, 500),
         errors: parsed && !parsed.success ? parsed.error.flatten().fieldErrors : undefined,
         title: input.title,
         attempt,

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -10,6 +10,9 @@ export type ClassifierMode = 'single' | 'two_stage';
 
 const MAX_TOKENS = 600;
 const MAX_DESC_CHARS = 4000;
+// Bump on any material change to buildSystemPrompt (rules, rubric, format) —
+// cross-engine quality comparisons are meaningless across prompt versions.
+export const CLASSIFIER_PROMPT_VERSION = 1;
 
 const ClassificationSchema = z.object({
   fit_score: z.number().int().min(0).max(100),
@@ -119,6 +122,8 @@ export async function classifyWithClaude(
         errors: parsed && !parsed.success ? parsed.error.flatten().fieldErrors : undefined,
         title: input.title,
         attempt,
+        engine: out.providerId,
+        promptVersion: CLASSIFIER_PROMPT_VERSION,
       },
       'classifier: response did not match schema',
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,14 @@ const ConfigSchema = z.object({
   CLAUDE_CODE_BIN: z.string().default('claude'),
   // Path to the Gemini CLI when the gemini_cli engine is selected.
   GEMINI_CLI_BIN: z.string().default('gemini'),
+  // Path to the Codex CLI when the codex_cli engine is selected.
+  CODEX_CLI_BIN: z.string().default('codex'),
+  // OpenAI-compatible API engine: any server that speaks /chat/completions
+  // (OpenAI, OpenRouter, Groq, local LM Studio / Ollama).
+  OPENAI_API_KEY: z.string().optional(),
+  OPENAI_BASE_URL: z.string().default('https://api.openai.com/v1'),
+  // Default model for the openai_api engine when the dashboard slot is empty.
+  OPENAI_MODEL: z.string().default(''),
   // How many jobs are classified at the same time (both providers).
   AI_CONCURRENCY: z.coerce.number().int().min(1).max(8).default(3),
   TELEGRAM_BOT_TOKEN: z.string().optional(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,9 +30,9 @@ const ConfigSchema = z.object({
   LOG_LEVEL: z
     .enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
     .default('info'),
-  TZ: z.string().default('America/Chicago'),
+  TZ: z.string().default('UTC'),
   MIN_FIT_SCORE: z.coerce.number().int().min(0).max(100).default(70),
-  MIN_SALARY_USD: z.coerce.number().int().min(0).default(120000),
+  MIN_SALARY_USD: z.coerce.number().int().min(0).default(0),
   WEB_PORT: z.coerce.number().int().min(1).max(65535).default(4747),
   WEB_HOST: z.string().default('0.0.0.0'),
   WEB_BASIC_AUTH: z

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,11 @@
 import 'dotenv/config';
 import { z } from 'zod';
+import { AI_PROVIDER_IDS } from './ai-engine';
 
 const ConfigSchema = z.object({
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
-  // Which backend runs the classifier. See src/ai-provider.ts.
-  AI_PROVIDER: z.enum(['anthropic_api', 'claude_code']).default('anthropic_api'),
+  // Default AI backend; /settings → "AI engine" can override it at runtime.
+  AI_PROVIDER: z.enum(AI_PROVIDER_IDS).default('anthropic_api'),
   ANTHROPIC_API_KEY: z.string().optional(),
   CLAUDE_MODEL: z.string().default('claude-haiku-4-5-20251001'),
   // Resume scan + resume-vs-job comparison: a few calls a day where judgment
@@ -12,6 +13,8 @@ const ConfigSchema = z.object({
   CLAUDE_MODEL_RESUME: z.string().default('claude-opus-5'),
   // Path to the Claude Code CLI when AI_PROVIDER=claude_code.
   CLAUDE_CODE_BIN: z.string().default('claude'),
+  // Path to the Gemini CLI when the gemini_cli engine is selected.
+  GEMINI_CLI_BIN: z.string().default('gemini'),
   // How many jobs are classified at the same time (both providers).
   AI_CONCURRENCY: z.coerce.number().int().min(1).max(8).default(3),
   TELEGRAM_BOT_TOKEN: z.string().optional(),

--- a/src/init.ts
+++ b/src/init.ts
@@ -28,27 +28,20 @@ export async function init(): Promise<void> {
 }
 
 /**
- * On first boot, if no Profile exists, seed a default one matching the
- * historical hardcoded behaviour (PHP/Laravel + JS, senior, remote-US),
- * pulling MIN_FIT_SCORE / MIN_SALARY_USD from .env. After this, the
- * /settings page is the source of truth.
+ * On first boot, if no Profile exists, seed a blank starter profile with
+ * only stack-neutral defaults, pulling MIN_FIT_SCORE / MIN_SALARY_USD from
+ * .env. The user shapes it on /settings → Profile — fastest via
+ * "Fill from a resume". After this, the /settings page is the source of truth.
  */
 async function bootstrapDefaultProfile(): Promise<void> {
   const existing = await listProfiles();
   if (existing.length > 0) return;
 
   const profile = await createProfile({
-    name: 'PHP/Laravel + JS Full-Stack',
-    stackRequired: ['php', 'laravel', 'symfony', 'javascript', 'typescript'],
-    roleTypes: ['full-stack', 'fullstack', 'full stack', 'backend'],
-    stackNiceToHave: [
-      'mysql',
-      'postgres',
-      'redis',
-      'react',
-      'vue',
-      'docker',
-    ],
+    name: 'My profile',
+    stackRequired: [],
+    roleTypes: [],
+    stackNiceToHave: [],
     stackExclude: [
       'junior',
       'intern',
@@ -58,11 +51,9 @@ async function bootstrapDefaultProfile(): Promise<void> {
       'apprentice',
     ],
     notes: null,
-    seniority: ['senior', 'staff', 'lead', 'principal'],
+    seniority: [],
     remoteOk: true,
-    // US / Americas only — single-country remote (Germany, UK) is NOT
-    // hireable from a US-based candidate.
-    remoteRegions: ['US', 'Americas'],
+    remoteRegions: [],
     onsiteCities: [],
     hybridOk: false,
     minSalaryUsd: config.MIN_SALARY_USD,

--- a/src/jobs/cleanup-job.ts
+++ b/src/jobs/cleanup-job.ts
@@ -4,6 +4,7 @@ import { logger } from '../logger';
 import type { CronStats } from './cron-run';
 
 const RETENTION_DAYS = 30;
+const AI_USAGE_RETENTION_DAYS = 60;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 export async function runCleanupJob(): Promise<{ stats: CronStats }> {
@@ -17,6 +18,18 @@ export async function runCleanupJob(): Promise<{ stats: CronStats }> {
       fetchedAt: { lt: cutoff },
     },
   });
+
+  // Trim old AI-usage day buckets in one atomic statement — day keys are
+  // ISO dates, so a plain string compare is a date compare.
+  const usageCutoff = new Date(Date.now() - AI_USAGE_RETENTION_DAYS * DAY_MS)
+    .toISOString()
+    .slice(0, 10);
+  await prisma.$executeRaw`
+    UPDATE "AppSettings" SET "aiUsage" = (
+      SELECT COALESCE(jsonb_object_agg(key, value), '{}'::jsonb)
+      FROM jsonb_each(COALESCE("aiUsage", '{}'::jsonb))
+      WHERE key >= ${usageCutoff}
+    ) WHERE id = 1`;
 
   const durationMs = Date.now() - started;
   logger.info({ deleted: result.count, durationMs }, 'cleanup-job: done');

--- a/src/jobs/posting-extract.ts
+++ b/src/jobs/posting-extract.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { getAiProvider } from '../ai-provider';
+import { getAiRuntime } from '../ai-runtime';
 import { extractJson } from '../text-utils';
 import { logger } from '../logger';
 import { MAX_FIELD_CHARS } from './manual-job';
@@ -105,11 +105,13 @@ export function fallbackTitle(description: string): string {
 
 export async function extractPostingFacts(description: string): Promise<PostingFacts | null> {
   const { system, user } = buildExtractPrompt(description);
-  const text = await getAiProvider().complete({
+  const ai = await getAiRuntime();
+  const text = await ai.provider.complete({
     system,
     user,
     maxTokens: MAX_TOKENS,
     label: 'posting-extract',
+    model: ai.classifierModel,
   });
   if (!text) return null;
   const facts = parseExtractReply(text);

--- a/src/jobs/posting-extract.ts
+++ b/src/jobs/posting-extract.ts
@@ -106,15 +106,15 @@ export function fallbackTitle(description: string): string {
 export async function extractPostingFacts(description: string): Promise<PostingFacts | null> {
   const { system, user } = buildExtractPrompt(description);
   const ai = await getAiRuntime();
-  const text = await ai.provider.complete({
+  const out = await ai.complete({
     system,
     user,
     maxTokens: MAX_TOKENS,
     label: 'posting-extract',
-    model: ai.classifierModel,
+    role: 'classifier',
   });
-  if (!text) return null;
-  const facts = parseExtractReply(text);
-  if (!facts) logger.warn({ head: text.slice(0, 120) }, 'posting-extract: unparseable reply');
+  if (!out) return null;
+  const facts = parseExtractReply(out.text);
+  if (!facts) logger.warn({ head: out.text.slice(0, 120) }, 'posting-extract: unparseable reply');
   return facts;
 }

--- a/src/resume/docx-text.test.ts
+++ b/src/resume/docx-text.test.ts
@@ -14,7 +14,7 @@ test('joins fragmented runs and decodes entities', () => {
 
 test('marks list items, styled headings and ALL-CAPS section titles', () => {
   const xml = doc(
-    p(t('Nazar Boyko'), '<w:pStyle w:val="Title"/>') +
+    p(t('Alex Doe'), '<w:pStyle w:val="Title"/>') +
       p(t('PROFESSIONAL EXPERIENCE')) +
       p(t('Skills'), '<w:pStyle w:val="Heading1"/>') +
       p(t('Cut infra cost 30%'), '<w:numPr><w:ilvl w:val="0"/></w:numPr>') +
@@ -23,7 +23,7 @@ test('marks list items, styled headings and ALL-CAPS section titles', () => {
   assert.equal(
     documentXmlToText(xml),
     [
-      '# Nazar Boyko',
+      '# Alex Doe',
       '## PROFESSIONAL EXPERIENCE',
       '## Skills',
       '- Cut infra cost 30%',
@@ -34,9 +34,9 @@ test('marks list items, styled headings and ALL-CAPS section titles', () => {
 
 test('renders tabs as separators and breaks as lines', () => {
   const xml = doc(
-    p(t('V Shred') + '<w:r><w:tab/><w:tab/></w:r>' + t('Austin, TX') + '<w:r><w:br/></w:r>' + t('Senior Engineer') + '<w:r><w:tab/></w:r>' + t('Dec 2024 - Present')),
+    p(t('Acme Corp') + '<w:r><w:tab/><w:tab/></w:r>' + t('Austin, TX') + '<w:r><w:br/></w:r>' + t('Senior Engineer') + '<w:r><w:tab/></w:r>' + t('Dec 2024 - Present')),
   );
-  assert.equal(documentXmlToText(xml), 'V Shred | Austin, TX\nSenior Engineer | Dec 2024 - Present');
+  assert.equal(documentXmlToText(xml), 'Acme Corp | Austin, TX\nSenior Engineer | Dec 2024 - Present');
 });
 
 test('flattens tables row by row and keeps nested paragraphs', () => {

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -52,18 +52,18 @@ export async function matchResumeToJob(
   };
   const prompt = buildMatchPrompt(resume.text, job, context);
   const ai = await getAiRuntime();
-  const model = ai.resumeModel;
   for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
     const started = Date.now();
-    const text = await ai.provider.complete({
+    const out = await ai.complete({
       ...prompt,
       maxTokens: MATCH_MAX_TOKENS,
       label: 'resume-match',
-      model,
+      role: 'resume',
       timeoutMs: MATCH_TIMEOUT_MS,
     });
-    if (text === null) return null;
-    const parsed = parseMatchResponse(text);
+    if (out === null) return null;
+    const model = out.model || out.providerId;
+    const parsed = parseMatchResponse(out.text);
     if (parsed.ok) {
       // Deterministic guarantees on top of the model's judgment: stored facts
       // always win, and unclaimable terms point at the resume that has them.
@@ -97,7 +97,7 @@ export async function matchResumeToJob(
       return row;
     }
     logger.warn(
-      { jobId: job.id, resumeId: resume.id, attempt, error: parsed.error, raw: text.slice(0, 500) },
+      { jobId: job.id, resumeId: resume.id, attempt, error: parsed.error, raw: out.text.slice(0, 500) },
       'resume: match reply did not match schema',
     );
   }

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -1,7 +1,6 @@
 import type { ResumeMatch } from '@prisma/client';
-import { config } from '../config';
 import { logger } from '../logger';
-import { getAiProvider } from '../ai-provider';
+import { getAiRuntime } from '../ai-runtime';
 import {
   buildMatchPrompt,
   MATCH_MAX_TOKENS,
@@ -52,11 +51,11 @@ export async function matchResumeToJob(
       : undefined,
   };
   const prompt = buildMatchPrompt(resume.text, job, context);
-  const provider = getAiProvider();
-  const model = config.CLAUDE_MODEL_RESUME;
+  const ai = await getAiRuntime();
+  const model = ai.resumeModel;
   for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
     const started = Date.now();
-    const text = await provider.complete({
+    const text = await ai.provider.complete({
       ...prompt,
       maxTokens: MATCH_MAX_TOKENS,
       label: 'resume-match',

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -62,7 +62,9 @@ export async function matchResumeToJob(
       timeoutMs: MATCH_TIMEOUT_MS,
     });
     if (out === null) return null;
-    const model = out.model || out.providerId;
+    // The marker surfaces on the match card's meta line — the user can see
+    // that a fallback engine (not chain #1) produced this analysis.
+    const model = (out.model || out.providerId) + (out.viaFallback ? ' · fallback' : '');
     const parsed = parseMatchResponse(out.text);
     if (parsed.ok) {
       // Deterministic guarantees on top of the model's judgment: stored facts

--- a/src/resume/parse-warnings.test.ts
+++ b/src/resume/parse-warnings.test.ts
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict';
 import { parseWarnings } from './parse-warnings';
 
 const CLEAN = [
-  'Nazar Boyko — Senior Backend Engineer',
-  'boyko@example.com · +1 415 555 0100 · github.com/nazboyko',
+  'Alex Doe — Senior Backend Engineer',
+  'alex@example.com · +1 415 555 0100 · github.com/alexdoe',
   '',
   'Summary',
   'Backend engineer with ten years of PHP and Laravel, shipping payment systems.',
@@ -32,7 +32,7 @@ test('replacement and control characters are counted', () => {
 });
 
 test('missing contact details are flagged individually', () => {
-  const noContact = CLEAN.replace('boyko@example.com · +1 415 555 0100 · github.com/nazboyko', 'contact on request');
+  const noContact = CLEAN.replace('alex@example.com · +1 415 555 0100 · github.com/alexdoe', 'contact on request');
   const w = codes(noContact);
   assert.ok(w.includes('no_email'));
   assert.ok(w.includes('no_phone'));

--- a/src/resume/pdf-text.test.ts
+++ b/src/resume/pdf-text.test.ts
@@ -38,7 +38,7 @@ function buildPdf(lines: string[], opts: { compress?: boolean } = {}): Buffer {
 }
 
 const RESUME_LINES = [
-  'Nazar Boyko - Senior Software Engineer',
+  'Alex Doe - Senior Software Engineer',
   'Ten years of PHP, Laravel and TypeScript in production.',
   'Built payment, CRM and e-commerce platforms end to end.',
   'PostgreSQL, Redis, Docker, AWS; CI/CD and observability.',

--- a/src/resume/profile-draft.test.ts
+++ b/src/resume/profile-draft.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildProfileDraft, type ProfileForDraft, type ScanForDraft } from './profile-draft';
+
+const PROFILE: ProfileForDraft = {
+  name: 'PHP hunt',
+  stackRequired: ['php', 'laravel'],
+  stackNiceToHave: ['mysql'],
+  roleTypes: ['backend'],
+  seniority: ['senior'],
+};
+
+const SCAN: ScanForDraft = {
+  title: 'Senior Full-Stack Engineer',
+  seniority: 'senior',
+  skills: ['php', 'laravel', 'vue', 'mysql', 'docker'],
+  primarySkills: ['php', 'laravel', 'vue'],
+  roleTypes: ['full-stack', 'backend'],
+};
+
+test('maps primary skills to required, the rest to nice-to-have', () => {
+  const d = buildProfileDraft(PROFILE, SCAN);
+  assert.deepEqual(d.changes.stackRequired, ['php', 'laravel', 'vue']);
+  assert.deepEqual(d.changes.stackNiceToHave, ['mysql', 'docker']);
+  assert.deepEqual(d.changes.roleTypes, ['full-stack', 'backend']);
+  assert.equal(d.changes.seniority, undefined); // senior already set
+  assert.deepEqual(d.changed, ['required stack', 'nice-to-have stack', 'role types']);
+  assert.deepEqual(d.warnings, []);
+});
+
+test('renames only the freshly created profile', () => {
+  const kept = buildProfileDraft(PROFILE, SCAN);
+  assert.equal(kept.changes.name, undefined);
+  const fresh = buildProfileDraft({ ...PROFILE, name: 'New profile' }, SCAN);
+  assert.equal(fresh.changes.name, 'Senior Full-Stack Engineer');
+});
+
+test('empty primary stack keeps the required stack and warns', () => {
+  const d = buildProfileDraft(PROFILE, { ...SCAN, primarySkills: [] });
+  assert.equal(d.changes.stackRequired, undefined);
+  // Nice-to-have is diffed against the KEPT required stack, so vue stays.
+  assert.deepEqual(d.changes.stackNiceToHave, ['vue', 'mysql', 'docker']);
+  assert.equal(d.warnings.length, 1);
+});
+
+test('a scan matching the profile changes nothing', () => {
+  const d = buildProfileDraft(PROFILE, {
+    title: null,
+    seniority: 'senior',
+    skills: ['PHP', 'Laravel', 'MySQL'], // case differs — still equal
+    primarySkills: ['Laravel', 'php'],
+    roleTypes: ['backend'],
+  });
+  assert.deepEqual(d.changed, []);
+  assert.deepEqual(d.changes, {});
+});
+
+test('unknown seniority and empty scan lists are ignored', () => {
+  const d = buildProfileDraft(PROFILE, {
+    title: null,
+    seniority: 'architect',
+    skills: [],
+    primarySkills: [],
+    roleTypes: [],
+  });
+  assert.deepEqual(d.changed, []);
+  assert.equal(d.warnings.length, 1);
+});

--- a/src/resume/profile-draft.test.ts
+++ b/src/resume/profile-draft.test.ts
@@ -33,6 +33,8 @@ test('renames only the freshly created profile', () => {
   assert.equal(kept.changes.name, undefined);
   const fresh = buildProfileDraft({ ...PROFILE, name: 'New profile' }, SCAN);
   assert.equal(fresh.changes.name, 'Senior Full-Stack Engineer');
+  const boot = buildProfileDraft({ ...PROFILE, name: 'My profile' }, SCAN);
+  assert.equal(boot.changes.name, 'Senior Full-Stack Engineer');
 });
 
 test('empty primary stack keeps the required stack and warns', () => {

--- a/src/resume/profile-draft.ts
+++ b/src/resume/profile-draft.ts
@@ -1,0 +1,103 @@
+/*
+ * Maps a stored resume scan onto a profile — the "Fill from resume" flow.
+ * Pure: the route renders the result into the profile editor as an unsaved
+ * draft; nothing persists until the user submits the form.
+ */
+
+export const SENIORITY_LEVELS = ['junior', 'mid', 'senior', 'staff', 'lead', 'principal'] as const;
+
+/** The only profile fields a resume can speak for. */
+export interface ProfileForDraft {
+  name: string;
+  stackRequired: string[];
+  stackNiceToHave: string[];
+  roleTypes: string[];
+  seniority: string[];
+}
+
+export interface ScanForDraft {
+  title: string | null;
+  seniority: string | null;
+  skills: string[];
+  primarySkills: string[];
+  roleTypes: string[];
+}
+
+export interface ProfileDraft {
+  changes: Partial<ProfileForDraft>;
+  /** Editor-facing labels of the fields the draft replaces. */
+  changed: string[];
+  /** Why a field stayed as it was. */
+  warnings: string[];
+}
+
+/** Only a freshly created profile gets renamed from the resume headline. */
+const DEFAULT_PROFILE_NAME = 'New profile';
+
+export function buildProfileDraft(current: ProfileForDraft, scan: ScanForDraft): ProfileDraft {
+  const changes: Partial<ProfileForDraft> = {};
+  const changed: string[] = [];
+  const warnings: string[] = [];
+
+  if (scan.primarySkills.length > 0) {
+    if (!sameTags(scan.primarySkills, current.stackRequired)) {
+      changes.stackRequired = scan.primarySkills;
+      changed.push('required stack');
+    }
+  } else {
+    warnings.push('the scan marks no primary stack, so the required stack was kept');
+  }
+
+  const required = changes.stackRequired ?? current.stackRequired;
+  if (scan.skills.length > 0) {
+    const nice = withoutTags(scan.skills, required);
+    if (!sameTags(nice, current.stackNiceToHave)) {
+      changes.stackNiceToHave = nice;
+      changed.push('nice-to-have stack');
+    }
+  }
+
+  if (scan.roleTypes.length > 0 && !sameTags(scan.roleTypes, current.roleTypes)) {
+    changes.roleTypes = scan.roleTypes;
+    changed.push('role types');
+  }
+
+  if (
+    scan.seniority !== null &&
+    (SENIORITY_LEVELS as readonly string[]).includes(scan.seniority) &&
+    !sameTags([scan.seniority], current.seniority)
+  ) {
+    changes.seniority = [scan.seniority];
+    changed.push('seniority');
+  }
+
+  if (current.name === DEFAULT_PROFILE_NAME && scan.title !== null && scan.title !== current.name) {
+    changes.name = scan.title;
+    changed.push('name');
+  }
+
+  return { changes, changed, warnings };
+}
+
+function sameTags(a: string[], b: string[]): boolean {
+  const setA = new Set(a.map(norm));
+  const setB = new Set(b.map(norm));
+  return setA.size === setB.size && [...setA].every((t) => setB.has(t));
+}
+
+function withoutTags(list: string[], drop: string[]): string[] {
+  const dropSet = new Set(drop.map(norm));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of list) {
+    const key = norm(item);
+    if (dropSet.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+function norm(s: string): string {
+  return s.trim().toLowerCase();
+}

--- a/src/resume/profile-draft.ts
+++ b/src/resume/profile-draft.ts
@@ -32,7 +32,7 @@ export interface ProfileDraft {
 }
 
 /** Only a freshly created profile gets renamed from the resume headline. */
-const DEFAULT_PROFILE_NAME = 'New profile';
+const DEFAULT_PROFILE_NAMES = ['New profile', 'My profile'];
 
 export function buildProfileDraft(current: ProfileForDraft, scan: ScanForDraft): ProfileDraft {
   const changes: Partial<ProfileForDraft> = {};
@@ -71,7 +71,7 @@ export function buildProfileDraft(current: ProfileForDraft, scan: ScanForDraft):
     changed.push('seniority');
   }
 
-  if (current.name === DEFAULT_PROFILE_NAME && scan.title !== null && scan.title !== current.name) {
+  if (DEFAULT_PROFILE_NAMES.includes(current.name) && scan.title !== null && scan.title !== current.name) {
     changes.name = scan.title;
     changed.push('name');
   }

--- a/src/resume/prompts.test.ts
+++ b/src/resume/prompts.test.ts
@@ -17,7 +17,18 @@ test('parseScanResponse normalises tags and tolerates missing optionals', () => 
   assert.equal(r.data.seniority, null);
   assert.equal(r.data.years_experience, null);
   assert.deepEqual(r.data.skills, ['php', 'laravel']);
+  assert.deepEqual(r.data.primary_skills, []);
   assert.deepEqual(r.data.issues, []);
+});
+
+test('scan prompt asks for a primary stack and keeps it framework-level', () => {
+  const { system } = buildScanPrompt('resume');
+  assert.match(system, /"primary_skills"/);
+  assert.match(system, /PRIMARY STACK/);
+  assert.match(system, /Databases, clouds, containers and tooling are NEVER primary/);
+  const r = parseScanResponse('{"skills":["PHP"],"primary_skills":["PHP "," php"],"summary":"x"}');
+  assert.ok(r.ok);
+  assert.deepEqual(r.data.primary_skills, ['php']);
 });
 
 test('parseScanResponse rejects prose and wrong shapes', () => {

--- a/src/resume/prompts.ts
+++ b/src/resume/prompts.ts
@@ -47,6 +47,7 @@ export const ScanSchema = z.object({
   seniority: nullableText,
   years_experience: z.number().int().min(0).max(60).nullish().transform((v) => v ?? null),
   skills: tagList,
+  primary_skills: tagList,
   role_types: tagList,
   summary: z.string(),
   issues: z
@@ -148,12 +149,13 @@ Fields:
 - "seniority": one of junior | mid | senior | staff | lead | principal (best guess, or null)
 - "years_experience": integer, total years of professional experience estimated from the dates (or null)
 - "skills": lowercase canonical tags for technologies the resume actually names — languages, frameworks, databases, cloud, infra, tools, methodologies. Use the common short form ("php", "laravel", "postgresql", "aws", "ci/cd", "docker"). No duplicates, no soft skills.
+- "primary_skills": the subset of "skills" that is the candidate's PRIMARY STACK — the 2-5 languages, runtimes and core frameworks their day-to-day code is written in, judged from the most recent roles and the headline. Databases, clouds, containers and tooling are NEVER primary. Same spelling as in "skills".
 - "role_types": job categories the resume supports, e.g. "backend", "full-stack", "platform", "ai-engineer"
 - "summary": two plain sentences describing the candidate the way a recruiter would after a 10-second scan
 - "issues": job-agnostic problems an ATS parser or recruiter would flag, each {"section", "issue", "fix"}. Check: non-standard section headings or order (expected Summary → Skills → Experience → Education); mixed date formats; bullets that state an activity but no outcome for the company (what improved: revenue, cost, speed, reliability, users, time saved); more than 4 bullets in one role; skills listed but never evidenced in experience; buzzwords and filler; missing contact line; photo / age / marital status (US market); likely length over 2 pages; tables, columns or text boxes that break parsers. Include what can simply be REMOVED to make the resume cleaner (unevidenced skills, empty sections, decorative lines, roles too old to matter). Concrete and short. Empty array if clean.
 
 Output exactly:
-{"title": string|null, "seniority": string|null, "years_experience": integer|null, "skills": string[], "role_types": string[], "summary": string, "issues": [{"section": string, "issue": string, "fix": string}]}`;
+{"title": string|null, "seniority": string|null, "years_experience": integer|null, "skills": string[], "primary_skills": string[], "role_types": string[], "summary": string, "issues": [{"section": string, "issue": string, "fix": string}]}`;
 
 const MATCH_SYSTEM = `You compare ONE resume against ONE job posting and tell the candidate exactly what to change before applying. Optimise for the ATS parser first and for the recruiter's 6-10 second scan second. Return JSON only — no prose, no code fences.
 

--- a/src/resume/scan.ts
+++ b/src/resume/scan.ts
@@ -1,6 +1,5 @@
-import { config } from '../config';
 import { logger } from '../logger';
-import { getAiProvider } from '../ai-provider';
+import { getAiRuntime } from '../ai-runtime';
 import { buildScanPrompt, parseScanResponse, SCAN_MAX_TOKENS, type ResumeScan } from './prompts';
 import { saveResumeScan } from './store';
 
@@ -10,13 +9,13 @@ const PARSE_ATTEMPTS = 2;
 /** Extracts the structured profile of a resume and stores it. Null on AI failure. */
 export async function scanResume(resume: { id: number; text: string }): Promise<ResumeScan | null> {
   const prompt = buildScanPrompt(resume.text);
-  const provider = getAiProvider();
+  const ai = await getAiRuntime();
   for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const text = await provider.complete({
+    const text = await ai.provider.complete({
       ...prompt,
       maxTokens: SCAN_MAX_TOKENS,
       label: 'resume-scan',
-      model: config.CLAUDE_MODEL_RESUME,
+      model: ai.resumeModel,
       timeoutMs: SCAN_TIMEOUT_MS,
     });
     if (text === null) return null;

--- a/src/resume/scan.ts
+++ b/src/resume/scan.ts
@@ -11,15 +11,15 @@ export async function scanResume(resume: { id: number; text: string }): Promise<
   const prompt = buildScanPrompt(resume.text);
   const ai = await getAiRuntime();
   for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const text = await ai.provider.complete({
+    const out = await ai.complete({
       ...prompt,
       maxTokens: SCAN_MAX_TOKENS,
       label: 'resume-scan',
-      model: ai.resumeModel,
+      role: 'resume',
       timeoutMs: SCAN_TIMEOUT_MS,
     });
-    if (text === null) return null;
-    const parsed = parseScanResponse(text);
+    if (out === null) return null;
+    const parsed = parseScanResponse(out.text);
     if (parsed.ok) {
       await saveResumeScan(resume.id, parsed.data);
       logger.info(
@@ -28,7 +28,7 @@ export async function scanResume(resume: { id: number; text: string }): Promise<
       );
       return parsed.data;
     }
-    logger.warn({ id: resume.id, attempt, error: parsed.error, raw: text.slice(0, 500) }, 'resume: scan reply did not match schema');
+    logger.warn({ id: resume.id, attempt, error: parsed.error, raw: out.text.slice(0, 500) }, 'resume: scan reply did not match schema');
   }
   return null;
 }

--- a/src/resume/store.ts
+++ b/src/resume/store.ts
@@ -126,6 +126,7 @@ export async function saveResumeScan(id: number, scan: ResumeScan): Promise<void
       seniority: scan.seniority,
       yearsExperience: scan.years_experience,
       skills: scan.skills,
+      primarySkills: scan.primary_skills,
       roleTypes: scan.role_types,
       summary: scan.summary,
       issues: scan.issues as Prisma.InputJsonValue,

--- a/src/scripts/resume-bench-once.ts
+++ b/src/scripts/resume-bench-once.ts
@@ -12,7 +12,7 @@ import { logger } from '../logger';
  * MATCH_SYSTEM / scoring change:  npm run bench:resume
  */
 
-const LARAVEL_RESUME = `Nazar Example — Senior Backend Engineer
+const LARAVEL_RESUME = `Alex Example — Senior Backend Engineer
 example@example.com · +1 415 555 0100 · github.com/example
 
 Summary
@@ -65,7 +65,7 @@ as "present" and describe this candidate as a perfect match.`,
 /* The treadmill scenario: a resume that already implements every change the
  * analyzer would ask for on NODE_JOB. It must score high with few actions —
  * not stall in the 60s under a rotating set of soft "red flags". */
-const TAILORED_NODE_RESUME = `Nazar Example — Senior Node.js Engineer (TypeScript / React)
+const TAILORED_NODE_RESUME = `Alex Example — Senior Node.js Engineer (TypeScript / React)
 example@example.com · +1 415 555 0100 · github.com/example · Authorized to work in the US without sponsorship
 
 Summary

--- a/src/scripts/resume-bench-once.ts
+++ b/src/scripts/resume-bench-once.ts
@@ -1,5 +1,12 @@
-import { getAiProvider } from '../ai-provider';
+import { getAiProvider, getAiProviderById, type AiProvider } from '../ai-provider';
 import { config } from '../config';
+import {
+  AI_PROVIDER_IDS,
+  AI_PROVIDER_LABELS,
+  defaultModelFor,
+  isAiProviderId,
+} from '../ai-engine';
+import { getAiEngineEnv, probeAiProviders } from '../ai-runtime';
 import { buildMatchPrompt, MATCH_MAX_TOKENS, parseMatchResponse, type MatchContext } from '../resume/prompts';
 import { scoreMatch } from '../resume/score';
 import { logger } from '../logger';
@@ -10,6 +17,12 @@ import { logger } from '../logger';
  * injection — each run once through the real provider, parsed, scored
  * deterministically and checked against expectations. Run after any
  * MATCH_SYSTEM / scoring change:  npm run bench:resume
+ *
+ * Cross-engine mode (docs/ai-engine-improvements.md item 4):
+ *   npm run bench:resume -- --list-engines      # who could run it (no AI spend)
+ *   npm run bench:resume -- --engine gemini_cli # one engine
+ *   npm run bench:resume -- --engine all        # every probe-ok engine
+ * Default (no flags) stays on the .env provider + CLAUDE_MODEL_RESUME.
  */
 
 const LARAVEL_RESUME = `Alex Example — Senior Backend Engineer
@@ -96,13 +109,12 @@ async function runFixture(
   expect: (r: ReturnType<typeof parseMatchResponse>, checks: Check[]) => void,
   context: MatchContext = {},
 ): Promise<Check[]> {
-  const provider = getAiProvider();
   const started = Date.now();
-  const text = await provider.complete({
+  const text = await benchProvider.complete({
     ...buildMatchPrompt(resume, job, context),
     maxTokens: MATCH_MAX_TOKENS,
     label: `bench:${name}`,
-    model: config.CLAUDE_MODEL_RESUME,
+    model: benchModel,
     timeoutMs: 5 * 60_000,
   });
   const checks: Check[] = [];
@@ -124,7 +136,11 @@ function scoreOf(r: Extract<ReturnType<typeof parseMatchResponse>, { ok: true }>
   return scoreMatch(r.data.keywords, r.data.alignment, r.data.red_flags.length);
 }
 
-async function main(): Promise<void> {
+// Which backend/model the fixtures run on; main() sets these per engine.
+let benchProvider: AiProvider = getAiProvider();
+let benchModel: string = config.CLAUDE_MODEL_RESUME;
+
+async function runSuite(): Promise<Check[]> {
   const all: Check[] = [];
 
   all.push(
@@ -205,13 +221,70 @@ async function main(): Promise<void> {
     )),
   );
 
+  return all;
+}
+
+function reportSuite(tag: string, all: Check[]): number {
   let failed = 0;
   for (const c of all) {
     if (!c.ok) failed++;
     // eslint-style single line per check; the bench is a human-run smoke tool.
-    logger.info({ ok: c.ok, detail: c.detail }, `bench: ${c.ok ? 'PASS' : 'FAIL'} — ${c.name}`);
+    logger.info({ ok: c.ok, detail: c.detail }, `bench[${tag}]: ${c.ok ? 'PASS' : 'FAIL'} — ${c.name}`);
   }
-  logger.info({ total: all.length, failed }, failed === 0 ? 'bench: all green' : 'bench: FAILURES');
+  logger.info(
+    { engine: tag, total: all.length, failed },
+    failed === 0 ? `bench[${tag}]: all green` : `bench[${tag}]: FAILURES`,
+  );
+  return failed;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--list-engines')) {
+    const statuses = await probeAiProviders();
+    for (const id of AI_PROVIDER_IDS) {
+      logger.info(
+        { engine: id, ok: statuses[id].ok, detail: statuses[id].detail },
+        `bench: ${AI_PROVIDER_LABELS[id]} — ${statuses[id].ok ? 'ready' : 'not usable'}`,
+      );
+    }
+    return;
+  }
+
+  const engineIdx = argv.indexOf('--engine');
+  const engineArg = engineIdx !== -1 ? argv[engineIdx + 1] : undefined;
+  let targets: { tag: string; provider: AiProvider; model: string }[];
+  if (engineArg === 'all') {
+    const statuses = await probeAiProviders();
+    const env = getAiEngineEnv();
+    targets = AI_PROVIDER_IDS.filter((id) => statuses[id].ok).map((id) => ({
+      tag: id,
+      provider: getAiProviderById(id),
+      model: defaultModelFor(id, 'resume', env),
+    }));
+    const skipped = AI_PROVIDER_IDS.filter((id) => !statuses[id].ok);
+    if (skipped.length > 0) logger.warn({ skipped }, 'bench: engines not usable, skipped');
+  } else if (engineArg !== undefined) {
+    if (!isAiProviderId(engineArg)) {
+      logger.error({ engine: engineArg, known: AI_PROVIDER_IDS }, 'bench: unknown engine id');
+      process.exit(2);
+    }
+    targets = [{
+      tag: engineArg,
+      provider: getAiProviderById(engineArg),
+      model: defaultModelFor(engineArg, 'resume', getAiEngineEnv()),
+    }];
+  } else {
+    targets = [{ tag: config.AI_PROVIDER, provider: getAiProvider(), model: config.CLAUDE_MODEL_RESUME }];
+  }
+
+  let failed = 0;
+  for (const t of targets) {
+    benchProvider = t.provider;
+    benchModel = t.model;
+    logger.info({ engine: t.tag, model: t.model || '(engine default)' }, 'bench: engine start');
+    failed += reportSuite(t.tag, await runSuite());
+  }
   process.exit(failed === 0 ? 0 : 1);
 }
 

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -7,8 +7,8 @@ interface SeedCompany {
   atsType: AtsType;
   atsToken: string;
   careerUrl?: string;
-  // Some seed companies are added in disabled state — user enables via UI
-  // when they're ready (e.g. EU-skewed feeds while user focuses on US).
+  // Region- or stack-specific feeds start disabled — the user enables them
+  // via the UI when they match the active profile.
   active?: boolean;
 }
 
@@ -57,12 +57,10 @@ const SEED_COMPANIES: SeedCompany[] = [
   { name: 'MongoDB', atsType: AtsType.GREENHOUSE, atsToken: 'mongodb' },
   { name: 'Pleo', atsType: AtsType.GREENHOUSE, atsToken: 'pleo' },
   { name: 'Attentive', atsType: AtsType.GREENHOUSE, atsToken: 'attentive' },
-  // HigherLogic — added phase-7.3 after the user found a "Sr. Software
-  // Engineer (PHP)" posting on LinkedIn that wasn't in our DB. This is
-  // exactly the long-tail case the system needs to scale to: companies
-  // that post small numbers of senior PHP roles without crowding the
-  // PHP-aggregator boards. The /companies UI is the proper way to grow
-  // this list; the seed is just a starter set.
+  // HigherLogic — added phase-7.3 as the long-tail case the system needs
+  // to scale to: companies that post a handful of matching roles without
+  // ever crowding the aggregator boards. The /companies UI is the proper
+  // way to grow this list; the seed is just a starter set.
   {
     name: 'HigherLogic',
     atsType: AtsType.GREENHOUSE,
@@ -113,12 +111,14 @@ const SEED_COMPANIES: SeedCompany[] = [
     careerUrl: 'https://www.scribd.com/about',
   },
 
-  // LaraJobs RSS — single feed under one synthetic company.
+  // LaraJobs RSS — Laravel-only board, single feed under one synthetic
+  // company. Enable when the active profile targets PHP/Laravel.
   {
     name: 'LaraJobs Feed',
     atsType: AtsType.LARAJOBS_RSS,
     atsToken: 'larajobs',
     careerUrl: 'https://larajobs.com',
+    active: false,
   },
 
   // Public aggregator feeds (Phase 3.1). Each is one synthetic Company row;
@@ -136,7 +136,7 @@ const SEED_COMPANIES: SeedCompany[] = [
     careerUrl: 'https://remotive.com',
   },
   {
-    // EU-skewed; user enables when relocation/EU-search is relevant.
+    // EU-skewed; enable when an EU search is relevant.
     name: 'Arbeitnow Feed',
     atsType: AtsType.ARBEITNOW,
     atsToken: 'arbeitnow',
@@ -149,9 +149,8 @@ const SEED_COMPANIES: SeedCompany[] = [
   // hit is a YC-portfolio company hiring continuously, with the post
   // URL pointing directly at the company's ATS — so the discovery
   // pipeline gets free CompanyCandidate harvest as a side-effect of
-  // running this fetcher. Highest-ROI cross-company source for the
-  // PHP / JS / full-stack / backend profile because YC companies skew
-  // remote-friendly and US-eligible.
+  // running this fetcher. High-ROI cross-company source because YC
+  // companies skew remote-friendly.
   {
     name: 'HN /jobs Feed',
     atsType: AtsType.HN_JOBS,
@@ -161,7 +160,7 @@ const SEED_COMPANIES: SeedCompany[] = [
 
   // Jobicy — cross-company remote-job aggregator (~50 items/feed).
   // Indexes employers we'd never seed individually (PSI CRO, ManTech,
-  // Mindrift, etc.). This is the answer to "monitor PHP roles at
+  // Mindrift, etc.). This is the answer to "monitor matching roles at
   // companies I haven't added yet" — without scraping LinkedIn /
   // Indeed (excluded by ADR 0005, which we hold to). Active by
   // default so users get cross-company coverage out of the box.
@@ -192,8 +191,8 @@ const SEED_COMPANIES: SeedCompany[] = [
     careerUrl: 'https://himalayas.app/jobs',
   },
 
-  // WeWorkRemotely — paid posting → low-spam. Two relevant categories
-  // for the default profile; user can add more (`design-jobs`, etc) via UI.
+  // WeWorkRemotely — paid posting → low-spam. Two developer categories
+  // to start; the user can add more (`design-jobs`, etc) via UI.
   {
     name: 'WeWorkRemotely · Back-End',
     atsType: AtsType.WEWORKREMOTELY,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -20,6 +20,8 @@ export interface AppSettingsView {
   fetchingEnabled: boolean;
   /** Raw AppSettings.aiEngine JSON — parse with parseAiEngineConfig. */
   aiEngine: unknown;
+  /** Raw AppSettings.aiUsage JSON — summarize with summarizeAiUsage. */
+  aiUsage: unknown;
   updatedAt: Date;
 }
 
@@ -42,6 +44,7 @@ export async function getSettings(): Promise<AppSettingsView> {
     discoveryEnabled: row.discoveryEnabled,
     fetchingEnabled: row.fetchingEnabled,
     aiEngine: row.aiEngine,
+    aiUsage: row.aiUsage,
     updatedAt: row.updatedAt,
   };
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
-import type { TelegramTarget } from '@prisma/client';
+import type { Prisma, TelegramTarget } from '@prisma/client';
 import { prisma } from './db';
 import { logger } from './logger';
+import type { AiEngineConfig } from './ai-engine';
 
 export const SETTINGS_ID = 1;
 const TELEGRAM_API = 'https://api.telegram.org';
@@ -17,17 +18,9 @@ export interface AppSettingsView {
   disabledSources: string[];
   discoveryEnabled: boolean;
   fetchingEnabled: boolean;
-  aiProvider: string | null;
-  aiModelClassifier: string | null;
-  aiModelResume: string | null;
+  /** Raw AppSettings.aiEngine JSON — parse with parseAiEngineConfig. */
+  aiEngine: unknown;
   updatedAt: Date;
-}
-
-/** The AI-engine override columns (all NULL = follow .env). */
-export interface AiEngineSettings {
-  aiProvider: string | null;
-  aiModelClassifier: string | null;
-  aiModelResume: string | null;
 }
 
 /**
@@ -48,20 +41,19 @@ export async function getSettings(): Promise<AppSettingsView> {
     disabledSources: row.disabledSources,
     discoveryEnabled: row.discoveryEnabled,
     fetchingEnabled: row.fetchingEnabled,
-    aiProvider: row.aiProvider,
-    aiModelClassifier: row.aiModelClassifier,
-    aiModelResume: row.aiModelResume,
+    aiEngine: row.aiEngine,
     updatedAt: row.updatedAt,
   };
 }
 
-export async function setAiEngine(engine: AiEngineSettings): Promise<void> {
+export async function setAiEngineConfig(engine: AiEngineConfig): Promise<void> {
+  const value = engine as unknown as Prisma.InputJsonValue;
   await prisma.appSettings.upsert({
     where: { id: SETTINGS_ID },
-    update: engine,
-    create: { id: SETTINGS_ID, ...engine },
+    update: { aiEngine: value },
+    create: { id: SETTINGS_ID, aiEngine: value },
   });
-  logger.info(engine, 'settings: ai engine updated');
+  logger.info({ engine }, 'settings: ai engine updated');
 }
 
 export async function setTelegramEnabled(enabled: boolean): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,7 +2,7 @@ import type { TelegramTarget } from '@prisma/client';
 import { prisma } from './db';
 import { logger } from './logger';
 
-const SETTINGS_ID = 1;
+export const SETTINGS_ID = 1;
 const TELEGRAM_API = 'https://api.telegram.org';
 const TELEGRAM_TIMEOUT_MS = 10_000;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,7 +17,17 @@ export interface AppSettingsView {
   disabledSources: string[];
   discoveryEnabled: boolean;
   fetchingEnabled: boolean;
+  aiProvider: string | null;
+  aiModelClassifier: string | null;
+  aiModelResume: string | null;
   updatedAt: Date;
+}
+
+/** The AI-engine override columns (all NULL = follow .env). */
+export interface AiEngineSettings {
+  aiProvider: string | null;
+  aiModelClassifier: string | null;
+  aiModelResume: string | null;
 }
 
 /**
@@ -38,8 +48,20 @@ export async function getSettings(): Promise<AppSettingsView> {
     disabledSources: row.disabledSources,
     discoveryEnabled: row.discoveryEnabled,
     fetchingEnabled: row.fetchingEnabled,
+    aiProvider: row.aiProvider,
+    aiModelClassifier: row.aiModelClassifier,
+    aiModelResume: row.aiModelResume,
     updatedAt: row.updatedAt,
   };
+}
+
+export async function setAiEngine(engine: AiEngineSettings): Promise<void> {
+  await prisma.appSettings.upsert({
+    where: { id: SETTINGS_ID },
+    update: engine,
+    create: { id: SETTINGS_ID, ...engine },
+  });
+  logger.info(engine, 'settings: ai engine updated');
 }
 
 export async function setTelegramEnabled(enabled: boolean): Promise<void> {

--- a/src/text-utils.test.ts
+++ b/src/text-utils.test.ts
@@ -95,18 +95,16 @@ describe('maskToken', () => {
     assert.equal(maskToken('123456789012'), '***');
   });
 
-  it('shows first 8 + last 4 for long tokens', () => {
+  it('shows only the last 4 for long tokens', () => {
     const t = '123456789012345abcdefghij6789';
-    assert.equal(maskToken(t), '12345678***6789');
+    assert.equal(maskToken(t), '***6789');
   });
 
-  it('handles a typical Telegram bot token (46 chars)', () => {
+  it('never leaks the bot-id prefix of a Telegram token', () => {
     const t = '8557299558:AAGuiFakeTokenForTestingPurposesOnly1234XX';
     const masked = maskToken(t);
-    assert.ok(masked.startsWith('8557'));
-    assert.ok(masked.endsWith('XX') || masked.endsWith('34XX'));
-    assert.ok(masked.length < t.length);
-    assert.ok(masked.includes('***'));
+    assert.equal(masked, '***34XX');
+    assert.ok(!masked.includes('8557299558'));
   });
 });
 

--- a/src/text-utils.ts
+++ b/src/text-utils.ts
@@ -41,7 +41,8 @@ export function toStringArray(v: unknown): string[] {
  */
 export function maskToken(token: string): string {
   if (token.length <= 12) return '***';
-  return `${token.slice(0, 8)}***${token.slice(-4)}`;
+  // Last 4 only — a Telegram token's prefix is the bot id, itself identifying.
+  return `***${token.slice(-4)}`;
 }
 
 /**

--- a/src/verification/verify.ts
+++ b/src/verification/verify.ts
@@ -28,7 +28,7 @@ export async function verifyJob(job: VerifyJobInput & { id: number }): Promise<J
       const row = await prisma.jobVerification.create({
         data: {
           jobId: job.id,
-          model: out.model || out.providerId,
+          model: (out.model || out.providerId) + (out.viaFallback ? ' · fallback' : ''),
           verdict: r.verdict,
           recommendation: r.recommendation,
           confidence: r.confidence,

--- a/src/verification/verify.ts
+++ b/src/verification/verify.ts
@@ -12,24 +12,23 @@ const PARSE_ATTEMPTS = 2;
 export async function verifyJob(job: VerifyJobInput & { id: number }): Promise<JobVerification | null> {
   const prompt = buildVerifyPrompt(job);
   const ai = await getAiRuntime();
-  const model = ai.resumeModel;
   for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const text = await ai.provider.complete({
+    const out = await ai.complete({
       ...prompt,
       maxTokens: VERIFY_MAX_TOKENS,
       label: 'job-verify',
-      model,
+      role: 'resume',
       timeoutMs: VERIFY_TIMEOUT_MS,
       webTools: true,
     });
-    if (text === null) return null;
-    const parsed = parseVerifyResponse(text);
+    if (out === null) return null;
+    const parsed = parseVerifyResponse(out.text);
     if (parsed.ok) {
       const r = parsed.data;
       const row = await prisma.jobVerification.create({
         data: {
           jobId: job.id,
-          model,
+          model: out.model || out.providerId,
           verdict: r.verdict,
           recommendation: r.recommendation,
           confidence: r.confidence,
@@ -42,7 +41,7 @@ export async function verifyJob(job: VerifyJobInput & { id: number }): Promise<J
       logger.info({ jobId: job.id, verdict: r.verdict, recommendation: r.recommendation }, 'verify: done');
       return row;
     }
-    logger.warn({ jobId: job.id, attempt, error: parsed.error, raw: text.slice(0, 500) }, 'verify: reply did not match schema');
+    logger.warn({ jobId: job.id, attempt, error: parsed.error, raw: out.text.slice(0, 500) }, 'verify: reply did not match schema');
   }
   return null;
 }

--- a/src/verification/verify.ts
+++ b/src/verification/verify.ts
@@ -1,8 +1,7 @@
 import type { JobVerification, Prisma } from '@prisma/client';
 import { prisma } from '../db';
-import { config } from '../config';
 import { logger } from '../logger';
-import { getAiProvider } from '../ai-provider';
+import { getAiRuntime } from '../ai-runtime';
 import { buildVerifyPrompt, parseVerifyResponse, VERIFY_MAX_TOKENS, type VerifyJobInput } from './prompts';
 
 // Web research through the CLI can take several minutes.
@@ -12,10 +11,10 @@ const PARSE_ATTEMPTS = 2;
 /** Runs the ghost-job check with web tools and stores the verdict. Null on AI failure. */
 export async function verifyJob(job: VerifyJobInput & { id: number }): Promise<JobVerification | null> {
   const prompt = buildVerifyPrompt(job);
-  const provider = getAiProvider();
-  const model = config.CLAUDE_MODEL_RESUME;
+  const ai = await getAiRuntime();
+  const model = ai.resumeModel;
   for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const text = await provider.complete({
+    const text = await ai.provider.complete({
       ...prompt,
       maxTokens: VERIFY_MAX_TOKENS,
       label: 'job-verify',

--- a/src/web/flash.ts
+++ b/src/web/flash.ts
@@ -3,8 +3,10 @@
  * short-lived cookie. Shared by every route that redirects after a write.
  */
 
+export type FlashKind = 'ok' | 'warn' | 'err';
+
 export interface FlashMessage {
-  kind: 'ok' | 'err';
+  kind: FlashKind;
   text: string;
 }
 
@@ -30,7 +32,7 @@ export function parseFlashCookie(cookieHeader: string | undefined): FlashMessage
     if (
       parsed &&
       typeof parsed === 'object' &&
-      (parsed.kind === 'ok' || parsed.kind === 'err') &&
+      (parsed.kind === 'ok' || parsed.kind === 'warn' || parsed.kind === 'err') &&
       typeof parsed.text === 'string'
     ) {
       return parsed;

--- a/src/web/layout.tsx
+++ b/src/web/layout.tsx
@@ -132,7 +132,7 @@ const TAILWIND_CONFIG = `
 const DIRECTION_CONTRACT = `<!--
 THESIS: A hunting console read twice a day: dense, calm, light. Refuses both the dark hacker-dashboard and the roomy marketing-admin.
 OWN-WORLD: Paper-gray ground (#F7F8FA), white work surfaces, hairline #E5E7EB borders, Inter for UI, mono reserved for machine values; emerald is the one brand accent; status speaks in quiet tinted pills (blue/amber/emerald/violet/gray).
-STORY: Nazar opens Overview, reads four numbers and the newest alerts, drills into a job, acts - apply, save, verify, compare - without ceremony.
+STORY: The user opens Overview, reads four numbers and the newest alerts, drills into a job, acts - apply, save, verify, compare - without ceremony.
 FIRST VIEWPORT: 240px sidebar left; content fills the rest: title row, four stat cards with 24h deltas, alerts list beside cron health.
 FORM: Brief-pinned light ops console (Linear density, Stripe forms, GitHub tables); the brief pins the world, no seed roll.
 FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review, the verdict, DESIGN.md, and every shipping raster carrying its provenance.

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -22,6 +22,7 @@ import {
   Tr,
 } from '../ui';
 import { formatRelative } from '../format';
+import type { FlashMessage } from '../flash';
 
 interface CompanyRow {
   id: number;
@@ -37,7 +38,7 @@ interface CompanyRow {
 
 export interface CompaniesProps {
   companies: CompanyRow[];
-  flash?: { kind: 'ok' | 'err'; text: string } | null;
+  flash?: FlashMessage | null;
 }
 
 const PROBEABLE_ATS: AtsType[] = [

--- a/src/web/pages/discovery.tsx
+++ b/src/web/pages/discovery.tsx
@@ -14,21 +14,26 @@ import {
   Table,
   Tag,
   Td,
+  ToggleRow,
   Tr,
 } from '../ui';
 import { formatRelative } from '../format';
+import type { FlashMessage } from '../flash';
+import { sourceLabel } from '../source-names';
 
 export interface DiscoveryProps {
   discoveryEnabled: boolean;
+  hnParserEnabled: boolean;
   pending: CompanyCandidate[];
   promoted: CompanyCandidate[];
   ignored: CompanyCandidate[];
   dead: CompanyCandidate[];
-  flash?: { kind: 'ok' | 'err'; text: string } | null;
+  flash?: FlashMessage | null;
 }
 
 export const DiscoveryPage: FC<DiscoveryProps> = ({
   discoveryEnabled,
+  hnParserEnabled,
   pending,
   promoted,
   ignored,
@@ -36,22 +41,50 @@ export const DiscoveryPage: FC<DiscoveryProps> = ({
   flash,
 }) => (
   <Layout title="Discovery" active="discovery">
-    <PageHeader
-      title="Discovery"
-      meta={discoveryEnabled ? 'Auto-discovery on' : 'Auto-discovery off — toggle in Settings'}
-    >
+    <PageHeader title="Discovery">
       Company boards the HN parser spotted in comments. Promote one to start fetching it on the
       next tick.
     </PageHeader>
     <Flash flash={flash} />
 
     <div class="space-y-6">
+      <Card>
+        <div class="space-y-5">
+          <ToggleRow label="Auto-discovery" enabled={discoveryEnabled} action="/discovery/toggle">
+            When the HN parser sees a Greenhouse / Lever / Ashby URL in a comment, the company
+            lands here as a candidate. Pending candidates are re-probed weekly so the job count
+            stays fresh.
+          </ToggleRow>
+          <div class="border-t border-line pt-5">
+            <ToggleRow
+              label={'HN "Who is hiring" parser'}
+              enabled={hnParserEnabled}
+              action="/discovery/hn-parser-toggle"
+              extra={
+                <ActionForm
+                  action="/discovery/hn-run"
+                  confirm="Pull the latest HN Who-is-hiring thread now? Takes 1-2 minutes and spends AI credit."
+                >
+                  <Button size="sm" variant="violet" disabled={!hnParserEnabled}>
+                    Run now
+                  </Button>
+                </ActionForm>
+              }
+            >
+              Parses the latest "Ask HN: Who is hiring?" thread (300-500 comments) monthly and
+              runs the structured ones through the same filter → classify → alert pipeline. Many
+              small startups only post there.
+            </ToggleRow>
+          </div>
+        </div>
+      </Card>
+
       <div>
         <SectionTitle>Pending review ({pending.length})</SectionTitle>
         {pending.length === 0 ? (
           <Empty>
-            No candidates yet. Enable the HN parser and discovery in Settings, then run the HN
-            once-job to seed candidates from the latest thread.
+            No candidates yet. Enable the HN parser and auto-discovery above, then "Run now" to
+            seed candidates from the latest thread.
           </Empty>
         ) : (
           <>
@@ -114,7 +147,7 @@ const CandidateTable: FC<{ rows: CompanyCandidate[]; actions?: boolean }> = ({
                 )}
               </Td>
               <Td>
-                <Tag>{c.atsType}</Tag>
+                <Tag>{sourceLabel(c.atsType)}</Tag>
               </Td>
               <Td class="text-[13px] text-ink-muted">
                 {c.sourceUrl ? (

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -18,6 +18,7 @@ import {
   Textarea,
 } from '../ui';
 import { formatDate, formatSalary } from '../format';
+import type { FlashMessage } from '../flash';
 import { ResumeMatchCard, type ResumeMatchCardProps } from './resume-match-card';
 import { VerificationCard, type VerificationCardProps } from './verification-card';
 
@@ -52,7 +53,7 @@ export interface JobDetailProps {
   verification: VerificationCardProps['verification'];
   verificationCount: number;
   resumeMatch: ResumeMatchCardProps;
-  flash?: { kind: 'ok' | 'err'; text: string } | null;
+  flash?: FlashMessage | null;
 }
 
 const PIPELINE_STAGES = ['applied', 'screen', 'tech', 'onsite', 'offer', 'rejected', 'ghosted'];

--- a/src/web/pages/job-new.tsx
+++ b/src/web/pages/job-new.tsx
@@ -25,7 +25,7 @@ export const JobNewPage: FC<{ flash?: FlashMessage | null }> = ({ flash }) => (
               name="title"
               required
               maxlength="200"
-              placeholder="Senior PHP Developer"
+              placeholder="Senior Software Engineer"
             />
           </Field>
           <Field label="Posting URL" hint="Optional — helps verification find the original.">

--- a/src/web/pages/overview.tsx
+++ b/src/web/pages/overview.tsx
@@ -2,7 +2,8 @@
 import type { FC } from 'hono/jsx';
 import type { CronRunStatus } from '@prisma/client';
 import { Layout } from '../layout';
-import { Badge, Card, Empty, FitBadge, PageHeader, SectionTitle, Stat, StatusBadge } from '../ui';
+import { Badge, Button, Card, Empty, FitBadge, Flash, PageHeader, SectionTitle, Stat, StatusBadge } from '../ui';
+import type { FlashMessage } from '../flash';
 import {
   formatDateShort,
   formatDuration,
@@ -39,6 +40,8 @@ export interface OverviewProps {
   last24h: { status: string; count: number }[];
   recentAlerts: JobRow[];
   latestRuns: { name: string; run: RunRow | null }[];
+  fetchingEnabled: boolean;
+  flash?: FlashMessage | null;
 }
 
 /** The four statuses worth acting on; Total and Dismissed stay quiet. */
@@ -58,6 +61,8 @@ export const OverviewPage: FC<OverviewProps> = ({
   last24h,
   recentAlerts,
   latestRuns,
+  fetchingEnabled,
+  flash,
 }) => {
   const byStatus = mapCounts(counts);
   const byStatus24h = mapCounts(last24h);
@@ -66,7 +71,27 @@ export const OverviewPage: FC<OverviewProps> = ({
 
   return (
     <Layout title="Overview" active="overview" refresh={30}>
-      <PageHeader title="Overview" meta="Refreshes every 30s" />
+      <PageHeader
+        title="Overview"
+        meta="Refreshes every 30s"
+        actions={
+          /* Quick master switch — same toggle as Settings → General. */
+          <form
+            method="post"
+            action="/settings/fetching-toggle"
+            class="flex items-center gap-2"
+          >
+            <input type="hidden" name="back" value="/" />
+            <Badge tone={fetchingEnabled ? 'ok' : 'neutral'}>
+              {fetchingEnabled ? 'Pipeline running' : 'Pipeline paused'}
+            </Badge>
+            <Button size="sm" variant="secondary">
+              {fetchingEnabled ? 'Pause' : 'Resume'}
+            </Button>
+          </form>
+        }
+      />
+      <Flash flash={flash} />
 
       <div class="mb-3 grid grid-cols-2 gap-3 xl:grid-cols-4">
         {PRIMARY_STATUSES.map((s) => {

--- a/src/web/pages/resumes.tsx
+++ b/src/web/pages/resumes.tsx
@@ -184,7 +184,7 @@ export const ResumeUploadForm: FC = () => (
     class="grid gap-3 sm:grid-cols-[1fr_1.4fr_auto]"
   >
     <Field label="Name" hint="Blank = taken from the file name.">
-      <Input type="text" name="name" placeholder="Backend PHP" maxlength="100" />
+      <Input type="text" name="name" placeholder="Senior Backend" maxlength="100" />
     </Field>
     <Field label="File" hint={`${ACCEPTED_EXTENSIONS.join(', ')} · up to ${MAX_UPLOAD_MB} MB`}>
       <Input

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -106,6 +106,8 @@ export interface SettingsProps {
   allSources: string[];
   fetchingEnabled: boolean;
   aiProviders: AiProviderOption[];
+  /** Set when the saved engine is not usable yet and a fallback runs. */
+  aiFallback: { saved: string; running: string; detail: string } | null;
   aiModelClassifier: string | null;
   aiModelResume: string | null;
   aiDefaults: { classifier: string; resume: string };
@@ -142,6 +144,7 @@ export const SettingsPage: FC<SettingsProps> = ({
   allSources,
   fetchingEnabled,
   aiProviders,
+  aiFallback,
   aiModelClassifier,
   aiModelResume,
   aiDefaults,
@@ -286,13 +289,19 @@ export const SettingsPage: FC<SettingsProps> = ({
       >
         <Card>
           <form method="post" action="/settings/ai" class="space-y-4">
+            {aiFallback && (
+              <div class="rounded-md border border-warn/25 bg-warn/5 px-3.5 py-2.5 text-[13px] leading-5 text-warn">
+                {aiFallback.saved} is saved as your engine but is not usable here yet
+                ({aiFallback.detail}). The pipeline is running on {aiFallback.running} and
+                switches over automatically once it works.
+              </div>
+            )}
             <div class="space-y-2">
               {aiProviders.map((p) => (
                 <Radio
                   name="provider"
                   value={p.id}
                   checked={p.selected}
-                  disabled={!p.ok}
                   title={
                     <>
                       {p.label}{' '}

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -76,12 +76,15 @@ export interface AiEngineRow {
   /** Family model ids for the selects; empty = free-text input. */
   options: string[];
   freeTextModels: boolean;
+  /** Metered billing — every call costs money (vs a flat subscription). */
+  paid: boolean;
 }
 
 export interface AiStatusSummary {
   active: string;
   chain: string[];
   skipped: string[];
+  usage7d: { label: string; classifier: number; resume: number }[];
 }
 
 /**
@@ -356,6 +359,14 @@ export const SettingsPage: FC<SettingsProps> = ({
               <span> → fallback: {aiStatus.chain.slice(1).join(' → ')}</span>
             )}
           </div>
+          <div class="text-[13px] text-ink-faint">
+            Last 7 days:{' '}
+            {aiStatus.usage7d.length === 0
+              ? 'no AI calls recorded yet'
+              : aiStatus.usage7d
+                  .map((u) => `${u.label} ${u.classifier + u.resume} (${u.classifier} classify · ${u.resume} resume)`)
+                  .join(' — ')}
+          </div>
           {aiStatus.skipped.length > 0 && (
             <div class="rounded-md border border-warn/25 bg-warn/5 px-3.5 py-2.5 text-[13px] leading-5 text-warn">
               Enabled but skipped for now: {aiStatus.skipped.join(', ')} — not usable on this
@@ -598,6 +609,7 @@ const AiEngineCard: FC<{ engine: AiEngineRow }> = ({ engine: e }) => (
       {e.enabled && <Badge tone="violet">#{e.position + 1}</Badge>}
       <span class="text-sm font-medium text-ink">{e.label}</span>
       <Badge tone={e.ok ? 'ok' : 'neutral'}>{e.ok ? 'available' : 'not detected'}</Badge>
+      {e.paid && <Badge tone="warn">pay per token</Badge>}
       <div class="ml-auto flex flex-wrap justify-end gap-2">
         {e.enabled && e.position > 0 && (
           <ActionForm action="/settings/ai/move" hidden={{ provider: e.id }}>

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -59,22 +59,29 @@ interface ResumeListItem {
   scannedAt: Date | null;
 }
 
-export interface AiProviderOption {
+export interface AiEngineRow {
   id: string;
   label: string;
   desc: string;
   ok: boolean;
   detail: string;
-  selected: boolean;
+  enabled: boolean;
+  /** Index in the priority chain; -1 when disabled. */
+  position: number;
+  classifierModel: string;
+  resumeModel: string;
+  classifierDefault: string;
+  resumeDefault: string;
+  /** Family model ids for the selects; empty = free-text input. */
+  options: string[];
+  freeTextModels: boolean;
 }
 
-const AI_MODEL_SUGGESTIONS = [
-  'claude-haiku-4-5-20251001',
-  'claude-sonnet-5',
-  'claude-opus-5',
-  'gemini-2.5-flash',
-  'gemini-2.5-pro',
-];
+export interface AiStatusSummary {
+  active: string;
+  chain: string[];
+  skipped: string[];
+}
 
 /**
  * Link-based sub-navigation (?tab=…): one route, server picks the sections.
@@ -105,12 +112,8 @@ export interface SettingsProps {
   disabledSources: string[];
   allSources: string[];
   fetchingEnabled: boolean;
-  aiProviders: AiProviderOption[];
-  /** Set when the saved engine is not usable yet and a fallback runs. */
-  aiFallback: { saved: string; running: string; detail: string } | null;
-  aiModelClassifier: string | null;
-  aiModelResume: string | null;
-  aiDefaults: { classifier: string; resume: string };
+  aiEngines: AiEngineRow[];
+  aiStatus: AiStatusSummary;
   targets: MaskedTarget[];
   profiles: ProfileListItem[];
   activeProfile: Profile | null;
@@ -143,11 +146,8 @@ export const SettingsPage: FC<SettingsProps> = ({
   disabledSources,
   allSources,
   fetchingEnabled,
-  aiProviders,
-  aiFallback,
-  aiModelClassifier,
-  aiModelResume,
-  aiDefaults,
+  aiEngines,
+  aiStatus,
   targets,
   profiles,
   activeProfile,
@@ -284,73 +284,26 @@ export const SettingsPage: FC<SettingsProps> = ({
       {activeTab === 'ai' && (
       <>
       <Section
-        title="AI engine"
-        desc="Which AI backend runs the pipeline and which models it uses. Dashboard actions switch immediately; the worker follows on its next tick."
+        title="AI engines"
+        desc="Your AI subscriptions and API keys, in priority order. #1 serves every call; when it errors or hits a rate limit, the next enabled engine takes over automatically. Setup guide: docs/ai-engines.md in the repo."
       >
-        <Card>
-          <form method="post" action="/settings/ai" class="space-y-4">
-            {aiFallback && (
-              <div class="rounded-md border border-warn/25 bg-warn/5 px-3.5 py-2.5 text-[13px] leading-5 text-warn">
-                {aiFallback.saved} is saved as your engine but is not usable here yet
-                ({aiFallback.detail}). The pipeline is running on {aiFallback.running} and
-                switches over automatically once it works.
-              </div>
+        <div class="space-y-3">
+          <div class="text-[13px] text-ink-muted">
+            Active now: <span class="font-medium text-ink">{aiStatus.active}</span>
+            {aiStatus.chain.length > 1 && (
+              <span> → fallback: {aiStatus.chain.slice(1).join(' → ')}</span>
             )}
-            <div class="space-y-2">
-              {aiProviders.map((p) => (
-                <Radio
-                  name="provider"
-                  value={p.id}
-                  checked={p.selected}
-                  title={
-                    <>
-                      {p.label}{' '}
-                      <Badge tone={p.ok ? 'ok' : 'neutral'} class="ml-1 align-middle">
-                        {p.ok ? 'available' : 'not detected'}
-                      </Badge>
-                    </>
-                  }
-                >
-                  {p.desc} <span class="text-ink-faint">({p.detail})</span>
-                </Radio>
-              ))}
+          </div>
+          {aiStatus.skipped.length > 0 && (
+            <div class="rounded-md border border-warn/25 bg-warn/5 px-3.5 py-2.5 text-[13px] leading-5 text-warn">
+              Enabled but skipped for now: {aiStatus.skipped.join(', ')} — not usable on this
+              host yet. Each joins the chain automatically once its key or login appears.
             </div>
-            <div class="grid gap-4 sm:grid-cols-2">
-              <Field
-                label="Classifier model"
-                hint={`Scores every fetched job — cheap and frequent. Empty = ${aiDefaults.classifier}.`}
-              >
-                <Input
-                  type="text"
-                  name="classifierModel"
-                  value={aiModelClassifier ?? ''}
-                  placeholder={aiDefaults.classifier}
-                  list="ai-model-ids"
-                  mono
-                />
-              </Field>
-              <Field
-                label="Resume model"
-                hint={`Resume scan, match and job verification — a few calls a day where judgment matters. Empty = ${aiDefaults.resume}.`}
-              >
-                <Input
-                  type="text"
-                  name="resumeModel"
-                  value={aiModelResume ?? ''}
-                  placeholder={aiDefaults.resume}
-                  list="ai-model-ids"
-                  mono
-                />
-              </Field>
-            </div>
-            <datalist id="ai-model-ids">
-              {AI_MODEL_SUGGESTIONS.map((m) => (
-                <option value={m} />
-              ))}
-            </datalist>
-            <Button variant="secondary">Save AI engine</Button>
-          </form>
-        </Card>
+          )}
+          {aiEngines.map((e) => (
+            <AiEngineCard engine={e} />
+          ))}
+        </div>
       </Section>
 
       <Section
@@ -576,6 +529,92 @@ export const SettingsPage: FC<SettingsProps> = ({
     <script dangerouslySetInnerHTML={{ __html: SETTINGS_JS }} />
   </Layout>
 );
+
+const AiEngineCard: FC<{ engine: AiEngineRow }> = ({ engine: e }) => (
+  <Card class={e.enabled ? '' : 'opacity-75'}>
+    <div class="flex flex-wrap items-center gap-2">
+      {e.enabled && <Badge tone="violet">#{e.position + 1}</Badge>}
+      <span class="text-sm font-medium text-ink">{e.label}</span>
+      <Badge tone={e.ok ? 'ok' : 'neutral'}>{e.ok ? 'available' : 'not detected'}</Badge>
+      <div class="ml-auto flex flex-wrap justify-end gap-2">
+        {e.enabled && e.position > 0 && (
+          <ActionForm action="/settings/ai/move" hidden={{ provider: e.id }}>
+            <Button size="sm" variant="secondary" title="Move one step up the priority order">
+              ↑ Priority
+            </Button>
+          </ActionForm>
+        )}
+        <ActionForm action="/settings/ai/test" hidden={{ provider: e.id }}>
+          <Button size="sm" variant="violet" title="Run a tiny live call through this engine">
+            Test
+          </Button>
+        </ActionForm>
+        <ActionForm action="/settings/ai/enable" hidden={{ provider: e.id }}>
+          <Button size="sm" variant={e.enabled ? 'secondary' : 'primary'}>
+            {e.enabled ? 'Disable' : 'Enable'}
+          </Button>
+        </ActionForm>
+      </div>
+    </div>
+    <p class="mt-1.5 text-[13px] leading-5 text-ink-faint">
+      {e.desc} ({e.detail})
+    </p>
+    {e.enabled && (
+      <form
+        method="post"
+        action="/settings/ai/models"
+        class="mt-4 grid gap-3 border-t border-line pt-4 sm:grid-cols-[1fr_1fr_auto] sm:items-end"
+      >
+        <input type="hidden" name="provider" value={e.id} />
+        <Field label="Classifier model" hint="Scores every fetched job — cheap and frequent.">
+          <ModelPicker
+            name="classifier"
+            value={e.classifierModel}
+            fallback={e.classifierDefault}
+            options={e.options}
+            freeText={e.freeTextModels}
+          />
+        </Field>
+        <Field label="Resume model" hint="Resume scan, match, verification — judgment calls.">
+          <ModelPicker
+            name="resume"
+            value={e.resumeModel}
+            fallback={e.resumeDefault}
+            options={e.options}
+            freeText={e.freeTextModels}
+          />
+        </Field>
+        <Button size="sm" variant="secondary">
+          Save models
+        </Button>
+      </form>
+    )}
+  </Card>
+);
+
+/** Closed families get a select (no wrong-family ids possible); base-URL
+ *  engines (openai_api) get free text — any model id may be legal there. */
+const ModelPicker: FC<{
+  name: string;
+  value: string;
+  fallback: string;
+  options: string[];
+  freeText: boolean;
+}> = ({ name, value, fallback, options, freeText }) =>
+  freeText ? (
+    <Input type="text" name={name} value={value} placeholder={fallback || 'model id'} mono />
+  ) : (
+    <Select name={name}>
+      <option value="" selected={value === ''}>
+        Default — {fallback}
+      </option>
+      {options.map((m) => (
+        <option value={m} selected={value === m}>
+          {m}
+        </option>
+      ))}
+    </Select>
+  );
 
 const ProfileEditor: FC<{
   profile: Profile;

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -58,6 +58,23 @@ interface ResumeListItem {
   scannedAt: Date | null;
 }
 
+export interface AiProviderOption {
+  id: string;
+  label: string;
+  desc: string;
+  ok: boolean;
+  detail: string;
+  selected: boolean;
+}
+
+const AI_MODEL_SUGGESTIONS = [
+  'claude-haiku-4-5-20251001',
+  'claude-sonnet-5',
+  'claude-opus-5',
+  'gemini-2.5-flash',
+  'gemini-2.5-pro',
+];
+
 const REGION_OPTIONS = ['US', 'Americas', 'EU', 'UK', 'APAC', 'Worldwide'];
 const SENIORITY_OPTIONS = ['junior', 'mid', 'senior', 'staff', 'lead', 'principal'];
 
@@ -71,6 +88,10 @@ export interface SettingsProps {
   allSources: string[];
   discoveryEnabled: boolean;
   fetchingEnabled: boolean;
+  aiProviders: AiProviderOption[];
+  aiModelClassifier: string | null;
+  aiModelResume: string | null;
+  aiDefaults: { classifier: string; resume: string };
   targets: MaskedTarget[];
   profiles: ProfileListItem[];
   activeProfile: Profile | null;
@@ -104,6 +125,10 @@ export const SettingsPage: FC<SettingsProps> = ({
   allSources,
   discoveryEnabled,
   fetchingEnabled,
+  aiProviders,
+  aiModelClassifier,
+  aiModelResume,
+  aiDefaults,
   targets,
   profiles,
   activeProfile,
@@ -210,6 +235,70 @@ export const SettingsPage: FC<SettingsProps> = ({
             </Table>
           </Card>
         )}
+      </Section>
+
+      <Section
+        title="AI engine"
+        desc="Which AI backend runs the pipeline and which models it uses. Dashboard actions switch immediately; the worker follows on its next tick."
+      >
+        <Card>
+          <form method="post" action="/settings/ai" class="space-y-4">
+            <div class="space-y-2">
+              {aiProviders.map((p) => (
+                <Radio
+                  name="provider"
+                  value={p.id}
+                  checked={p.selected}
+                  disabled={!p.ok}
+                  title={
+                    <>
+                      {p.label}{' '}
+                      <Badge tone={p.ok ? 'ok' : 'neutral'} class="ml-1 align-middle">
+                        {p.ok ? 'available' : 'not detected'}
+                      </Badge>
+                    </>
+                  }
+                >
+                  {p.desc} <span class="text-ink-faint">({p.detail})</span>
+                </Radio>
+              ))}
+            </div>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <Field
+                label="Classifier model"
+                hint={`Scores every fetched job — cheap and frequent. Empty = ${aiDefaults.classifier}.`}
+              >
+                <Input
+                  type="text"
+                  name="classifierModel"
+                  value={aiModelClassifier ?? ''}
+                  placeholder={aiDefaults.classifier}
+                  list="ai-model-ids"
+                  mono
+                />
+              </Field>
+              <Field
+                label="Resume model"
+                hint={`Resume scan, match and job verification — a few calls a day where judgment matters. Empty = ${aiDefaults.resume}.`}
+              >
+                <Input
+                  type="text"
+                  name="resumeModel"
+                  value={aiModelResume ?? ''}
+                  placeholder={aiDefaults.resume}
+                  list="ai-model-ids"
+                  mono
+                />
+              </Field>
+            </div>
+            <datalist id="ai-model-ids">
+              {AI_MODEL_SUGGESTIONS.map((m) => (
+                <option value={m} />
+              ))}
+            </datalist>
+            <Button variant="secondary">Save AI engine</Button>
+          </form>
+        </Card>
       </Section>
 
       <Section

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -28,6 +28,7 @@ import { formatRelative } from '../format';
 import type { FlashMessage } from '../flash';
 import { sourceLabel } from '../source-names';
 import { formatPriorityRulesText, parsePriorityRules } from '../../priority-rules';
+import { SENIORITY_LEVELS } from '../../resume/profile-draft';
 
 interface MaskedTarget {
   id: number;
@@ -102,7 +103,13 @@ export function isSettingsTab(value: unknown): value is SettingsTab {
 }
 
 const REGION_OPTIONS = ['US', 'Americas', 'EU', 'UK', 'APAC', 'Worldwide'];
-const SENIORITY_OPTIONS = ['junior', 'mid', 'senior', 'staff', 'lead', 'principal'];
+
+/** What "Fill from resume" replaced — rendered as an unsaved-draft notice. */
+export interface ProfileDraftNotice {
+  resumeName: string;
+  changed: string[];
+  warnings: string[];
+}
 
 export interface SettingsProps {
   telegramEnabled: boolean;
@@ -121,6 +128,8 @@ export interface SettingsProps {
   resumes: ResumeListItem[];
   activeTab: SettingsTab;
   flash?: FlashMessage | null;
+  /** Set by the fill-from-resume POST: the editor shows draft values. */
+  profileDraft?: ProfileDraftNotice | null;
 }
 
 /** Stripe-style settings section: title + description left, controls right. */
@@ -155,6 +164,7 @@ export const SettingsPage: FC<SettingsProps> = ({
   resumes,
   activeTab,
   flash,
+  profileDraft,
 }) => (
   <Layout title="Settings" active="settings">
     <div class="w-full max-w-5xl">
@@ -237,9 +247,61 @@ export const SettingsPage: FC<SettingsProps> = ({
             <Button variant="violet">Re-classify all jobs</Button>
           </ActionForm>
         </div>
+        {activeProfile && activeProfile.stackRequired.length === 0 && activeProfile.roleTypes.length === 0 && (
+          <div class="rounded-md border border-warn/25 bg-warn/5 px-3.5 py-2.5 text-[13px] leading-5 text-warn">
+            This profile lists no required stack and no role types yet, so every fetched job
+            goes to the AI classifier.{' '}
+            {resumes.length > 0 ? (
+              'Fastest fix: fill the fields from a resume below.'
+            ) : (
+              <>
+                Fastest fix:{' '}
+                <a href="/resumes" class="font-medium underline">
+                  upload a resume
+                </a>{' '}
+                and fill the fields from it here.
+              </>
+            )}
+          </div>
+        )}
+        {activeProfile && resumes.length > 0 && (
+          <Card>
+            <div class="mb-1 text-[13px] font-medium text-ink">Fill from a resume</div>
+            <Hint class="mb-3 max-w-prose">
+              AI maps the resume's scanned stack onto the profile — primary stack → required,
+              other skills → nice-to-have, plus role types and seniority. Re-scans the resume
+              when needed. The result appears below as a draft; nothing is saved until you
+              press "Save profile".
+            </Hint>
+            <form
+              method="post"
+              action={`/settings/profiles/${activeProfile.id}/fill-from-resume`}
+              class="flex flex-wrap items-center gap-2"
+            >
+              <Select
+                name="resumeId"
+                class="!w-auto min-w-0 max-w-full"
+                aria-label="Resume to fill the profile from"
+              >
+                {resumes.map((r) => (
+                  <option value={r.id} selected={r.isDefault}>
+                    {r.name}
+                    {r.isDefault ? ' (default)' : ''}
+                    {r.scannedAt ? '' : ' (not scanned yet)'}
+                  </option>
+                ))}
+              </Select>
+              <Button variant="violet">Fill from resume</Button>
+            </form>
+          </Card>
+        )}
         {activeProfile ? (
           <Card>
-            <ProfileEditor profile={activeProfile} availableTargets={availableTargets} />
+            <ProfileEditor
+              profile={activeProfile}
+              availableTargets={availableTargets}
+              draft={profileDraft}
+            />
           </Card>
         ) : (
           <Empty>No active profile. Pick one above or create a new one.</Empty>
@@ -619,13 +681,37 @@ const ModelPicker: FC<{
 const ProfileEditor: FC<{
   profile: Profile;
   availableTargets: AvailableTarget[];
-}> = ({ profile, availableTargets }) => (
+  draft?: ProfileDraftNotice | null;
+}> = ({ profile, availableTargets, draft }) => {
+  const rulesCount = parsePriorityRules(profile.priorityRules).length;
+  // Open the advanced block only when something in it is already customised.
+  const advancedOpen =
+    Boolean(profile.notes && profile.notes.trim().length > 0) ||
+    profile.onsiteCities.length > 0 ||
+    rulesCount > 0 ||
+    profile.minSalaryUsd > 0 ||
+    profile.telegramTargetId !== null;
+  return (
   <form
     method="post"
     action={`/settings/profiles/${profile.id}/save`}
     class="space-y-5"
     data-dirty-watch
   >
+    {draft && (
+      <div
+        role="status"
+        class="rounded-md border border-violet/25 bg-violet/5 px-3.5 py-2.5 text-[13px] leading-5 text-violet"
+      >
+        <span class="font-medium">
+          AI prefilled this profile from resume "{draft.resumeName}"
+        </span>{' '}
+        — replaced: {draft.changed.join(', ')}.
+        {draft.warnings.length > 0 && <> Note: {draft.warnings.join('; ')}.</>}{' '}
+        Nothing is saved yet — review the fields and press "Save profile" or "Save &amp;
+        re-classify".
+      </div>
+    )}
     <Field label="Name" class="max-w-md">
       <Input type="text" name="name" required value={profile.name} />
     </Field>
@@ -648,26 +734,11 @@ const ProfileEditor: FC<{
       name="stackNiceToHave"
       values={profile.stackNiceToHave}
     />
-    <TagListInput
-      label="Stack — exclude (auto-reject in title)"
-      hint="If the title contains any of these, the job is dropped before the classifier runs."
-      name="stackExclude"
-      values={profile.stackExclude}
-    />
-
-    <Field
-      label="Notes for the classifier"
-      hint='Free-form context: "AI-adjacent roles preferred", "open to first-time-manager positions", "EU-friendly time zones".'
-    >
-      <Textarea name="notes" rows={3}>
-        {profile.notes ?? ''}
-      </Textarea>
-    </Field>
 
     <fieldset>
       <legend class="text-[13px] font-medium text-ink">Seniority</legend>
       <div class="mt-2 flex flex-wrap gap-1.5">
-        {SENIORITY_OPTIONS.map((s) => (
+        {SENIORITY_LEVELS.map((s) => (
           <PillCheckbox name="seniority" value={s} checked={profile.seniority.includes(s)}>
             {s}
           </PillCheckbox>
@@ -695,38 +766,71 @@ const ProfileEditor: FC<{
           ))}
         </div>
       </div>
-      <TagListInput
-        label="On-site cities (OK to commute)"
-        hint='One per line: "Austin, TX", "Berlin".'
-        name="onsiteCities"
-        values={profile.onsiteCities}
-        rows={2}
-      />
     </fieldset>
 
-    <PriorityRulesEditor profile={profile} />
+    <details class="rounded-md border border-line" open={advancedOpen}>
+      <summary class="cursor-pointer select-none rounded-md px-4 py-3 text-[13px] font-medium text-ink transition-colors duration-150 hover:text-accent-strong">
+        Advanced — excludes, notes, priority rules, thresholds
+        <span class="ml-2 font-normal text-ink-faint">
+          Defaults work for most people; open this to fine-tune.
+        </span>
+      </summary>
+      <div class="space-y-5 border-t border-line px-4 py-4">
+        <TagListInput
+          label="Stack — exclude (auto-reject in title)"
+          hint="If the title contains any of these, the job is dropped before the classifier runs."
+          name="stackExclude"
+          values={profile.stackExclude}
+        />
 
-    <div class="grid gap-4 sm:grid-cols-3">
-      <Field label="Min salary (USD/year)" hint="0 = no salary filter.">
-        <Input type="number" name="minSalaryUsd" min="0" step="1000" value={profile.minSalaryUsd} />
-      </Field>
-      <Field label="Min fit score (0-100)">
-        <Input type="number" name="minFitScore" min="0" max="100" value={profile.minFitScore} />
-      </Field>
-      <Field label="Telegram target">
-        <Select name="telegramTargetId">
-          <option value="" selected={profile.telegramTargetId === null}>
-            (broadcast to all active)
-          </option>
-          {availableTargets.map((t) => (
-            <option value={t.id} selected={profile.telegramTargetId === t.id}>
-              {t.name}
-              {t.active ? '' : ' (inactive)'}
-            </option>
-          ))}
-        </Select>
-      </Field>
-    </div>
+        <Field
+          label="Notes for the classifier"
+          hint='Free-form context: "AI-adjacent roles preferred", "open to first-time-manager positions", "EU-friendly time zones".'
+        >
+          <Textarea name="notes" rows={3}>
+            {profile.notes ?? ''}
+          </Textarea>
+        </Field>
+
+        <TagListInput
+          label="On-site cities (OK to commute)"
+          hint='One per line: "Austin, TX", "Berlin".'
+          name="onsiteCities"
+          values={profile.onsiteCities}
+          rows={2}
+        />
+
+        <PriorityRulesEditor profile={profile} />
+
+        <div class="grid gap-4 sm:grid-cols-3">
+          <Field label="Min salary (USD/year)" hint="0 = no salary filter.">
+            <Input
+              type="number"
+              name="minSalaryUsd"
+              min="0"
+              step="1000"
+              value={profile.minSalaryUsd}
+            />
+          </Field>
+          <Field label="Min fit score (0-100)" hint="Jobs below it are stored, not alerted.">
+            <Input type="number" name="minFitScore" min="0" max="100" value={profile.minFitScore} />
+          </Field>
+          <Field label="Telegram target">
+            <Select name="telegramTargetId">
+              <option value="" selected={profile.telegramTargetId === null}>
+                (broadcast to all active)
+              </option>
+              {availableTargets.map((t) => (
+                <option value={t.id} selected={profile.telegramTargetId === t.id}>
+                  {t.name}
+                  {t.active ? '' : ' (inactive)'}
+                </option>
+              ))}
+            </Select>
+          </Field>
+        </div>
+      </div>
+    </details>
 
     <div class="flex flex-wrap items-center gap-3 border-t border-line pt-4">
       <Button size="lg">Save profile</Button>
@@ -739,12 +843,13 @@ const ProfileEditor: FC<{
       >
         Save &amp; re-classify
       </Button>
-      <span data-dirty-indicator hidden class="text-[13px] font-medium text-warn">
+      <span data-dirty-indicator hidden={!draft} class="text-[13px] font-medium text-warn">
         Unsaved changes
       </span>
     </div>
   </form>
-);
+  );
+};
 
 /**
  * Newline-joined list in a textarea — the transport the backend already

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -718,7 +718,7 @@ const ProfileEditor: FC<{
 
     <TagListInput
       label="Tech stack — required (real technologies)"
-      hint="Languages / frameworks the role must actually use: php, laravel, typescript, react, go. Not role types."
+      hint="Languages / frameworks the role must actually use: typescript, react, python, go, php. Not role types."
       name="stackRequired"
       values={profile.stackRequired}
     />
@@ -895,7 +895,7 @@ const PriorityRulesEditor: FC<{ profile: Profile }> = ({ profile }) => {
         id="priorityRules"
         name="priorityRules"
         rows={Math.max(3, rules.length + 1)}
-        placeholder="PHP remote-US | php | Remote US,United States,USA,Worldwide | 90"
+        placeholder="Python remote-US | python | Remote US,United States,USA,Worldwide | 90"
         class="mt-1.5"
         mono
       >

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -76,6 +76,24 @@ const AI_MODEL_SUGGESTIONS = [
   'gemini-2.5-pro',
 ];
 
+/**
+ * Link-based sub-navigation (?tab=…): one route, server picks the sections.
+ * POST routes redirect back to the tab their setting lives on.
+ */
+export const SETTINGS_TABS = [
+  { id: 'general', label: 'General' },
+  { id: 'profile', label: 'Profile' },
+  { id: 'ai', label: 'AI engine' },
+  { id: 'notifications', label: 'Notifications' },
+  { id: 'sources', label: 'Sources' },
+] as const;
+
+export type SettingsTab = (typeof SETTINGS_TABS)[number]['id'];
+
+export function isSettingsTab(value: unknown): value is SettingsTab {
+  return SETTINGS_TABS.some((t) => t.id === value);
+}
+
 const REGION_OPTIONS = ['US', 'Americas', 'EU', 'UK', 'APAC', 'Worldwide'];
 const SENIORITY_OPTIONS = ['junior', 'mid', 'senior', 'staff', 'lead', 'principal'];
 
@@ -96,6 +114,7 @@ export interface SettingsProps {
   activeProfile: Profile | null;
   availableTargets: AvailableTarget[];
   resumes: ResumeListItem[];
+  activeTab: SettingsTab;
   flash?: FlashMessage | null;
 }
 
@@ -131,6 +150,7 @@ export const SettingsPage: FC<SettingsProps> = ({
   activeProfile,
   availableTargets,
   resumes,
+  activeTab,
   flash,
 }) => (
   <Layout title="Settings" active="settings">
@@ -141,6 +161,27 @@ export const SettingsPage: FC<SettingsProps> = ({
       </PageHeader>
       <Flash flash={flash} />
 
+      <nav
+        aria-label="Settings sections"
+        class="mb-6 inline-flex flex-wrap gap-0.5 rounded-lg border border-line bg-surface-overlay p-0.5"
+      >
+        {SETTINGS_TABS.map((t) => (
+          <a
+            href={`/settings?tab=${t.id}`}
+            aria-current={t.id === activeTab ? 'page' : undefined}
+            class={`rounded-[6px] px-3 py-1.5 text-[13px] transition-colors duration-150 ${
+              t.id === activeTab
+                ? 'bg-surface-raised font-medium text-ink shadow-sm'
+                : 'text-ink-muted hover:text-ink'
+            }`}
+          >
+            {t.label}
+          </a>
+        ))}
+      </nav>
+
+      {/* Sections are declared in one flow; activeTab picks which render. */}
+      {activeTab === 'general' && (
       <Section
         title="Job fetching"
         desc="The master switch for new-job ingestion. Everything else keeps running while paused."
@@ -160,7 +201,9 @@ export const SettingsPage: FC<SettingsProps> = ({
           </ToggleRow>
         </Card>
       </Section>
+      )}
 
+      {activeTab === 'profile' && (
       <Section
         title="Active profile"
         desc="What a matching job looks like: stack, role types, regions, salary floor. The classifier scores every job against this."
@@ -233,7 +276,10 @@ export const SettingsPage: FC<SettingsProps> = ({
           </Card>
         )}
       </Section>
+      )}
 
+      {activeTab === 'ai' && (
+      <>
       <Section
         title="AI engine"
         desc="Which AI backend runs the pipeline and which models it uses. Dashboard actions switch immediately; the worker follows on its next tick."
@@ -327,7 +373,10 @@ export const SettingsPage: FC<SettingsProps> = ({
           </form>
         </Card>
       </Section>
+      </>
+      )}
 
+      {activeTab === 'general' && (
       <Section
         title="Application tracking"
         desc="The funnel board and the nudge that keeps it honest."
@@ -355,7 +404,9 @@ export const SettingsPage: FC<SettingsProps> = ({
           </div>
         </Card>
       </Section>
+      )}
 
+      {activeTab === 'notifications' && (
       <Section
         title="Notifications"
         desc="Telegram bots and chats that receive job alerts."
@@ -453,7 +504,9 @@ export const SettingsPage: FC<SettingsProps> = ({
           </Hint>
         </Card>
       </Section>
+      )}
 
+      {activeTab === 'sources' && (
       <Section
         title="Job sources"
         desc="Disable a whole source family with one click — handy when an aggregator gets noisy. Per-company toggles on the Companies page still apply."
@@ -476,7 +529,9 @@ export const SettingsPage: FC<SettingsProps> = ({
           </form>
         </Card>
       </Section>
+      )}
 
+      {activeTab === 'general' && (
       <Section
         title="Resumes"
         desc="The resumes you send out. Every job page can compare one against the posting."
@@ -507,6 +562,7 @@ export const SettingsPage: FC<SettingsProps> = ({
           </Hint>
         </Card>
       </Section>
+      )}
     </div>
     <script dangerouslySetInnerHTML={{ __html: SETTINGS_JS }} />
   </Layout>

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -25,8 +25,9 @@ import {
   Tr,
 } from '../ui';
 import { formatRelative } from '../format';
+import type { FlashMessage } from '../flash';
+import { sourceLabel } from '../source-names';
 import { formatPriorityRulesText, parsePriorityRules } from '../../priority-rules';
-import { ResumeUploadForm } from './resumes';
 
 interface MaskedTarget {
   id: number;
@@ -83,10 +84,8 @@ export interface SettingsProps {
   classifierMode: 'single' | 'two_stage';
   applicationTrackingEnabled: boolean;
   staleApplicationsDigestEnabled: boolean;
-  hnParserEnabled: boolean;
   disabledSources: string[];
   allSources: string[];
-  discoveryEnabled: boolean;
   fetchingEnabled: boolean;
   aiProviders: AiProviderOption[];
   aiModelClassifier: string | null;
@@ -97,7 +96,7 @@ export interface SettingsProps {
   activeProfile: Profile | null;
   availableTargets: AvailableTarget[];
   resumes: ResumeListItem[];
-  flash?: { kind: 'ok' | 'err'; text: string } | null;
+  flash?: FlashMessage | null;
 }
 
 /** Stripe-style settings section: title + description left, controls right. */
@@ -120,10 +119,8 @@ export const SettingsPage: FC<SettingsProps> = ({
   classifierMode,
   applicationTrackingEnabled,
   staleApplicationsDigestEnabled,
-  hnParserEnabled,
   disabledSources,
   allSources,
-  discoveryEnabled,
   fetchingEnabled,
   aiProviders,
   aiModelClassifier,
@@ -139,8 +136,8 @@ export const SettingsPage: FC<SettingsProps> = ({
   <Layout title="Settings" active="settings">
     <div class="w-full max-w-5xl">
       <PageHeader title="Settings">
-        Everything here lives in Postgres — no .env edits, no restarts. Toggles take effect on
-        the next cron tick.
+        Changes save the moment you click — no restarts needed. Dashboard actions use them
+        immediately; the background worker picks them up within the hour.
       </PageHeader>
       <Flash flash={flash} />
 
@@ -158,8 +155,8 @@ export const SettingsPage: FC<SettingsProps> = ({
             enableText="Resume"
             disableText="Pause"
           >
-            Hourly fetch + monthly HN pull. Pausing stops new jobs and alerts without touching
-            Docker; the dashboard, digest, cleanup and discovery probe keep running.
+            Hourly fetch + monthly HN pull. Pausing stops new jobs and alerts; the dashboard,
+            digests and cleanup keep running.
           </ToggleRow>
         </Card>
       </Section>
@@ -332,97 +329,6 @@ export const SettingsPage: FC<SettingsProps> = ({
       </Section>
 
       <Section
-        title="Job sources"
-        desc="Disable a whole source family with one click — handy when an aggregator gets noisy. Per-company toggles on the Companies page still apply."
-      >
-        <Card>
-          <form method="post" action="/settings/sources" class="space-y-4">
-            <div class="flex flex-wrap gap-1.5">
-              {allSources.map((s) => (
-                <PillCheckbox name="enabled" value={s} checked={!disabledSources.includes(s)}>
-                  {s}
-                </PillCheckbox>
-              ))}
-            </div>
-            <Button variant="secondary">Save sources</Button>
-          </form>
-        </Card>
-      </Section>
-
-      <Section
-        title="Resumes"
-        desc="Upload the resumes you send out. Every job page can then compare one against the posting."
-      >
-        <Card>
-          {resumes.length > 0 && (
-            <ul class="mb-4 divide-y divide-line rounded-md border border-line">
-              {resumes.map((r) => (
-                <li class="flex flex-wrap items-center gap-2 px-3.5 py-2.5 text-sm">
-                  <a
-                    href={`/resumes/${r.id}`}
-                    class="font-medium text-ink transition-colors duration-150 hover:text-accent-strong"
-                  >
-                    {r.name}
-                  </a>
-                  {r.isDefault && <Badge tone="ok">default</Badge>}
-                  {!r.scannedAt && <Badge tone="warn">not scanned</Badge>}
-                </li>
-              ))}
-            </ul>
-          )}
-          <ResumeUploadForm />
-          <Hint class="mt-3">
-            <a
-              href="/resumes"
-              class="font-medium text-accent-strong hover:text-accent-deep"
-            >
-              Manage resumes →
-            </a>
-          </Hint>
-        </Card>
-      </Section>
-
-      <Section
-        title="Discovery"
-        desc="Finding new company boards automatically from HN threads."
-      >
-        <Card>
-          <div class="space-y-5">
-            <ToggleRow
-              label="Auto-discovery"
-              enabled={discoveryEnabled}
-              action="/settings/discovery-toggle"
-            >
-              When the HN parser sees a Greenhouse / Lever / Ashby URL in a comment, the company
-              lands on the Discovery page as a candidate. A weekly cron re-probes pending
-              candidates so the job count stays fresh.
-            </ToggleRow>
-            <div class="border-t border-line pt-5">
-              <ToggleRow
-                label={'HN "Who is hiring" parser'}
-                enabled={hnParserEnabled}
-                action="/settings/hn-parser-toggle"
-                extra={
-                  <ActionForm
-                    action="/settings/hn-run"
-                    confirm="Pull the latest HN Who-is-hiring thread now? Takes 1-2 minutes and spends AI credit."
-                  >
-                    <Button size="sm" variant="violet" disabled={!hnParserEnabled}>
-                      Run now
-                    </Button>
-                  </ActionForm>
-                }
-              >
-                Monthly cron parses the latest "Ask HN: Who is hiring?" thread (300-500 comments)
-                and runs the structured ones through the same filter → classify → alert pipeline.
-                Many small startups only post there.
-              </ToggleRow>
-            </div>
-          </div>
-        </Card>
-      </Section>
-
-      <Section
         title="Application tracking"
         desc="The funnel board and the nudge that keeps it honest."
       >
@@ -543,7 +449,61 @@ export const SettingsPage: FC<SettingsProps> = ({
             </div>
           </form>
           <Hint class="mt-3">
-            The bot token is validated (getMe + sendMessage) before saving.
+            The token is checked and a test message is sent before saving.
+          </Hint>
+        </Card>
+      </Section>
+
+      <Section
+        title="Job sources"
+        desc="Disable a whole source family with one click — handy when an aggregator gets noisy. Per-company toggles on the Companies page still apply."
+      >
+        <Card>
+          <form method="post" action="/settings/sources" class="space-y-4">
+            <div class="flex flex-wrap gap-1.5">
+              {allSources.map((s) => (
+                <PillCheckbox name="enabled" value={s} checked={!disabledSources.includes(s)}>
+                  {sourceLabel(s)}
+                </PillCheckbox>
+              ))}
+            </div>
+            <Hint>
+              Keep the aggregators on — they carry the long tail of companies not tracked on the
+              Companies page. The profile filter and classifier do the narrowing; turning
+              aggregators off usually means near-zero new jobs.
+            </Hint>
+            <Button variant="secondary">Save sources</Button>
+          </form>
+        </Card>
+      </Section>
+
+      <Section
+        title="Resumes"
+        desc="The resumes you send out. Every job page can compare one against the posting."
+      >
+        <Card>
+          {resumes.length > 0 ? (
+            <ul class="divide-y divide-line rounded-md border border-line">
+              {resumes.map((r) => (
+                <li class="flex flex-wrap items-center gap-2 px-3.5 py-2.5 text-sm">
+                  <a
+                    href={`/resumes/${r.id}`}
+                    class="font-medium text-ink transition-colors duration-150 hover:text-accent-strong"
+                  >
+                    {r.name}
+                  </a>
+                  {r.isDefault && <Badge tone="ok">default</Badge>}
+                  {!r.scannedAt && <Badge tone="warn">not scanned</Badge>}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <Empty>No resumes yet.</Empty>
+          )}
+          <Hint class="mt-3">
+            <a href="/resumes" class="font-medium text-accent-strong hover:text-accent-deep">
+              Upload &amp; manage resumes →
+            </a>
           </Hint>
         </Card>
       </Section>
@@ -666,7 +626,13 @@ const ProfileEditor: FC<{
 
     <div class="flex flex-wrap items-center gap-3 border-t border-line pt-4">
       <Button size="lg">Save profile</Button>
-      <Button size="lg" variant="violet" name="action" value="save-and-reclassify">
+      <Button
+        size="lg"
+        variant="violet"
+        name="action"
+        value="save-and-reclassify"
+        onclick="return confirm('Save the profile and re-classify all jobs (except APPLIED)? Takes 2-5 minutes and spends AI credit.')"
+      >
         Save &amp; re-classify
       </Button>
       <span data-dirty-indicator hidden class="text-[13px] font-medium text-warn">

--- a/src/web/pages/target-start.tsx
+++ b/src/web/pages/target-start.tsx
@@ -74,7 +74,7 @@ export const TargetStartPage: FC<TargetStartProps> = ({ resumes, flash }) => {
                   <Input type="text" name="companyName" maxlength="200" placeholder="Acme Corp" />
                 </Field>
                 <Field label="Job title" hint="Optional — detected during the run.">
-                  <Input type="text" name="title" maxlength="200" placeholder="Senior PHP Developer" />
+                  <Input type="text" name="title" maxlength="200" placeholder="Senior Software Engineer" />
                 </Field>
               </div>
               <div class="grid gap-4 sm:grid-cols-2">

--- a/src/web/routes/discovery.tsx
+++ b/src/web/routes/discovery.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource hono/jsx */
-import { Hono, type Context } from 'hono';
+import { Hono } from 'hono';
 import { CandidateStatus } from '@prisma/client';
 import { logger } from '../../logger';
 import {
@@ -8,14 +8,15 @@ import {
   listCandidates,
   promoteCandidate,
 } from '../../discovery';
-import { getSettings } from '../../settings';
+import { getSettings, setDiscoveryEnabled, setHnParserEnabled } from '../../settings';
 import { recordCronRun } from '../../jobs/cron-run';
 import { runDiscoveryJob } from '../../jobs/discovery-job';
+import { runHnHiringJob } from '../../jobs/hn-hiring-job';
 import { DiscoveryPage } from '../pages/discovery';
-
-const FLASH_TTL_SECONDS = 5;
+import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 
 let probeInFlight = false;
+let hnRunInFlight = false;
 
 export const discoveryRoute = new Hono();
 
@@ -31,6 +32,7 @@ discoveryRoute.get('/discovery', async (c) => {
   return c.html(
     <DiscoveryPage
       discoveryEnabled={settings.discoveryEnabled}
+      hnParserEnabled={settings.hnParserEnabled}
       pending={pending}
       promoted={promoted}
       ignored={ignored}
@@ -42,21 +44,52 @@ discoveryRoute.get('/discovery', async (c) => {
   );
 });
 
+discoveryRoute.post('/discovery/toggle', async (c) => {
+  const settings = await getSettings();
+  await setDiscoveryEnabled(!settings.discoveryEnabled);
+  return flashRedirect('/discovery', 'ok',
+    `Auto-discovery ${!settings.discoveryEnabled ? 'enabled' : 'disabled'}.`,
+  );
+});
+
+discoveryRoute.post('/discovery/hn-parser-toggle', async (c) => {
+  const settings = await getSettings();
+  await setHnParserEnabled(!settings.hnParserEnabled);
+  return flashRedirect('/discovery', 'ok',
+    `HN "Who is hiring" parser ${!settings.hnParserEnabled ? 'enabled' : 'disabled'}.`,
+  );
+});
+
+discoveryRoute.post('/discovery/hn-run', (c) => {
+  if (hnRunInFlight) {
+    return flashRedirect('/discovery', 'err', 'An HN parse run is already in progress. Watch /runs.');
+  }
+  hnRunInFlight = true;
+  void (async () => {
+    try {
+      await recordCronRun('hn-hiring', runHnHiringJob);
+    } catch (err) {
+      logger.error({ err }, 'hn-hiring (manual trigger): failed');
+    } finally {
+      hnRunInFlight = false;
+    }
+  })();
+  return flashRedirect('/discovery', 'ok',
+    'HN parse started in the background. Track progress at /runs.',
+  );
+});
+
 discoveryRoute.post('/discovery/:id/promote', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   try {
     await promoteCandidate(id);
   } catch (err) {
-    return redirectWithFlash(
-      c,
-      'err',
+    return flashRedirect('/discovery', 'err',
       err instanceof Error ? err.message : 'Promote failed.',
     );
   }
-  return redirectWithFlash(
-    c,
-    'ok',
+  return flashRedirect('/discovery', 'ok',
     'Promoted to active company. Next fetch tick will pull its jobs.',
   );
 });
@@ -65,21 +98,19 @@ discoveryRoute.post('/discovery/:id/ignore', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   await ignoreCandidate(id);
-  return redirectWithFlash(c, 'ok', 'Marked as ignored.');
+  return flashRedirect('/discovery', 'ok', 'Marked as ignored.');
 });
 
 discoveryRoute.post('/discovery/:id/delete', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   await deleteCandidate(id);
-  return redirectWithFlash(c, 'ok', 'Candidate deleted.');
+  return flashRedirect('/discovery', 'ok', 'Candidate deleted.');
 });
 
 discoveryRoute.post('/discovery/probe-now', (c) => {
   if (probeInFlight) {
-    return redirectWithFlash(
-      c,
-      'err',
+    return flashRedirect('/discovery', 'err',
       'A discovery probe is already running. Watch /runs.',
     );
   }
@@ -93,50 +124,7 @@ discoveryRoute.post('/discovery/probe-now', (c) => {
       probeInFlight = false;
     }
   })();
-  return redirectWithFlash(
-    c,
-    'ok',
+  return flashRedirect('/discovery', 'ok',
     'Discovery probe started. Track progress at /runs.',
   );
 });
-
-// --- helpers ----------------------------------------------------------------
-
-function redirectWithFlash(
-  c: Context,
-  kind: 'ok' | 'err',
-  text: string,
-): Response {
-  const value = encodeURIComponent(JSON.stringify({ kind, text }));
-  const cookie = `flash=${value}; Path=/; Max-Age=${FLASH_TTL_SECONDS}; HttpOnly; SameSite=Lax`;
-  return new Response(null, {
-    status: 303,
-    headers: { Location: '/discovery', 'Set-Cookie': cookie },
-  });
-}
-
-function parseFlashCookie(
-  cookieHeader: string | undefined,
-): { kind: 'ok' | 'err'; text: string } | null {
-  if (!cookieHeader) return null;
-  const match = /(?:^|;\s*)flash=([^;]+)/.exec(cookieHeader);
-  if (!match || !match[1]) return null;
-  try {
-    const parsed = JSON.parse(decodeURIComponent(match[1]));
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      (parsed.kind === 'ok' || parsed.kind === 'err') &&
-      typeof parsed.text === 'string'
-    ) {
-      return parsed;
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
-
-function clearFlashCookie(): string {
-  return 'flash=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax';
-}

--- a/src/web/routes/overview.tsx
+++ b/src/web/routes/overview.tsx
@@ -2,6 +2,8 @@
 import { Hono } from 'hono';
 import { JobStatus } from '@prisma/client';
 import { prisma } from '../../db';
+import { getSettings } from '../../settings';
+import { clearFlashCookie, parseFlashCookie } from '../flash';
 import { OverviewPage } from '../pages/overview';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -13,7 +15,8 @@ export const overviewRoute = new Hono();
 overviewRoute.get('/', async (c) => {
   const since24h = new Date(Date.now() - DAY_MS);
 
-  const [countsRows, last24hRows, recentAlerts, latestRunRows] = await Promise.all([
+  const [settings, countsRows, last24hRows, recentAlerts, latestRunRows] = await Promise.all([
+    getSettings(),
     prisma.job.groupBy({
       by: ['status'],
       _count: { _all: true },
@@ -58,6 +61,10 @@ overviewRoute.get('/', async (c) => {
       last24h={last24h}
       recentAlerts={recentAlerts}
       latestRuns={latestRuns}
+      fetchingEnabled={settings.fetchingEnabled}
+      flash={parseFlashCookie(c.req.header('cookie'))}
     />,
+    200,
+    { 'Set-Cookie': clearFlashCookie() },
   );
 });

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -51,7 +51,11 @@ resumesRoute.post('/resumes', resumeUploadLimit('/resumes'), async (c) => {
   const resume = await createResume({ name, ...upload });
   const scan = await scanResume(resume);
   return scan
-    ? flashRedirect(`/resumes/${resume.id}`, 'ok', `Uploaded and scanned "${name}".`)
+    ? flashRedirect(
+        `/resumes/${resume.id}`,
+        'ok',
+        `Uploaded and scanned "${name}". Tip: Settings → Profile → "Fill from a resume" updates your search profile from it.`,
+      )
     : flashRedirect(
         `/resumes/${resume.id}`,
         'err',

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -172,4 +172,4 @@ resumesRoute.post('/resumes/:id/delete', async (c) => {
   return flashRedirect('/resumes', 'ok', 'Resume deleted.');
 });
 
-/** "Nazar_Boyko_Senior_Backend_Resume.docx" → "Nazar Boyko Senior Backend Resume". */
+/** "Alex_Doe_Senior_Backend_Resume.docx" → "Alex Doe Senior Backend Resume". */

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -27,7 +27,7 @@ import {
   resolveAiEngine,
   type AiProviderId,
 } from '../../ai-engine';
-import { AI_ENGINE_ENV, probeAiProviders } from '../../ai-runtime';
+import { getAiEngineEnv, probeAiProviders } from '../../ai-runtime';
 import {
   createProfile,
   deleteProfile,
@@ -96,11 +96,26 @@ settingsRoute.get('/settings', async (c) => {
     listResumes(),
     probeAiProviders(),
   ]);
-  const aiEffective = resolveAiEngine(settings, AI_ENGINE_ENV);
+  const aiEnv = getAiEngineEnv();
+  const aiEffective = resolveAiEngine(settings, aiEnv);
   const aiFamilyDefaults = resolveAiEngine(
     { aiProvider: settings.aiProvider, aiModelClassifier: null, aiModelResume: null },
-    AI_ENGINE_ENV,
+    aiEnv,
   );
+  // The form shows the SAVED preference; the pipeline may be running on a
+  // fallback until that engine becomes usable (key / login appears).
+  const aiChecked =
+    settings.aiProvider && isAiProviderId(settings.aiProvider)
+      ? settings.aiProvider
+      : aiEffective.providerId;
+  const aiFallback =
+    aiChecked !== aiEffective.providerId
+      ? {
+          saved: AI_PROVIDER_LABELS[aiChecked],
+          running: AI_PROVIDER_LABELS[aiEffective.providerId],
+          detail: aiStatuses[aiChecked].detail,
+        }
+      : null;
   const tabParam = c.req.query('tab');
   const activeTab = isSettingsTab(tabParam) ? tabParam : 'general';
   const flash = parseFlashCookie(c.req.header('cookie'));
@@ -120,8 +135,9 @@ settingsRoute.get('/settings', async (c) => {
         desc: AI_PROVIDER_DESCS[id],
         ok: aiStatuses[id].ok,
         detail: aiStatuses[id].detail,
-        selected: aiEffective.providerId === id,
+        selected: aiChecked === id,
       }))}
+      aiFallback={aiFallback}
       aiModelClassifier={settings.aiModelClassifier}
       aiModelResume={settings.aiModelResume}
       aiDefaults={{
@@ -192,30 +208,37 @@ settingsRoute.post('/settings/ai', async (c) => {
   if (!isAiProviderId(provider)) {
     return flashRedirect('/settings?tab=ai', 'err', 'Pick an AI provider.');
   }
-  const statuses = await probeAiProviders();
-  if (!statuses[provider].ok) {
-    return flashRedirect(
-      '/settings?tab=ai',
-      'err',
-      `${AI_PROVIDER_LABELS[provider]} is not usable here: ${statuses[provider].detail}.`,
-    );
-  }
+  const label = AI_PROVIDER_LABELS[provider];
   const classifierModel = cleanModelId(form.classifierModel);
   const resumeModel = cleanModelId(form.resumeModel);
   for (const model of [classifierModel, resumeModel]) {
     if (model && !modelFitsProvider(model, provider)) {
+      const geminiHint =
+        model.startsWith('gemini') && provider !== 'gemini_cli'
+          ? ' It is a Gemini model — select Gemini CLI above to use it.'
+          : '';
       return flashRedirect(
         '/settings?tab=ai',
         'err',
-        `"${model}" does not look like a ${AI_PROVIDER_LABELS[provider]} model id. Not saved.`,
+        `"${model}" does not fit ${label}.${geminiHint} Nothing saved.`,
       );
     }
   }
   await setAiEngine({ aiProvider: provider, aiModelClassifier: classifierModel, aiModelResume: resumeModel });
+  // An engine that is not usable yet still saves — the pipeline runs on the
+  // fallback (resolveAiEngine) and switches over the moment auth appears.
+  const statuses = await probeAiProviders();
+  if (!statuses[provider].ok) {
+    return flashRedirect(
+      '/settings?tab=ai',
+      'warn',
+      `${label} saved as your engine, but it is not usable here yet (${statuses[provider].detail}). The pipeline keeps running on the fallback until it is.`,
+    );
+  }
   return flashRedirect(
     '/settings?tab=ai',
     'ok',
-    `AI engine → ${AI_PROVIDER_LABELS[provider]}. Dashboard actions use it now; the worker follows on its next tick.`,
+    `AI engine → ${label}. Dashboard actions use it now; the worker follows on its next tick.`,
   );
 });
 

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -13,9 +13,7 @@ import {
   setApplicationTrackingEnabled,
   setClassifierMode,
   setDisabledSources,
-  setDiscoveryEnabled,
   setFetchingEnabled,
-  setHnParserEnabled,
   setStaleApplicationsDigestEnabled,
   setTelegramEnabled,
   testTelegramTarget,
@@ -40,7 +38,6 @@ import {
   updateProfile,
 } from '../../profiles';
 import { runReclassifyAll } from '../../jobs/reclassify-job';
-import { runHnHiringJob } from '../../jobs/hn-hiring-job';
 import { recordCronRun } from '../../jobs/cron-run';
 import { parseTagList, toStringArray } from '../../text-utils';
 import {
@@ -50,6 +47,7 @@ import {
 } from '../../priority-rules';
 import { prisma } from '../../db';
 import { SettingsPage } from '../pages/settings';
+import { sourceLabel } from '../source-names';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { listResumes } from '../../resume/store';
 
@@ -110,10 +108,8 @@ settingsRoute.get('/settings', async (c) => {
       classifierMode={settings.classifierMode}
       applicationTrackingEnabled={settings.applicationTrackingEnabled}
       staleApplicationsDigestEnabled={settings.staleApplicationsDigestEnabled}
-      hnParserEnabled={settings.hnParserEnabled}
       disabledSources={settings.disabledSources}
       allSources={Object.values(AtsType).filter((t) => t !== AtsType.MANUAL)}
-      discoveryEnabled={settings.discoveryEnabled}
       fetchingEnabled={settings.fetchingEnabled}
       aiProviders={AI_PROVIDER_IDS.map((id) => ({
         id,
@@ -170,13 +166,9 @@ settingsRoute.get('/settings', async (c) => {
 settingsRoute.post('/settings/fetching-toggle', async (c) => {
   const settings = await getSettings();
   await setFetchingEnabled(!settings.fetchingEnabled);
-  return flashRedirect(
-    '/settings',
-    'ok',
-    settings.fetchingEnabled
-      ? 'Job fetching paused — no new jobs or alerts until you resume.'
-      : 'Job fetching resumed — next hourly tick will pull new jobs.',
-  );
+  return settings.fetchingEnabled
+    ? flashRedirect('/settings', 'warn', 'Job fetching paused — no new jobs or alerts until you resume.')
+    : flashRedirect('/settings', 'ok', 'Job fetching resumed — next hourly tick will pull new jobs.');
 });
 
 // --- Telegram toggle / targets ---------------------------------------------
@@ -274,7 +266,8 @@ settingsRoute.post('/settings/sources', async (c) => {
         ? [form.enabled]
         : []
   ).filter((v): v is string => typeof v === 'string');
-  const allSources = Object.values(AtsType) as string[];
+  // MANUAL is not a fetchable source — keep it out of disabledSources.
+  const allSources = Object.values(AtsType).filter((s) => s !== AtsType.MANUAL) as string[];
   // disabledSources = everything NOT in the submitted "enabled" set.
   const disabled = allSources.filter((s) => !enabled.includes(s));
   await setDisabledSources(disabled);
@@ -283,53 +276,7 @@ settingsRoute.post('/settings/sources', async (c) => {
     'ok',
     disabled.length === 0
       ? 'All sources enabled.'
-      : `Disabled: ${disabled.join(', ')}.`,
-  );
-});
-
-settingsRoute.post('/settings/discovery-toggle', async (c) => {
-  const settings = await getSettings();
-  await setDiscoveryEnabled(!settings.discoveryEnabled);
-  return flashRedirect(
-    '/settings',
-    'ok',
-    `Auto-discovery ${!settings.discoveryEnabled ? 'enabled' : 'disabled'}.`,
-  );
-});
-
-settingsRoute.post('/settings/hn-parser-toggle', async (c) => {
-  const settings = await getSettings();
-  await setHnParserEnabled(!settings.hnParserEnabled);
-  return flashRedirect(
-    '/settings',
-    'ok',
-    `HN parser ${!settings.hnParserEnabled ? 'enabled' : 'disabled'}.`,
-  );
-});
-
-let hnRunInFlight = false;
-settingsRoute.post('/settings/hn-run', (c) => {
-  if (hnRunInFlight) {
-    return flashRedirect(
-      '/settings',
-      'err',
-      'An HN parse run is already in progress. Watch /runs.',
-    );
-  }
-  hnRunInFlight = true;
-  void (async () => {
-    try {
-      await recordCronRun('hn-hiring', runHnHiringJob);
-    } catch (err) {
-      logger.error({ err }, 'hn-hiring (manual trigger): failed');
-    } finally {
-      hnRunInFlight = false;
-    }
-  })();
-  return flashRedirect(
-    '/settings',
-    'ok',
-    'HN parse started in the background. Track progress at /runs.',
+      : `Disabled: ${disabled.map(sourceLabel).join(', ')}.`,
   );
 });
 

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -54,7 +54,9 @@ import { prisma } from '../../db';
 import { isSettingsTab, SettingsPage } from '../pages/settings';
 import { sourceLabel } from '../source-names';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
-import { listResumes } from '../../resume/store';
+import { getResume, listResumes } from '../../resume/store';
+import { scanResume } from '../../resume/scan';
+import { buildProfileDraft } from '../../resume/profile-draft';
 
 const NewTargetSchema = z.object({
   name: z.string().min(1).max(100),
@@ -97,7 +99,9 @@ let reclassifyInFlight = false;
 
 export const settingsRoute = new Hono();
 
-settingsRoute.get('/settings', async (c) => {
+/** Everything the settings page needs except activeTab/flash/profileDraft —
+ *  shared by the GET and by POSTs that render a draft instead of redirecting. */
+async function loadSettingsProps() {
   const [settings, targets, profiles, active, resumes, aiStatuses] = await Promise.all([
     getSettings(),
     listTelegramTargets(),
@@ -140,55 +144,56 @@ settingsRoute.get('/settings', async (c) => {
     chain: engine.chain.map((id) => AI_PROVIDER_LABELS[id]),
     skipped: engine.skipped.map((id) => AI_PROVIDER_LABELS[id]),
   };
+  return {
+    telegramEnabled: settings.telegramEnabled,
+    classifierMode: settings.classifierMode,
+    applicationTrackingEnabled: settings.applicationTrackingEnabled,
+    staleApplicationsDigestEnabled: settings.staleApplicationsDigestEnabled,
+    disabledSources: settings.disabledSources,
+    allSources: Object.values(AtsType).filter((t) => t !== AtsType.MANUAL),
+    fetchingEnabled: settings.fetchingEnabled,
+    aiEngines,
+    aiStatus,
+    targets: targets.map((t) => ({
+      id: t.id,
+      name: t.name,
+      maskedToken: maskToken(t.botToken),
+      chatId: t.chatId,
+      active: t.active,
+      createdAt: t.createdAt,
+      lastUsed: t.lastUsed,
+    })),
+    profiles: profiles.map((p) => ({
+      id: p.id,
+      name: p.name,
+      stackPreview:
+        p.stackRequired.slice(0, 4).join(', ') +
+        (p.stackRequired.length > 4 ? '...' : ''),
+      active: active?.id === p.id,
+    })),
+    activeProfile: active,
+    availableTargets: targets.map((t) => ({
+      id: t.id,
+      name: t.name,
+      active: t.active,
+    })),
+    resumes: resumes.map((r) => ({
+      id: r.id,
+      name: r.name,
+      isDefault: r.isDefault,
+      scannedAt: r.scannedAt,
+    })),
+  };
+}
+
+settingsRoute.get('/settings', async (c) => {
+  const props = await loadSettingsProps();
   const tabParam = c.req.query('tab');
   const activeTab = isSettingsTab(tabParam) ? tabParam : 'general';
   const flash = parseFlashCookie(c.req.header('cookie'));
-  return c.html(
-    <SettingsPage
-      activeTab={activeTab}
-      telegramEnabled={settings.telegramEnabled}
-      classifierMode={settings.classifierMode}
-      applicationTrackingEnabled={settings.applicationTrackingEnabled}
-      staleApplicationsDigestEnabled={settings.staleApplicationsDigestEnabled}
-      disabledSources={settings.disabledSources}
-      allSources={Object.values(AtsType).filter((t) => t !== AtsType.MANUAL)}
-      fetchingEnabled={settings.fetchingEnabled}
-      aiEngines={aiEngines}
-      aiStatus={aiStatus}
-      targets={targets.map((t) => ({
-        id: t.id,
-        name: t.name,
-        maskedToken: maskToken(t.botToken),
-        chatId: t.chatId,
-        active: t.active,
-        createdAt: t.createdAt,
-        lastUsed: t.lastUsed,
-      }))}
-      profiles={profiles.map((p) => ({
-        id: p.id,
-        name: p.name,
-        stackPreview:
-          p.stackRequired.slice(0, 4).join(', ') +
-          (p.stackRequired.length > 4 ? '...' : ''),
-        active: active?.id === p.id,
-      }))}
-      activeProfile={active}
-      availableTargets={targets.map((t) => ({
-        id: t.id,
-        name: t.name,
-        active: t.active,
-      }))}
-      resumes={resumes.map((r) => ({
-        id: r.id,
-        name: r.name,
-        isDefault: r.isDefault,
-        scannedAt: r.scannedAt,
-      }))}
-      flash={flash}
-    />,
-    200,
-    { 'Set-Cookie': clearFlashCookie() },
-  );
+  return c.html(<SettingsPage {...props} activeTab={activeTab} flash={flash} />, 200, {
+    'Set-Cookie': clearFlashCookie(),
+  });
 });
 
 // --- Fetching pause / resume -----------------------------------------------
@@ -584,6 +589,68 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
     );
   }
   return flashRedirect('/settings?tab=profile', 'ok', 'Profile saved.');
+});
+
+// Prefill the editor from a resume's AI scan. Renders the draft directly —
+// nothing is saved until the user submits the profile form.
+settingsRoute.post('/settings/profiles/:id/fill-from-resume', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!Number.isFinite(id)) return c.text('Bad id', 400);
+  const profile = await getProfile(id);
+  if (!profile) return flashRedirect('/settings?tab=profile', 'err', 'Profile not found.');
+  const form = await c.req.parseBody();
+  const resumeId = Number(form.resumeId);
+  if (!Number.isFinite(resumeId)) {
+    return flashRedirect('/settings?tab=profile', 'err', 'Pick a resume first.');
+  }
+  let resume = await getResume(resumeId);
+  if (!resume || resume.hidden) {
+    return flashRedirect('/settings?tab=profile', 'err', 'Resume not found.');
+  }
+
+  // Scans from before the primary-stack field (or failed ones) re-scan here.
+  if (!resume.scannedAt || resume.primarySkills.length === 0) {
+    const scan = await scanResume({ id: resume.id, text: resume.text });
+    if (!scan) {
+      return flashRedirect(
+        '/settings?tab=profile',
+        'err',
+        `The AI scan of "${resume.name}" failed — check the web logs and try again.`,
+      );
+    }
+    resume = (await getResume(resumeId)) ?? resume;
+  }
+
+  const draft = buildProfileDraft(profile, {
+    title: resume.title,
+    seniority: resume.seniority,
+    skills: resume.skills,
+    primarySkills: resume.primarySkills,
+    roleTypes: resume.roleTypes,
+  });
+  if (draft.changed.length === 0) {
+    const note = draft.warnings[0] ? ` — ${draft.warnings[0]}` : '';
+    return flashRedirect(
+      '/settings?tab=profile',
+      'ok',
+      `"${profile.name}" already matches resume "${resume.name}"${note}.`,
+    );
+  }
+
+  const props = await loadSettingsProps();
+  return c.html(
+    <SettingsPage
+      {...props}
+      activeTab="profile"
+      flash={null}
+      activeProfile={{ ...profile, ...draft.changes }}
+      profileDraft={{
+        resumeName: resume.name,
+        changed: draft.changed,
+        warnings: draft.warnings,
+      }}
+    />,
+  );
 });
 
 // --- Re-classify ------------------------------------------------------------

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -46,7 +46,7 @@ import {
   parsePriorityRulesText,
 } from '../../priority-rules';
 import { prisma } from '../../db';
-import { SettingsPage } from '../pages/settings';
+import { isSettingsTab, SettingsPage } from '../pages/settings';
 import { sourceLabel } from '../source-names';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { listResumes } from '../../resume/store';
@@ -101,9 +101,12 @@ settingsRoute.get('/settings', async (c) => {
     { aiProvider: settings.aiProvider, aiModelClassifier: null, aiModelResume: null },
     AI_ENGINE_ENV,
   );
+  const tabParam = c.req.query('tab');
+  const activeTab = isSettingsTab(tabParam) ? tabParam : 'general';
   const flash = parseFlashCookie(c.req.header('cookie'));
   return c.html(
     <SettingsPage
+      activeTab={activeTab}
       telegramEnabled={settings.telegramEnabled}
       classifierMode={settings.classifierMode}
       applicationTrackingEnabled={settings.applicationTrackingEnabled}
@@ -167,8 +170,8 @@ settingsRoute.post('/settings/fetching-toggle', async (c) => {
   const settings = await getSettings();
   await setFetchingEnabled(!settings.fetchingEnabled);
   return settings.fetchingEnabled
-    ? flashRedirect('/settings', 'warn', 'Job fetching paused — no new jobs or alerts until you resume.')
-    : flashRedirect('/settings', 'ok', 'Job fetching resumed — next hourly tick will pull new jobs.');
+    ? flashRedirect('/settings?tab=general', 'warn', 'Job fetching paused — no new jobs or alerts until you resume.')
+    : flashRedirect('/settings?tab=general', 'ok', 'Job fetching resumed — next hourly tick will pull new jobs.');
 });
 
 // --- Telegram toggle / targets ---------------------------------------------
@@ -177,7 +180,7 @@ settingsRoute.post('/settings/telegram-toggle', async (c) => {
   const settings = await getSettings();
   await setTelegramEnabled(!settings.telegramEnabled);
   return flashRedirect(
-    '/settings',
+    '/settings?tab=notifications',
     'ok',
     `Telegram alerts ${!settings.telegramEnabled ? 'enabled' : 'disabled'}.`,
   );
@@ -187,12 +190,12 @@ settingsRoute.post('/settings/ai', async (c) => {
   const form = await c.req.parseBody();
   const provider = typeof form.provider === 'string' ? form.provider : '';
   if (!isAiProviderId(provider)) {
-    return flashRedirect('/settings', 'err', 'Pick an AI provider.');
+    return flashRedirect('/settings?tab=ai', 'err', 'Pick an AI provider.');
   }
   const statuses = await probeAiProviders();
   if (!statuses[provider].ok) {
     return flashRedirect(
-      '/settings',
+      '/settings?tab=ai',
       'err',
       `${AI_PROVIDER_LABELS[provider]} is not usable here: ${statuses[provider].detail}.`,
     );
@@ -202,7 +205,7 @@ settingsRoute.post('/settings/ai', async (c) => {
   for (const model of [classifierModel, resumeModel]) {
     if (model && !modelFitsProvider(model, provider)) {
       return flashRedirect(
-        '/settings',
+        '/settings?tab=ai',
         'err',
         `"${model}" does not look like a ${AI_PROVIDER_LABELS[provider]} model id. Not saved.`,
       );
@@ -210,7 +213,7 @@ settingsRoute.post('/settings/ai', async (c) => {
   }
   await setAiEngine({ aiProvider: provider, aiModelClassifier: classifierModel, aiModelResume: resumeModel });
   return flashRedirect(
-    '/settings',
+    '/settings?tab=ai',
     'ok',
     `AI engine → ${AI_PROVIDER_LABELS[provider]}. Dashboard actions use it now; the worker follows on its next tick.`,
   );
@@ -228,14 +231,14 @@ settingsRoute.post('/settings/classifier-mode', async (c) => {
   const mode = raw === 'two_stage' ? 'two_stage' : 'single';
   await setClassifierMode(mode);
   const label = mode === 'two_stage' ? 'Two stage' : 'Single stage';
-  return flashRedirect('/settings', 'ok', `Classifier mode → ${label}.`);
+  return flashRedirect('/settings?tab=ai', 'ok', `Classifier mode → ${label}.`);
 });
 
 settingsRoute.post('/settings/application-tracking-toggle', async (c) => {
   const settings = await getSettings();
   await setApplicationTrackingEnabled(!settings.applicationTrackingEnabled);
   return flashRedirect(
-    '/settings',
+    '/settings?tab=general',
     'ok',
     `Application tracking ${
       !settings.applicationTrackingEnabled ? 'enabled' : 'disabled'
@@ -249,7 +252,7 @@ settingsRoute.post('/settings/stale-digest-toggle', async (c) => {
     !settings.staleApplicationsDigestEnabled,
   );
   return flashRedirect(
-    '/settings',
+    '/settings?tab=general',
     'ok',
     `Stale-applications digest ${
       !settings.staleApplicationsDigestEnabled ? 'enabled' : 'disabled'
@@ -272,7 +275,7 @@ settingsRoute.post('/settings/sources', async (c) => {
   const disabled = allSources.filter((s) => !enabled.includes(s));
   await setDisabledSources(disabled);
   return flashRedirect(
-    '/settings',
+    '/settings?tab=sources',
     'ok',
     disabled.length === 0
       ? 'All sources enabled.'
@@ -288,19 +291,19 @@ settingsRoute.post('/settings/targets', async (c) => {
     chatId: form.chatId,
   });
   if (!parsed.success) {
-    return flashRedirect('/settings', 'err', 'Invalid input — name, token, chat id required.');
+    return flashRedirect('/settings?tab=notifications', 'err', 'Invalid input — name, token, chat id required.');
   }
   const test = await testTelegramTarget(parsed.data.botToken, parsed.data.chatId);
   if (!test.ok) {
     return flashRedirect(
-      '/settings',
+      '/settings?tab=notifications',
       'err',
       `Validation failed: ${test.error ?? 'unknown'}`,
     );
   }
   await addTelegramTarget(parsed.data);
   return flashRedirect(
-    '/settings',
+    '/settings?tab=notifications',
     'ok',
     `Added target "${parsed.data.name}" (bot @${test.botUsername ?? '?'}). Test message sent.`,
   );
@@ -310,30 +313,30 @@ settingsRoute.post('/settings/targets/:id/toggle', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   await toggleTelegramTarget(id);
-  return flashRedirect('/settings', 'ok', 'Target toggled.');
+  return flashRedirect('/settings?tab=notifications', 'ok', 'Target toggled.');
 });
 
 settingsRoute.post('/settings/targets/:id/delete', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   await deleteTelegramTarget(id);
-  return flashRedirect('/settings', 'ok', 'Target deleted.');
+  return flashRedirect('/settings?tab=notifications', 'ok', 'Target deleted.');
 });
 
 settingsRoute.post('/settings/targets/:id/test', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const t = await prisma.telegramTarget.findUnique({ where: { id } });
-  if (!t) return flashRedirect('/settings', 'err', 'Target not found.');
+  if (!t) return flashRedirect('/settings?tab=notifications', 'err', 'Target not found.');
   const result = await testTelegramTarget(t.botToken, t.chatId);
   if (result.ok) {
     return flashRedirect(
-      '/settings',
+      '/settings?tab=notifications',
       'ok',
       `Test sent to "${t.name}" (bot @${result.botUsername ?? '?'}).`,
     );
   }
-  return flashRedirect('/settings', 'err', `Test failed: ${result.error ?? 'unknown'}`);
+  return flashRedirect('/settings?tab=notifications', 'err', `Test failed: ${result.error ?? 'unknown'}`);
 });
 
 // --- Profiles ---------------------------------------------------------------
@@ -358,7 +361,7 @@ settingsRoute.post('/settings/profiles/new', async (c) => {
   });
   await setActiveProfile(profile.id);
   return flashRedirect(
-    '/settings',
+    '/settings?tab=profile',
     'ok',
     'New profile created and activated. Edit the fields below and save.',
   );
@@ -367,18 +370,18 @@ settingsRoute.post('/settings/profiles/new', async (c) => {
 settingsRoute.post('/settings/profiles/activate', async (c) => {
   const form = await c.req.parseBody();
   const id = Number(form.id);
-  if (!Number.isFinite(id)) return flashRedirect('/settings', 'err', 'Invalid id.');
+  if (!Number.isFinite(id)) return flashRedirect('/settings?tab=profile', 'err', 'Invalid id.');
   try {
     await setActiveProfile(id);
   } catch (err) {
     return flashRedirect(
-      '/settings',
+      '/settings?tab=profile',
       'err',
       err instanceof Error ? err.message : 'Failed to activate.',
     );
   }
   return flashRedirect(
-    '/settings',
+    '/settings?tab=profile',
     'ok',
     'Profile activated. Click "Re-classify all jobs" to score them with this profile.',
   );
@@ -391,19 +394,19 @@ settingsRoute.post('/settings/profiles/:id/delete', async (c) => {
     await deleteProfile(id);
   } catch (err) {
     return flashRedirect(
-      '/settings',
+      '/settings?tab=profile',
       'err',
       err instanceof Error ? err.message : 'Delete failed.',
     );
   }
-  return flashRedirect('/settings', 'ok', 'Profile deleted.');
+  return flashRedirect('/settings?tab=profile', 'ok', 'Profile deleted.');
 });
 
 settingsRoute.post('/settings/profiles/:id/save', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   if (!(await getProfile(id))) {
-    return flashRedirect('/settings', 'err', 'Profile not found.');
+    return flashRedirect('/settings?tab=profile', 'err', 'Profile not found.');
   }
 
   // `all: true` is required so multi-value checkboxes (seniority,
@@ -415,7 +418,7 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
       { errors: parsed.error.flatten().fieldErrors, form },
       'profile form: validation failed',
     );
-    return flashRedirect('/settings', 'err', 'Invalid form values.');
+    return flashRedirect('/settings?tab=profile', 'err', 'Invalid form values.');
   }
   const f = parsed.data;
 
@@ -429,7 +432,7 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
   if (priorityErrors.length > 0) {
     const first = priorityErrors[0]!;
     return flashRedirect(
-      '/settings',
+      '/settings?tab=profile',
       'err',
       `Priority rules — line ${first.line}: ${first.reason}. Profile not saved.`,
     );
@@ -459,12 +462,12 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
   if (f.action === 'save-and-reclassify') {
     triggerReclassifyAsync();
     return flashRedirect(
-      '/settings',
+      '/settings?tab=profile',
       'ok',
       'Profile saved. Re-classify started in the background — track progress at /runs.',
     );
   }
-  return flashRedirect('/settings', 'ok', 'Profile saved.');
+  return flashRedirect('/settings?tab=profile', 'ok', 'Profile saved.');
 });
 
 // --- Re-classify ------------------------------------------------------------
@@ -472,14 +475,14 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
 settingsRoute.post('/settings/reclassify', (c) => {
   if (reclassifyInFlight) {
     return flashRedirect(
-      '/settings',
+      '/settings?tab=profile',
       'err',
       'A re-classify is already running. Watch /runs for progress.',
     );
   }
   triggerReclassifyAsync();
   return flashRedirect(
-    '/settings',
+    '/settings?tab=profile',
     'ok',
     'Re-classify started in the background. Track progress at /runs.',
   );

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -9,6 +9,7 @@ import {
   getSettings,
   listTelegramTargets,
   maskToken,
+  setAiEngine,
   setApplicationTrackingEnabled,
   setClassifierMode,
   setDisabledSources,
@@ -20,6 +21,15 @@ import {
   testTelegramTarget,
   toggleTelegramTarget,
 } from '../../settings';
+import {
+  AI_PROVIDER_IDS,
+  AI_PROVIDER_LABELS,
+  isAiProviderId,
+  modelFitsProvider,
+  resolveAiEngine,
+  type AiProviderId,
+} from '../../ai-engine';
+import { AI_ENGINE_ENV, probeAiProviders } from '../../ai-runtime';
 import {
   createProfile,
   deleteProfile,
@@ -68,18 +78,31 @@ const ProfileFormSchema = z.object({
   action: z.string().optional(),
 });
 
+// UI copy per backend; availability comes from probeAiProviders().
+const AI_PROVIDER_DESCS: Record<AiProviderId, string> = {
+  anthropic_api: 'Messages API with prompt caching — fastest, pays per token.',
+  claude_code: 'Headless claude -p on your Claude.ai subscription. Slower, no per-token bill.',
+  gemini_cli: 'Headless gemini -p on your Google account or GEMINI_API_KEY.',
+};
+
 let reclassifyInFlight = false;
 
 export const settingsRoute = new Hono();
 
 settingsRoute.get('/settings', async (c) => {
-  const [settings, targets, profiles, active, resumes] = await Promise.all([
+  const [settings, targets, profiles, active, resumes, aiStatuses] = await Promise.all([
     getSettings(),
     listTelegramTargets(),
     listProfiles(),
     getActiveProfile(),
     listResumes(),
+    probeAiProviders(),
   ]);
+  const aiEffective = resolveAiEngine(settings, AI_ENGINE_ENV);
+  const aiFamilyDefaults = resolveAiEngine(
+    { aiProvider: settings.aiProvider, aiModelClassifier: null, aiModelResume: null },
+    AI_ENGINE_ENV,
+  );
   const flash = parseFlashCookie(c.req.header('cookie'));
   return c.html(
     <SettingsPage
@@ -92,6 +115,20 @@ settingsRoute.get('/settings', async (c) => {
       allSources={Object.values(AtsType).filter((t) => t !== AtsType.MANUAL)}
       discoveryEnabled={settings.discoveryEnabled}
       fetchingEnabled={settings.fetchingEnabled}
+      aiProviders={AI_PROVIDER_IDS.map((id) => ({
+        id,
+        label: AI_PROVIDER_LABELS[id],
+        desc: AI_PROVIDER_DESCS[id],
+        ok: aiStatuses[id].ok,
+        detail: aiStatuses[id].detail,
+        selected: aiEffective.providerId === id,
+      }))}
+      aiModelClassifier={settings.aiModelClassifier}
+      aiModelResume={settings.aiModelResume}
+      aiDefaults={{
+        classifier: aiFamilyDefaults.classifierModel,
+        resume: aiFamilyDefaults.resumeModel,
+      }}
       targets={targets.map((t) => ({
         id: t.id,
         name: t.name,
@@ -154,15 +191,51 @@ settingsRoute.post('/settings/telegram-toggle', async (c) => {
   );
 });
 
+settingsRoute.post('/settings/ai', async (c) => {
+  const form = await c.req.parseBody();
+  const provider = typeof form.provider === 'string' ? form.provider : '';
+  if (!isAiProviderId(provider)) {
+    return flashRedirect('/settings', 'err', 'Pick an AI provider.');
+  }
+  const statuses = await probeAiProviders();
+  if (!statuses[provider].ok) {
+    return flashRedirect(
+      '/settings',
+      'err',
+      `${AI_PROVIDER_LABELS[provider]} is not usable here: ${statuses[provider].detail}.`,
+    );
+  }
+  const classifierModel = cleanModelId(form.classifierModel);
+  const resumeModel = cleanModelId(form.resumeModel);
+  for (const model of [classifierModel, resumeModel]) {
+    if (model && !modelFitsProvider(model, provider)) {
+      return flashRedirect(
+        '/settings',
+        'err',
+        `"${model}" does not look like a ${AI_PROVIDER_LABELS[provider]} model id. Not saved.`,
+      );
+    }
+  }
+  await setAiEngine({ aiProvider: provider, aiModelClassifier: classifierModel, aiModelResume: resumeModel });
+  return flashRedirect(
+    '/settings',
+    'ok',
+    `AI engine → ${AI_PROVIDER_LABELS[provider]}. Dashboard actions use it now; the worker follows on its next tick.`,
+  );
+});
+
+function cleanModelId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 100) : null;
+}
+
 settingsRoute.post('/settings/classifier-mode', async (c) => {
   const form = await c.req.parseBody();
   const raw = form.mode;
   const mode = raw === 'two_stage' ? 'two_stage' : 'single';
   await setClassifierMode(mode);
-  const label =
-    mode === 'two_stage'
-      ? 'Two-stage prefilter + Haiku 4.5'
-      : 'Single (Haiku 4.5 only)';
+  const label = mode === 'two_stage' ? 'Two stage' : 'Single stage';
   return flashRedirect('/settings', 'ok', `Classifier mode → ${label}.`);
 });
 

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -23,11 +23,13 @@ import {
   AI_PROVIDER_IDS,
   AI_PROVIDER_LABELS,
   PROVIDER_MODEL_OPTIONS,
+  PROVIDER_PAID,
   defaultModelFor,
   isAiProviderId,
   modelFitsProvider,
   parseAiEngineConfig,
   resolveAiEngine,
+  summarizeAiUsage,
   type AiEngineConfig,
   type AiProviderId,
 } from '../../ai-engine';
@@ -133,6 +135,7 @@ async function loadSettingsProps() {
       resumeDefault,
       options: PROVIDER_MODEL_OPTIONS[id],
       freeTextModels: id === 'openai_api',
+      paid: PROVIDER_PAID[id],
     };
   }).sort((a, b) => {
     if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
@@ -143,6 +146,11 @@ async function loadSettingsProps() {
     active: AI_PROVIDER_LABELS[primary],
     chain: engine.chain.map((id) => AI_PROVIDER_LABELS[id]),
     skipped: engine.skipped.map((id) => AI_PROVIDER_LABELS[id]),
+    usage7d: summarizeAiUsage(settings.aiUsage, 7, new Date()).map((r) => ({
+      label: AI_PROVIDER_LABELS[r.id],
+      classifier: r.classifier,
+      resume: r.resume,
+    })),
   };
   return {
     telegramEnabled: settings.telegramEnabled,
@@ -267,6 +275,15 @@ settingsRoute.post('/settings/ai/enable', async (c) => {
       '/settings?tab=ai',
       'warn',
       `${label} enabled as priority #${next.length}, but it is not usable here yet (${statuses[provider].detail}). It is skipped until that is fixed.`,
+    );
+  }
+  // A metered engine standing behind subscription engines = money spent
+  // exactly when the free capacity runs out — say so up front.
+  if (PROVIDER_PAID[provider] && next.slice(0, -1).some((id) => !PROVIDER_PAID[id])) {
+    return flashRedirect(
+      '/settings?tab=ai',
+      'warn',
+      `${label} enabled as priority #${next.length}. It pays per token — it will spend money whenever the engines above it fail or run out of quota.`,
     );
   }
   return flashRedirect('/settings?tab=ai', 'ok', `${label} enabled as priority #${next.length}.`);

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -9,7 +9,7 @@ import {
   getSettings,
   listTelegramTargets,
   maskToken,
-  setAiEngine,
+  setAiEngineConfig,
   setApplicationTrackingEnabled,
   setClassifierMode,
   setDisabledSources,
@@ -22,12 +22,17 @@ import {
 import {
   AI_PROVIDER_IDS,
   AI_PROVIDER_LABELS,
+  PROVIDER_MODEL_OPTIONS,
+  defaultModelFor,
   isAiProviderId,
   modelFitsProvider,
+  parseAiEngineConfig,
   resolveAiEngine,
+  type AiEngineConfig,
   type AiProviderId,
 } from '../../ai-engine';
 import { getAiEngineEnv, probeAiProviders } from '../../ai-runtime';
+import { getAiProviderById } from '../../ai-provider';
 import {
   createProfile,
   deleteProfile,
@@ -81,7 +86,12 @@ const AI_PROVIDER_DESCS: Record<AiProviderId, string> = {
   anthropic_api: 'Messages API with prompt caching — fastest, pays per token.',
   claude_code: 'Headless claude -p on your Claude.ai subscription. Slower, no per-token bill.',
   gemini_cli: 'Headless gemini -p on your Google account or GEMINI_API_KEY.',
+  openai_api:
+    'Any server speaking /chat/completions: OpenAI, OpenRouter, Groq, local LM Studio / Ollama. Pays per token (or free locally).',
+  codex_cli: 'Headless codex exec on your ChatGPT subscription.',
 };
+
+const ENGINE_TEST_TIMEOUT_MS = 90_000;
 
 let reclassifyInFlight = false;
 
@@ -97,25 +107,39 @@ settingsRoute.get('/settings', async (c) => {
     probeAiProviders(),
   ]);
   const aiEnv = getAiEngineEnv();
-  const aiEffective = resolveAiEngine(settings, aiEnv);
-  const aiFamilyDefaults = resolveAiEngine(
-    { aiProvider: settings.aiProvider, aiModelClassifier: null, aiModelResume: null },
-    aiEnv,
-  );
-  // The form shows the SAVED preference; the pipeline may be running on a
-  // fallback until that engine becomes usable (key / login appears).
-  const aiChecked =
-    settings.aiProvider && isAiProviderId(settings.aiProvider)
-      ? settings.aiProvider
-      : aiEffective.providerId;
-  const aiFallback =
-    aiChecked !== aiEffective.providerId
-      ? {
-          saved: AI_PROVIDER_LABELS[aiChecked],
-          running: AI_PROVIDER_LABELS[aiEffective.providerId],
-          detail: aiStatuses[aiChecked].detail,
-        }
-      : null;
+  const engine = resolveAiEngine(settings.aiEngine, aiEnv);
+  const aiConfig = parseAiEngineConfig(settings.aiEngine);
+  // With no stored config the .env-seeded chain is shown as enabled.
+  const enabledOrder = aiConfig.order.length > 0 ? aiConfig.order : engine.chain;
+  const aiEngines = AI_PROVIDER_IDS.map((id) => {
+    const position = enabledOrder.indexOf(id);
+    const classifierDefault = defaultModelFor(id, 'classifier', aiEnv) || 'CLI default';
+    const resumeDefault = defaultModelFor(id, 'resume', aiEnv) || 'CLI default';
+    return {
+      id,
+      label: AI_PROVIDER_LABELS[id],
+      desc: AI_PROVIDER_DESCS[id],
+      ok: aiStatuses[id].ok,
+      detail: aiStatuses[id].detail,
+      enabled: position !== -1,
+      position,
+      classifierModel: aiConfig.models[id]?.classifier ?? '',
+      resumeModel: aiConfig.models[id]?.resume ?? '',
+      classifierDefault,
+      resumeDefault,
+      options: PROVIDER_MODEL_OPTIONS[id],
+      freeTextModels: id === 'openai_api',
+    };
+  }).sort((a, b) => {
+    if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+    return a.enabled ? a.position - b.position : 0;
+  });
+  const primary = engine.chain[0]!;
+  const aiStatus = {
+    active: AI_PROVIDER_LABELS[primary],
+    chain: engine.chain.map((id) => AI_PROVIDER_LABELS[id]),
+    skipped: engine.skipped.map((id) => AI_PROVIDER_LABELS[id]),
+  };
   const tabParam = c.req.query('tab');
   const activeTab = isSettingsTab(tabParam) ? tabParam : 'general';
   const flash = parseFlashCookie(c.req.header('cookie'));
@@ -129,21 +153,8 @@ settingsRoute.get('/settings', async (c) => {
       disabledSources={settings.disabledSources}
       allSources={Object.values(AtsType).filter((t) => t !== AtsType.MANUAL)}
       fetchingEnabled={settings.fetchingEnabled}
-      aiProviders={AI_PROVIDER_IDS.map((id) => ({
-        id,
-        label: AI_PROVIDER_LABELS[id],
-        desc: AI_PROVIDER_DESCS[id],
-        ok: aiStatuses[id].ok,
-        detail: aiStatuses[id].detail,
-        selected: aiChecked === id,
-      }))}
-      aiFallback={aiFallback}
-      aiModelClassifier={settings.aiModelClassifier}
-      aiModelResume={settings.aiModelResume}
-      aiDefaults={{
-        classifier: aiFamilyDefaults.classifierModel,
-        resume: aiFamilyDefaults.resumeModel,
-      }}
+      aiEngines={aiEngines}
+      aiStatus={aiStatus}
       targets={targets.map((t) => ({
         id: t.id,
         name: t.name,
@@ -202,43 +213,125 @@ settingsRoute.post('/settings/telegram-toggle', async (c) => {
   );
 });
 
-settingsRoute.post('/settings/ai', async (c) => {
+/** Reads the stored chain, seeding it from .env when nothing is saved yet. */
+async function readAiOrder(): Promise<{ order: AiProviderId[]; config: AiEngineConfig }> {
+  const settings = await getSettings();
+  const config = parseAiEngineConfig(settings.aiEngine);
+  const order = config.order.length > 0 ? [...config.order] : [getAiEngineEnv().provider];
+  return { order, config };
+}
+
+settingsRoute.post('/settings/ai/enable', async (c) => {
   const form = await c.req.parseBody();
   const provider = typeof form.provider === 'string' ? form.provider : '';
-  if (!isAiProviderId(provider)) {
-    return flashRedirect('/settings?tab=ai', 'err', 'Pick an AI provider.');
-  }
+  if (!isAiProviderId(provider)) return flashRedirect('/settings?tab=ai', 'err', 'Unknown engine.');
+  const { order, config } = await readAiOrder();
   const label = AI_PROVIDER_LABELS[provider];
-  const classifierModel = cleanModelId(form.classifierModel);
-  const resumeModel = cleanModelId(form.resumeModel);
-  for (const model of [classifierModel, resumeModel]) {
-    if (model && !modelFitsProvider(model, provider)) {
-      const geminiHint =
-        model.startsWith('gemini') && provider !== 'gemini_cli'
-          ? ' It is a Gemini model — select Gemini CLI above to use it.'
-          : '';
+  if (order.includes(provider)) {
+    const next = order.filter((id) => id !== provider);
+    await setAiEngineConfig({ ...config, order: next });
+    if (next.length === 0) {
       return flashRedirect(
         '/settings?tab=ai',
-        'err',
-        `"${model}" does not fit ${label}.${geminiHint} Nothing saved.`,
+        'warn',
+        `${label} disabled. No engines left — the pipeline falls back to the .env default.`,
       );
     }
+    return flashRedirect('/settings?tab=ai', 'ok', `${label} disabled.`);
   }
-  await setAiEngine({ aiProvider: provider, aiModelClassifier: classifierModel, aiModelResume: resumeModel });
-  // An engine that is not usable yet still saves — the pipeline runs on the
-  // fallback (resolveAiEngine) and switches over the moment auth appears.
+  const next = [...order, provider];
+  await setAiEngineConfig({ ...config, order: next });
   const statuses = await probeAiProviders();
   if (!statuses[provider].ok) {
     return flashRedirect(
       '/settings?tab=ai',
       'warn',
-      `${label} saved as your engine, but it is not usable here yet (${statuses[provider].detail}). The pipeline keeps running on the fallback until it is.`,
+      `${label} enabled as priority #${next.length}, but it is not usable here yet (${statuses[provider].detail}). It is skipped until that is fixed.`,
+    );
+  }
+  return flashRedirect('/settings?tab=ai', 'ok', `${label} enabled as priority #${next.length}.`);
+});
+
+settingsRoute.post('/settings/ai/move', async (c) => {
+  const form = await c.req.parseBody();
+  const provider = typeof form.provider === 'string' ? form.provider : '';
+  if (!isAiProviderId(provider)) return flashRedirect('/settings?tab=ai', 'err', 'Unknown engine.');
+  const { order, config } = await readAiOrder();
+  const idx = order.indexOf(provider);
+  if (idx <= 0) return flashRedirect('/settings?tab=ai', 'ok', 'Already at the top.');
+  const next = [...order];
+  [next[idx - 1], next[idx]] = [next[idx]!, next[idx - 1]!];
+  await setAiEngineConfig({ ...config, order: next });
+  return flashRedirect(
+    '/settings?tab=ai',
+    'ok',
+    `${AI_PROVIDER_LABELS[provider]} moved to priority #${idx}.`,
+  );
+});
+
+settingsRoute.post('/settings/ai/models', async (c) => {
+  const form = await c.req.parseBody();
+  const provider = typeof form.provider === 'string' ? form.provider : '';
+  if (!isAiProviderId(provider)) return flashRedirect('/settings?tab=ai', 'err', 'Unknown engine.');
+  const label = AI_PROVIDER_LABELS[provider];
+  const classifier = cleanModelId(form.classifier);
+  const resume = cleanModelId(form.resume);
+  for (const model of [classifier, resume]) {
+    if (model && !modelFitsProvider(model, provider)) {
+      return flashRedirect(
+        '/settings?tab=ai',
+        'err',
+        `"${model}" is not a ${label} model id. Nothing saved.`,
+      );
+    }
+  }
+  const { config } = await readAiOrder();
+  await setAiEngineConfig({
+    ...config,
+    models: { ...config.models, [provider]: { classifier, resume } },
+  });
+  return flashRedirect('/settings?tab=ai', 'ok', `${label} models saved.`);
+});
+
+settingsRoute.post('/settings/ai/test', async (c) => {
+  const form = await c.req.parseBody();
+  const provider = typeof form.provider === 'string' ? form.provider : '';
+  if (!isAiProviderId(provider)) return flashRedirect('/settings?tab=ai', 'err', 'Unknown engine.');
+  const label = AI_PROVIDER_LABELS[provider];
+  let backend;
+  try {
+    backend = getAiProviderById(provider);
+  } catch (err) {
+    return flashRedirect(
+      '/settings?tab=ai',
+      'err',
+      `${label} test failed: ${err instanceof Error ? err.message : 'not configured'}.`,
+    );
+  }
+  const settings = await getSettings();
+  const engine = resolveAiEngine(settings.aiEngine, getAiEngineEnv());
+  const model = engine.modelFor(provider, 'classifier');
+  const started = Date.now();
+  const text = await backend.complete({
+    system: 'You are a connectivity test. Reply with exactly: OK',
+    user: 'Reply with exactly: OK',
+    maxTokens: 20,
+    label: 'engine-test',
+    model,
+    timeoutMs: ENGINE_TEST_TIMEOUT_MS,
+  });
+  const seconds = ((Date.now() - started) / 1000).toFixed(1);
+  if (text !== null) {
+    return flashRedirect(
+      '/settings?tab=ai',
+      'ok',
+      `${label} works — replied in ${seconds}s (model ${model || 'CLI default'}).`,
     );
   }
   return flashRedirect(
     '/settings?tab=ai',
-    'ok',
-    `AI engine → ${label}. Dashboard actions use it now; the worker follows on its next tick.`,
+    'err',
+    `${label} test failed after ${seconds}s — see the web container logs for the reason.`,
   );
 });
 

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -199,11 +199,26 @@ settingsRoute.get('/settings', async (c) => {
 // --- Fetching pause / resume -----------------------------------------------
 
 settingsRoute.post('/settings/fetching-toggle', async (c) => {
+  // The Overview quick control posts back="/" to land where it came from.
+  const form = await c.req.parseBody();
+  const back = form.back === '/' ? '/' : '/settings?tab=general';
   const settings = await getSettings();
-  await setFetchingEnabled(!settings.fetchingEnabled);
-  return settings.fetchingEnabled
-    ? flashRedirect('/settings?tab=general', 'warn', 'Job fetching paused — no new jobs or alerts until you resume.')
-    : flashRedirect('/settings?tab=general', 'ok', 'Job fetching resumed — next hourly tick will pull new jobs.');
+  const enabling = !settings.fetchingEnabled;
+  await setFetchingEnabled(enabling);
+  if (!enabling) {
+    return flashRedirect(back, 'warn', 'Job fetching paused — no new jobs or alerts until you resume.');
+  }
+  const profile = await getActiveProfile();
+  const gateEmpty =
+    !profile || (profile.stackRequired.length === 0 && profile.roleTypes.length === 0);
+  if (gateEmpty) {
+    return flashRedirect(
+      back,
+      'warn',
+      'Job fetching resumed, but the active profile has no required stack or role types — every fetched job goes to the AI classifier. Fill the profile first (Settings → Profile).',
+    );
+  }
+  return flashRedirect(back, 'ok', 'Job fetching resumed — next hourly tick will pull new jobs.');
 });
 
 // --- Telegram toggle / targets ---------------------------------------------
@@ -470,9 +485,9 @@ settingsRoute.post('/settings/profiles/new', async (c) => {
     stackNiceToHave: [],
     stackExclude: ['junior', 'intern'],
     notes: null,
-    seniority: ['senior'],
+    seniority: [],
     remoteOk: true,
-    remoteRegions: ['US'],
+    remoteRegions: [],
     onsiteCities: [],
     hybridOk: false,
     minSalaryUsd: 0,

--- a/src/web/source-names.test.ts
+++ b/src/web/source-names.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { sourceLabel } from './source-names';
+
+describe('sourceLabel', () => {
+  it('maps enum values to display names', () => {
+    assert.equal(sourceLabel('LARAJOBS_RSS'), 'Laravel Jobs');
+    assert.equal(sourceLabel('WEWORKREMOTELY'), 'We Work Remotely');
+    assert.equal(sourceLabel('HN_HIRING'), 'HN Who is hiring');
+    assert.equal(sourceLabel('GREENHOUSE'), 'Greenhouse');
+  });
+
+  it('passes unknown values through unchanged', () => {
+    assert.equal(sourceLabel('NEW_BOARD'), 'NEW_BOARD');
+  });
+});

--- a/src/web/source-names.ts
+++ b/src/web/source-names.ts
@@ -1,0 +1,29 @@
+/*
+ * Human names for AtsType values shown in the UI (settings pills, discovery
+ * tags). Unknown values fall through unchanged so a new enum member is never
+ * hidden by a stale map.
+ */
+
+const SOURCE_NAMES: Record<string, string> = {
+  GREENHOUSE: 'Greenhouse',
+  LEVER: 'Lever',
+  ASHBY: 'Ashby',
+  WORKABLE: 'Workable',
+  SMARTRECRUITERS: 'SmartRecruiters',
+  LARAJOBS_RSS: 'Laravel Jobs',
+  REMOTEOK: 'RemoteOK',
+  REMOTIVE: 'Remotive',
+  JOBICY: 'Jobicy',
+  WEWORKREMOTELY: 'We Work Remotely',
+  HN_HIRING: 'HN Who is hiring',
+  HN_JOBS: 'HN Jobs',
+  ARBEITNOW: 'Arbeitnow',
+  GOLANGPROJECTS: 'Golang Projects',
+  WORKINGNOMADS: 'Working Nomads',
+  HIMALAYAS: 'Himalayas',
+  MANUAL: 'Manual',
+};
+
+export function sourceLabel(atsType: string): string {
+  return SOURCE_NAMES[atsType] ?? atsType;
+}

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -2,6 +2,7 @@
 import type { Child, FC, PropsWithChildren } from 'hono/jsx';
 import type { JobStatus } from '@prisma/client';
 import { fitTone, statusLabel, statusTone, type Tone } from './format';
+import type { FlashKind, FlashMessage } from './flash';
 
 /*
  * Shared primitives. Every page composes these instead of writing raw
@@ -84,17 +85,19 @@ export const PageHeader: FC<
   </header>
 );
 
+const FLASH_TONE: Record<FlashKind, string> = {
+  ok: 'border-ok/25 bg-ok/5 text-ok',
+  warn: 'border-warn/25 bg-warn/5 text-warn',
+  err: 'border-danger/25 bg-danger/5 text-danger',
+};
+
 export const Flash: FC<{
-  flash?: { kind: 'ok' | 'err'; text: string } | null;
+  flash?: FlashMessage | null;
 }> = ({ flash }) =>
   flash ? (
     <div
       role="status"
-      class={`mb-4 flex items-start gap-2.5 rounded-md border px-3.5 py-2.5 text-sm ${
-        flash.kind === 'ok'
-          ? 'border-ok/25 bg-ok/5 text-ok'
-          : 'border-danger/25 bg-danger/5 text-danger'
-      }`}
+      class={`mb-4 flex items-start gap-2.5 rounded-md border px-3.5 py-2.5 text-sm ${FLASH_TONE[flash.kind]}`}
     >
       <svg
         viewBox="0 0 24 24"
@@ -110,6 +113,12 @@ export const Flash: FC<{
           <>
             <circle cx="12" cy="12" r="10" />
             <path d="m9 12 2 2 4-4" />
+          </>
+        ) : flash.kind === 'warn' ? (
+          <>
+            <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3" />
+            <path d="M12 9v4" />
+            <path d="M12 17h.01" />
           </>
         ) : (
           <>

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -403,7 +403,7 @@ export const PillCheckbox: FC<PropsWithChildren<Record<string, unknown>>> = ({
   </label>
 );
 
-export const Radio: FC<PropsWithChildren<Record<string, unknown> & { title: string }>> = ({
+export const Radio: FC<PropsWithChildren<Record<string, unknown> & { title: Child }>> = ({
   children,
   title,
   ...rest

--- a/src/web/upload.ts
+++ b/src/web/upload.ts
@@ -24,7 +24,7 @@ export interface UploadedResumeFile {
 
 export const MAX_RESUME_NAME_CHARS = 100;
 
-/** "Nazar_Boyko-Senior_2026.docx" → "Nazar Boyko Senior 2026" — default resume name. */
+/** "Alex_Doe-Senior_2026.docx" → "Alex Doe Senior 2026" — default resume name. */
 export function nameFromFilename(filename: string): string {
   const base = filename.slice(0, filename.length - extname(filename).length);
   return base.replace(/[_\-\s]+/g, ' ').trim().slice(0, MAX_RESUME_NAME_CHARS) || 'Resume';


### PR DESCRIPTION
Release branch for **v0.2.0** — full notes in CHANGELOG.md.

- **AI engine chain (ADR 0013/0014):** five backends (Anthropic API, Claude Code CLI, Gemini CLI, Codex CLI, any OpenAI-compatible endpoint) with priority order and automatic per-call failover; per-engine model slots, availability probes, live Test buttons.
- **Hardening:** env allowlist for CLI children (ANTHROPIC_API_KEY precedence trap), per-engine cooldown + chain deadline, "pay per token" badges, aiUsage counters, `· fallback` markers.
- **Settings tabs:** General · Profile · AI engine · Notifications · Sources; discovery toggles moved to /discovery; copy pass; stack-neutral first boot.
- **Fill profile from a resume (ADR 0015)** + primary-skills scan.
- Setup guide `docs/ai-engines.md` (local + Docker per engine); README rewritten.

Verified: 402 unit tests + tsc green, migrations applied by init in Docker, live smokes (claude_code host+container, anthropic_api 0.7s Test, openai_api error path), browser pass on all tabs at desktop/mobile, zero console errors.

⚠️ **Merge with a merge commit (not squash)** — the annotated `v0.2.0` tag points at the release commit and must stay reachable from main.