### PR TITLE
Readable job descriptions + full-width dashboard (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-08-30
+
+### Fixed
+- **Job descriptions are readable again.** `stripHtml` used to strip tags
+  before decoding entities, so feeds that ship the body HTML-escaped
+  (Greenhouse — 82 % of stored jobs) kept raw `<div>…` markup as visible
+  text, and the final `\s+` collapse flattened every description into a
+  single-line wall. Entities now decode first (`&amp;` last, so
+  double-escaped input stays literal), line structure is rebuilt from block
+  tags, `<br>` and `<li>` (→ `• ` bullets), and prose like `salary > 100k`
+  or `<3` survives stripping. Covered by new unit tests.
+- **Stored rows repaired.** Two one-shot scripts (both support `--dry-run`):
+  `backfill-descriptions` re-cleans rows that still carry markup and decodes
+  entities in pasted jobs; `refetch-descriptions` re-pulls the boards and
+  updated 601 stored descriptions in place. stripHtml is deliberately NOT
+  re-run on clean plaintext — it is not idempotent (CLAUDE.md gotcha 12).
+- Manual pastes decode literal entities (`&nbsp;`, `&amp;`) before saving.
+
+### Changed
+- **Full-width dashboard.** Every page now stretches to the screen like the
+  Jobs table: the prose-width caps (`max-w-prose`, `75ch`) and per-page
+  column limits are gone, so the job description, classifier summary, hints,
+  Settings, the paste form and the Target editor all fill their containers.
+  The /companies explainer reflows into two columns; the description card
+  renders decoded paragraphs via `whitespace-pre-line`.
+
 ## [0.2.0] — 2026-08-30
 
 ### Added
@@ -250,7 +276,10 @@ commit history.
 | 2026-08-27 | Node 24, pause toggle, AI provider seam, first dashboard redesign, parallel classifier |
 | 2026-08-28 | Resume module, targeted view, ghost-job verification, light-theme redesign — **v0.1.0** |
 | 2026-08-29 | PDF uploads, /target auto-detect flow, deterministic score, match-workspace UX refactor — **v0.1.1** |
+| 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 
-[Unreleased]: https://github.com/nazboyko/job-hunter/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/nazboyko/job-hunter/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/nazboyko/job-hunter/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/nazboyko/job-hunter/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/nazboyko/job-hunter/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/nazboyko/job-hunter/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | What | File |
 | --- | --- |
 | HTTP retry, timeout, default User-Agent | `src/http.ts` |
+| HTML → plaintext (entities, paragraphs, bullets) | `src/http.ts:stripHtml` + `decodeHtmlEntities` (gotcha 12) |
 | Pure helpers (parsing, hashing, masking) | `src/text-utils.ts` |
 | The cron list (6 schedules) | `src/index.ts:registerCron` |
 | What runs on container boot | `src/init.ts` |
@@ -266,6 +267,28 @@ GitLab CI/CD the posting wanted. Removals now carry two hard rules
 (PROTECTED contact line; KEEP WANTED KEYWORDS with itemised drop/keep
 lists) — guard test "removals rules protect the contact line".
 
+### 12. stripHtml: decode entities FIRST, and never re-run it on its own output
+
+Three lessons paid for with one broken evening (2026-08-30):
+
+- **Greenhouse ships job bodies HTML-escaped** (`&lt;p&gt;…`). The old
+  strip-tags-then-decode order found no tags to strip, then the decode step
+  rematerialised them — all 535 stored Greenhouse descriptions carried raw
+  `<div class="content-intro">…` markup as visible text. Decode first,
+  and decode `&amp;` LAST so `&amp;lt;` stays a literal `&lt;` instead of
+  double-decoding into a phantom tag.
+- **Line structure comes from block tags, not source newlines.** Raw `\n`
+  in HTML is whitespace; stripHtml collapses it, then rebuilds paragraphs
+  from `<p>/<div>/<h*>` boundaries, `<br>` and `<li>` (→ `• `). That is what
+  makes descriptions readable — see the tests in `src/http.test.ts`.
+- **stripHtml is NOT idempotent on its own plaintext output** — a second
+  pass reads the newlines it just created as whitespace and flattens them.
+  `backfill-descriptions.ts` therefore only strips rows that still match a
+  markup regex; everything else gets entity decoding only. When structure
+  is already lost, `refetch-descriptions.ts` re-pulls the boards and updates
+  descriptions in place (no inserts). Never point either script at MANUAL
+  rows with tag stripping — pasted prose like "salary < 100k" is not markup.
+
 ---
 
 ## ATS templates (when adding a new source)
@@ -304,6 +327,8 @@ Always:
 | Tail the worker | `docker compose logs -f app` |
 | Tail the dashboard | `docker compose logs -f web` |
 | psql into the DB | `docker compose exec postgres psql -U jobhunter -d jobhunter` |
+| Re-clean stored descriptions (rows with leftover markup) | `docker compose exec app node dist/scripts/backfill-descriptions.js --dry-run`, then without the flag |
+| Re-pull descriptions from the boards (structure lost) | `docker compose exec app node dist/scripts/refetch-descriptions.js --dry-run`, then without the flag |
 | Migrate after a schema change | `DATABASE_URL=… npx prisma migrate dev --name <name>` |
 | Re-classify everything against the active profile | UI: `/settings` → "Re-classify all jobs" |
 | Pause all alerts temporarily | UI: `/settings` → "Telegram alerts" → Disable |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-hunter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-hunter",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-hunter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Self-hosted AI job hunter: monitors 16 ATS / aggregator sources, classifies postings with Claude against your profile, verifies ghost jobs, matches your resume, alerts via Telegram.",
   "license": "MIT",

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -69,7 +69,7 @@ export async function runAllFetchers(): Promise<FetcherResult[]> {
   return out;
 }
 
-async function fetchOne(company: {
+export async function fetchOne(company: {
   id: number;
   atsType: AtsType;
   atsToken: string;

--- a/src/http.test.ts
+++ b/src/http.test.ts
@@ -63,6 +63,62 @@ describe('stripHtml', () => {
   it('decodes &apos; (XML-style apostrophe)', () => {
     assert.equal(stripHtml('it&apos;s ok'), "it's ok");
   });
+
+  // --- structure preservation (paragraphs, bullets, line breaks) ---
+
+  it('turns block tags into paragraph breaks', () => {
+    assert.equal(
+      stripHtml('<h3>About</h3><p>First.</p><p>Second.</p>'),
+      'About\n\nFirst.\n\nSecond.',
+    );
+  });
+
+  it('renders list items as bullet lines', () => {
+    assert.equal(
+      stripHtml('<p>Stack:</p><ul><li>Go</li><li>Kubernetes</li></ul><p>Done.</p>'),
+      'Stack:\n\n• Go\n• Kubernetes\n\nDone.',
+    );
+  });
+
+  it('turns <br> into a single line break', () => {
+    assert.equal(stripHtml('line one<br>line two<br/>line three'), 'line one\nline two\nline three');
+  });
+
+  it('treats source newlines as whitespace, not structure', () => {
+    // Hard-wrapped HTML source must not produce fake mid-sentence breaks.
+    assert.equal(stripHtml('<p>wrapped\nacross\nlines</p>'), 'wrapped across lines');
+  });
+
+  it('caps consecutive blank lines at one empty line', () => {
+    assert.equal(stripHtml('<div><p>a</p></div><div><p>b</p></div>'), 'a\n\nb');
+  });
+
+  // --- escaped feeds (Greenhouse ships the body HTML-escaped) ---
+
+  it('restores structure from an HTML-escaped body', () => {
+    const escaped =
+      '&lt;div class="content-intro"&gt;&lt;h3&gt;&lt;strong&gt;Who We Are&lt;/strong&gt;&lt;/h3&gt; &lt;p&gt;Verkada is transforming.&lt;/p&gt;&lt;/div&gt;';
+    assert.equal(stripHtml(escaped), 'Who We Are\n\nVerkada is transforming.');
+  });
+
+  it('does not double-decode &amp;lt;', () => {
+    assert.equal(stripHtml('a &amp;lt;b&amp;gt; c'), 'a &lt;b&gt; c');
+  });
+
+  it('keeps loose < and > comparisons in prose', () => {
+    assert.equal(
+      stripHtml('we <3 offsites, salary > 100k and load < 5ms'),
+      'we <3 offsites, salary > 100k and load < 5ms',
+    );
+  });
+
+  it('drops HTML comments', () => {
+    assert.equal(stripHtml('a<!-- hidden note -->b'), 'a b');
+  });
+
+  it('ignores out-of-range numeric entities instead of throwing', () => {
+    assert.equal(stripHtml('ok &#x110000; still ok'), 'ok still ok');
+  });
 });
 
 describe('sleep', () => {

--- a/src/http.ts
+++ b/src/http.ts
@@ -93,24 +93,58 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function stripHtml(html: string): string {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
+/** Code points outside the Unicode range would make String.fromCodePoint throw. */
+function safeCodePoint(n: number): string {
+  return n >= 0 && n <= 0x10ffff ? String.fromCodePoint(n) : '';
+}
+
+/**
+ * Decode the HTML entities job feeds actually emit. `&amp;` is decoded LAST,
+ * so double-escaped input ("&amp;lt;") yields the literal "&lt;" instead of
+ * decoding twice and materialising a phantom tag.
+ */
+export function decodeHtmlEntities(text: string): string {
+  return text
     .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&apos;/gi, "'")
     // Generic numeric entities: &#x2F; → '/', &#39; → "'", &#x27; → "'"
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
-    )
-    .replace(/&#(\d+);/g, (_, dec) =>
-      String.fromCodePoint(parseInt(dec, 10)),
-    )
-    .replace(/\s+/g, ' ')
-    .trim();
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => safeCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => safeCodePoint(parseInt(dec, 10)))
+    .replace(/&amp;/gi, '&');
+}
+
+/** Tags that end a line of text; each boundary becomes a newline. */
+const BLOCK_TAG_RE =
+  /<\/?(?:p|div|section|article|header|footer|main|aside|table|thead|tbody|tr|ul|ol|dl|dt|dd|blockquote|figure|figcaption|form|fieldset|pre|h[1-6])(?:\s[^>]*)?\/?>/gi;
+
+/**
+ * HTML → readable plaintext. Entities are decoded FIRST because some ATS
+ * feeds (Greenhouse) ship the whole body HTML-escaped — stripping before
+ * decoding used to let those tags rematerialise into the stored text.
+ * Raw newlines in the source are treated as whitespace (HTML semantics);
+ * line structure is rebuilt from block tags, <br> and <li> instead, so
+ * descriptions keep their paragraphs and bullet lists.
+ */
+export function stripHtml(html: string): string {
+  return (
+    decodeHtmlEntities(html)
+      // Source newlines/tabs are not structure — block tags below are.
+      .replace(/\s+/g, ' ')
+      .replace(/<!--[\s\S]*?-->/g, ' ')
+      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<li(?:\s[^>]*)?>/gi, '\n• ')
+      .replace(/<\/li>/gi, ' ')
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(BLOCK_TAG_RE, '\n')
+      // Only real tag shapes — "<3" or "a < b" in prose must survive.
+      .replace(/<\/?[a-zA-Z][^>]*>/g, ' ')
+      .replace(/[^\S\n]+/g, ' ')
+      .replace(/ *\n */g, '\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim()
+  );
 }

--- a/src/jobs/manual-job.ts
+++ b/src/jobs/manual-job.ts
@@ -2,6 +2,7 @@ import { AtsType, JobStatus } from '@prisma/client';
 import type { Job } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../db';
+import { decodeHtmlEntities } from '../http';
 import { logger } from '../logger';
 import { hashShortId } from '../text-utils';
 import { classifyExistingJob } from './classify-existing';
@@ -38,13 +39,16 @@ export type ManualJobResult =
   | { kind: 'created'; job: Job; classified: boolean };
 
 export async function createManualJob(f: ManualJobInput): Promise<ManualJobResult> {
+  // Pastes copied from rendered pages occasionally carry literal entities
+  // ("&nbsp;", "&amp;") — decode them so the stored text reads clean.
+  const description = decodeHtmlEntities(f.description).trim();
   const atsToken = slugify(f.companyName);
   const company = await prisma.company.upsert({
     where: { atsType_atsToken: { atsType: AtsType.MANUAL, atsToken } },
     update: {},
     create: { name: f.companyName, atsType: AtsType.MANUAL, atsToken, active: false },
   });
-  const externalId = `manual-${hashShortId(`${f.title}\n${f.description}`)}`;
+  const externalId = `manual-${hashShortId(`${f.title}\n${description}`)}`;
   const existing = await prisma.job.findUnique({
     where: { companyId_externalId: { companyId: company.id, externalId } },
   });
@@ -57,7 +61,7 @@ export async function createManualJob(f: ManualJobInput): Promise<ManualJobResul
       title: f.title,
       url: f.url,
       location: f.location,
-      description: f.description,
+      description,
       salaryMin: f.salaryMin ?? null,
       salaryMax: f.salaryMax ?? null,
       postedAt: new Date(),

--- a/src/scripts/backfill-descriptions.ts
+++ b/src/scripts/backfill-descriptions.ts
@@ -1,0 +1,84 @@
+import { AtsType } from '@prisma/client';
+import { logger } from '../logger';
+import { prisma } from '../db';
+import { decodeHtmlEntities, stripHtml } from '../http';
+
+/*
+ * One-shot repair for stored job descriptions.
+ *
+ * Until 2026-08 stripHtml stripped tags BEFORE decoding entities, so feeds
+ * that ship the body HTML-escaped (Greenhouse) kept the full markup in the
+ * stored text, and every feed lost its line structure. Re-running the fixed
+ * stripHtml over stored rows restores paragraphs for every description that
+ * still carries its markup. MANUAL rows are user-pasted plaintext — they
+ * only get entity decoding (no tag stripping), matching createManualJob.
+ *
+ * Usage: node dist/scripts/backfill-descriptions.js [--dry-run]
+ */
+
+const DRY_RUN = process.argv.includes('--dry-run');
+/** A cleanup that shrinks a long description this hard is a bug, not a fix. */
+const SUSPICIOUS_MIN_CHARS = 200;
+const SUSPICIOUS_SOURCE_CHARS = 1000;
+const TAG_RE = /<(p|div|ul|ol|li|br|h[1-6]|strong|em|b|table|span|a)[ >/]/i;
+
+async function main(): Promise<void> {
+  const jobs = await prisma.job.findMany({
+    select: { id: true, description: true, company: { select: { atsType: true } } },
+    orderBy: { id: 'asc' },
+  });
+
+  let changed = 0;
+  let hadMarkup = 0;
+  let skippedSuspicious = 0;
+  const samples: { id: number; before: string; after: string }[] = [];
+
+  for (const job of jobs) {
+    const before = job.description;
+    if (before.length === 0) continue;
+    // stripHtml is NOT idempotent on its own plaintext output (it reads
+    // newlines as HTML whitespace), so only rows that still carry markup go
+    // through it; everything else — MANUAL included — gets entity decoding.
+    const after =
+      job.company.atsType !== AtsType.MANUAL && TAG_RE.test(before)
+        ? stripHtml(before)
+        : decodeHtmlEntities(before).trim();
+    if (after === before) continue;
+
+    if (after.length < SUSPICIOUS_MIN_CHARS && before.length > SUSPICIOUS_SOURCE_CHARS) {
+      skippedSuspicious++;
+      logger.warn(
+        { jobId: job.id, beforeChars: before.length, afterChars: after.length },
+        'backfill-descriptions: suspicious shrink — skipped',
+      );
+      continue;
+    }
+
+    if (TAG_RE.test(before)) hadMarkup++;
+    changed++;
+    if (samples.length < 2 && TAG_RE.test(before)) {
+      samples.push({ id: job.id, before: before.slice(0, 200), after: after.slice(0, 200) });
+    }
+    if (!DRY_RUN) {
+      await prisma.job.update({ where: { id: job.id }, data: { description: after } });
+    }
+  }
+
+  for (const s of samples) {
+    logger.info({ jobId: s.id, before: s.before, after: s.after }, 'backfill-descriptions: sample');
+  }
+  logger.info(
+    { scanned: jobs.length, changed, hadMarkup, skippedSuspicious, dryRun: DRY_RUN },
+    DRY_RUN
+      ? 'backfill-descriptions: dry run — nothing written'
+      : 'backfill-descriptions: done',
+  );
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .then(() => process.exit(0))
+  .catch((err) => {
+    logger.error({ err }, 'backfill-descriptions: failed');
+    void prisma.$disconnect().finally(() => process.exit(1));
+  });

--- a/src/scripts/refetch-descriptions.ts
+++ b/src/scripts/refetch-descriptions.ts
@@ -1,0 +1,82 @@
+import { AtsType } from '@prisma/client';
+import { logger } from '../logger';
+import { prisma } from '../db';
+import { sleep } from '../http';
+import { fetchOne } from '../fetchers/index';
+
+/*
+ * One-shot repair: re-pull every board that has stored jobs and update the
+ * stored descriptions in place with the current stripHtml output. Only the
+ * description column changes — no inserts, no status or classification
+ * touches. Companion to backfill-descriptions for rows whose line structure
+ * cannot be recovered from the stored text alone. Jobs no longer listed
+ * upstream are left as they are.
+ *
+ * Usage: node dist/scripts/refetch-descriptions.js [--dry-run]
+ */
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const POLITE_DELAY_MS = 1_000;
+
+async function main(): Promise<void> {
+  const companies = await prisma.company.findMany({
+    where: { atsType: { not: AtsType.MANUAL }, jobs: { some: {} } },
+    select: { id: true, name: true, atsType: true, atsToken: true },
+    orderBy: { id: 'asc' },
+  });
+
+  let fetched = 0;
+  let matched = 0;
+  let updated = 0;
+
+  for (const company of companies) {
+    try {
+      const fresh = await fetchOne(company);
+      fetched += fresh.length;
+      const stored = await prisma.job.findMany({
+        where: { companyId: company.id },
+        select: { id: true, externalId: true, description: true },
+      });
+      const byExternalId = new Map(stored.map((j) => [j.externalId, j]));
+
+      let companyUpdated = 0;
+      for (const job of fresh) {
+        const row = byExternalId.get(job.externalId);
+        if (!row || job.description.length === 0) continue;
+        matched++;
+        if (row.description === job.description) continue;
+        updated++;
+        companyUpdated++;
+        if (!DRY_RUN) {
+          await prisma.job.update({
+            where: { id: row.id },
+            data: { description: job.description },
+          });
+        }
+      }
+      logger.info(
+        { company: company.name, ats: company.atsType, fresh: fresh.length, updated: companyUpdated },
+        'refetch-descriptions: company done',
+      );
+    } catch (err) {
+      logger.error(
+        { err, company: company.name, ats: company.atsType },
+        'refetch-descriptions: company failed — skipped',
+      );
+    }
+    await sleep(POLITE_DELAY_MS);
+  }
+
+  logger.info(
+    { companies: companies.length, fetched, matched, updated, dryRun: DRY_RUN },
+    DRY_RUN ? 'refetch-descriptions: dry run — nothing written' : 'refetch-descriptions: done',
+  );
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .then(() => process.exit(0))
+  .catch((err) => {
+    logger.error({ err }, 'refetch-descriptions: failed');
+    void prisma.$disconnect().finally(() => process.exit(1));
+  });

--- a/src/web/layout.tsx
+++ b/src/web/layout.tsx
@@ -21,8 +21,14 @@ interface LayoutProps {
   /**
    * App-frame mode: cap the content column at the viewport so a flex-1 region
    * inside the page can own its scrolling (Jobs table, Applications board).
+   * Implies full width.
    */
   fill?: boolean;
+  /**
+   * Skip the default centred max-w-screen-xl content column — for pages that
+   * manage their own width (the Target editor).
+   */
+  wide?: boolean;
 }
 
 const NAV: { key: NavKey; href: string; label: string }[] = [
@@ -161,6 +167,7 @@ export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
   active,
   refresh,
   fill = false,
+  wide = false,
   children,
 }) => (
   <html lang="en">
@@ -199,7 +206,7 @@ export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
             <div
               class={`flex w-full flex-col px-4 py-5 sm:px-6 lg:px-8 ${
                 fill ? 'h-full' : 'min-h-full'
-              }`}
+              } ${fill || wide ? '' : 'mx-auto max-w-screen-xl'}`}
             >
               {children}
             </div>

--- a/src/web/layout.tsx
+++ b/src/web/layout.tsx
@@ -21,14 +21,8 @@ interface LayoutProps {
   /**
    * App-frame mode: cap the content column at the viewport so a flex-1 region
    * inside the page can own its scrolling (Jobs table, Applications board).
-   * Implies full width.
    */
   fill?: boolean;
-  /**
-   * Skip the default centred max-w-screen-xl content column — for pages that
-   * manage their own width (the Target editor).
-   */
-  wide?: boolean;
 }
 
 const NAV: { key: NavKey; href: string; label: string }[] = [
@@ -167,7 +161,6 @@ export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
   active,
   refresh,
   fill = false,
-  wide = false,
   children,
 }) => (
   <html lang="en">
@@ -206,7 +199,7 @@ export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
             <div
               class={`flex w-full flex-col px-4 py-5 sm:px-6 lg:px-8 ${
                 fill ? 'h-full' : 'min-h-full'
-              } ${fill || wide ? '' : 'mx-auto max-w-screen-xl'}`}
+              }`}
             >
               {children}
             </div>

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -91,7 +91,7 @@ export const CompaniesPage: FC<CompaniesProps> = ({ companies, flash }) => (
 
     <Card class="mb-4">
       <SectionTitle>Add company</SectionTitle>
-      <Hint class="mb-4 max-w-prose">
+      <Hint class="mb-4">
         We probe the public ATS endpoint before saving and refuse invalid tokens. Aggregator
         feeds have no per-company token — those are seeded once via <Code>src/seed.ts</Code>.
       </Hint>

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -60,8 +60,9 @@ export const CompaniesPage: FC<CompaniesProps> = ({ companies, flash }) => (
       <summary class="cursor-pointer select-none px-5 py-3 text-sm font-medium text-ink transition-colors duration-150 hover:bg-surface-overlay/50">
         How coverage works
       </summary>
-      <div class="space-y-2 border-t border-line px-5 py-4 text-sm leading-6 text-ink-muted">
-        <p class="max-w-prose">
+      {/* Two columns keep a readable measure while filling the panel. */}
+      <div class="grid gap-x-8 gap-y-2 border-t border-line px-5 py-4 text-sm leading-6 text-ink-muted sm:grid-cols-2">
+        <p>
           Greenhouse, Lever, Ashby, Workable and SmartRecruiters are{' '}
           <strong class="font-medium text-ink">HR vendors, not job boards</strong>. Their public
           APIs only answer <Code>/boards/&lt;slug&gt;/jobs</Code>, so this table is the full
@@ -75,7 +76,7 @@ export const CompaniesPage: FC<CompaniesProps> = ({ companies, flash }) => (
           </a>
           ).
         </p>
-        <p class="max-w-prose">
+        <p>
           The long tail comes from cross-company aggregators —{' '}
           {AGGREGATORS.map((a) => (
             <>

--- a/src/web/pages/discovery.tsx
+++ b/src/web/pages/discovery.tsx
@@ -88,7 +88,7 @@ export const DiscoveryPage: FC<DiscoveryProps> = ({
           </Empty>
         ) : (
           <>
-            <Hint class="mb-3 max-w-prose">
+            <Hint class="mb-3">
               Sorted by jobs currently visible on the board.
             </Hint>
             <CandidateTable rows={pending} actions />

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -166,7 +166,7 @@ export const JobDetailPage: FC<JobDetailProps> = ({
           <Card>
             <SectionTitle>Classifier</SectionTitle>
             {job.summary && (
-              <p class="mb-3 max-w-prose text-sm leading-6 text-ink">{job.summary}</p>
+              <p class="mb-3 text-sm leading-6 text-ink">{job.summary}</p>
             )}
             <dl class="space-y-2">
               <TagRow label="Tech" items={job.techMatch} tone="ok" />
@@ -186,7 +186,7 @@ export const JobDetailPage: FC<JobDetailProps> = ({
 
         <Card>
           <SectionTitle>Description</SectionTitle>
-          <div class="max-w-[75ch] whitespace-pre-line break-words text-sm leading-6 text-ink-muted">
+          <div class="whitespace-pre-line break-words text-sm leading-6 text-ink-muted">
             {job.description || '(empty)'}
           </div>
         </Card>

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -186,9 +186,9 @@ export const JobDetailPage: FC<JobDetailProps> = ({
 
         <Card>
           <SectionTitle>Description</SectionTitle>
-          <pre class="max-w-[75ch] whitespace-pre-wrap break-words font-sans text-sm leading-6 text-ink-muted">
+          <div class="max-w-[75ch] whitespace-pre-line break-words text-sm leading-6 text-ink-muted">
             {job.description || '(empty)'}
-          </pre>
+          </div>
         </Card>
       </div>
     </div>

--- a/src/web/pages/job-new.tsx
+++ b/src/web/pages/job-new.tsx
@@ -6,7 +6,7 @@ import type { FlashMessage } from '../flash';
 
 export const JobNewPage: FC<{ flash?: FlashMessage | null }> = ({ flash }) => (
   <Layout title="Paste a job" active="jobs">
-    <div class="mx-auto w-full max-w-3xl">
+    <div class="w-full">
       <PageHeader title="Paste a job" back={{ href: '/jobs', label: 'All jobs' }}>
         For postings the fetchers don't see (LinkedIn, a recruiter's email, a friend's
         referral). It becomes a normal job: scored against your profile, then Verify checks the

--- a/src/web/pages/job-new.tsx
+++ b/src/web/pages/job-new.tsx
@@ -6,7 +6,7 @@ import type { FlashMessage } from '../flash';
 
 export const JobNewPage: FC<{ flash?: FlashMessage | null }> = ({ flash }) => (
   <Layout title="Paste a job" active="jobs">
-    <div class="w-full max-w-3xl">
+    <div class="mx-auto w-full max-w-3xl">
       <PageHeader title="Paste a job" back={{ href: '/jobs', label: 'All jobs' }}>
         For postings the fetchers don't see (LinkedIn, a recruiter's email, a friend's
         referral). It becomes a normal job: scored against your profile, then Verify checks the

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -201,7 +201,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({ resume, matches, warni
       <Card class="mt-4">
         <SectionTitle>What the ATS sees</SectionTitle>
         {warnings.length === 0 ? (
-          <Hint>
+          <Hint class="max-w-prose">
             Extraction looks clean — selectable text, contact details found, normal length. Parsers
             should read this file the way you do.
           </Hint>
@@ -220,7 +220,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({ resume, matches, warni
             Extracted text ({resume.text.length.toLocaleString()} chars) — exactly what the AI and
             an ATS parser get
           </summary>
-          <pre class="mt-3 whitespace-pre-wrap break-words font-sans text-sm leading-6 text-ink-muted">
+          <pre class="mt-3 max-w-[75ch] whitespace-pre-wrap break-words font-sans text-sm leading-6 text-ink-muted">
             {resume.text}
           </pre>
         </details>

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -95,7 +95,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({ resume, matches, warni
                 </span>
               </div>
               {resume.summary && (
-                <p class="max-w-prose text-sm leading-6 text-ink">{resume.summary}</p>
+                <p class="text-sm leading-6 text-ink">{resume.summary}</p>
               )}
               <TagRow label="Roles" items={resume.roleTypes} tone="info" />
               <TagRow label="Skills" items={resume.skills} tone="ok" />
@@ -129,7 +129,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({ resume, matches, warni
         </Card>
       </div>
 
-      <Card class="mt-4 max-w-3xl">
+      <Card class="mt-4">
         <SectionTitle>Upload a new version</SectionTitle>
         <form
           method="post"
@@ -201,7 +201,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({ resume, matches, warni
       <Card class="mt-4">
         <SectionTitle>What the ATS sees</SectionTitle>
         {warnings.length === 0 ? (
-          <Hint class="max-w-prose">
+          <Hint>
             Extraction looks clean — selectable text, contact details found, normal length. Parsers
             should read this file the way you do.
           </Hint>
@@ -220,7 +220,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({ resume, matches, warni
             Extracted text ({resume.text.length.toLocaleString()} chars) — exactly what the AI and
             an ATS parser get
           </summary>
-          <pre class="mt-3 max-w-[75ch] whitespace-pre-wrap break-words font-sans text-sm leading-6 text-ink-muted">
+          <pre class="mt-3 whitespace-pre-wrap break-words font-sans text-sm leading-6 text-ink-muted">
             {resume.text}
           </pre>
         </details>

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -303,7 +303,7 @@ export const MatchReport: FC<{
           Open targeted view →
         </a>
       </div>
-      <p class="max-w-prose text-sm leading-6 text-ink">{match.summary}</p>
+      <p class="text-sm leading-6 text-ink">{match.summary}</p>
       {bd && <ScoreBreakdownChips bd={bd} />}
 
       <DeltaBox match={match} previous={previous} />

--- a/src/web/pages/resumes.tsx
+++ b/src/web/pages/resumes.tsx
@@ -142,13 +142,13 @@ export const ResumesPage: FC<{
       </Card>
     )}
 
-    <Card class="max-w-3xl">
+    <Card>
       <SectionTitle>Upload a resume</SectionTitle>
       <ResumeUploadForm />
     </Card>
 
     {facts.length > 0 && (
-      <Card class="mt-4 max-w-3xl">
+      <Card class="mt-4">
         <SectionTitle>Confirmed facts</SectionTitle>
         <Hint class="mb-3">
           Your answers to "do you have this?" questions from comparisons. They feed every future

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -170,7 +170,7 @@ export const SettingsPage: FC<SettingsProps> = ({
   profileDraft,
 }) => (
   <Layout title="Settings" active="settings">
-    <div class="mx-auto w-full max-w-5xl">
+    <div class="w-full">
       <PageHeader title="Settings">
         Changes save the moment you click — no restarts needed. Dashboard actions use them
         immediately; the background worker picks them up within the hour.
@@ -270,7 +270,7 @@ export const SettingsPage: FC<SettingsProps> = ({
         {activeProfile && resumes.length > 0 && (
           <Card>
             <div class="mb-1 text-[13px] font-medium text-ink">Fill from a resume</div>
-            <Hint class="mb-3 max-w-prose">
+            <Hint class="mb-3">
               AI maps the resume's scanned stack onto the profile — primary stack → required,
               other skills → nice-to-have, plus role types and seniority. Re-scans the resume
               when needed. The result appears below as a draft; nothing is saved until you
@@ -892,13 +892,13 @@ const PriorityRulesEditor: FC<{ profile: Profile }> = ({ profile }) => {
       <label class="block text-[13px] font-medium text-ink" for="priorityRules">
         Priority rules (post-classifier overrides)
       </label>
-      <Hint class="mt-0.5 max-w-prose">
+      <Hint class="mt-0.5">
         One rule per line: <Code>LABEL | techs,csv | regions,csv | MIN_FIT</Code>. If the title
         or description contains any tech and the location matches any region phrase, fit is
         clamped up to MIN_FIT and the location check passes. Empty regions match anywhere.{' '}
         <Code>#</Code> starts a comment. A bad line stops the save.
       </Hint>
-      <Hint class="mt-1 max-w-prose text-warn">
+      <Hint class="mt-1 text-warn">
         Region entries are phrases — every word must appear in the location.{' '}
         <Code>Remote US</Code> matches "Dallas (Remote US)" but not "Remote · Germany". Avoid a
         bare <Code>Remote</Code>; prefer <Code>Remote US,United States,USA,Worldwide</Code>.

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -170,7 +170,7 @@ export const SettingsPage: FC<SettingsProps> = ({
   profileDraft,
 }) => (
   <Layout title="Settings" active="settings">
-    <div class="w-full max-w-5xl">
+    <div class="mx-auto w-full max-w-5xl">
       <PageHeader title="Settings">
         Changes save the moment you click — no restarts needed. Dashboard actions use them
         immediately; the background worker picks them up within the hour.

--- a/src/web/pages/target-start.tsx
+++ b/src/web/pages/target-start.tsx
@@ -51,7 +51,7 @@ export const TargetStartPage: FC<TargetStartProps> = ({ resumes, flash }) => {
         method="post"
         action="/target"
         enctype="multipart/form-data"
-        class="w-full max-w-6xl"
+        class="w-full"
       >
         <div class="grid items-start gap-4 lg:grid-cols-2">
           <Card>

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -123,10 +123,8 @@ export const TargetPage: FC<TargetPageProps> = ({
       : null,
   };
   return (
-    <Layout title={`Resume match · ${job.title}`} active="jobs" wide>
-      {/* wide opts out of the layout's screen-xl column; 2xl (1536px) keeps
-          the two editor panes comfortable on ultra-wide monitors. */}
-      <div class="mx-auto w-full max-w-screen-2xl">
+    <Layout title={`Resume match · ${job.title}`} active="jobs">
+      <div class="w-full">
       <nav aria-label="Breadcrumb" class="mb-1.5 flex items-center gap-1.5 text-[13px] text-ink-faint">
         <a href="/jobs" class="transition-colors duration-150 hover:text-ink">
           Jobs
@@ -219,7 +217,7 @@ export const TargetPage: FC<TargetPageProps> = ({
           </div>
 
           {/* Why this score: the stack verdict + the deterministic components. */}
-          <div class="min-w-0 max-w-prose space-y-1.5">
+          <div class="min-w-0 space-y-1.5">
             <p class="text-sm leading-6 text-ink">{match.summary}</p>
             {breakdown && <ScoreBreakdownChips bd={breakdown} />}
             {(actions.length > 0 || removals.length > 0) && (

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -123,9 +123,9 @@ export const TargetPage: FC<TargetPageProps> = ({
       : null,
   };
   return (
-    <Layout title={`Resume match · ${job.title}`} active="jobs">
-      {/* The layout main is unbounded; without a cap this workspace scatters on
-          ultra-wide monitors. 2xl (1536px) keeps two panes comfortable. */}
+    <Layout title={`Resume match · ${job.title}`} active="jobs" wide>
+      {/* wide opts out of the layout's screen-xl column; 2xl (1536px) keeps
+          the two editor panes comfortable on ultra-wide monitors. */}
       <div class="mx-auto w-full max-w-screen-2xl">
       <nav aria-label="Breadcrumb" class="mb-1.5 flex items-center gap-1.5 text-[13px] text-ink-faint">
         <a href="/jobs" class="transition-colors duration-150 hover:text-ink">

--- a/src/web/pages/verification-card.tsx
+++ b/src/web/pages/verification-card.tsx
@@ -79,7 +79,7 @@ export const VerificationCard: FC<VerificationCardProps> = ({
 
       {verification && (
         <div class="mt-4 space-y-4">
-          <p class="max-w-prose text-sm leading-6 text-ink">{verification.summary}</p>
+          <p class="text-sm leading-6 text-ink">{verification.summary}</p>
 
           {verification.redFlags.length > 0 && (
             <ul class="space-y-1 text-sm text-ink-muted">
@@ -97,7 +97,7 @@ export const VerificationCard: FC<VerificationCardProps> = ({
           {verification.companySnapshot && (
             <div>
               <div class="mb-1.5 text-[13px] font-medium text-ink-muted">Company snapshot</div>
-              <p class="max-w-prose text-sm leading-6 text-ink-muted">
+              <p class="text-sm leading-6 text-ink-muted">
                 {verification.companySnapshot}
               </p>
             </div>

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -80,7 +80,7 @@ export const PageHeader: FC<
       )}
     </div>
     {children && (
-      <div class="mt-1.5 max-w-3xl text-[13px] leading-5 text-ink-faint">{children}</div>
+      <div class="mt-1.5 text-[13px] leading-5 text-ink-faint">{children}</div>
     )}
   </header>
 );
@@ -522,7 +522,7 @@ export const ToggleRow: FC<
           {enabled ? onLabel : offLabel}
         </Badge>
       </div>
-      <Hint class="mt-1 max-w-prose">{children}</Hint>
+      <Hint class="mt-1">{children}</Hint>
     </div>
     <div class="flex shrink-0 flex-col items-end gap-2">
       <ActionForm action={action}>


### PR DESCRIPTION
Fixes the two dashboard readability problems and ships **v0.2.1**.

## Data layer
- **`stripHtml` rewrite** — decode entities *before* stripping tags: Greenhouse ships job bodies HTML-escaped, so all 535 stored GH descriptions (82 % of the DB) carried raw `<div class="content-intro">…` markup as visible text. Line structure is now rebuilt from block tags, `<br>` and `<li>` (→ `• ` bullets) instead of being flattened by the old `\s+` collapse, `&amp;` decodes last (double-escaped input stays literal), and prose like `salary > 100k` / `<3` survives. +11 unit tests.
- **Stored rows repaired** — two one-shot scripts, both with `--dry-run`: `backfill-descriptions` re-cleans rows that still carry markup; `refetch-descriptions` re-pulls the boards and updated 601 descriptions in place. Verified in Postgres: 0 rows with tags; single-line walls remain only for ~45 jobs already delisted upstream.
- Manual pastes decode literal `&nbsp;` / `&amp;` before saving.

## Layout
- **Full width everywhere** (like the Jobs table): prose caps (`max-w-prose`, `75ch`) and per-page column limits removed — job description, classifier summary, hints, Settings, the paste form and the Target editor fill the screen. The `/companies` explainer reflows into two columns; descriptions render paragraphs via `whitespace-pre-line`.

## Notes
- `stripHtml` is **not idempotent** on its own plaintext output — documented as CLAUDE.md gotcha 12; the backfill gates on a markup regex, and MANUAL rows only ever get entity decoding.
- Verified: `tsc` clean, 412 tests green, Docker images rebuilt, pages checked at 1920 px and 375 px (no horizontal scroll).
