### PR TITLE
release discipline + pre-merge review gate

### DIFF
--- a/.claude/skills/code-review-expert/SKILL.md
+++ b/.claude/skills/code-review-expert/SKILL.md
@@ -9,6 +9,11 @@ description: "Expert code review of current git changes with a senior engineer l
 
 Perform a structured review of the current git changes with focus on SOLID, architecture, removal candidates, and security risks. Default to review-only output unless the user asks to implement changes.
 
+**Mandatory pre-merge pass (since 2026-08-31):** every feature branch
+runs this skill over `git diff main...HEAD` BEFORE its PR is opened
+(commit-discipline "Pre-merge gate"). In that mode, apply the P0/P1
+fixes directly, and list P2/P3 findings in the PR body as follow-ups.
+
 ## Severity Levels
 
 | Level | Name | Description | Action |

--- a/.claude/skills/commit-discipline/SKILL.md
+++ b/.claude/skills/commit-discipline/SKILL.md
@@ -59,6 +59,23 @@ in SPEC.md; the outcome part is mandatory. Bad: phase-8, wip, nazar-dev.
 
 Branches are short-lived: merged within a day or two, deleted after merge. Never rewrite shared history, never force-push shared branches. When a feature branch passes its verification, push it and open a PR right away (standing policy 2026-08-31, one per feature); merging to main stays with Nazar.
 
+## Pre-merge gate (before opening the PR)
+
+Per-commit hygiene is not enough — before the PR, review the **whole
+branch diff** with fresh eyes:
+
+- Run the `code-review-expert` skill over `git diff main...HEAD`
+  (mandatory since 2026-08-31).
+- Ask of every added line: is it needed at all, can it be simpler, can
+  it be more readable? Delete speculative code now, not "later".
+- P0/P1 findings are fixed before the PR exists; P2/P3 go into the PR
+  body as named follow-ups — never silently dropped.
+- The PR description includes a "Release notes" draft (see the
+  `release-discipline` skill) so the post-merge release is one command.
+
+Tags and GitHub releases after the merge follow the `release-discipline`
+skill (annotated minor per feature, release parity with tags).
+
 ## Split large refactors
 
 Not "refactor classifier" but a sequence: extract ai provider, move prompt builders, remove duplicated retry loop. Small commits make history reviewable.

--- a/.claude/skills/release-discipline/SKILL.md
+++ b/.claude/skills/release-discipline/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: release-discipline
+description: Tag and GitHub-release rules for this repository — when a merge gets a version tag, how releases stay in parity with tags, and the release-notes format. Read after every PR merge, before tagging, and at the start of a new stage (parity check).
+---
+
+# Release Discipline
+
+One runtime feature = one branch = one PR = one annotated minor tag = one
+GitHub release. Tags without releases are a process failure the same way
+finished-but-uncommitted work is (we shipped v0.3.0 and v0.4.0 tags while
+the release list still ended at v0.2.0 — this skill exists so that never
+repeats).
+
+## When a merge gets a tag
+
+| Merge | Tag |
+|---|---|
+| Runtime feature (new behaviour, schema, sources, UI) | **`vX.Y.0`** — minor bump, annotated, on the merge commit |
+| Follow-up fix to an already-released feature | **`vX.Y.1`** — patch bump on that feature's minor |
+| Docs-only / process-only / `.claude` skills / CI config | **no tag** — rides with the next minor |
+| Pure-module prerequisite invisible to the user (e.g. F7 fact gate before F8) | may skip its own tag and be tagged with the feature that surfaces it |
+
+Tag numbers follow **actual integration order**, not the plan registry.
+Annotated only (`git tag -a`), never lightweight; never move or reuse a
+pushed tag — a wrong tag is followed by the next number, not rewritten.
+
+```
+git tag -a v0.5.0 -m "<feature name>" <merge-sha>
+git push origin v0.5.0
+```
+
+## Release parity (the rule this skill enforces)
+
+**Every pushed `vX.Y.*` tag gets a GitHub release immediately — the
+latest release must always equal the latest tag.** Patch tags get a
+release too when they changed deployed behaviour (our v0.2.1 did).
+
+```
+gh release create vX.Y.0 --title "vX.Y.0 — <feature name>" --notes "<notes>"
+```
+
+- Claude drafts the release notes inside the PR description (a "Release
+  notes" section), so after Nazar merges + tags, creating the release is
+  one command with no writing left.
+- After the tag is pushed, create the release right away in the same
+  session; if Nazar tags outside a session, the next session creates it
+  during the parity check.
+
+## Parity check (start of every stage)
+
+Before starting a new feature branch, compare:
+
+```
+git fetch --tags && git tag -l | tail -3 && gh release list | head -3
+```
+
+If tags lead the releases, **backfill the missing releases first** —
+notes reconstructed from the PR body / merge commit of that tag. Only
+then start the new stage.
+
+## Release-notes format
+
+Short and scannable — this is a solo project's changelog, not marketing:
+
+```
+## What's new
+- 3–6 bullets, user-visible behaviour first
+## Schema
+- one line per migration (or "no schema changes")
+## Verification
+- one line: tests count, smoke runs, screenshots
+## References
+- ADR links, plan section (docs/feature-expansion-plan.md §N)
+```
+
+## Division of labour
+
+Nazar reviews, merges and tags (Claude puts the exact `git tag` command
+in the PR summary). Claude keeps releases in parity: draft notes in the
+PR, create the release after the tag appears, backfill on parity-check
+misses.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,14 @@
   verification matrix, push it and create the PR without waiting to be
   asked — one feature = one branch = one PR. Never merge to `main`
   yourself; Nazar reviews, merges and tags.
+- **Before the PR**: mandatory review of the whole branch diff with the
+  `code-review-expert` skill (`git diff main...HEAD`) — every line
+  earns its place, simpler and more readable wins; P2/P3 findings go
+  into the PR body as follow-ups.
+- **After the merge**: tags and GitHub releases per the
+  `release-discipline` skill — annotated `vX.Y.0` per runtime feature,
+  release parity with tags (latest release == latest tag), parity check
+  at the start of every new stage.
 - Task backlog for Claude Code sessions lives in [docs/TASKS.md](./docs/TASKS.md).
 
 ## Stack

--- a/docs/feature-expansion-plan.md
+++ b/docs/feature-expansion-plan.md
@@ -52,18 +52,28 @@ features under one tag.
 4. **Verify** per the feature's test matrix (below). Never weaken a failing
    test; report skipped smoke runs as skipped. Run the copy-check from the
    ground rules.
-5. **PR**: as soon as the verification matrix passes, push the branch
-   and open a PR (standing policy since 2026-08-31 — one per feature,
-   no waiting to be asked). Merging to `main` stays with Nazar.
-6. **Tag**: after merge, an annotated tag `vX.Y.0` on the merge commit —
-   one minor bump per feature, patch bumps (`vX.Y.1`) for follow-up
-   fixes to that feature. Docs-only / process-only merges get NO tag.
-   Tag numbers are assigned in *actual* integration order; the registry
-   below is the recommended order, not a reservation.
+5. **Pre-merge review (mandatory since 2026-08-31):** run the
+   `code-review-expert` skill over the whole branch diff
+   (`git diff main...HEAD`) — is every added line needed, can it be
+   simpler or more readable? Fix P0/P1 before the PR exists; list P2/P3
+   in the PR body as named follow-ups.
+6. **PR**: as soon as the verification matrix passes and the review is
+   applied, push the branch and open a PR (standing policy since
+   2026-08-31 — one per feature, no waiting to be asked). Include a
+   "Release notes" draft in the PR body. Merging to `main` stays with
+   Nazar.
+7. **Tag + release** (release-discipline skill): after merge, an
+   annotated tag `vX.Y.0` on the merge commit — one minor bump per
+   feature, patch bumps (`vX.Y.1`) for follow-up fixes to that feature.
+   Docs-only / process-only merges get NO tag. Every pushed tag gets a
+   GitHub release immediately (latest release == latest tag; backfill on
+   parity-check misses). Tag numbers are assigned in *actual*
+   integration order; the registry below is the recommended order, not a
+   reservation.
    ```
    git tag -a v0.3.0 -m "liveness ladder"
    ```
-7. **Rollback path**: every feature that changes runtime behaviour ships
+8. **Rollback path**: every feature that changes runtime behaviour ships
    behind a settings toggle where feasible (AppSettings column →
    settings.ts → /settings UI, per the CLAUDE.md toggle recipe). Migrations
    are additive-only (new columns/tables, no destructive rewrites), so


### PR DESCRIPTION
Process-only PR (no tag per the new rule itself).

- New `release-discipline` skill: when a merge gets a tag (minor per runtime feature, patch for follow-ups, none for docs/process), annotated-tag mechanics, **release parity** — every pushed tag gets a GitHub release immediately, parity check at the start of every stage with backfill.
- `commit-discipline`: new **pre-merge gate** — mandatory `code-review-expert` pass over `git diff main...HEAD` before every PR (every line earns its place, simpler/more readable wins; P0/P1 fixed, P2/P3 listed in the PR body), plus a Release-notes draft in each PR.
- `code-review-expert`: marked as the mandatory pre-merge pass.
- CLAUDE.md + plan §0.1 wired accordingly (lifecycle now: verify → review → PR → tag+release → rollback).

**Release notes:** none — process-only.