### PR TITLE
F3: cross-source SimHash dedup + URL-key discipline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -170,6 +170,7 @@ src/
   ai-provider.ts               ← AiProvider seam: AnthropicApiProvider | ClaudeCodeProvider
   ai-provider-parse.ts         ← pure parser for `claude -p` JSON output (tested)
   concurrency.ts               ← createLimiter(max), pure
+  fingerprint.ts               ← SimHash of a JD body + cross-listing search, pure (ADR 0018)
   classifier.ts                ← classifyJob wrapper + classifyWithClaude (full prompt)
   classifier-prefilter.ts      ← preClassify (short prompt)
   notifier.ts                  ← Telegram MarkdownV2 send, multi-target broadcast

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,8 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | HTTP retry, timeout, default User-Agent | `src/http.ts` |
 | HTML → plaintext (entities, paragraphs, bullets) | `src/http.ts:stripHtml` + `decodeHtmlEntities` (gotcha 12) |
 | Pure helpers (parsing, hashing, masking) | `src/text-utils.ts` |
+| Near-duplicate detection across sources (SimHash, Hamming) | `src/fingerprint.ts` (ADR 0018); wired in `jobs/process-jobs.ts` |
+| Stable id for a feed row with no id of its own | `src/text-utils.ts:feedItemKey` (URL key → text key → null, never `''`) |
 | The cron list (6 schedules) | `src/index.ts:registerCron` |
 | What runs on container boot | `src/init.ts` |
 | Adding a new ATS source — single-feed template | `src/fetchers/larajobs.ts` (LARAJOBS_RSS) or `src/fetchers/golangprojects.ts` (single RSS) |
@@ -347,6 +349,7 @@ Always:
 | Tail the dashboard | `docker compose logs -f web` |
 | psql into the DB | `docker compose exec postgres psql -U jobhunter -d jobhunter` |
 | Re-clean stored descriptions (rows with leftover markup) | `docker compose exec app node dist/scripts/backfill-descriptions.js --dry-run`, then without the flag |
+| Fingerprint existing jobs + link cross-listings | `docker compose exec app node dist/scripts/backfill-fingerprints.js --dry-run`, then without the flag |
 | Re-pull descriptions from the boards (structure lost) | `docker compose exec app node dist/scripts/refetch-descriptions.js --dry-run`, then without the flag |
 | Migrate after a schema change | `DATABASE_URL=… npx prisma migrate dev --name <name>` |
 | Re-classify everything against the active profile | UI: `/settings` → "Re-classify all jobs" |

--- a/SPEC.md
+++ b/SPEC.md
@@ -155,6 +155,28 @@ greenhouse/lever/ashby/workable/smartrecruiters) and writes
 re-validates each pending candidate's slug and updates `jobsSeen`,
 marking 4xx-returning slugs as DEAD.
 
+## Cross-source dedup (F3)
+
+Dedup is per `(companyId, externalId)`, which cannot see the same posting
+arriving through two sources. `src/fingerprint.ts` adds a 64-bit SimHash over
+the description (3-token shingles, markup/entities/URLs stripped first).
+
+A new job is compared against the last 90 days **at other companies only**, at
+Hamming ≤ 7; a hit sets `Job.crossListedOfJobId` and shows as "Also listed
+elsewhere — apply through one channel only" on `/jobs/:id` (both directions)
+and as a line in the Telegram alert. **Annotation only** — nothing is merged,
+hidden or skipped, so a wrong link costs a confusing note and nothing else.
+
+Bodies under 400 normalized characters get no fingerprint and never match:
+truncated aggregator teasers (Jobicy, LaraJobs, Rippling) carry only a company
+blurb, so two different roles at one company would otherwise look identical.
+Same-company matches are deliberately left alone — a quarter of them are
+genuinely different roles sharing boilerplate (ADR 0018); reposts are F11.
+
+Existing rows are fingerprinted by
+`node dist/scripts/backfill-fingerprints.js` (`--dry-run` first); re-running
+it links nothing new.
+
 ## Company starter packs (F14)
 
 `/companies` → **Add a starter pack**: curated segments (PHP/Laravel & CMS,

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -370,7 +370,14 @@ external project, copy-check before merge.
       robots-allowed `/api/v2`). NoDesk, JustJoin, NoFluffJobs rejected
       at re-analysis on robots grounds → ADR 0005 addendum. Salary
       decision: v1 folds salary into description text (F19 revisits)
-- [ ] F3 SimHash cross-source dedup + URL-key discipline — v0.5.0
+- [x] F3 SimHash cross-source dedup + URL-key discipline — v0.6.0
+      (branch `simhash-dedup`, ADR 0018): measuring the plan's constants on
+      our 731 jobs moved the guard from 200 to 400 normalized chars (Jobicy
+      teasers are byte-identical across different roles) and the threshold
+      from Hamming 5 to 7 (9/9 cross-company matches genuine; first false
+      positive at 10). The plan's "skip same-company matches" was dropped —
+      27% of them are genuinely different roles. Annotation only; skipping
+      the duplicate's paid classification stays deferred
 - [ ] F4 source health monitoring (quiet-source card) — v0.6.0
 - [ ] F5 status-transition ledger + funnel/calibration stats — v0.7.0
 - [ ] F6 follow-up cadence with pin/retire/auto-seed in the stale digest — v0.8.0

--- a/docs/adr/0018-simhash-annotates-never-merges.md
+++ b/docs/adr/0018-simhash-annotates-never-merges.md
@@ -1,0 +1,101 @@
+# 0018 — Cross-listing is annotated, never merged, and its constants come from our own corpus
+
+**Status:** Accepted (2026-08-31)
+
+## Context
+
+Dedup is per `(companyId, externalId)`. The same posting reaching us через
+RemoteOK, the company's own Greenhouse board and an aggregator is three rows
+and up to three paid classifications, and — worse — an invitation to apply
+twice through two channels. F3 adds a content fingerprint (SimHash over the
+JD body) to spot it.
+
+The plan (feature-expansion-plan.md §4) proposed two constants and one
+behaviour: fingerprint bodies over **200 normalized chars**, match at
+**Hamming ≤ 5**, and on a **same-company** match treat it as a repost and
+**skip** it. All three were measured against our own 731 stored jobs before
+any code was written, and two of them are wrong for our data.
+
+**The 200-char guard sits just below our worst source.** Jobicy ships
+truncated teasers — normalized length 239 median, 284 max — that contain the
+company blurb and nothing role-specific:
+
+> `Hiring company: ClickUp. Type: full time.` + "At ClickUp, we're building
+> the future of work: …" (cut off at ~250 chars)
+
+Two different ClickUp roles ("Senior Backend Engineer" and "Staff Backend
+Engineer, Hierarchy") therefore have **byte-identical descriptions** and a
+distance of 0. At a 200-char guard that produced 24 false pairs; at 400 it
+produces none, and no real body is lost — our sources with genuine content
+start around 550 normalized chars (HN_HIRING p10 = 779, Greenhouse median
+6522). Raising the guard further to 500 or 800 changes nothing, so 400 sits
+in the middle of a clean gap.
+
+**Skipping same-company matches would silently drop real jobs.** At Hamming
+≤ 5, 34 of the 127 same-company matches (27%) are genuinely different roles
+that merely share a company's boilerplate:
+
+- Affirm — "Senior Software Engineer, Backend (Infrastructure)" vs
+  "(Authentication Experience)" vs "(PBA – Growth)"
+- TaskRabbit — "Customer Support Advocate" in German vs Spanish vs Portuguese
+- Square — "Manager, Field Sales – Houston" vs "– Los Angeles" vs
+  "– Orange County" (distance 1–2)
+
+For a candidate these are distinct opportunities, and the plan's own
+acceptance criterion already says "no data loss is possible by
+construction". The measurement resolves the contradiction against the
+"skip" bullet.
+
+**The threshold is 7, not 5.** Every cross-company match up to distance 7 is
+a genuine cross-listing (9/9), including the pairs distance 5 splits apart:
+Lemon.io listed simultaneously on WeWorkRemotely, Remotive and RemoteOK, and
+Reddit's "Backend Software Engineer, PDP Experience" on both WeWorkRemotely
+and Reddit's own Greenhouse board. The first false positive appears at
+distance 10 — Proxify AB's React role against its Python role — so 7 keeps
+a two-bit margin. The error costs are asymmetric in the same direction: a
+wrong annotation is a confusing note, a missed one is applying twice through
+two channels.
+
+## Decision
+
+`src/fingerprint.ts` (pure): `normalizeJdText` → `simhash64` over 3-token
+shingles → `hamming64`. A body under **400 normalized characters** gets no
+fingerprint, and a body under 3 tokens gets none (an unspaced CJK body
+normalizes to one token, and an all-zero hash would match every other
+degenerate body). No fingerprint never matches anything.
+
+A new job is compared against fingerprints from the last 90 days **at other
+companies only**, at **Hamming ≤ 7**. A match sets `Job.crossListedOfJobId`
+and surfaces as "≈ also listed at X — apply through one channel only" on
+`/jobs/:id` and in the Telegram alert. **Annotation only**: no row is
+merged, hidden, or dropped, and the duplicate is still classified on its own
+merits. Same-company matches are left alone entirely — that is F11's repost
+territory, and the measurement above shows why F3 must not touch them.
+
+Skipping the duplicate's paid classification (the plan's flagged decision
+point) is **deferred**. Cross-company precision is 100% on our corpus, but
+that corpus contains only nine such pairs; inheriting a verdict on a wrong
+match would dismiss a real job, which is exactly the data loss this ADR
+rules out. Revisit once the annotations have run long enough to measure.
+
+Schema is additive: `Job.descriptionSimhash BIGINT?` and
+`Job.crossListedOfJobId Int?` (nullable self-relation), hand-written
+migration per gotcha 7.
+
+## Consequences
+
+- Jobicy, LaraJobs and Rippling bodies never get a fingerprint under the
+  400-char guard, so cross-listings that reach us *only* through those feeds
+  stay invisible. Accepted: a fingerprint built from a company blurb cannot
+  distinguish roles, so the alternative is not detection but false
+  detection.
+- The 90-day scan is a full comparison against every fingerprint in the
+  window — ~700 rows today, microseconds. The plan's banded index on hash
+  quarters is deferred until a timing shows it matters.
+- The constants are tuned on a corpus that is 75% Greenhouse. Starter packs
+  (F14) are about to widen it; re-measure when the mix has changed.
+- URL-key discipline lands in the same feature but fixes nothing observable
+  today: no stored job has a tracking parameter, and the only query
+  parameter in the corpus is `gh_jid`, which is functional and kept. It is
+  preventive hardening for the fallback path that hashes a URL into an
+  `externalId`, and it changes no existing row.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0015 — The profile is drafted from the resume scan, never written by AI](./0015-profile-draft-from-resume-scan.md)
 - [0016 — Job liveness via a free three-rung ladder before AI verify](./0016-liveness-ladder.md)
 - [0017 — Starter-pack entries pin a hand-verified board](./0017-starter-packs-pin-verified-boards.md)
+- [0018 — Cross-listing is annotated, never merged](./0018-simhash-annotates-never-merges.md)
 
 ## When to write a new one
 

--- a/prisma/migrations/20260831160000_add_simhash_dedup/migration.sql
+++ b/prisma/migrations/20260831160000_add_simhash_dedup/migration.sql
@@ -1,0 +1,15 @@
+-- F3 (ADR 0018): content fingerprint + cross-listing annotation.
+-- Additive only: both columns are nullable, so existing rows stay valid and
+-- a revert strands no data.
+ALTER TABLE "Job" ADD COLUMN "descriptionSimhash" BIGINT;
+ALTER TABLE "Job" ADD COLUMN "crossListedOfJobId" INTEGER;
+
+-- ON DELETE SET NULL: deleting the original must not cascade into the
+-- duplicate — the annotation is a hint, not ownership.
+ALTER TABLE "Job" ADD CONSTRAINT "Job_crossListedOfJobId_fkey"
+  FOREIGN KEY ("crossListedOfJobId") REFERENCES "Job"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- The dedup scan reads fingerprints from the last 90 days.
+CREATE INDEX "Job_fetchedAt_descriptionSimhash_idx"
+  ON "Job"("fetchedAt", "descriptionSimhash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,12 +109,22 @@ model Job {
   livenessCode      String?
   livenessCheckedAt DateTime?
 
+  // F3 (ADR 0018): SimHash of the description, and the earlier job at ANOTHER
+  // company this one near-duplicates. Annotation only — nothing is merged or
+  // hidden, so a wrong link costs a confusing note and nothing else.
+  descriptionSimhash BigInt?
+  crossListedOfJobId Int?
+  crossListedOf      Job?    @relation("CrossListing", fields: [crossListedOfJobId], references: [id], onDelete: SetNull)
+  crossListings      Job[]   @relation("CrossListing")
+
   resumeMatches ResumeMatch[]
   verifications JobVerification[]
 
   @@unique([companyId, externalId])
   @@index([status, fetchedAt])
   @@index([pipelineStage, appliedAt])
+  // The dedup scan reads fingerprints from the last 90 days.
+  @@index([fetchedAt, descriptionSimhash])
 }
 
 model CronRun {

--- a/src/fetchers/golangprojects.ts
+++ b/src/fetchers/golangprojects.ts
@@ -1,6 +1,6 @@
 import Parser from 'rss-parser';
 import { stripHtml } from '../http';
-import { hashShortId } from '../text-utils';
+import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
 const FEED_URL = 'https://www.golangprojects.com/rss.xml';
@@ -29,9 +29,12 @@ export async function fetchGolangProjects(
   companyId: number,
 ): Promise<NormalizedJob[]> {
   const feed = await parser.parseURL(FEED_URL);
-  return feed.items.map((item) => {
+  return feed.items.flatMap((item) => {
     const link = item.link ?? '';
-    const externalId = item.guid ?? hashShortId(link || (item.title ?? ''));
+    const externalId = item.guid ?? feedItemKey(link, item.title);
+    // Nothing identifies this row — skip it rather than hash '' and merge
+    // every such row onto one shared id.
+    if (!externalId) return [];
     const description =
       item.contentSnippet ?? (item.content ? stripHtml(item.content) : '') ?? '';
     return {

--- a/src/fetchers/jobicy.test.ts
+++ b/src/fetchers/jobicy.test.ts
@@ -6,7 +6,7 @@ const COMPANY_ID = 99;
 
 describe('mapJobicyItem', () => {
   it('extracts <job_listing:location> instead of defaulting to Remote', () => {
-    const job = mapJobicyItem(
+    const job = mustmapJobicyItem(
       {
         title: 'Senior PHP Developer',
         link: 'https://jobicy.com/jobs/142345-senior-php',
@@ -19,7 +19,7 @@ describe('mapJobicyItem', () => {
   });
 
   it('falls back to "Remote" when location field is missing or empty', () => {
-    const a = mapJobicyItem(
+    const a = mustmapJobicyItem(
       {
         title: 'X',
         link: 'https://jobicy.com/jobs/1',
@@ -28,7 +28,7 @@ describe('mapJobicyItem', () => {
       COMPANY_ID,
     );
     assert.equal(a.location, 'Remote');
-    const b = mapJobicyItem(
+    const b = mustmapJobicyItem(
       {
         title: 'X',
         link: 'https://jobicy.com/jobs/1',
@@ -41,7 +41,7 @@ describe('mapJobicyItem', () => {
   });
 
   it('embeds hiring company + job type into description', () => {
-    const job = mapJobicyItem(
+    const job = mustmapJobicyItem(
       {
         title: 'Senior SAP Integration Developer',
         link: 'https://jobicy.com/jobs/142515',
@@ -59,7 +59,7 @@ describe('mapJobicyItem', () => {
   });
 
   it('preserves description when no custom fields are set', () => {
-    const job = mapJobicyItem(
+    const job = mustmapJobicyItem(
       {
         title: 'X',
         link: 'https://jobicy.com/jobs/1',
@@ -72,7 +72,7 @@ describe('mapJobicyItem', () => {
   });
 
   it('uses guid for externalId when present', () => {
-    const job = mapJobicyItem(
+    const job = mustmapJobicyItem(
       {
         title: 'X',
         link: 'https://jobicy.com/jobs/142345',
@@ -85,7 +85,7 @@ describe('mapJobicyItem', () => {
   });
 
   it('synthesises a stable externalId from link when guid is missing', () => {
-    const job = mapJobicyItem(
+    const job = mustmapJobicyItem(
       {
         title: 'X',
         link: 'https://jobicy.com/jobs/142345',
@@ -98,7 +98,7 @@ describe('mapJobicyItem', () => {
   });
 
   it('handles empty contentSnippet without crashing', () => {
-    const job = mapJobicyItem(
+    const job = mustmapJobicyItem(
       {
         title: 'X',
         link: 'https://jobicy.com/jobs/1',
@@ -111,3 +111,11 @@ describe('mapJobicyItem', () => {
     assert.equal(job.description, 'Hiring company: Acme Inc.');
   });
 });
+
+/** The mapper returns null only for rows nothing identifies; every fixture
+ *  here is keyable, so assert that before the per-field checks. */
+function mustmapJobicyItem(...args: Parameters<typeof mapJobicyItem>): NonNullable<ReturnType<typeof mapJobicyItem>> {
+  const job = mapJobicyItem(...args);
+  assert.ok(job, 'expected the fixture to map to a job');
+  return job;
+}

--- a/src/fetchers/jobicy.ts
+++ b/src/fetchers/jobicy.ts
@@ -1,6 +1,6 @@
 import Parser from 'rss-parser';
 import { stripHtml } from '../http';
-import { hashShortId } from '../text-utils';
+import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
 const FEED_URL_TEMPLATE = (category: string) =>
@@ -52,7 +52,7 @@ export async function fetchJobicy(
   category: string = DEFAULT_CATEGORY,
 ): Promise<NormalizedJob[]> {
   const feed = await parser.parseURL(FEED_URL_TEMPLATE(category));
-  return feed.items.map((item) => mapJobicyItem(item, companyId));
+  return feed.items.flatMap((item) => mapJobicyItem(item, companyId) ?? []);
 }
 
 /**
@@ -64,9 +64,12 @@ export async function fetchJobicy(
 export function mapJobicyItem(
   item: JobicyItem,
   companyId: number,
-): NormalizedJob {
+): NormalizedJob | null {
   const link = item.link ?? '';
-  const externalId = item.guid ?? hashShortId(link || (item.title ?? ''));
+  const externalId = item.guid ?? feedItemKey(link, item.title);
+  // Nothing identifies this row — skip it rather than hash '' and merge
+  // every such row onto one shared id.
+  if (!externalId) return null;
   const baseDescription =
     item.contentSnippet ??
     (item.content ? stripHtml(item.content) : '') ??

--- a/src/fetchers/larajobs.test.ts
+++ b/src/fetchers/larajobs.test.ts
@@ -12,12 +12,12 @@ describe('mapLarajobsItem', () => {
       pubDate: 'Thu, 16 Apr 2026 15:01:42 +0000',
       jobLocation: 'United States/Remote (USA Only)',
     };
-    const job = mapLarajobsItem(item, COMPANY_ID);
+    const job = mustmapLarajobsItem(item, COMPANY_ID);
     assert.equal(job.location, 'United States/Remote (USA Only)');
   });
 
   it('falls back to "Remote" when <job:location> is missing or empty', () => {
-    const a = mapLarajobsItem(
+    const a = mustmapLarajobsItem(
       {
         title: 'X',
         link: 'https://larajobs.com/job/1',
@@ -27,7 +27,7 @@ describe('mapLarajobsItem', () => {
     );
     assert.equal(a.location, 'Remote');
 
-    const b = mapLarajobsItem(
+    const b = mustmapLarajobsItem(
       {
         title: 'X',
         link: 'https://larajobs.com/job/1',
@@ -40,7 +40,7 @@ describe('mapLarajobsItem', () => {
   });
 
   it('embeds salary / company / tags / type into description', () => {
-    const job = mapLarajobsItem(
+    const job = mustmapLarajobsItem(
       {
         title: 'Senior Laravel/Vue Engineer',
         link: 'https://larajobs.com/job/3869',
@@ -62,7 +62,7 @@ describe('mapLarajobsItem', () => {
   });
 
   it('preserves original description when no custom fields present', () => {
-    const job = mapLarajobsItem(
+    const job = mustmapLarajobsItem(
       {
         title: 'Senior Laravel Developer',
         link: 'https://larajobs.com/job/1',
@@ -75,7 +75,7 @@ describe('mapLarajobsItem', () => {
   });
 
   it('handles empty contentSnippet without crashing', () => {
-    const job = mapLarajobsItem(
+    const job = mustmapLarajobsItem(
       {
         title: 'X',
         link: 'https://larajobs.com/job/1',
@@ -89,7 +89,7 @@ describe('mapLarajobsItem', () => {
   });
 
   it('uses guid for externalId when present', () => {
-    const job = mapLarajobsItem(
+    const job = mustmapLarajobsItem(
       {
         title: 'X',
         link: 'https://larajobs.com/job/3869',
@@ -102,7 +102,7 @@ describe('mapLarajobsItem', () => {
   });
 
   it('synthesises a stable externalId from link when guid is absent', () => {
-    const job = mapLarajobsItem(
+    const job = mustmapLarajobsItem(
       {
         title: 'X',
         link: 'https://larajobs.com/job/3869',
@@ -114,3 +114,22 @@ describe('mapLarajobsItem', () => {
     assert.match(job.externalId, /^[0-9a-f]{16}$/);
   });
 });
+
+describe('mapLarajobsItem keying', () => {
+  it('drops a row that nothing identifies', () => {
+  // No guid, no link, no title: hashing '' would give every such row the
+  // same externalId and merge them into one job.
+    assert.equal(mapLarajobsItem({ link: '', title: '' }, COMPANY_ID), null);
+    assert.equal(mapLarajobsItem({}, COMPANY_ID), null);
+  // A link alone is enough to key it.
+    assert.ok(mapLarajobsItem({ link: 'https://larajobs.com/job/7' }, COMPANY_ID));
+  });
+});
+
+/** The mapper returns null only for rows nothing identifies; every fixture
+ *  here is keyable, so assert that before the per-field checks. */
+function mustmapLarajobsItem(...args: Parameters<typeof mapLarajobsItem>): NonNullable<ReturnType<typeof mapLarajobsItem>> {
+  const job = mapLarajobsItem(...args);
+  assert.ok(job, 'expected the fixture to map to a job');
+  return job;
+}

--- a/src/fetchers/larajobs.ts
+++ b/src/fetchers/larajobs.ts
@@ -1,6 +1,6 @@
 import Parser from 'rss-parser';
 import { stripHtml } from '../http';
-import { hashShortId } from '../text-utils';
+import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
 const FEED_URL = 'https://larajobs.com/feed';
@@ -52,7 +52,7 @@ export async function fetchLarajobs(
   companyId: number,
 ): Promise<NormalizedJob[]> {
   const feed = await parser.parseURL(FEED_URL);
-  return feed.items.map((item) => mapLarajobsItem(item, companyId));
+  return feed.items.flatMap((item) => mapLarajobsItem(item, companyId) ?? []);
 }
 
 /**
@@ -64,9 +64,12 @@ export async function fetchLarajobs(
 export function mapLarajobsItem(
   item: LarajobsItem,
   companyId: number,
-): NormalizedJob {
+): NormalizedJob | null {
   const link = item.link ?? '';
-  const externalId = item.guid ?? hashShortId(link || (item.title ?? ''));
+  const externalId = item.guid ?? feedItemKey(link, item.title);
+  // Nothing identifies this row — skip it rather than hash '' and merge
+  // every such row onto one shared id.
+  if (!externalId) return null;
   const baseDescription =
     item.contentSnippet ??
     (item.content ? stripHtml(item.content) : '') ??

--- a/src/fetchers/weworkremotely.ts
+++ b/src/fetchers/weworkremotely.ts
@@ -1,6 +1,6 @@
 import Parser from 'rss-parser';
 import { stripHtml } from '../http';
-import { hashShortId } from '../text-utils';
+import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
 const PARSER_TIMEOUT_MS = 10_000;
@@ -37,9 +37,12 @@ export async function fetchWeWorkRemotely(
   const slug = (company.atsToken || 'back-end-programming').trim();
   const url = `https://weworkremotely.com/categories/remote-${slug}-jobs.rss`;
   const feed = await parser.parseURL(url);
-  return feed.items.map((item) => {
+  return feed.items.flatMap((item) => {
     const link = item.link ?? '';
-    const externalId = item.guid ?? hashShortId(link || (item.title ?? ''));
+    const externalId = item.guid ?? feedItemKey(link, item.title);
+    // Nothing identifies this row — skip it rather than hash '' and merge
+    // every such row onto one shared id.
+    if (!externalId) return [];
     const description =
       item.contentSnippet ?? (item.content ? stripHtml(item.content) : '') ?? '';
     return {

--- a/src/fetchers/workingnomads.ts
+++ b/src/fetchers/workingnomads.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { fetchWithRetry, stripHtml } from '../http';
-import { hashShortId } from '../text-utils';
+import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
 const ENDPOINT = 'https://www.workingnomads.com/api/exposed_jobs/';
@@ -51,17 +51,21 @@ export function mapWorkingNomadsFeed(
   for (const item of top.data) {
     const parsed = WorkingNomadsJobSchema.safeParse(item);
     if (!parsed.success) continue;
-    out.push(toNormalized(parsed.data, companyId));
+    const job = toNormalized(parsed.data, companyId);
+    // Nothing identifies this row — skip it rather than hash '' and merge
+    // every such row onto one shared id.
+    if (job) out.push(job);
   }
   return out;
 }
 
-function toNormalized(j: WorkingNomadsJob, companyId: number): NormalizedJob {
+function toNormalized(j: WorkingNomadsJob, companyId: number): NormalizedJob | null {
   // Job URLs look like https://www.workingnomads.com/job/go/1818986/ —
   // the numeric segment is the stable posting id.
   const externalId =
     /\/job\/go\/(\d+)/.exec(j.url)?.[1] ??
-    hashShortId(`${j.url}|${j.title}|${j.company_name ?? ''}`);
+    feedItemKey(j.url, j.title, j.company_name);
+  if (!externalId) return null;
   const postedAt = j.pub_date ? new Date(j.pub_date) : new Date();
   return {
     companyId,

--- a/src/fingerprint.test.ts
+++ b/src/fingerprint.test.ts
@@ -6,7 +6,6 @@ import {
   findCrossListing,
   fromDbBigInt,
   hamming64,
-  isNearDuplicate,
   normalizeJdText,
   normalizedLength,
   simhash64,
@@ -110,14 +109,6 @@ test('a body under three tokens gets no fingerprint', () => {
   // An unspaced CJK body normalizes to one giant token; an all-zero hash
   // would otherwise match every other degenerate body.
   assert.equal(simhash64('シニアエンジニアを募集しています'.repeat(40)), null);
-});
-
-test('a missing fingerprint never counts as a duplicate', () => {
-  const h = simhash64(longBody('backend'));
-  assert.equal(isNearDuplicate(null, h), false);
-  assert.equal(isNearDuplicate(h, null), false);
-  assert.equal(isNearDuplicate(null, null), false);
-  assert.equal(isNearDuplicate(undefined, h), false);
 });
 
 test('hamming64 counts differing bits', () => {

--- a/src/fingerprint.test.ts
+++ b/src/fingerprint.test.ts
@@ -1,0 +1,145 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MAX_HAMMING_DISTANCE,
+  MIN_NORMALIZED_CHARS,
+  findCrossListing,
+  hamming64,
+  isNearDuplicate,
+  normalizeJdText,
+  normalizedLength,
+  simhash64,
+} from './fingerprint';
+
+/** A body comfortably over the guard, built from varied prose. */
+function longBody(seed: string): string {
+  const sentences = [
+    `We are hiring a ${seed} engineer to build and operate our platform.`,
+    'You will design services, review code and mentor other engineers.',
+    'Our stack is PHP, Laravel, TypeScript, Postgres and Docker on AWS.',
+    'We offer remote work, a learning budget and twenty-five days of leave.',
+    'Applicants should have at least five years of professional experience.',
+    'The team ships continuously and owns what it builds end to end.',
+    'You will work closely with product managers, designers and analysts.',
+    'We run weekly demos and keep written decision records for every change.',
+    'Interviews are a screening call, a technical pairing session and a chat.',
+  ];
+  return sentences.join(' ');
+}
+
+test('normalizeJdText strips markup, entities and URLs', () => {
+  const tokens = normalizeJdText(
+    '<p>Senior&nbsp;Engineer</p> apply at https://example.com/jobs?a=1 &amp; enjoy',
+  );
+  assert.deepEqual(tokens, ['senior', 'engineer', 'apply', 'at', 'enjoy']);
+});
+
+test('normalizeJdText keeps non-Latin scripts', () => {
+  assert.deepEqual(normalizeJdText('Розробник Laravel у Києві'), [
+    'розробник',
+    'laravel',
+    'у',
+    'києві',
+  ]);
+  assert.deepEqual(normalizeJdText('シニアエンジニア'), ['シニアエンジニア']);
+});
+
+test('normalizeJdText tolerates junk input', () => {
+  assert.deepEqual(normalizeJdText(null), []);
+  assert.deepEqual(normalizeJdText(undefined), []);
+  assert.deepEqual(normalizeJdText(''), []);
+  assert.deepEqual(normalizeJdText('<<<>>>'), []);
+});
+
+test('identical text fingerprints to distance 0', () => {
+  const a = simhash64(longBody('backend'));
+  const b = simhash64(longBody('backend'));
+  assert.notEqual(a, null);
+  assert.equal(hamming64(a!, b!), 0);
+});
+
+test('markup differences do not change the fingerprint', () => {
+  const plain = simhash64(longBody('backend'));
+  const marked = simhash64(`<div><p>${longBody('backend')}</p></div>`);
+  assert.equal(hamming64(plain!, marked!), 0);
+});
+
+test('a few edited words stay within the match threshold', () => {
+  const original = longBody('backend');
+  const edited = original
+    .replace('twenty-five days of leave', 'thirty days of leave')
+    .replace('five years', 'six years');
+  const distance = hamming64(simhash64(original)!, simhash64(edited)!);
+  assert.ok(
+    distance > 0 && distance <= MAX_HAMMING_DISTANCE,
+    `expected a small non-zero distance, got ${distance}`,
+  );
+});
+
+test('unrelated bodies land far outside the threshold', () => {
+  const jd = longBody('backend');
+  const other = [
+    'Our bakery is looking for a pastry chef with a passion for sourdough.',
+    'Shifts start at four in the morning and the kitchen closes at noon.',
+    'Experience with laminated dough and seasonal menus is appreciated.',
+    'We provide uniforms, meals on shift and a monthly transport pass.',
+    'The role is on site in Lviv and involves lifting heavy trays daily.',
+    'Weekend availability is required during the winter holiday season.',
+    'Our head baker will train you on our starter and fermentation schedule.',
+    'We source flour from two regional mills and mill some grains ourselves.',
+    'Applicants need a food handling certificate before their first shift.',
+  ].join(' ');
+  assert.ok(hamming64(simhash64(jd)!, simhash64(other)!) > MAX_HAMMING_DISTANCE);
+});
+
+test('a body under the guard gets no fingerprint', () => {
+  // The exact shape that broke the plan's 200-char guard: a truncated
+  // aggregator teaser with only the company blurb (ADR 0018).
+  const teaser =
+    'Hiring company: ClickUp. Type: full time. At ClickUp, we are building ' +
+    'the future of work: the first truly converged AI workspace unifying ' +
+    'tasks, docs, chat, calendar and enterprise search, all supercharged...';
+  assert.ok(normalizedLength(normalizeJdText(teaser)) < MIN_NORMALIZED_CHARS);
+  assert.equal(simhash64(teaser), null);
+});
+
+test('a body under three tokens gets no fingerprint', () => {
+  assert.equal(simhash64('a b'), null);
+  // An unspaced CJK body normalizes to one giant token; an all-zero hash
+  // would otherwise match every other degenerate body.
+  assert.equal(simhash64('シニアエンジニアを募集しています'.repeat(40)), null);
+});
+
+test('a missing fingerprint never counts as a duplicate', () => {
+  const h = simhash64(longBody('backend'));
+  assert.equal(isNearDuplicate(null, h), false);
+  assert.equal(isNearDuplicate(h, null), false);
+  assert.equal(isNearDuplicate(null, null), false);
+  assert.equal(isNearDuplicate(undefined, h), false);
+});
+
+test('hamming64 counts differing bits', () => {
+  assert.equal(hamming64(0n, 0n), 0);
+  assert.equal(hamming64(0b1011n, 0b1001n), 1);
+  assert.equal(hamming64(0n, 0xffffffffffffffffn), 64);
+});
+
+test('findCrossListing ignores the same company and picks the closest', () => {
+  const fingerprint = 0b1111n;
+  const candidates = [
+    { id: 1, companyId: 7, descriptionSimhash: 0b1111n }, // same company
+    { id: 2, companyId: 9, descriptionSimhash: 0b1011n }, // distance 1
+    { id: 3, companyId: 8, descriptionSimhash: 0b1110n }, // distance 1, earlier
+    { id: 4, companyId: 9, descriptionSimhash: null },
+  ];
+  const hit = findCrossListing(fingerprint, 7, candidates);
+  assert.equal(hit?.job.id, 2);
+  assert.equal(hit?.distance, 1);
+});
+
+test('findCrossListing returns null past the threshold or without a fingerprint', () => {
+  const candidates = [{ id: 1, companyId: 9, descriptionSimhash: 0xffn }];
+  assert.equal(findCrossListing(0n, 7, candidates), null);
+  assert.equal(findCrossListing(null, 7, candidates), null);
+  assert.equal(findCrossListing(0n, 7, []), null);
+});

--- a/src/fingerprint.test.ts
+++ b/src/fingerprint.test.ts
@@ -4,11 +4,13 @@ import {
   MAX_HAMMING_DISTANCE,
   MIN_NORMALIZED_CHARS,
   findCrossListing,
+  fromDbBigInt,
   hamming64,
   isNearDuplicate,
   normalizeJdText,
   normalizedLength,
   simhash64,
+  toDbBigInt,
 } from './fingerprint';
 
 /** A body comfortably over the guard, built from varied prose. */
@@ -122,6 +124,35 @@ test('hamming64 counts differing bits', () => {
   assert.equal(hamming64(0n, 0n), 0);
   assert.equal(hamming64(0b1011n, 0b1001n), 1);
   assert.equal(hamming64(0n, 0xffffffffffffffffn), 64);
+});
+
+test('a top-bit fingerprint survives the signed BIGINT round trip', () => {
+  // Postgres BIGINT is signed: this value is what Prisma refused outright
+  // before the conversion existed.
+  const hash = 13153543119183686648n;
+  const stored = toDbBigInt(hash)!;
+  assert.ok(stored < 0n, 'expected the signed form to be negative');
+  assert.ok(stored >= -(2n ** 63n) && stored < 2n ** 63n, 'must fit in BIGINT');
+  assert.equal(fromDbBigInt(stored), hash);
+  assert.equal(toDbBigInt(null), null);
+  assert.equal(fromDbBigInt(null), null);
+});
+
+test('hamming64 is correct across the signed/unsigned boundary', () => {
+  const a = 13153543119183686648n;
+  const b = a ^ 0b1011n; // three bits apart
+  assert.equal(hamming64(a, b), 3);
+  // Same answer when either side arrives in its stored signed form.
+  assert.equal(hamming64(toDbBigInt(a)!, b), 3);
+  assert.equal(hamming64(toDbBigInt(a)!, toDbBigInt(b)!), 3);
+});
+
+test('findCrossListing matches candidates stored in signed form', () => {
+  const hash = 13153543119183686648n;
+  const candidates = [
+    { id: 5, companyId: 2, descriptionSimhash: toDbBigInt(hash) },
+  ];
+  assert.equal(findCrossListing(hash, 1, candidates)?.job.id, 5);
 });
 
 test('findCrossListing ignores the same company and picks the closest', () => {

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -113,19 +113,6 @@ export function hamming64(a: bigint, b: bigint): number {
   return bits;
 }
 
-/**
- * Do two fingerprints describe the same posting? A missing fingerprint is not
- * a match — "we could not tell" must never read as "duplicate".
- */
-export function isNearDuplicate(
-  a: bigint | null | undefined,
-  b: bigint | null | undefined,
-  maxDistance: number = MAX_HAMMING_DISTANCE,
-): boolean {
-  if (a === null || a === undefined || b === null || b === undefined) return false;
-  return hamming64(a, b) <= maxDistance;
-}
-
 export interface FingerprintedJob {
   id: number;
   companyId: number;

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -1,0 +1,143 @@
+/**
+ * Content fingerprints for near-duplicate job descriptions (SimHash over
+ * 3-token shingles). Pure — no DB, no HTTP, no config.
+ *
+ * Constants below were measured on our own corpus, not guessed; the evidence
+ * and the failure they prevent are in ADR 0018.
+ */
+
+import { createHash } from 'node:crypto';
+
+/**
+ * A body shorter than this carries no role-specific signal. Jobicy ships
+ * truncated teasers (normalized max 284 chars) that are byte-identical across
+ * different roles at one company; sources with real bodies start around 550.
+ */
+export const MIN_NORMALIZED_CHARS = 400;
+
+/** Shingle width. Three tokens is enough context that common phrases
+ *  ("we are looking for") stop dominating the vote. */
+const SHINGLE_TOKENS = 3;
+
+/**
+ * Bits that may differ before two bodies stop counting as the same posting.
+ * Every cross-company match up to 7 in our corpus was a genuine cross-listing;
+ * the first false positive appears at 10.
+ */
+export const MAX_HAMMING_DISTANCE = 7;
+
+const HTML_TAG = /<[^>]+>/g;
+const HTML_ENTITY = /&(?:#x?[0-9a-f]+|[a-z]+);/gi;
+const URL_LIKE = /https?:\/\/\S+|www\.\S+/gi;
+/** Letters, marks and digits in any script — never `[a-z0-9]`, which would
+ *  reduce a Cyrillic or CJK body to nothing. */
+const TOKEN = /[\p{L}\p{M}\p{N}]+/gu;
+
+/**
+ * JD body → comparable tokens. Markup, entities and URLs are noise that
+ * differs between two copies of the same posting, so they go first.
+ */
+export function normalizeJdText(text: string | null | undefined): string[] {
+  if (typeof text !== 'string' || text.length === 0) return [];
+  const stripped = text
+    .toLowerCase()
+    .replace(HTML_TAG, ' ')
+    .replace(HTML_ENTITY, ' ')
+    .replace(URL_LIKE, ' ')
+    .normalize('NFKC');
+  return stripped.match(TOKEN) ?? [];
+}
+
+/** Length of the normalized body, counting one separator per token. */
+export function normalizedLength(tokens: readonly string[]): number {
+  let total = 0;
+  for (const t of tokens) total += t.length + 1;
+  return total;
+}
+
+/**
+ * 64-bit SimHash: hash every 3-token shingle, let each shingle vote once per
+ * bit, and keep the majority. Returns null when the body is too short or too
+ * thin to fingerprint — a null never matches anything, which is the safe
+ * direction.
+ */
+export function simhash64(text: string | null | undefined): bigint | null {
+  const tokens = normalizeJdText(text);
+  if (tokens.length < SHINGLE_TOKENS) return null;
+  if (normalizedLength(tokens) < MIN_NORMALIZED_CHARS) return null;
+
+  const votes = new Int32Array(64);
+  for (let i = 0; i + SHINGLE_TOKENS <= tokens.length; i++) {
+    const shingle = tokens.slice(i, i + SHINGLE_TOKENS).join(' ');
+    const digest = createHash('sha1').update(shingle).digest();
+    // First 8 bytes of the digest are the shingle's 64-bit hash.
+    for (let bit = 0; bit < 64; bit++) {
+      const byte = digest[bit >> 3] ?? 0;
+      const isSet = (byte >> (bit & 7)) & 1;
+      votes[bit] = (votes[bit] ?? 0) + (isSet ? 1 : -1);
+    }
+  }
+
+  let hash = 0n;
+  for (let bit = 0; bit < 64; bit++) {
+    if ((votes[bit] ?? 0) > 0) hash |= 1n << BigInt(bit);
+  }
+  return hash;
+}
+
+/** Number of differing bits between two fingerprints. */
+export function hamming64(a: bigint, b: bigint): number {
+  let diff = a ^ b;
+  let bits = 0;
+  while (diff !== 0n) {
+    diff &= diff - 1n;
+    bits++;
+  }
+  return bits;
+}
+
+/**
+ * Do two fingerprints describe the same posting? A missing fingerprint is not
+ * a match — "we could not tell" must never read as "duplicate".
+ */
+export function isNearDuplicate(
+  a: bigint | null | undefined,
+  b: bigint | null | undefined,
+  maxDistance: number = MAX_HAMMING_DISTANCE,
+): boolean {
+  if (a === null || a === undefined || b === null || b === undefined) return false;
+  return hamming64(a, b) <= maxDistance;
+}
+
+export interface FingerprintedJob {
+  id: number;
+  companyId: number;
+  descriptionSimhash: bigint | null;
+}
+
+/**
+ * Closest cross-company near-duplicate of `fingerprint`, or null. Same-company
+ * rows are skipped by design: at this threshold a quarter of them are
+ * genuinely different roles sharing a company's boilerplate, and reposts are
+ * F11's problem (ADR 0018).
+ */
+export function findCrossListing(
+  fingerprint: bigint | null,
+  companyId: number,
+  candidates: readonly FingerprintedJob[],
+  maxDistance: number = MAX_HAMMING_DISTANCE,
+): { job: FingerprintedJob; distance: number } | null {
+  if (fingerprint === null) return null;
+
+  let best: { job: FingerprintedJob; distance: number } | null = null;
+  for (const candidate of candidates) {
+    if (candidate.companyId === companyId) continue;
+    if (candidate.descriptionSimhash === null) continue;
+    const distance = hamming64(fingerprint, candidate.descriptionSimhash);
+    if (distance > maxDistance) continue;
+    if (best === null || distance < best.distance) {
+      best = { job: candidate, distance };
+    }
+  }
+  return best;
+}

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -85,9 +85,26 @@ export function simhash64(text: string | null | undefined): bigint | null {
   return hash;
 }
 
-/** Number of differing bits between two fingerprints. */
+/**
+ * Postgres `BIGINT` is **signed**, so a fingerprint with the top bit set does
+ * not fit as-is — Prisma rejects it outright. These two reinterpret the same
+ * 64 bits across that boundary; they are not a lossy conversion.
+ */
+export function toDbBigInt(hash: bigint | null): bigint | null {
+  return hash === null ? null : BigInt.asIntN(64, hash);
+}
+
+export function fromDbBigInt(value: bigint | null): bigint | null {
+  return value === null ? null : BigInt.asUintN(64, value);
+}
+
+/**
+ * Number of differing bits between two fingerprints. Masked to 64 bits so it
+ * is correct whether the caller passes the signed form read back from the
+ * database or the unsigned form `simhash64` returns.
+ */
 export function hamming64(a: bigint, b: bigint): number {
-  let diff = a ^ b;
+  let diff = BigInt.asUintN(64, a ^ b);
   let bits = 0;
   while (diff !== 0n) {
     diff &= diff - 1n;
@@ -121,15 +138,15 @@ export interface FingerprintedJob {
  * genuinely different roles sharing a company's boilerplate, and reposts are
  * F11's problem (ADR 0018).
  */
-export function findCrossListing(
+export function findCrossListing<T extends FingerprintedJob>(
   fingerprint: bigint | null,
   companyId: number,
-  candidates: readonly FingerprintedJob[],
+  candidates: readonly T[],
   maxDistance: number = MAX_HAMMING_DISTANCE,
-): { job: FingerprintedJob; distance: number } | null {
+): { job: T; distance: number } | null {
   if (fingerprint === null) return null;
 
-  let best: { job: FingerprintedJob; distance: number } | null = null;
+  let best: { job: T; distance: number } | null = null;
   for (const candidate of candidates) {
     if (candidate.companyId === companyId) continue;
     if (candidate.descriptionSimhash === null) continue;

--- a/src/jobs/fetch-job.ts
+++ b/src/jobs/fetch-job.ts
@@ -68,6 +68,7 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     alerted: 0,
     alertFailed: 0,
     priorityBoosted: 0,
+    crossListed: 0,
   };
   await processNormalizedJobs(fetched, profile, classifierMode, inner);
 

--- a/src/jobs/hn-hiring-job.ts
+++ b/src/jobs/hn-hiring-job.ts
@@ -90,6 +90,7 @@ export async function runHnHiringJob(): Promise<{ stats: CronStats }> {
     alerted: 0,
     alertFailed: 0,
     priorityBoosted: 0,
+    crossListed: 0,
   };
   await processNormalizedJobs(items, profile, settings.classifierMode, inner);
 

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -7,7 +7,13 @@ import { passesBaseFilter } from '../filter';
 import { classifyJob } from '../classifier';
 import { sendTelegramAlert } from '../notifier';
 import { applyPriorityFloor, parsePriorityRules } from '../priority-rules';
-import { findCrossListing, simhash64, type FingerprintedJob } from '../fingerprint';
+import {
+  findCrossListing,
+  fromDbBigInt,
+  simhash64,
+  toDbBigInt,
+  type FingerprintedJob,
+} from '../fingerprint';
 
 export { applyPriorityFloor };
 import type {
@@ -269,11 +275,12 @@ function decideDismissReason(
 /** Fingerprints from the dedup window, oldest first. */
 async function loadRecentFingerprints(): Promise<FingerprintedJob[]> {
   const since = new Date(Date.now() - DEDUP_WINDOW_DAYS * 24 * 60 * 60 * 1000);
-  return prisma.job.findMany({
+  const rows = await prisma.job.findMany({
     where: { fetchedAt: { gte: since }, descriptionSimhash: { not: null } },
     select: { id: true, companyId: true, descriptionSimhash: true },
     orderBy: { fetchedAt: 'asc' },
   });
+  return rows.map((r) => ({ ...r, descriptionSimhash: fromDbBigInt(r.descriptionSimhash) }));
 }
 
 /** Company of an already-stored job — only read when a cross-listing hits, so
@@ -300,7 +307,7 @@ function buildJobData(
 ): Prisma.JobCreateInput {
   return {
     company: { connect: { id: job.companyId } },
-    descriptionSimhash: dedup.descriptionSimhash,
+    descriptionSimhash: toDbBigInt(dedup.descriptionSimhash),
     ...(dedup.crossListedOfJobId !== null && {
       crossListedOf: { connect: { id: dedup.crossListedOfJobId } },
     }),

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -7,6 +7,7 @@ import { passesBaseFilter } from '../filter';
 import { classifyJob } from '../classifier';
 import { sendTelegramAlert } from '../notifier';
 import { applyPriorityFloor, parsePriorityRules } from '../priority-rules';
+import { findCrossListing, simhash64, type FingerprintedJob } from '../fingerprint';
 
 export { applyPriorityFloor };
 import type {
@@ -31,7 +32,11 @@ export interface ProcessStats {
   alerted: number;
   alertFailed: number;
   priorityBoosted: number;
+  crossListed: number;
 }
+
+/** How far back the cross-listing scan looks. */
+const DEDUP_WINDOW_DAYS = 90;
 
 /**
  * Shared inner loop used by runFetchJob and runHnHiringJob: filter, dedupe,
@@ -63,6 +68,12 @@ export async function processNormalizedJobs(
     seen.add(key);
     candidates.push(item);
   }
+
+  // Fingerprints of everything ingested in the dedup window, read once for
+  // the whole batch. Cross-listing is an annotation, so this never changes
+  // which jobs get classified (ADR 0018).
+  const recentFingerprints =
+    candidates.length > 0 ? await loadRecentFingerprints() : [];
 
   // Classify up to AI_CONCURRENCY jobs at once; results are consumed in the
   // original order, so persisting and alerting stay sequential and ordered.
@@ -109,15 +120,44 @@ export async function processNormalizedJobs(
     const finalClassification = priority.classification;
     const appliedLabels = priority.applied.map((r) => r.label);
 
+    const fingerprint = simhash64(job.description);
+    const crossListing = findCrossListing(
+      fingerprint,
+      job.companyId,
+      recentFingerprints,
+    );
+    if (crossListing) {
+      stats.crossListed++;
+      logger.info(
+        {
+          title: job.title,
+          companyName,
+          originalJobId: crossListing.job.id,
+          distance: crossListing.distance,
+        },
+        'process-jobs: cross-listed posting',
+      );
+    }
+    const dedup = {
+      descriptionSimhash: fingerprint,
+      crossListedOfJobId: crossListing?.job.id ?? null,
+    };
+
     const dismissReason = decideDismissReason(finalClassification, profile);
     if (dismissReason) {
-      await prisma.job.create({
+      const dismissed = await prisma.job.create({
         data: buildJobData(
           job,
           finalClassification,
           JobStatus.DISMISSED,
           appliedLabels,
+          dedup,
         ),
+      });
+      recentFingerprints.push({
+        id: dismissed.id,
+        companyId: job.companyId,
+        descriptionSimhash: fingerprint,
       });
       stats.persisted++;
       stats.dismissed++;
@@ -134,7 +174,18 @@ export async function processNormalizedJobs(
     }
 
     const created = await prisma.job.create({
-      data: buildJobData(job, finalClassification, JobStatus.NEW, appliedLabels),
+      data: buildJobData(
+        job,
+        finalClassification,
+        JobStatus.NEW,
+        appliedLabels,
+        dedup,
+      ),
+    });
+    recentFingerprints.push({
+      id: created.id,
+      companyId: job.companyId,
+      descriptionSimhash: fingerprint,
     });
     stats.persisted++;
 
@@ -151,6 +202,9 @@ export async function processNormalizedJobs(
           techMatch: created.techMatch,
           redFlags: created.redFlags,
           summary: created.summary ?? '',
+          crossListedAt: crossListing
+            ? await companyNameOfJob(crossListing.job.id)
+            : null,
         },
         profile,
       );
@@ -212,14 +266,44 @@ function decideDismissReason(
   return null;
 }
 
+/** Fingerprints from the dedup window, oldest first. */
+async function loadRecentFingerprints(): Promise<FingerprintedJob[]> {
+  const since = new Date(Date.now() - DEDUP_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  return prisma.job.findMany({
+    where: { fetchedAt: { gte: since }, descriptionSimhash: { not: null } },
+    select: { id: true, companyId: true, descriptionSimhash: true },
+    orderBy: { fetchedAt: 'asc' },
+  });
+}
+
+/** Company of an already-stored job — only read when a cross-listing hits, so
+ *  the window scan itself stays a two-column read. */
+async function companyNameOfJob(jobId: number): Promise<string | null> {
+  const row = await prisma.job.findUnique({
+    where: { id: jobId },
+    select: { company: { select: { name: true } } },
+  });
+  return row?.company.name ?? null;
+}
+
+interface DedupData {
+  descriptionSimhash: bigint | null;
+  crossListedOfJobId: number | null;
+}
+
 function buildJobData(
   job: NormalizedJob,
   c: ClaudeClassification,
   status: JobStatus,
   priorityRulesApplied: string[],
+  dedup: DedupData,
 ): Prisma.JobCreateInput {
   return {
     company: { connect: { id: job.companyId } },
+    descriptionSimhash: dedup.descriptionSimhash,
+    ...(dedup.crossListedOfJobId !== null && {
+      crossListedOf: { connect: { id: dedup.crossListedOfJobId } },
+    }),
     externalId: job.externalId,
     title: job.title,
     url: job.url,

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   escapeMarkdownV2,
   escapeMarkdownV2Url,
+  formatJobMessage,
   formatSalary,
 } from './notifier';
 
@@ -75,5 +76,36 @@ describe('escapeMarkdownV2Url', () => {
       escapeMarkdownV2Url('https://example.com/a\\b'),
       'https://example.com/a\\\\b',
     );
+  });
+});
+
+describe('formatJobMessage', () => {
+  const base = {
+    title: 'Senior Engineer',
+    companyName: 'Acme',
+    location: 'Remote',
+    url: 'https://example.com/jobs/1',
+    fitScore: 88,
+    salaryMin: null,
+    salaryMax: null,
+    techMatch: [],
+    redFlags: [],
+    summary: '',
+  };
+
+  it('omits the cross-listing line when there is none', () => {
+    assert.equal(formatJobMessage(base).includes('Also listed at'), false);
+    assert.equal(
+      formatJobMessage({ ...base, crossListedAt: null }).includes('Also listed at'),
+      false,
+    );
+  });
+
+  it('escapes the cross-listed company name', () => {
+    // Parentheses, dots and hyphens all need escaping in MarkdownV2 — an
+    // unescaped one makes Telegram reject the entire message.
+    const msg = formatJobMessage({ ...base, crossListedAt: 'Acme (US) Inc. - Jobs' });
+    assert.match(msg, /Also listed at Acme \\\(US\\\) Inc\\\. \\- Jobs/);
+    assert.match(msg, /apply through one channel only/);
   });
 });

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -160,6 +160,11 @@ function formatJobMessage(job: AlertJob): string {
   if (job.redFlags.length > 0) {
     lines.push(`⚠️ Flags: ${escapeMarkdownV2(job.redFlags.join(', '))}`);
   }
+  if (job.crossListedAt) {
+    lines.push(
+      `🔁 Also listed at ${escapeMarkdownV2(job.crossListedAt)} — apply through one channel only`,
+    );
+  }
   if (job.summary) {
     lines.push(`_${escapeMarkdownV2(job.summary)}_`);
   }

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -144,7 +144,9 @@ async function deliverToTarget(
   }
 }
 
-function formatJobMessage(job: AlertJob): string {
+/** Pure — exported so the MarkdownV2 escaping can be unit-tested; Telegram
+ *  rejects a whole message on a single unescaped special character. */
+export function formatJobMessage(job: AlertJob): string {
   const lines: string[] = [];
   lines.push(`*New role match — fit ${job.fitScore}/100*`);
   lines.push(

--- a/src/scripts/backfill-fingerprints.ts
+++ b/src/scripts/backfill-fingerprints.ts
@@ -1,0 +1,102 @@
+import { logger } from '../logger';
+import { prisma } from '../db';
+import { findCrossListing, simhash64, toDbBigInt } from '../fingerprint';
+
+/*
+ * One-shot backfill for F3 (ADR 0018): fingerprint every stored description
+ * and link the cross-company near-duplicates that are already in the table.
+ * Without it the feature only sees jobs fetched from now on.
+ *
+ * Annotation only — no row is merged, hidden or deleted, and an existing
+ * crossListedOfJobId is never overwritten. Safe to re-run.
+ *
+ * Usage: node dist/scripts/backfill-fingerprints.js [--dry-run]
+ */
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main(): Promise<void> {
+  const jobs = await prisma.job.findMany({
+    select: {
+      id: true,
+      companyId: true,
+      title: true,
+      description: true,
+      crossListedOfJobId: true,
+      company: { select: { name: true } },
+    },
+    // Oldest first: a duplicate points at the posting we saw first.
+    orderBy: { fetchedAt: 'asc' },
+  });
+
+  const scanned: Array<{
+    id: number;
+    companyId: number;
+    descriptionSimhash: bigint | null;
+    title: string;
+    companyName: string;
+  }> = [];
+  let fingerprinted = 0;
+  let skipped = 0;
+  let linked = 0;
+
+  for (const job of jobs) {
+    const fingerprint = simhash64(job.description);
+    if (fingerprint === null) skipped++;
+    else fingerprinted++;
+
+    const match =
+      job.crossListedOfJobId === null
+        ? findCrossListing(fingerprint, job.companyId, scanned)
+        : null;
+
+    // Computed outside the dry-run branch on purpose: a value the database
+    // would reject must fail the dry run too.
+    const stored = toDbBigInt(fingerprint);
+    if (!DRY_RUN) {
+      await prisma.job.update({
+        where: { id: job.id },
+        data: {
+          descriptionSimhash: stored,
+          ...(match && { crossListedOfJobId: match.job.id }),
+        },
+      });
+    }
+
+    if (match) {
+      linked++;
+      logger.info(
+        {
+          jobId: job.id,
+          title: job.title,
+          company: job.company.name,
+          originalJobId: match.job.id,
+          originalTitle: match.job.title,
+          originalCompany: match.job.companyName,
+          distance: match.distance,
+        },
+        'backfill-fingerprints: cross-listing',
+      );
+    }
+
+    scanned.push({
+      id: job.id,
+      companyId: job.companyId,
+      descriptionSimhash: fingerprint,
+      title: job.title,
+      companyName: job.company.name,
+    });
+  }
+
+  logger.info(
+    { total: jobs.length, fingerprinted, skipped, linked, dryRun: DRY_RUN },
+    'backfill-fingerprints: done',
+  );
+}
+
+main()
+  .catch((err) => {
+    logger.error({ err }, 'backfill-fingerprints: failed');
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/text-utils.test.ts
+++ b/src/text-utils.test.ts
@@ -2,6 +2,9 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   daysSince,
+  feedItemKey,
+  normalizeTextKey,
+  normalizeUrlKey,
   decideStageStrategy,
   extractAtsToken,
   extractJson,
@@ -326,4 +329,57 @@ describe('daysSince', () => {
   it('returns 15 for 15 days', () => {
     assert.equal(daysSince(new Date('2026-04-12T12:00:00Z'), NOW), 15);
   });
+});
+
+describe('url and text keys', () => {
+  it('normalizeUrlKey strips tracking params but keeps functional ones', () => {
+  assert.equal(
+    normalizeUrlKey('https://job-boards.greenhouse.io/acme/jobs/42?gh_jid=42&utm_source=x&gh_src=abc'),
+    'job-boards.greenhouse.io/acme/jobs/42?gh_jid=42',
+  );
+  assert.equal(
+    normalizeUrlKey('http://block.xyz/careers/jobs/5367290008?gh_jid=5367290008'),
+    'block.xyz/careers/jobs/5367290008?gh_jid=5367290008',
+  );
+  });
+
+  it('normalizeUrlKey folds away differences that do not identify a posting', () => {
+  const canonical = normalizeUrlKey('https://Example.com/jobs/7/?b=2&a=1');
+  assert.equal(canonical, 'example.com/jobs/7?a=1&b=2');
+  // Same posting, different ordering, trailing slash, fragment and campaign.
+  assert.equal(normalizeUrlKey('https://example.com/jobs/7?a=1&b=2#apply'), canonical);
+  assert.equal(normalizeUrlKey('https://example.com/jobs/7?utm_medium=cpc&b=2&a=1'), canonical);
+  });
+
+  it('normalizeUrlKey returns null for junk, never an empty string', () => {
+  for (const junk of ['', '   ', 'n/a', 'N/A', 'javascript:alert(1)', null, undefined]) {
+    assert.equal(normalizeUrlKey(junk), null, `expected null for ${JSON.stringify(junk)}`);
+  }
+  });
+
+  it('normalizeTextKey keeps non-Latin names distinct', () => {
+  assert.equal(normalizeTextKey('  Acme,  Inc. '), 'acme inc');
+  assert.notEqual(normalizeTextKey('Розробник'), normalizeTextKey('Дизайнер'));
+  assert.equal(normalizeTextKey('Розробник'), 'розробник');
+  assert.equal(normalizeTextKey('株式会社テスト'), '株式会社テスト');
+  // Precomposed letters survive: NFKC must not decompose-then-strip.
+  assert.equal(normalizeTextKey('Żółć ėė'), 'żółć ėė');
+  assert.equal(normalizeTextKey('!!!'), null);
+  assert.equal(normalizeTextKey(''), null);
+  });
+
+  it('feedItemKey prefers the URL and falls back to text', () => {
+  const withUrl = feedItemKey('https://example.com/jobs/7?utm_source=x', 'Title', 'Acme');
+  assert.equal(withUrl, feedItemKey('https://example.com/jobs/7', 'Different', 'Names'));
+  const fromText = feedItemKey('', 'Backend Engineer', 'Acme');
+  assert.equal(fromText, feedItemKey(null, 'backend  engineer!', 'ACME'));
+  assert.notEqual(fromText, withUrl);
+  });
+
+  it('feedItemKey returns null when nothing identifies the row', () => {
+  assert.equal(feedItemKey('', '', ''), null);
+  assert.equal(feedItemKey(null, null), null);
+  assert.equal(feedItemKey('n/a', '!!!'), null);
+  });
+
 });

--- a/src/text-utils.ts
+++ b/src/text-utils.ts
@@ -14,6 +14,85 @@ export function hashShortId(input: string): string {
 }
 
 /**
+ * Query parameters that identify a *campaign*, not a posting. Two links that
+ * differ only here are the same job, so they must hash to the same id.
+ * Literal names (plus the `utm_` family) — never a broad pattern, which would
+ * eventually eat a functional parameter like Greenhouse's `gh_jid`.
+ */
+const TRACKING_PARAMS = new Set([
+  'gh_src',
+  'fbclid',
+  'gclid',
+  'mc_cid',
+  'mc_eid',
+  '_hsenc',
+  '_hsmi',
+  'trk',
+  'trkCampaign',
+  'ref',
+  'source',
+]);
+
+/**
+ * A URL reduced to what identifies the posting: no tracking parameters, no
+ * fragment, lower-cased host, sorted query. Returns **null** — never `''` —
+ * for junk, so callers cannot collapse unrelated rows onto one shared key.
+ */
+export function normalizeUrlKey(input: string | null | undefined): string | null {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return null;
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+  const kept = [...url.searchParams.entries()]
+    .filter(([k]) => !TRACKING_PARAMS.has(k) && !k.toLowerCase().startsWith('utm_'))
+    // Sorted so two orderings of the same parameters agree.
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+  const query = kept.map(([k, v]) => `${k}=${v}`).join('&');
+  const path = url.pathname.replace(/\/+$/, '');
+  return `${url.host.toLowerCase()}${path}${query ? `?${query}` : ''}`;
+}
+
+/**
+ * Free text reduced to a comparable key. NFKC then letters/marks/digits in
+ * **any** script — an ASCII-only strip would map every Cyrillic or CJK
+ * company name to the empty string and collide them all. Null for junk.
+ */
+export function normalizeTextKey(input: string | null | undefined): string | null {
+  if (typeof input !== 'string') return null;
+  const tokens = input.normalize('NFKC').toLowerCase().match(/[\p{L}\p{M}\p{N}]+/gu);
+  if (!tokens || tokens.length === 0) return null;
+  return tokens.join(' ');
+}
+
+/**
+ * Stable externalId for a feed row that carries no id of its own: the
+ * normalized URL if there is one, else title + company. Null when neither
+ * yields anything — the caller must skip the row rather than hash `''`,
+ * which would merge every junk row into one.
+ */
+export function feedItemKey(
+  url: string | null | undefined,
+  ...textParts: Array<string | null | undefined>
+): string | null {
+  const urlKey = normalizeUrlKey(url);
+  if (urlKey !== null) return hashShortId(urlKey);
+  const text = textParts
+    .map((p) => normalizeTextKey(p))
+    .filter((p): p is string => p !== null)
+    .join('|');
+  return text.length > 0 ? hashShortId(text) : null;
+}
+
+/**
  * Parses a textarea value into a list of trimmed tags. Accepts both newline
  * and comma separators. Empty entries are dropped.
  */

--- a/src/text-utils.ts
+++ b/src/text-utils.ts
@@ -29,8 +29,6 @@ const TRACKING_PARAMS = new Set([
   '_hsmi',
   'trk',
   'trkCampaign',
-  'ref',
-  'source',
 ]);
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,4 +38,6 @@ export interface AlertJob {
   techMatch: string[];
   redFlags: string[];
   summary: string;
+  /** Company this posting is also listed at (F3 cross-listing annotation). */
+  crossListedAt?: string | null;
 }

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -48,6 +48,15 @@ interface JobDetail {
   liveness: string | null;
   livenessCode: string | null;
   livenessCheckedAt: Date | null;
+  // F3 (ADR 0018): the same posting seen at another company's source.
+  crossListedOf: CrossListedJob | null;
+  crossListings: CrossListedJob[];
+}
+
+export interface CrossListedJob {
+  id: number;
+  title: string;
+  company: { name: string };
 }
 
 export interface JobDetailProps {
@@ -79,6 +88,7 @@ export const JobDetailPage: FC<JobDetailProps> = ({
   <Layout title={job.title} active="jobs">
     <PageHeaderBlock job={job} />
     <Flash flash={flash} />
+    <CrossListingNotice job={job} />
 
     <div class="grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_340px]">
       {/* Right rail first in DOM so facts and actions lead on small screens. */}
@@ -202,6 +212,39 @@ export const JobDetailPage: FC<JobDetailProps> = ({
     </div>
   </Layout>
 );
+
+/**
+ * "The same posting is also over there." Both directions are shown: the job
+ * this one duplicates, and later arrivals that duplicate it. Nothing is
+ * merged or hidden — the point is to stop you applying twice (ADR 0018).
+ */
+const CrossListingNotice: FC<{ job: JobDetail }> = ({ job }) => {
+  const others = [
+    ...(job.crossListedOf ? [job.crossListedOf] : []),
+    ...job.crossListings,
+  ];
+  if (others.length === 0) return null;
+  return (
+    <div class="mb-4 rounded-lg border border-warn/25 bg-warn/5 px-4 py-3 text-sm text-ink">
+      <p class="font-medium">
+        Also listed elsewhere — apply through one channel only
+      </p>
+      <ul class="mt-1.5 space-y-1 text-[13px] text-ink-muted">
+        {others.map((o) => (
+          <li>
+            <a
+              href={`/jobs/${o.id}`}
+              class="font-medium text-accent-strong transition-colors duration-150 hover:text-accent-deep"
+            >
+              {o.title}
+            </a>{' '}
+            at {o.company.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
 
 const PageHeaderBlock: FC<{ job: JobDetail }> = ({ job }) => (
   <header class="mb-5 shrink-0">

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -150,7 +150,17 @@ jobsRoute.get('/jobs/:id', async (c) => {
   const [job, settings, resumes, matches, verifications] = await Promise.all([
     prisma.job.findUnique({
       where: { id },
-      include: { company: { select: { id: true, name: true, atsType: true } } },
+      include: {
+        company: { select: { id: true, name: true, atsType: true } },
+        // F3: the posting this one near-duplicates, and any that
+        // near-duplicate it — the link is annotation only (ADR 0018).
+        crossListedOf: {
+          select: { id: true, title: true, company: { select: { name: true } } },
+        },
+        crossListings: {
+          select: { id: true, title: true, company: { select: { name: true } } },
+        },
+      },
     }),
     getSettings(),
     listResumes(),


### PR DESCRIPTION
F3 from [docs/feature-expansion-plan.md §4](docs/feature-expansion-plan.md).
A 64-bit SimHash over the job description spots the same posting arriving
through two sources, and annotates it: **"Also listed elsewhere — apply
through one channel only"** on `/jobs/:id` (both directions) and a line in the
Telegram alert. Nothing is merged, hidden or skipped.

## The measurement changed the design

The plan proposed two constants and one behaviour. All three were measured
against our 731 stored jobs before any code was written; two are wrong for our
data. Evidence in [ADR 0018](docs/adr/0018-simhash-annotates-never-merges.md).

**The 200-char guard sits just under our worst source.** Jobicy ships
truncated teasers (normalized 239 median, 284 max) containing only the company
blurb. Two different ClickUp roles — "Senior Backend Engineer" and "Staff
Backend Engineer, Hierarchy" — have byte-identical descriptions and distance
**0**. At a 200-char guard that is 24 false pairs; at **400** it is zero, and
no real body is lost (sources with content start ~550; HN_HIRING p10 = 779).
500 and 800 change nothing, so 400 sits mid-gap.

**Skipping same-company matches would silently drop real jobs.** 34 of 127
same-company matches at distance ≤ 5 (27%) are genuinely different roles
sharing boilerplate:

| Company | Roles matched | d |
|---|---|---|
| Affirm | Backend (Infrastructure) vs (Authentication) vs (PBA – Growth) | 5 |
| TaskRabbit | Support Advocate German vs Spanish vs Portuguese | 2–5 |
| Square | Field Sales Houston vs Los Angeles vs Orange County | 1–2 |

The plan's own acceptance criterion says "no data loss is possible by
construction", so the measurement resolves the contradiction against the
"skip" bullet. Same-company matches are left entirely to F11.

**The threshold is 7, not 5.** Every cross-company match up to 7 is genuine
(9/9), including the ones distance 5 splits apart — Lemon.io listed on
WeWorkRemotely + Remotive + RemoteOK, and Reddit's "Backend Software Engineer,
PDP Experience" on both WeWorkRemotely and Reddit's own Greenhouse board. The
first false positive appears at **10** (Proxify's React role vs its Python
role), leaving a two-bit margin. Error costs are asymmetric the same way: a
wrong annotation is a confusing note, a missed one is applying twice.

## What the backfill found in the existing corpus

`backfill-fingerprints.js` fingerprinted 648 of 732 rows (84 under the guard)
and linked **6 cross-listings**, every one genuine:

- Lemon.io — WeWorkRemotely + RemoteOK + Remotive (3-way)
- Reddit — WeWorkRemotely ↔ Reddit's own Greenhouse board
- Newrich Network — a job you pasted by hand ↔ WeWorkRemotely
- Slate Magazine ↔ Supporting Cast (same JD, related companies)

## A bug the dry-run hid

Postgres `BIGINT` is **signed**, so a fingerprint with the top bit set is
rejected outright by Prisma — it would have failed on the first fetch tick.
The `--dry-run` missed it because it skipped the write. Fixed with
`toDbBigInt`/`fromDbBigInt` at the persistence boundary (`hamming64` masks to
64 bits so it is correct on either form), and the dry-run now computes the
stored value so a conversion bug cannot hide there again.

## Also in this branch: URL-key discipline

`normalizeUrlKey` drops tracking parameters (literal denylist + the `utm_`
family) and keeps functional ones — `gh_jid` is a posting id on some Greenhouse
boards. `normalizeTextKey` is NFKC over any script, never `[a-z0-9]`, which
would map every Cyrillic or CJK name to `''` and collide them. `feedItemKey`
returns **null** rather than hashing `''`, and the five fetchers that
synthesise an id now skip a row nothing identifies.

Honest scope note: this fixes nothing observable today — **no stored job has a
tracking parameter**, and no stored `externalId` came from the hash path, so
the change re-ingests nothing. It is preventive hardening ahead of F10's VC
boards.

## Verification

- `lint:types` + `npm test` green — **524 tests**, 24 new (fingerprint,
  URL/text keys, alert formatting, mapper skip cases).
- Migration applied in the app container from the real init path
  (`prisma migrate deploy`), columns + FK + index confirmed in psql.
- Backfill: dry-run → real run → **re-run links 0** (idempotent), 6 links stand.
- `/jobs/:id` shows the notice in both directions (duplicate → original and
  original → duplicate); screenshots 1200 px + 375 px; 0 console errors; no
  horizontal page scroll at 375.
- One live fetch tick through the new ingest path: 3340 fetched, 231
  duplicates, 0 classified, `crossListed: 0` — clean, and no AI spend.

**Not verified:** no new job arrived in that tick, so the per-job fingerprint
branch inside `process-jobs` has not run against live data. It is covered by
unit tests and by the backfill exercising the same `simhash64` →
`findCrossListing` → `toDbBigInt` path on all 732 rows.

**Note on your environment:** verifying the migration meant rebuilding the
`app` container from this branch, so your worker is already running this code
and its cron will fetch on schedule. The backfill has also been run for real —
annotation only, reversible with
`UPDATE "Job" SET "crossListedOfJobId" = NULL, "descriptionSimhash" = NULL;`

## Follow-ups (not in this PR)

- **P2** Skipping the duplicate's paid classification (the plan's flagged
  decision point) stays deferred: precision is 100% but on nine pairs, and
  inheriting a verdict on a wrong match would dismiss a real job. Revisit once
  the annotations have run long enough to measure.
- **P3** The constants are tuned on a corpus that is 75% Greenhouse; starter
  packs (F14) are about to widen it — re-measure when the mix changes.
- **P3** The 90-day scan compares against every fingerprint in the window
  (~700 rows today, microseconds). The plan's banded index on hash quarters is
  deferred until a timing shows it matters.
- **P3** `findCrossListing` is O(new × window); at 10k+ jobs per window this
  is worth timing before it becomes the answer to "why is the tick slow".

## Release notes

```
## What's new
- The same job arriving from two sources is now spotted by a content fingerprint and flagged: "Also listed elsewhere — apply through one channel only" on the job page and in the Telegram alert
- Nothing is merged or hidden — both rows stay, so a wrong flag costs a note and nothing else
- Backfill script fingerprints existing jobs and links what it finds (6 real cross-listings in the current 732)
- Feed rows that nothing identifies are skipped instead of sharing one synthesised id; tracking parameters no longer change a job's id

## Schema
- Job.descriptionSimhash (BIGINT, nullable), Job.crossListedOfJobId (nullable self-FK, ON DELETE SET NULL), index on (fetchedAt, descriptionSimhash) — additive

## Verification
- 524 unit tests green; migration applied via the container init path; backfill dry-run + real run + idempotent re-run; one live fetch tick; screenshots 1200/375, 0 console errors

## References
- ADR 0018 — cross-listing is annotated, never merged
- docs/feature-expansion-plan.md §4 (F3)
```

## After merge

```
git tag -a v0.6.0 -m "cross-source dedup" <merge-sha>
git push origin v0.6.0
```
