### PR TITLE
F4: source health monitoring (v0.7.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | HTML → plaintext (entities, paragraphs, bullets) | `src/http.ts:stripHtml` + `decodeHtmlEntities` (gotcha 12) |
 | Pure helpers (parsing, hashing, masking) | `src/text-utils.ts` |
 | Near-duplicate detection across sources (SimHash, Hamming) | `src/fingerprint.ts` (ADR 0018); wired in `jobs/process-jobs.ts` |
+| Per-source health (error→status, failure streak, quiet/silent) | `src/fetchers/source-health.ts` (pure, ADR 0019); recorded by the wrapper in `fetchers/index.ts:runAllFetchers` |
 | Stable id for a feed row with no id of its own | `src/text-utils.ts:feedItemKey` (URL key → text key → null, never `''`) |
 | The cron list (6 schedules) | `src/index.ts:registerCron` |
 | What runs on container boot | `src/init.ts` |
@@ -177,6 +178,8 @@ When the question is **"how does the user toggle / configure X?"**:
 | What | Page |
 | --- | --- |
 | Pause / resume all new-job fetching | `/settings` General tab → "Job fetching" |
+| See which boards stopped answering | `/companies` → "Quiet sources" card (Re-probe to repair) |
+| Telegram line when a source goes quiet | `/settings` Notifications tab → "Source health alerts" |
 | Pick / order AI engines + models, test them | `/settings` AI engine tab (per-engine cards: Enable, ↑ priority, model selects, Test) |
 | Add / remove tracked company | `/companies` (with manual probe before save) |
 | Bulk-add a curated segment of companies | `/companies` → "Add a starter pack" (preview → confirm → added disabled → "Enable all") |
@@ -287,6 +290,35 @@ a ZIP code, another highlighted a whole skills line containing Docker and
 GitLab CI/CD the posting wanted. Removals now carry two hard rules
 (PROTECTED contact line; KEEP WANTED KEYWORDS with itemised drop/keep
 lists) — guard test "removals rules protect the contact line".
+
+### 13. `empty` from a fetcher is not proof the board is alive
+
+Measured 2026-08-30 across all 71 active sources. Two failure modes hide
+behind a zero count, and a naive "no jobs = healthy" rule marks both green
+forever:
+
+- **7 of 10 per-company vendors `return []` on a malformed top-level
+  payload** (Workable, Recruitee, BambooHR, Pinpoint, Breezy, Rippling,
+  SmartRecruiters). Only Greenhouse / Lever / Ashby throw on shape drift.
+- **SmartRecruiters answers HTTP 200 with `totalFound: 0` for every
+  identifier** — `Visa`, `Bosch`, `IKEA`, and a random non-existent string
+  alike, under our UA and a browser UA. A dead slug there is byte-identical
+  to a live board.
+
+Hence ADR 0019 keeps two signals, not one: the failure streak (`ok` and
+`empty` reset it, everything else increments) *and* `lastOkAt`, which
+advances only on `ok`. A source stuck on `empty` ages into "silent" without
+ever touching the streak.
+
+Two related traps in the same area:
+
+- **Status must come from the RAW pre-filter count.** 46 of 65 active
+  companies hold zero `Job` rows — that is `passesBaseFilter` doing its job,
+  not a broken board. Reading health off stored jobs makes the feature noise.
+- **A timeout does not arrive as an `AbortError`.** `fetchWithRetry` rewrites
+  it into a plain `Error` whose only marker is the message
+  `… timed out after Nms`. And a dead BambooHR slug arrives as a *refused
+  redirect* (302 → `redirect: 'error'`), not a 404.
 
 ### 12. stripHtml: decode entities FIRST, and never re-run it on its own output
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -378,7 +378,19 @@ external project, copy-check before merge.
       positive at 10). The plan's "skip same-company matches" was dropped —
       27% of them are genuinely different roles. Annotation only; skipping
       the duplicate's paid classification stays deferred
-- [ ] F4 source health monitoring (quiet-source card) — v0.6.0
+- [x] F4 source health monitoring (quiet-source card) — v0.7.0
+      (branch `source-health`, ADR 0019). Tag is v0.7.0, not the plan's
+      v0.6.0: numbers follow actual integration order and F3 took v0.6.0.
+      Re-analysis on live data found two dead slugs already failing
+      silently (`GREENHOUSE:pleo`, `LEVER:plaid`) and killed the plan's
+      "empty is healthy" as a sufficient rule — SmartRecruiters returns
+      200 + `totalFound:0` for every id including Bosch and IKEA, and 7 of
+      10 vendors swallow a malformed payload into `[]`. So health carries
+      two signals (failure streak + `lastOkAt` silence) and the vocabulary
+      gained `rate_limit` and `bad_payload` (both observed live). Streak
+      >= 3 kept: fetch is hourly and the transient-failure base rate across
+      71 sources measured zero. ADR 0016's feed-vanish item: deferred
+      again, gate written down (list-completeness assertion)
 - [ ] F5 status-transition ledger + funnel/calibration stats — v0.7.0
 - [ ] F6 follow-up cadence with pin/retire/auto-seed in the stale digest — v0.8.0
 - [ ] F7 fact gate (anti-hallucination pure module) — v0.9.0

--- a/docs/adr/0016-liveness-ladder.md
+++ b/docs/adr/0016-liveness-ladder.md
@@ -48,7 +48,9 @@ one extra GET per user click does not change that posture.
 `state`, SR `active`) — a vendor changing payload shape degrades to
 `uncertain`, never to a wrong `expired`
 ❌ deferred: marking jobs `expired` when they vanish from a polled board
-feed (worker-side; design together with F4 source health)
+feed (worker-side; design together with F4 source health) — designed in
+[ADR 0019](./0019-source-health-streaks.md) and deferred again, with the
+gate written down there (list-completeness assertion)
 
 ## When to revisit
 

--- a/docs/adr/0019-source-health-streaks.md
+++ b/docs/adr/0019-source-health-streaks.md
@@ -1,0 +1,122 @@
+# 0019 — Source health is a per-company streak; `empty` resets it but does not prove health
+
+**Status:** Accepted (2026-08-30)
+
+## Context
+
+`runAllFetchers` catches every per-company error, logs it, and moves on.
+Nothing is persisted, so a rotated board slug is invisible forever — the
+row just stops contributing jobs. A read-only sweep of all 71 active
+sources on 2026-08-30 (`fetchOne` per company, raw pre-filter counts)
+found this already true in our own database:
+
+| Result | Count | Detail |
+|---|---|---|
+| jobs returned | 67 | healthy |
+| **HTTP 404** | **2** | `GREENHOUSE:pleo`, `LEVER:plaid` — deterministic, re-checked twice |
+| 0 postings, HTTP 200 | 2 | `ASHBY:niantic`, `SMARTRECRUITERS:Visa` |
+
+Two dead slugs had been failing silently. The error shapes that actually
+reach a caller of `fetchOne` were measured, not assumed:
+
+| Cause | Thrown value | Discriminator |
+|---|---|---|
+| dead slug (9 of 10 vendors) | `HttpError` | `.status` 404/410 |
+| gated board | `HttpError` | `.status` 401/403 |
+| Cloudflare rate limit (observed live on Workable) | `HttpError` | `.status` 429 |
+| vendor outage, after 2 retries | `HttpError` | `.status` >= 500 |
+| dead BambooHR slug (302 → `redirect: 'error'`) | `TypeError` | `cause.message = 'unexpected redirect'` |
+| dead host / DNS | `TypeError` | `cause.code = ENOTFOUND` |
+| refused connection | `TypeError` | `cause.code = ECONNREFUSED` |
+| timeout | plain `Error` | message `… timed out after Nms` — `fetchWithRetry` rewrites `AbortError`, so `err.name` is useless here |
+| payload shape change (Greenhouse/Lever/Ashby) | plain `Error` | message `… schema invalid …` |
+| payload shape change (7 other vendors) | **nothing — returns `[]`** | **invisible** |
+
+The last row is the reason `empty` cannot mean healthy. Confirmed live:
+`api.smartrecruiters.com/v1/companies/<id>/postings` answers HTTP 200 with
+`totalFound: 0` for *every* identifier tried — `Visa`, `Bosch`, `Ubisoft`,
+`IKEA`, and a random non-existent string alike, under both our UA and a
+browser UA. For SmartRecruiters a dead slug, a live board and a typo are
+byte-identical, and 7 of 10 vendors turn a malformed payload into the same
+`[]`. A single "failures" counter would mark all of that permanently
+healthy.
+
+## Decision
+
+Three additive columns on `Company`, written by a thin wrapper around
+`fetchOne` in `src/fetchers/index.ts`:
+
+```prisma
+lastFetchStatus     String?    // ok | empty | slug_gone | auth | rate_limit | server | network | bad_payload | unknown
+consecutiveFailures Int  @default(0)
+lastOkAt            DateTime?  // advances ONLY on ok
+```
+
+Two pure, unit-tested functions carry all the logic
+(`src/fetchers/source-health.ts`): `classifyFetchError(err)` implements the
+table above, and `nextStreak(status, current)` implements the streak.
+
+**The streak rule is inverted on purpose:** `ok` and `empty` reset to 0,
+**everything else increments** — including `unknown`. A new error kind added
+later cannot fall outside the streak by omission; the worst it can do is
+land in `unknown` and still be counted.
+
+**`lastOkAt` advances only on `ok`** (≥1 posting returned, pre-filter). That
+makes it a second, independent signal: a source stuck on `empty` — a
+SmartRecruiters slug that will never resolve, a vendor that quietly started
+returning `[]` — shows an ageing `lastOkAt` while its streak stays 0. The
+`/companies` "quiet sources" card therefore lists two kinds of row:
+**failing** (`consecutiveFailures >= 3`) and **silent** (`ok`/`empty` but no
+posting for 14 days). Both offer one-click re-probe via the existing
+`probeAts`.
+
+Status is recorded from the fetcher's **raw** return, before
+`passesBaseFilter`. 46 of 65 active companies currently hold zero `Job`
+rows — that is the profile filter, not source health, and conflating the
+two would make the whole feature noise.
+
+Thresholds are hypotheses measured where measurement was possible. `>= 3`
+is kept: fetch is hourly, so three ticks is three hours and nine HTTP
+attempts (`fetchWithRetry` already absorbs blips with two retries), and the
+observed transient-failure base rate across 71 sources is zero. The 14-day
+silence threshold could **not** be measured — `lastOkAt` has no history yet
+— so it is deliberately conservative and stated as unmeasured.
+
+Only the Telegram digest line is behind a toggle
+(`AppSettings.sourceHealthAlerts`, default on). The columns and the card
+are always-on: they add a signal, never suppress a job.
+
+## Consequences
+
+✅ a rotated slug surfaces on `/companies` within three hours instead of never
+✅ `unknown` is inside the streak, so an unmapped future error still escalates
+✅ `rate_limit` is labelled distinctly — a 429 never reads as "your slug is dead"
+✅ the two dead slugs above become visible on the first tick after deploy
+❌ SmartRecruiters can never report `slug_gone`; it degrades to the 14-day
+silence signal, which is the honest limit of what that API tells us
+❌ 7 vendors still swallow shape drift into `[]`; only the silence signal
+catches it, and only after 14 days
+❌ the silence threshold is a guess until `lastOkAt` accumulates history
+
+## Deferred (from ADR 0016), with the gate written down
+
+ADR 0016 deferred "marking jobs expired when they vanish from a polled board
+feed" to be designed together with this feature. Designed, and **deferred
+again** — the missing piece is not the health signal, which now exists, but
+**list completeness**: no fetcher can assert that a 200 response contained
+the whole board. Several cap pages by constant, and the SmartRecruiters
+observation above is a live example of a 200 that is silently empty. Under
+ADR 0016's asymmetry doctrine ("a false `expired` hides a live job forever")
+inferring death from absence in a possibly-truncated list is exactly the
+trade we refuse.
+
+Gate to land it: a fetcher-level completeness assertion (vendor `total`
+cross-checked against rows received) plus a `status = ok` guard, so
+truncation can never masquerade as vanishing.
+
+## When to revisit
+
+`lastOkAt` accumulates a few weeks of history — re-measure the 14-day
+silence threshold on the real distribution the way F3's constants were
+re-measured. Or SmartRecruiters' Posting API starts answering again, which
+would also un-break ADR 0016's rung-1 check for that vendor.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0016 — Job liveness via a free three-rung ladder before AI verify](./0016-liveness-ladder.md)
 - [0017 — Starter-pack entries pin a hand-verified board](./0017-starter-packs-pin-verified-boards.md)
 - [0018 — Cross-listing is annotated, never merged](./0018-simhash-annotates-never-merges.md)
+- [0019 — Source health is a per-company streak; `empty` resets it but does not prove health](./0019-source-health-streaks.md)
 
 ## When to write a new one
 

--- a/prisma/migrations/20260831170000_add_source_health/migration.sql
+++ b/prisma/migrations/20260831170000_add_source_health/migration.sql
@@ -1,0 +1,10 @@
+-- F4 (ADR 0019): per-source health — status vocabulary + failure streak.
+-- Additive only: every column is nullable or defaulted, so existing rows
+-- stay valid and a revert strands no data.
+ALTER TABLE "Company" ADD COLUMN "lastFetchStatus" TEXT;
+ALTER TABLE "Company" ADD COLUMN "consecutiveFailures" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "Company" ADD COLUMN "lastOkAt" TIMESTAMP(3);
+
+-- Digest line for sources that crossed the streak threshold (ADR 0019).
+-- Default TRUE: the alert adds a signal, it never suppresses a job.
+ALTER TABLE "AppSettings" ADD COLUMN "sourceHealthAlerts" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,19 @@ model Company {
   createdAt DateTime @default(now())
   jobs      Job[]
 
+  // F4 source health (ADR 0019). Written by the fetchOne wrapper from the
+  // RAW pre-filter result, so the profile filter can never look like a
+  // broken board. Status vocabulary: ok | empty | slug_gone | auth |
+  // rate_limit | server | network | bad_payload | unknown.
+  lastFetchStatus     String?
+  // Streak is inverted on purpose: ok and empty reset it, EVERYTHING else
+  // increments — an error kind added later cannot fall out of it silently.
+  consecutiveFailures Int       @default(0)
+  // Advances only on `ok` (>= 1 posting). An ageing lastOkAt on a reachable
+  // source is the second signal: SmartRecruiters answers 200 + totalFound:0
+  // for every id, so `empty` alone never proves a board is alive.
+  lastOkAt            DateTime?
+
   @@unique([atsType, atsToken])
 }
 
@@ -180,6 +193,9 @@ model AppSettings {
   // call (ai-runtime.ts:recordUsage), trimmed to 60 days by the cleanup
   // cron, summarized on /settings → AI engine.
   aiUsage                        Json?
+  // F4 (ADR 0019): one digest line when a source crosses the failure
+  // streak. Default TRUE — the alert adds a signal, never suppresses a job.
+  sourceHealthAlerts             Boolean  @default(true)
   updatedAt                      DateTime @updatedAt
 }
 

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -2,7 +2,7 @@ import { AtsType } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../logger';
 import { sleep } from '../http';
-import { getSettings } from '../settings';
+import { getSettings, toAtsTypes } from '../settings';
 import {
   QUIET_STREAK,
   classifyFetchCount,
@@ -43,9 +43,7 @@ export interface FetcherResult {
 
 export async function runAllFetchers(): Promise<FetcherResult[]> {
   const settings = await getSettings();
-  const disabled = settings.disabledSources.filter(
-    (s): s is AtsType => (Object.values(AtsType) as string[]).includes(s),
-  );
+  const disabled = toAtsTypes(settings.disabledSources);
   if (disabled.length > 0) {
     logger.info({ disabled }, 'fetchers: skipping disabled source families');
   }

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -3,6 +3,13 @@ import { prisma } from '../db';
 import { logger } from '../logger';
 import { sleep } from '../http';
 import { getSettings } from '../settings';
+import {
+  QUIET_STREAK,
+  classifyFetchCount,
+  classifyFetchError,
+  nextStreak,
+  type FetchStatus,
+} from './source-health';
 import { fetchGreenhouse } from './greenhouse';
 import { fetchLever } from './lever';
 import { fetchAshby } from './ashby';
@@ -54,25 +61,61 @@ export async function runAllFetchers(): Promise<FetcherResult[]> {
   const out: FetcherResult[] = [];
 
   for (const company of companies) {
+    let status: FetchStatus;
     try {
       const jobs = await fetchOne(company);
+      // Status comes from the RAW count, before passesBaseFilter — a profile
+      // that matches nothing is not a broken board (ADR 0019).
+      status = classifyFetchCount(jobs.length);
       logger.info(
-        { company: company.name, count: jobs.length, ats: company.atsType },
+        { company: company.name, count: jobs.length, ats: company.atsType, status },
         'fetcher: ok',
       );
       for (const job of jobs) {
         out.push({ job, companyName: company.name });
       }
     } catch (err) {
+      status = classifyFetchError(err);
       logger.error(
-        { err, company: company.name, ats: company.atsType },
+        { err, company: company.name, ats: company.atsType, status },
         'fetcher: failed',
       );
     }
+    await recordFetchHealth(company, status);
     await sleep(POLITE_DELAY_MS);
   }
 
   return out;
+}
+
+/**
+ * Persist one source's health (ADR 0019). Never allowed to break the tick:
+ * a health write that fails must not cost us the jobs we just fetched.
+ */
+async function recordFetchHealth(
+  company: { id: number; name: string; consecutiveFailures: number },
+  status: FetchStatus,
+): Promise<void> {
+  const streak = nextStreak(status, company.consecutiveFailures);
+  try {
+    await prisma.company.update({
+      where: { id: company.id },
+      data: {
+        lastFetchStatus: status,
+        consecutiveFailures: streak,
+        ...(status === 'ok' ? { lastOkAt: new Date() } : {}),
+      },
+    });
+  } catch (err) {
+    logger.error({ err, company: company.name }, 'fetcher: health write failed');
+    return;
+  }
+  if (streak === QUIET_STREAK) {
+    logger.warn(
+      { company: company.name, status, streak },
+      'fetcher: source crossed the quiet threshold',
+    );
+  }
 }
 
 export async function fetchOne(company: {

--- a/src/fetchers/source-health.test.ts
+++ b/src/fetchers/source-health.test.ts
@@ -1,0 +1,216 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { HttpError } from '../http';
+import {
+  FETCH_STATUSES,
+  QUIET_STREAK,
+  SILENT_DAYS,
+  classifyFetchCount,
+  classifyFetchError,
+  describeStatus,
+  isFailing,
+  isSilent,
+  nextStreak,
+  quietReason,
+  type FetchStatus,
+  type SourceHealth,
+} from './source-health';
+
+const http = (status: number): HttpError =>
+  new HttpError(`HTTP ${status} for https://x/y`, status, 'https://x/y');
+
+/** undici's shape: TypeError('fetch failed') carrying the real reason. */
+function fetchFailed(cause: { code?: string; message?: string }): TypeError {
+  return new TypeError('fetch failed', { cause: Object.assign(new Error(cause.message ?? 'x'), cause) });
+}
+
+describe('classifyFetchError — measured vendor behaviour', () => {
+  it('404 and 410 mean the slug is gone', () => {
+    assert.equal(classifyFetchError(http(404)), 'slug_gone');
+    assert.equal(classifyFetchError(http(410)), 'slug_gone');
+  });
+
+  it('401 and 403 mean the board is gated, not dead', () => {
+    assert.equal(classifyFetchError(http(401)), 'auth');
+    assert.equal(classifyFetchError(http(403)), 'auth');
+  });
+
+  it('429 is its own status — a rate limit must never read as a dead slug', () => {
+    assert.equal(classifyFetchError(http(429)), 'rate_limit');
+  });
+
+  it('5xx is the vendor, not us', () => {
+    assert.equal(classifyFetchError(http(500)), 'server');
+    assert.equal(classifyFetchError(http(503)), 'server');
+  });
+
+  it('an unmapped 4xx falls to unknown, which still counts', () => {
+    assert.equal(classifyFetchError(http(418)), 'unknown');
+  });
+
+  it('a refused redirect is a dead slug — how BambooHR presents one', () => {
+    assert.equal(
+      classifyFetchError(fetchFailed({ message: 'unexpected redirect' })),
+      'slug_gone',
+    );
+  });
+
+  it('transport codes are network', () => {
+    assert.equal(classifyFetchError(fetchFailed({ code: 'ENOTFOUND' })), 'network');
+    assert.equal(classifyFetchError(fetchFailed({ code: 'ECONNREFUSED' })), 'network');
+    assert.equal(classifyFetchError(fetchFailed({ code: 'ETIMEDOUT' })), 'network');
+  });
+
+  it('a bare "fetch failed" with no cause code is still network', () => {
+    assert.equal(classifyFetchError(new TypeError('fetch failed')), 'network');
+  });
+
+  it('reads a timeout from the message — fetchWithRetry drops the AbortError name', () => {
+    const err = new Error('Request to https://x/y timed out after 10000ms');
+    assert.equal(err.name, 'Error');
+    assert.equal(classifyFetchError(err), 'network');
+  });
+
+  it('a schema mismatch is a bad payload, not a network problem', () => {
+    assert.equal(
+      classifyFetchError(new Error('Greenhouse schema invalid for "acme": ...')),
+      'bad_payload',
+    );
+  });
+
+  it('HTML served with a 200 dies in resp.json() as a SyntaxError', () => {
+    assert.equal(classifyFetchError(new SyntaxError('Unexpected token <')), 'bad_payload');
+  });
+
+  it('never invents ok or empty — those come from the row count', () => {
+    for (const err of [http(404), http(500), new Error('boom'), null, undefined]) {
+      const status = classifyFetchError(err);
+      assert.notEqual(status, 'ok');
+      assert.notEqual(status, 'empty');
+    }
+  });
+
+  it('anything unrecognised is unknown, never silently healthy', () => {
+    assert.equal(classifyFetchError(new Error('who knows')), 'unknown');
+    assert.equal(classifyFetchError('a string'), 'unknown');
+    assert.equal(classifyFetchError(null), 'unknown');
+  });
+});
+
+describe('classifyFetchCount', () => {
+  it('splits on the raw pre-filter count', () => {
+    assert.equal(classifyFetchCount(7), 'ok');
+    assert.equal(classifyFetchCount(0), 'empty');
+  });
+});
+
+describe('nextStreak — the inversion', () => {
+  it('ok and empty reset', () => {
+    assert.equal(nextStreak('ok', 9), 0);
+    assert.equal(nextStreak('empty', 9), 0);
+  });
+
+  it('every other status increments', () => {
+    for (const status of FETCH_STATUSES) {
+      if (status === 'ok' || status === 'empty') continue;
+      assert.equal(nextStreak(status, 2), 3, `${status} must increment`);
+    }
+  });
+
+  it('unknown increments — a new error kind cannot fall out of the streak', () => {
+    assert.equal(nextStreak('unknown', 0), 1);
+  });
+
+  it('exactly two statuses are treated as healthy', () => {
+    const healthy = FETCH_STATUSES.filter((s) => nextStreak(s, 5) === 0);
+    assert.deepEqual([...healthy], ['ok', 'empty']);
+  });
+
+  it('a corrupt negative counter cannot make the streak go backwards', () => {
+    assert.equal(nextStreak('server', -4), 1);
+  });
+});
+
+const NOW = new Date('2026-08-30T12:00:00Z');
+const daysAgo = (n: number): Date => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+
+const health = (over: Partial<SourceHealth> = {}): SourceHealth => ({
+  lastFetchStatus: 'ok',
+  consecutiveFailures: 0,
+  lastOkAt: NOW,
+  createdAt: daysAgo(400),
+  ...over,
+});
+
+describe('isFailing', () => {
+  it('trips exactly at the threshold', () => {
+    assert.equal(isFailing(health({ consecutiveFailures: QUIET_STREAK - 1 })), false);
+    assert.equal(isFailing(health({ consecutiveFailures: QUIET_STREAK })), true);
+  });
+});
+
+describe('isSilent', () => {
+  it('a source that keeps producing postings is not silent', () => {
+    assert.equal(isSilent(health({ lastOkAt: daysAgo(1) }), NOW), false);
+  });
+
+  it('trips at SILENT_DAYS without a posting', () => {
+    assert.equal(isSilent(health({ lastOkAt: daysAgo(SILENT_DAYS - 1) }), NOW), false);
+    assert.equal(isSilent(health({ lastOkAt: daysAgo(SILENT_DAYS) }), NOW), true);
+  });
+
+  it('catches the SmartRecruiters case: reachable, 200, forever empty', () => {
+    const sr = health({ lastFetchStatus: 'empty', lastOkAt: null, createdAt: daysAgo(60) });
+    assert.equal(isFailing(sr), false);
+    assert.equal(isSilent(sr, NOW), true);
+  });
+
+  it('a never-fetched source is unknown, not silent', () => {
+    assert.equal(
+      isSilent(health({ lastFetchStatus: null, lastOkAt: null, createdAt: daysAgo(90) }), NOW),
+      false,
+    );
+  });
+
+  it('a company added yesterday is not silent', () => {
+    assert.equal(
+      isSilent(health({ lastFetchStatus: 'empty', lastOkAt: null, createdAt: daysAgo(1) }), NOW),
+      false,
+    );
+  });
+
+  it('failing wins over silent — the louder signal is the specific one', () => {
+    const both = health({ lastFetchStatus: 'slug_gone', consecutiveFailures: 5, lastOkAt: daysAgo(90) });
+    assert.equal(isSilent(both, NOW), false);
+    assert.equal(quietReason(both, NOW), 'failing');
+  });
+});
+
+describe('quietReason', () => {
+  it('is null for a healthy source', () => {
+    assert.equal(quietReason(health(), NOW), null);
+  });
+
+  it('reports silence when the streak is clean', () => {
+    assert.equal(quietReason(health({ lastOkAt: daysAgo(30) }), NOW), 'silent');
+  });
+});
+
+describe('describeStatus', () => {
+  it('labels every status in the vocabulary', () => {
+    for (const status of FETCH_STATUSES) {
+      const { label, tone } = describeStatus(status);
+      assert.ok(label.length > 0, `${status} needs a label`);
+      assert.notEqual(tone, 'none', `${status} must not fall through to the default`);
+    }
+  });
+
+  it('falls back for a null or unseen status', () => {
+    assert.equal(describeStatus(null).tone, 'none');
+    assert.equal(describeStatus('something-new').tone, 'none');
+  });
+
+  it('never calls a rate limit a dead slug', () => {
+    assert.notEqual(describeStatus('rate_limit').tone, describeStatus('slug_gone').tone);
+  });
+});

--- a/src/fetchers/source-health.ts
+++ b/src/fetchers/source-health.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure source-health logic (ADR 0019). No I/O — the only import is the
+ * HttpError class, so this file unit-tests without Prisma or the network.
+ *
+ * The error shapes below were measured against the live vendors on
+ * 2026-08-30, not assumed: `fetchWithRetry` rewrites an aborted request
+ * into a plain Error (so `err.name` is useless for timeouts), a dead
+ * BambooHR slug arrives as a redirect refusal rather than a 404, and
+ * Cloudflare answers 429 for a board that is perfectly alive.
+ */
+import { HttpError } from '../http';
+
+export const FETCH_STATUSES = [
+  'ok',
+  'empty',
+  'slug_gone',
+  'auth',
+  'rate_limit',
+  'server',
+  'network',
+  'bad_payload',
+  'unknown',
+] as const;
+
+export type FetchStatus = (typeof FETCH_STATUSES)[number];
+
+/** Statuses that clear the streak. Everything else increments it. */
+const HEALTHY: ReadonlySet<FetchStatus> = new Set<FetchStatus>(['ok', 'empty']);
+
+/** Three hourly ticks — see ADR 0019 for why the base rate allows this. */
+export const QUIET_STREAK = 3;
+
+/**
+ * Days without a single posting before a reachable source counts as silent.
+ * Unmeasured on purpose: `lastOkAt` has no history yet, so this is the
+ * conservative end of the guess and is due a re-measure (ADR 0019).
+ */
+export const SILENT_DAYS = 14;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Transport-level failure codes Node surfaces on `TypeError.cause`. */
+const NETWORK_CODES: ReadonlySet<string> = new Set([
+  'ENOTFOUND',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPIPE',
+]);
+
+function causeOf(err: unknown): { code?: string; message?: string } {
+  const cause = (err as { cause?: unknown })?.cause;
+  if (cause === null || typeof cause !== 'object') return {};
+  const c = cause as { code?: unknown; message?: unknown };
+  return {
+    code: typeof c.code === 'string' ? c.code : undefined,
+    message: typeof c.message === 'string' ? c.message : undefined,
+  };
+}
+
+/**
+ * A thrown value from `fetchOne` → a status. Never returns `ok` or `empty`:
+ * those describe a successful fetch and come from the row count instead.
+ */
+export function classifyFetchError(err: unknown): FetchStatus {
+  if (err instanceof HttpError) {
+    if (err.status === 404 || err.status === 410) return 'slug_gone';
+    if (err.status === 401 || err.status === 403) return 'auth';
+    if (err.status === 429) return 'rate_limit';
+    if (err.status >= 500) return 'server';
+    return 'unknown';
+  }
+
+  const name = (err as { name?: unknown })?.name;
+  // A 200 carrying HTML instead of JSON dies in resp.json().
+  if (name === 'SyntaxError' || name === 'ZodError') return 'bad_payload';
+
+  const { code, message: causeMessage } = causeOf(err);
+  // `redirect: 'error'` refusing a vendor's 302-to-marketing-page. Measured
+  // on BambooHR, where that — not a 404 — is how a dead slug presents.
+  if (causeMessage !== undefined && /unexpected redirect/i.test(causeMessage)) {
+    return 'slug_gone';
+  }
+  if (code !== undefined && NETWORK_CODES.has(code)) return 'network';
+
+  const message = (err as { message?: unknown })?.message;
+  if (typeof message === 'string') {
+    // fetchWithRetry's own rewrite of an AbortError.
+    if (/timed out after \d+ms/.test(message)) return 'network';
+    if (/schema invalid/i.test(message)) return 'bad_payload';
+    // Any other transport failure undici reports as a bare "fetch failed".
+    if (name === 'TypeError' && /fetch failed/i.test(message)) return 'network';
+  }
+  if (name === 'AbortError') return 'network';
+
+  return 'unknown';
+}
+
+/** A successful fetch → a status, from the RAW pre-filter row count. */
+export function classifyFetchCount(count: number): FetchStatus {
+  return count > 0 ? 'ok' : 'empty';
+}
+
+/**
+ * The streak, inverted on purpose: `ok` and `empty` reset, EVERYTHING else
+ * increments — including `unknown`. A status added later cannot fall out of
+ * the streak by omission; the worst it can do is be counted.
+ */
+export function nextStreak(status: FetchStatus, current: number): number {
+  if (HEALTHY.has(status)) return 0;
+  return Math.max(0, current) + 1;
+}
+
+export interface SourceHealth {
+  lastFetchStatus: string | null;
+  consecutiveFailures: number;
+  lastOkAt: Date | null;
+  createdAt: Date;
+}
+
+/** Loud breakage: the source is throwing and has been for QUIET_STREAK ticks. */
+export function isFailing(h: SourceHealth): boolean {
+  return h.consecutiveFailures >= QUIET_STREAK;
+}
+
+/**
+ * Quiet breakage: reachable, but it has produced no posting for SILENT_DAYS.
+ * This is the only signal that catches a SmartRecruiters slug that will
+ * never resolve, or a vendor that silently started answering `[]`.
+ * A source we have never fetched is not silent — it is unknown.
+ */
+export function isSilent(h: SourceHealth, now: Date): boolean {
+  if (h.lastFetchStatus === null || isFailing(h)) return false;
+  const since = h.lastOkAt ?? h.createdAt;
+  return now.getTime() - since.getTime() >= SILENT_DAYS * DAY_MS;
+}
+
+export type QuietReason = 'failing' | 'silent';
+
+export function quietReason(h: SourceHealth, now: Date): QuietReason | null {
+  if (isFailing(h)) return 'failing';
+  if (isSilent(h, now)) return 'silent';
+  return null;
+}
+
+export type HealthTone = 'good' | 'idle' | 'bad' | 'warn' | 'none';
+
+/** Display label + tone for the `/companies` status dot. */
+export function describeStatus(status: string | null): {
+  label: string;
+  tone: HealthTone;
+} {
+  switch (status) {
+    case 'ok':
+      return { label: 'OK', tone: 'good' };
+    case 'empty':
+      return { label: 'No postings', tone: 'idle' };
+    case 'slug_gone':
+      return { label: 'Slug not found', tone: 'bad' };
+    case 'auth':
+      return { label: 'Board is gated', tone: 'bad' };
+    case 'bad_payload':
+      return { label: 'Unreadable payload', tone: 'bad' };
+    case 'rate_limit':
+      return { label: 'Rate-limited', tone: 'warn' };
+    case 'server':
+      return { label: 'Vendor error', tone: 'warn' };
+    case 'network':
+      return { label: 'Unreachable', tone: 'warn' };
+    case 'unknown':
+      return { label: 'Unknown error', tone: 'warn' };
+    default:
+      return { label: 'Not fetched yet', tone: 'none' };
+  }
+}

--- a/src/jobs/digest-job.ts
+++ b/src/jobs/digest-job.ts
@@ -1,9 +1,9 @@
-import { AtsType, JobStatus } from '@prisma/client';
+import { JobStatus } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../logger';
 import { sendDigest, type QuietSourceAlert } from '../notifier';
 import { QUIET_STREAK } from '../fetchers/source-health';
-import { getSettings } from '../settings';
+import { getSettings, toAtsTypes } from '../settings';
 import type { CronStats } from './cron-run';
 import type { AlertJob } from '../types';
 
@@ -50,13 +50,12 @@ export async function runDigestJob(): Promise<{ stats: CronStats }> {
 async function quietSources(): Promise<QuietSourceAlert[]> {
   const settings = await getSettings();
   if (!settings.sourceHealthAlerts) return [];
+  const disabled = toAtsTypes(settings.disabledSources);
   const rows = await prisma.company.findMany({
     where: {
       active: true,
       consecutiveFailures: { gte: QUIET_STREAK },
-      ...(settings.disabledSources.length > 0
-        ? { atsType: { notIn: settings.disabledSources as AtsType[] } }
-        : {}),
+      ...(disabled.length > 0 ? { atsType: { notIn: disabled } } : {}),
     },
     select: { name: true, atsType: true, lastFetchStatus: true, consecutiveFailures: true },
     orderBy: [{ consecutiveFailures: 'desc' }, { name: 'asc' }],

--- a/src/jobs/digest-job.ts
+++ b/src/jobs/digest-job.ts
@@ -1,7 +1,9 @@
-import { JobStatus } from '@prisma/client';
+import { AtsType, JobStatus } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../logger';
-import { sendDigest } from '../notifier';
+import { sendDigest, type QuietSourceAlert } from '../notifier';
+import { QUIET_STREAK } from '../fetchers/source-health';
+import { getSettings } from '../settings';
 import type { CronStats } from './cron-run';
 import type { AlertJob } from '../types';
 
@@ -34,8 +36,35 @@ export async function runDigestJob(): Promise<{ stats: CronStats }> {
     summary: j.summary ?? '',
   }));
 
-  await sendDigest(alerts);
+  await sendDigest(alerts, undefined, await quietSources());
   const durationMs = Date.now() - started;
   logger.info({ count: alerts.length, durationMs }, 'digest-job: done');
   return { stats: { count: alerts.length, durationMs } };
+}
+
+/**
+ * Sources that crossed the failure streak (ADR 0019), behind its toggle.
+ * Only actively polled rows qualify — a disabled company, or one in a source
+ * family the user switched off, is quiet by instruction.
+ */
+async function quietSources(): Promise<QuietSourceAlert[]> {
+  const settings = await getSettings();
+  if (!settings.sourceHealthAlerts) return [];
+  const rows = await prisma.company.findMany({
+    where: {
+      active: true,
+      consecutiveFailures: { gte: QUIET_STREAK },
+      ...(settings.disabledSources.length > 0
+        ? { atsType: { notIn: settings.disabledSources as AtsType[] } }
+        : {}),
+    },
+    select: { name: true, atsType: true, lastFetchStatus: true, consecutiveFailures: true },
+    orderBy: [{ consecutiveFailures: 'desc' }, { name: 'asc' }],
+  });
+  return rows.map((r) => ({
+    name: r.name,
+    atsType: r.atsType,
+    status: r.lastFetchStatus,
+    streak: r.consecutiveFailures,
+  }));
 }

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -5,6 +5,7 @@ import {
   escapeMarkdownV2Url,
   formatJobMessage,
   formatSalary,
+  formatSourceHealthLine,
 } from './notifier';
 
 describe('formatSalary', () => {
@@ -107,5 +108,55 @@ describe('formatJobMessage', () => {
     const msg = formatJobMessage({ ...base, crossListedAt: 'Acme (US) Inc. - Jobs' });
     assert.match(msg, /Also listed at Acme \\\(US\\\) Inc\\\. \\- Jobs/);
     assert.match(msg, /apply through one channel only/);
+  });
+});
+
+describe('formatSourceHealthLine', () => {
+  it('is empty when nothing is quiet, so the digest gains no line', () => {
+    assert.equal(formatSourceHealthLine([]), '');
+  });
+
+  it('names the source, its vendor and the streak', () => {
+    const line = formatSourceHealthLine([
+      { name: 'Pleo', atsType: 'GREENHOUSE', status: 'slug_gone', streak: 4 },
+    ]);
+    assert.match(line, /1 quiet source\*/);
+    assert.match(line, /Pleo/);
+    assert.match(line, /GREENHOUSE/);
+    assert.match(line, /slug not found/);
+    assert.match(line, /4/);
+  });
+
+  it('pluralises and joins several sources', () => {
+    const line = formatSourceHealthLine([
+      { name: 'Pleo', atsType: 'GREENHOUSE', status: 'slug_gone', streak: 4 },
+      { name: 'Plaid', atsType: 'LEVER', status: 'slug_gone', streak: 3 },
+    ]);
+    assert.match(line, /2 quiet sources\*/);
+    assert.match(line, /Pleo.*Plaid/);
+  });
+
+  it('escapes MarkdownV2 in the company name and the parenthesised detail', () => {
+    const line = formatSourceHealthLine([
+      { name: 'Acme (EU) - Ltd.', atsType: 'LEVER', status: 'rate_limit', streak: 3 },
+    ]);
+    assert.match(line, /Acme \\\(EU\\\) \\- Ltd\\\./);
+    // The literal parens we add around the detail are escaped too.
+    assert.ok(!/[^\\]\(GREENHOUSE|[^\\]\(LEVER/.test(line));
+  });
+
+  it('never calls a rate limit a dead slug', () => {
+    const line = formatSourceHealthLine([
+      { name: 'X', atsType: 'WORKABLE', status: 'rate_limit', streak: 3 },
+    ]);
+    assert.match(line, /rate\\-limited/);
+    assert.doesNotMatch(line, /slug not found/);
+  });
+
+  it('renders a status it has never seen without crashing', () => {
+    const line = formatSourceHealthLine([
+      { name: 'X', atsType: 'ASHBY', status: null, streak: 3 },
+    ]);
+    assert.match(line, /not fetched yet/);
   });
 });

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -153,6 +153,29 @@ describe('formatSourceHealthLine', () => {
     assert.doesNotMatch(line, /slug not found/);
   });
 
+  it('caps the list so a total outage cannot overflow the message limit', () => {
+    const many = Array.from({ length: 71 }, (_, i) => ({
+      name: `Company number ${i}`,
+      atsType: 'GREENHOUSE',
+      status: 'network',
+      streak: 3,
+    }));
+    const line = formatSourceHealthLine(many);
+    assert.match(line, /71 quiet sources\*/);
+    assert.match(line, /and 63 more/);
+    assert.ok(line.length < 1000, `line was ${line.length} chars`);
+  });
+
+  it('names every source when there are few enough', () => {
+    const few = Array.from({ length: 8 }, (_, i) => ({
+      name: `C${i}`,
+      atsType: 'LEVER',
+      status: 'slug_gone',
+      streak: 3,
+    }));
+    assert.doesNotMatch(formatSourceHealthLine(few), /more/);
+  });
+
   it('renders a status it has never seen without crashing', () => {
     const line = formatSourceHealthLine([
       { name: 'X', atsType: 'ASHBY', status: null, streak: 3 },

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -6,6 +6,7 @@ import {
 } from './settings';
 import { prisma } from './db';
 import type { Profile, TelegramTarget } from '@prisma/client';
+import { describeStatus } from './fetchers/source-health';
 import type { AlertJob } from './types';
 
 const TELEGRAM_API = 'https://api.telegram.org';
@@ -23,12 +24,17 @@ export async function sendTelegramAlert(
 export async function sendDigest(
   jobs: AlertJob[],
   profile?: Profile,
+  quiet: QuietSourceAlert[] = [],
 ): Promise<void> {
+  const healthLine = formatSourceHealthLine(quiet);
   if (jobs.length === 0) {
-    await broadcast(escapeMarkdownV2('No new matches in the last 24h.'), profile);
+    const empty = escapeMarkdownV2('No new matches in the last 24h.');
+    await broadcast(healthLine ? `${empty}\n\n${healthLine}` : empty, profile);
     return;
   }
-  const header = `*Daily digest — ${jobs.length} match${jobs.length === 1 ? '' : 'es'}*`;
+  const header = `*Daily digest — ${jobs.length} match${jobs.length === 1 ? '' : 'es'}*${
+    healthLine ? `\n${healthLine}` : ''
+  }`;
   const blocks = jobs.map(formatJobMessage);
   const separator = '\n\n———\n\n';
 
@@ -181,6 +187,32 @@ export function formatSalary(min: number | null, max: number | null): string {
   if (min !== null) return `${fmt(min)}+`;
   if (max !== null) return `up to ${fmt(max)}`;
   return '—';
+}
+
+export interface QuietSourceAlert {
+  name: string;
+  atsType: string;
+  /** Raw FetchStatus — rendered through describeStatus for the label. */
+  status: string | null;
+  streak: number;
+}
+
+/**
+ * One digest line for sources that crossed the failure streak (ADR 0019).
+ * Failing sources only: a silent board is a judgement call that belongs on
+ * the dashboard, and nagging about it daily is how a digest trains its
+ * reader to stop looking.
+ */
+export function formatSourceHealthLine(sources: QuietSourceAlert[]): string {
+  if (sources.length === 0) return '';
+  const items = sources.map(
+    (s) =>
+      `${escapeMarkdownV2(s.name)} ${escapeMarkdownV2(
+        `(${s.atsType}, ${describeStatus(s.status).label.toLowerCase()} ×${s.streak})`,
+      )}`,
+  );
+  const header = `⚠️ *${sources.length} quiet source${sources.length === 1 ? '' : 's'}*`;
+  return `${header} — ${items.join(', ')}`;
 }
 
 export function escapeMarkdownV2(text: string): string {

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -12,6 +12,13 @@ import type { AlertJob } from './types';
 const TELEGRAM_API = 'https://api.telegram.org';
 const TELEGRAM_TIMEOUT_MS = 10_000;
 const MAX_MESSAGE_LENGTH = 4096;
+/**
+ * Quiet sources named in full before the line collapses to a count. A total
+ * outage marks every source at once, and an uncapped list would push the
+ * digest header past MAX_MESSAGE_LENGTH — Telegram then rejects the whole
+ * message, losing the alert exactly when it matters most.
+ */
+const MAX_QUIET_NAMED = 8;
 
 export async function sendTelegramAlert(
   job: AlertJob,
@@ -205,12 +212,16 @@ export interface QuietSourceAlert {
  */
 export function formatSourceHealthLine(sources: QuietSourceAlert[]): string {
   if (sources.length === 0) return '';
-  const items = sources.map(
-    (s) =>
-      `${escapeMarkdownV2(s.name)} ${escapeMarkdownV2(
-        `(${s.atsType}, ${describeStatus(s.status).label.toLowerCase()} ×${s.streak})`,
-      )}`,
-  );
+  const items = sources
+    .slice(0, MAX_QUIET_NAMED)
+    .map(
+      (s) =>
+        `${escapeMarkdownV2(s.name)} ${escapeMarkdownV2(
+          `(${s.atsType}, ${describeStatus(s.status).label.toLowerCase()} ×${s.streak})`,
+        )}`,
+    );
+  const hidden = sources.length - items.length;
+  if (hidden > 0) items.push(escapeMarkdownV2(`and ${hidden} more`));
   const header = `⚠️ *${sources.length} quiet source${sources.length === 1 ? '' : 's'}*`;
   return `${header} — ${items.join(', ')}`;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,4 @@
+import { AtsType } from '@prisma/client';
 import type { Prisma, TelegramTarget } from '@prisma/client';
 import { prisma } from './db';
 import { logger } from './logger';
@@ -129,6 +130,16 @@ export async function setFetchingEnabled(enabled: boolean): Promise<void> {
     create: { id: SETTINGS_ID, fetchingEnabled: enabled },
   });
   logger.info({ enabled }, enabled ? 'settings: job fetching resumed' : 'settings: job fetching paused');
+}
+
+/**
+ * `disabledSources` is a free-form String[] column. Anything that is not a
+ * live AtsType has to be dropped before it reaches a Prisma enum filter —
+ * one stale value there throws and takes the whole job down with it.
+ */
+export function toAtsTypes(values: string[]): AtsType[] {
+  const known = Object.values(AtsType) as string[];
+  return values.filter((v): v is AtsType => known.includes(v));
 }
 
 export async function setSourceHealthAlerts(enabled: boolean): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,6 +18,8 @@ export interface AppSettingsView {
   disabledSources: string[];
   discoveryEnabled: boolean;
   fetchingEnabled: boolean;
+  /** One digest line when a source crosses the failure streak (ADR 0019). */
+  sourceHealthAlerts: boolean;
   /** Raw AppSettings.aiEngine JSON — parse with parseAiEngineConfig. */
   aiEngine: unknown;
   /** Raw AppSettings.aiUsage JSON — summarize with summarizeAiUsage. */
@@ -43,6 +45,7 @@ export async function getSettings(): Promise<AppSettingsView> {
     disabledSources: row.disabledSources,
     discoveryEnabled: row.discoveryEnabled,
     fetchingEnabled: row.fetchingEnabled,
+    sourceHealthAlerts: row.sourceHealthAlerts,
     aiEngine: row.aiEngine,
     aiUsage: row.aiUsage,
     updatedAt: row.updatedAt,
@@ -126,6 +129,14 @@ export async function setFetchingEnabled(enabled: boolean): Promise<void> {
     create: { id: SETTINGS_ID, fetchingEnabled: enabled },
   });
   logger.info({ enabled }, enabled ? 'settings: job fetching resumed' : 'settings: job fetching paused');
+}
+
+export async function setSourceHealthAlerts(enabled: boolean): Promise<void> {
+  await prisma.appSettings.upsert({
+    where: { id: SETTINGS_ID },
+    update: { sourceHealthAlerts: enabled },
+    create: { id: SETTINGS_ID, sourceHealthAlerts: enabled },
+  });
 }
 
 function normaliseClassifierMode(raw: string): ClassifierMode {

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -22,6 +22,13 @@ import {
   Tr,
 } from '../ui';
 import { formatRelative } from '../format';
+import {
+  QUIET_STREAK,
+  SILENT_DAYS,
+  describeStatus,
+  type HealthTone,
+  type QuietReason,
+} from '../../fetchers/source-health';
 import type { FlashMessage } from '../flash';
 import { StarterPackPicker, type PackSegmentChoice } from './starter-pack';
 
@@ -35,13 +42,91 @@ interface CompanyRow {
   jobsTotal: number;
   alertedTotal: number;
   lastFetchedAt: Date | null;
+  lastFetchStatus: string | null;
+  consecutiveFailures: number;
+  lastOkAt: Date | null;
+  quiet: QuietReason | null;
 }
 
 export interface CompaniesProps {
   companies: CompanyRow[];
   packs: PackSegmentChoice[];
   flash?: FlashMessage | null;
+  fetchingEnabled: boolean;
 }
+
+const DOT_TONE: Record<HealthTone, string> = {
+  good: 'bg-ok',
+  idle: 'bg-ink-faint',
+  bad: 'bg-danger',
+  warn: 'bg-warn',
+  none: 'bg-line',
+};
+
+/** Status dot + label, the per-row half of ADR 0019. */
+const HealthDot: FC<{ status: string | null; streak: number }> = ({ status, streak }) => {
+  const { label, tone } = describeStatus(status);
+  const title = streak > 0 ? `${label} — ${streak} tick${streak === 1 ? '' : 's'} in a row` : label;
+  return (
+    <span class="inline-flex items-center gap-2 whitespace-nowrap" title={title}>
+      <span class={`h-2 w-2 shrink-0 rounded-full ${DOT_TONE[tone]}`} aria-hidden="true" />
+      <span class="text-[13px] text-ink-muted">{label}</span>
+      <span class="sr-only">{title}</span>
+    </span>
+  );
+};
+
+const QuietSources: FC<{ companies: CompanyRow[]; fetchingEnabled: boolean }> = ({
+  companies,
+  fetchingEnabled,
+}) => {
+  const quiet = companies.filter((c) => c.quiet !== null);
+  if (quiet.length === 0) return null;
+  return (
+    <Card class="mb-4">
+      <SectionTitle>
+        Quiet sources <Badge tone="warn">{quiet.length}</Badge>
+      </SectionTitle>
+      <Hint class="mb-4">
+        A board that stopped answering is usually a rotated slug. <em>Failing</em> means{' '}
+        {QUIET_STREAK} consecutive ticks ended in an error; <em>silent</em> means the board is
+        reachable but has returned no posting for {SILENT_DAYS} days — the only signal that
+        catches a vendor answering 200 with an empty list. Re-probe runs the same public check
+        the add-company form uses.
+        {!fetchingEnabled && (
+          <>
+            {' '}
+            <strong class="font-medium text-ink">Fetching is paused</strong>, so these numbers
+            are frozen where the last tick left them.
+          </>
+        )}
+      </Hint>
+      <div class="flex flex-col gap-2">
+        {quiet.map((c) => (
+          <div class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-line bg-surface-raised px-4 py-3">
+            <div class="min-w-0">
+              <div class="truncate font-medium text-ink">{c.name}</div>
+              <div class="mt-0.5 flex flex-wrap items-center gap-2 text-[13px] text-ink-muted">
+                <Tag>{c.atsType.replace('_', ' ')}</Tag>
+                <Code>{c.atsToken}</Code>
+                <span>
+                  {c.quiet === 'failing'
+                    ? `${describeStatus(c.lastFetchStatus).label.toLowerCase()} — ${c.consecutiveFailures} ticks in a row`
+                    : `last posting ${formatRelative(c.lastOkAt) || 'never seen'}`}
+                </span>
+              </div>
+            </div>
+            <ActionForm action={`/companies/${c.id}/reprobe`}>
+              <Button size="sm" variant="secondary">
+                Re-probe
+              </Button>
+            </ActionForm>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+};
 
 const PROBEABLE_ATS: AtsType[] = [
   AtsType.GREENHOUSE,
@@ -58,10 +143,17 @@ const PROBEABLE_ATS: AtsType[] = [
 
 const AGGREGATORS = ['LARAJOBS', 'REMOTEOK', 'REMOTIVE', 'JOBICY', 'WEWORKREMOTELY', 'HN_HIRING'];
 
-export const CompaniesPage: FC<CompaniesProps> = ({ companies, packs, flash }) => (
+export const CompaniesPage: FC<CompaniesProps> = ({
+  companies,
+  packs,
+  flash,
+  fetchingEnabled,
+}) => (
   <Layout title="Companies" active="companies">
     <PageHeader title="Companies" meta={`${companies.length} sources`} />
     <Flash flash={flash} />
+
+    <QuietSources companies={companies} fetchingEnabled={fetchingEnabled} />
 
     <details class="mb-4 rounded-lg border border-line bg-surface-raised shadow-sm">
       <summary class="cursor-pointer select-none px-5 py-3 text-sm font-medium text-ink transition-colors duration-150 hover:bg-surface-overlay/50">
@@ -142,6 +234,7 @@ export const CompaniesPage: FC<CompaniesProps> = ({ companies, packs, flash }) =
                 'Name',
                 'Source',
                 'Token',
+                'Health',
                 <span class="block text-right">Jobs</span>,
                 <span class="block text-right">Alerted</span>,
                 <span class="block text-right">Last fetch</span>,
@@ -171,6 +264,9 @@ export const CompaniesPage: FC<CompaniesProps> = ({ companies, packs, flash }) =
                     <Tag>{c.atsType.replace('_', ' ')}</Tag>
                   </Td>
                   <Td class="font-mono text-xs text-ink-muted">{c.atsToken}</Td>
+                  <Td>
+                    <HealthDot status={c.lastFetchStatus} streak={c.consecutiveFailures} />
+                  </Td>
                   <Td class="text-right tabular-nums text-ink-muted">{c.jobsTotal}</Td>
                   <Td
                     class={`text-right tabular-nums ${

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -66,12 +66,17 @@ const DOT_TONE: Record<HealthTone, string> = {
 /** Status dot + label, the per-row half of ADR 0019. */
 const HealthDot: FC<{ status: string | null; streak: number }> = ({ status, streak }) => {
   const { label, tone } = describeStatus(status);
-  const title = streak > 0 ? `${label} — ${streak} tick${streak === 1 ? '' : 's'} in a row` : label;
+  // The label is already text, so the dot is decorative and the streak is the
+  // only part a screen reader would otherwise miss.
+  const streakText = streak > 0 ? `${streak} tick${streak === 1 ? '' : 's'} in a row` : '';
   return (
-    <span class="inline-flex items-center gap-2 whitespace-nowrap" title={title}>
+    <span
+      class="inline-flex items-center gap-2 whitespace-nowrap"
+      title={streakText ? `${label} — ${streakText}` : label}
+    >
       <span class={`h-2 w-2 shrink-0 rounded-full ${DOT_TONE[tone]}`} aria-hidden="true" />
       <span class="text-[13px] text-ink-muted">{label}</span>
-      <span class="sr-only">{title}</span>
+      {streakText && <span class="sr-only">, {streakText}</span>}
     </span>
   );
 };

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -109,10 +109,15 @@ const QuietSources: FC<{ companies: CompanyRow[]; fetchingEnabled: boolean }> = 
               <div class="mt-0.5 flex flex-wrap items-center gap-2 text-[13px] text-ink-muted">
                 <Tag>{c.atsType.replace('_', ' ')}</Tag>
                 <Code>{c.atsToken}</Code>
+                <Badge tone={c.quiet === 'failing' ? 'danger' : 'warn'}>
+                  {c.quiet === 'failing' ? 'Failing' : 'Silent'}
+                </Badge>
                 <span>
                   {c.quiet === 'failing'
                     ? `${describeStatus(c.lastFetchStatus).label.toLowerCase()} — ${c.consecutiveFailures} ticks in a row`
-                    : `last posting ${formatRelative(c.lastOkAt) || 'never seen'}`}
+                    : c.lastOkAt
+                      ? `last posting ${formatRelative(c.lastOkAt)}`
+                      : 'no posting since we started tracking it'}
                 </span>
               </div>
             </div>

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -119,6 +119,7 @@ export interface SettingsProps {
   classifierMode: 'single' | 'two_stage';
   applicationTrackingEnabled: boolean;
   staleApplicationsDigestEnabled: boolean;
+  sourceHealthAlerts: boolean;
   disabledSources: string[];
   allSources: string[];
   fetchingEnabled: boolean;
@@ -155,6 +156,7 @@ export const SettingsPage: FC<SettingsProps> = ({
   classifierMode,
   applicationTrackingEnabled,
   staleApplicationsDigestEnabled,
+  sourceHealthAlerts,
   disabledSources,
   allSources,
   fetchingEnabled,
@@ -454,6 +456,14 @@ export const SettingsPage: FC<SettingsProps> = ({
           >
             When off, nothing is sent regardless of targets. Jobs are still classified and
             stored.
+          </ToggleRow>
+          <ToggleRow
+            label="Source health alerts"
+            enabled={sourceHealthAlerts}
+            action="/settings/source-health-toggle"
+          >
+            Adds one line to the daily digest when a tracked board stops answering —
+            usually a rotated slug. The quiet-sources card on Companies is always on.
           </ToggleRow>
         </Card>
 

--- a/src/web/routes/companies.tsx
+++ b/src/web/routes/companies.tsx
@@ -5,6 +5,8 @@ import { z } from 'zod';
 import { prisma } from '../../db';
 import { logger } from '../../logger';
 import { probeAts } from '../../ats-probe';
+import { quietReason } from '../../fetchers/source-health';
+import { getSettings } from '../../settings';
 import { toStringArray } from '../../text-utils';
 import {
   companiesInSegments,
@@ -71,6 +73,8 @@ companiesRoute.get('/companies', async (c) => {
     alertedMap.set(row.companyId, row._count._all);
   }
 
+  const settings = await getSettings();
+  const now = new Date();
   const rows = companies.map((c) => ({
     id: c.id,
     name: c.name,
@@ -81,6 +85,15 @@ companiesRoute.get('/companies', async (c) => {
     jobsTotal: c._count.jobs,
     alertedTotal: alertedMap.get(c.id) ?? 0,
     lastFetchedAt: c.jobs[0]?.fetchedAt ?? null,
+    lastFetchStatus: c.lastFetchStatus,
+    consecutiveFailures: c.consecutiveFailures,
+    lastOkAt: c.lastOkAt,
+    // Only sources we actually poll can be judged: a disabled row, or one in
+    // a source family the user switched off, is silent by instruction.
+    quiet:
+      c.active && !settings.disabledSources.includes(c.atsType)
+        ? quietReason(c, now)
+        : null,
   }));
 
   const counts = countsBySegment();
@@ -91,7 +104,12 @@ companiesRoute.get('/companies', async (c) => {
 
   const flash = parseFlashCookie(c.req.header('cookie'));
   return c.html(
-    <CompaniesPage companies={rows} packs={packs} flash={flash} />,
+    <CompaniesPage
+      companies={rows}
+      packs={packs}
+      flash={flash}
+      fetchingEnabled={settings.fetchingEnabled}
+    />,
     200,
     { 'Set-Cookie': clearFlashCookie() },
   );
@@ -226,6 +244,45 @@ companiesRoute.post('/companies/:id/toggle-active', async (c) => {
     c,
     'ok',
     `${current.name} ${current.active ? 'disabled' : 'enabled'}.`,
+  );
+});
+
+/**
+ * Repair path for a quiet source: re-run the same public probe the add form
+ * uses. A probe that comes back clean clears the streak, so a source that
+ * recovered stops nagging without waiting for the next tick.
+ */
+companiesRoute.post('/companies/:id/reprobe', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!Number.isFinite(id)) return c.text('Bad id', 400);
+  const company = await prisma.company.findUnique({
+    where: { id },
+    select: { name: true, atsType: true, atsToken: true },
+  });
+  if (!company) return c.text('Not found', 404);
+
+  const probe = await probeAts(company.atsType, company.atsToken);
+  if (!probe.ok) {
+    return redirectWithFlash(
+      c,
+      'err',
+      `${company.name}: ${probe.error ?? 'probe failed'}`,
+    );
+  }
+
+  const jobsCount = probe.jobsCount ?? 0;
+  await prisma.company.update({
+    where: { id },
+    data: {
+      lastFetchStatus: jobsCount > 0 ? 'ok' : 'empty',
+      consecutiveFailures: 0,
+      ...(jobsCount > 0 ? { lastOkAt: new Date() } : {}),
+    },
+  });
+  return redirectWithFlash(
+    c,
+    'ok',
+    `${company.name}: board answered with ${jobsCount} posting${jobsCount === 1 ? '' : 's'}.`,
   );
 });
 

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -14,6 +14,7 @@ import {
   setClassifierMode,
   setDisabledSources,
   setFetchingEnabled,
+  setSourceHealthAlerts,
   setStaleApplicationsDigestEnabled,
   setTelegramEnabled,
   testTelegramTarget,
@@ -157,6 +158,7 @@ async function loadSettingsProps() {
     classifierMode: settings.classifierMode,
     applicationTrackingEnabled: settings.applicationTrackingEnabled,
     staleApplicationsDigestEnabled: settings.staleApplicationsDigestEnabled,
+    sourceHealthAlerts: settings.sourceHealthAlerts,
     disabledSources: settings.disabledSources,
     allSources: Object.values(AtsType).filter((t) => t !== AtsType.MANUAL),
     fetchingEnabled: settings.fetchingEnabled,
@@ -410,6 +412,16 @@ settingsRoute.post('/settings/stale-digest-toggle', async (c) => {
     `Stale-applications digest ${
       !settings.staleApplicationsDigestEnabled ? 'enabled' : 'disabled'
     }.`,
+  );
+});
+
+settingsRoute.post('/settings/source-health-toggle', async (c) => {
+  const settings = await getSettings();
+  await setSourceHealthAlerts(!settings.sourceHealthAlerts);
+  return flashRedirect(
+    '/settings?tab=notifications',
+    'ok',
+    `Source health alerts ${!settings.sourceHealthAlerts ? 'enabled' : 'disabled'}.`,
   );
 });
 


### PR DESCRIPTION
F4 from the expansion plan. A company rotates its board slug, the fetcher
returns zero jobs, and nothing ever says so. This records per-source
reachability with a real status vocabulary and escalates on streaks.

**Tag: `v0.7.0`, not the plan's `v0.6.0`** — F3 took v0.6.0, and §0.1 step 7
assigns numbers in actual integration order.

## What the re-analysis changed

Measured before writing code, not assumed. A read-only sweep called
`fetchOne` for all 71 active sources and recorded raw pre-filter counts:

| Result | Count | Detail |
|---|---|---|
| jobs returned | 67 | healthy |
| **HTTP 404** | **2** | `GREENHOUSE:pleo`, `LEVER:plaid` — deterministic, re-checked twice |
| 0 postings, HTTP 200 | 2 | `ASHBY:niantic`, `SMARTRECRUITERS:Visa` |

**Two dead slugs were already failing silently in the live database.** They
show up on `/companies` in the screenshot below.

Three plan assumptions did not survive contact with the data:

1. **"`empty` is healthy" is not sufficient.** 7 of 10 per-company vendors
   `return []` on a malformed top-level payload (only Greenhouse / Lever /
   Ashby throw), and `api.smartrecruiters.com` answers HTTP 200 with
   `totalFound: 0` for *every* identifier — `Visa`, `Bosch`, `Ubisoft`,
   `IKEA` and a random non-existent string alike, under our UA and a browser
   UA. A single failure counter marks all of that permanently green. So
   health carries **two** signals: the failure streak, and `lastOkAt` (which
   advances only on `ok`) ageing into "silent".
2. **The status vocabulary needed two more entries.** `rate_limit` — observed
   live, Cloudflare answered 429 for a Workable board that was fine — and
   `bad_payload`. Mapping a 429 to `slug_gone` would tell you your board is
   dead when it is merely busy.
3. **The error shapes are not what they look like.** A timeout does *not*
   arrive as an `AbortError` (`fetchWithRetry` rewrites it into a plain
   `Error`; only the message identifies it), and a dead BambooHR slug arrives
   as a *refused redirect*, not a 404. The map is built on measured
   discriminators — the table is in ADR 0019.

**Threshold `>= 3` kept.** Fetch is hourly, so three ticks is three hours and
nine HTTP attempts (`fetchWithRetry` already absorbs blips with two retries),
and the observed transient-failure base rate across 71 sources is zero. The
14-day silence threshold could **not** be measured — `lastOkAt` has no history
yet — so it is conservative and flagged as unmeasured, due a re-measure the
way F3's constants were.

**Status is read from the raw pre-filter count.** 46 of 65 active companies
hold zero `Job` rows; that is `passesBaseFilter` working, not a broken board.
On `/companies` you can see Andela at `Jobs 0` / `Health OK`.

## ADR 0016's deferred item — decided, not left silent

ADR 0016 deferred "marking jobs expired when they vanish from a polled board
feed" to be designed with F4. Designed, and **deferred again with the gate
written down**: the blocker is not the health signal (that now exists) but
**list completeness** — no fetcher can assert a 200 contained the whole board,
several cap pages by constant, and SmartRecruiters above is a live example of
a 200 that is silently empty. Under ADR 0016's asymmetry doctrine ("a false
`expired` hides a live job forever") that trade is refused. Gate to land it: a
vendor `total` cross-check plus a `status = ok` guard. ADR 0016 now links here.

## Changes

- `Company.lastFetchStatus / consecutiveFailures / lastOkAt` +
  `AppSettings.sourceHealthAlerts`, hand-written migration (gotcha 7),
  additive only.
- `src/fetchers/source-health.ts` — pure: `classifyFetchError`,
  `classifyFetchCount`, `nextStreak`, `isFailing` / `isSilent` /
  `quietReason`, `describeStatus`. 31 unit tests.
- The streak is **inverted on purpose**: `ok` and `empty` reset, everything
  else increments including `unknown`, so a future error kind cannot fall out
  of it by omission. A test asserts exactly two statuses are treated as
  healthy — adding a third fails the build.
- Wrapper in `runAllFetchers`; a failed health write logs and returns rather
  than costing the tick its jobs.
- `/companies`: status dot per row, "Quiet sources" card with Failing/Silent
  badges and one-click Re-probe (reuses `probeAts` as the repair path — a
  clean probe clears the streak).
- One digest line behind the `sourceHealthAlerts` toggle (Notifications tab).

## Verification

- `npm run lint:types` + `npm test` — **563 pass, 0 fail**.
- Migration applied in the container: `20260831170000_add_source_health`,
  all four columns present, recorded in `_prisma_migrations`.
- **Smoke** (DB writes, reverted): `SoftwareMill` (id 2240, disabled) pointed
  at a bad slug and activated; three ticks gave `slug_gone` streak 1 → 2 → 3,
  and the threshold warning fired at 3. Re-probe on the bad slug refused with
  a clear error and left the streak intact; after restoring the slug, re-probe
  reported "board answered with 0 postings" and cleared the streak. Row
  restored to its exact pre-smoke state (verified against a saved snapshot).
  The health columns on the other 70 rows are the feature running normally —
  the hourly tick would have written them anyway.
- UI: every route 200, settings toggle round-trips (off → DB false → on),
  screenshots at 1200px and 375px, **0 console errors**.
- Digest line rendered against real data, MarkdownV2 escaping correct:
  `⚠️ *2 quiet sources* — Plaid \(LEVER, slug not found ×3\), Pleo \(GREENHOUSE, slug not found ×3\)`
- **Skipped:** `npm run test:telegram` — a real outward send was not in the
  verification list, and the escaping is covered by unit tests.
- Copy-check: nothing external was consulted; the map is built from our own
  code and live vendor responses observed by curl.

## Pre-merge review (code-review-expert)

Two **P1** found and fixed on the branch:

1. **Unbounded digest header.** A network outage marks every source at once;
   an uncapped list pushed the digest header past Telegram's 4096-char limit,
   which rejects the whole message — losing the alert exactly when it matters
   most. Now capped at 8 named + "and N more", with a test.
2. **Unchecked `as AtsType[]` cast** on `disabledSources` in the digest query.
   One stale value throws on the Prisma enum filter and takes the digest down.
   Both call sites now go through a single checked `toAtsTypes` reader.

Plus a P2: the status dot's `sr-only` text duplicated the visible label when
there was no streak.

## Follow-ups (P2/P3, not in this PR)

- **`isSilent` has no warm-up.** It anchors on `createdAt` when `lastOkAt` is
  null, so on first deploy any long-tracked source that is empty *right now*
  reads as silent immediately. Both rows it flagged here are true positives
  (neither has ever produced a posting), but the signal deserves a re-measure
  once `lastOkAt` has a few weeks of history.
- **SmartRecruiters may be dead as a source**, not just unprobeable — the
  Posting API returned `totalFound: 0` for every major customer tested. Worth
  its own look; it also degrades ADR 0016's rung-1 liveness check for that
  vendor.
- **7 vendors still swallow shape drift into `[]`.** Only the 14-day silence
  signal catches it. A per-fetcher "payload looked wrong" signal would catch
  it on the first tick.
- `sendDigest(alerts, undefined, quiet)` — the positional `undefined` for
  `profile` is ugly; an options object would read better, but the signature
  has four call sites.

## Release notes draft — v0.7.0 "source health monitoring"

> Tracked job boards now report whether they are actually answering. Every
> fetch records a status per source (`ok`, `empty`, `slug not found`, `gated`,
> `rate-limited`, `vendor error`, `unreachable`, `unreadable payload`), and a
> board that fails three ticks in a row — or stays reachable but silent for
> two weeks — is listed in a "Quiet sources" card at the top of Companies with
> a one-click re-probe to repair it. Each row also carries a health dot, read
> from the board's raw output rather than from stored jobs, so a strict
> profile filter never looks like a broken board. Optionally, one line in the
> daily Telegram digest names sources that went quiet.
>
> Turning this on immediately surfaced two boards in this deployment that had
> been failing silently: `GREENHOUSE:pleo` and `LEVER:plaid`.
