### PR TITLE
F7: fact gate — deterministic anti-hallucination check (no tag, ships with F8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@
 - `src/resume/` is the resume module: `zip.ts`, `docx-text.ts`, `pdf-text.ts`
   (unpdf, ADR 0011), `resume-text.ts`, `prompts.ts`, `pick.ts`, `score.ts`
   (ADR 0012), `facts.ts`, `diff.ts`, `parse-warnings.ts`,
-  `profile-draft.ts` (ADR 0015) are pure (tested);
+  `profile-draft.ts` (ADR 0015), `fact-check.ts` (ADR 0020) are pure (tested);
   `scan.ts` / `match.ts` call the AI provider; `store.ts` is the only file
   that touches Prisma. Web-only — the worker never imports it (ADR 0008).
 - `src/web/public/score.mjs` mirrors `src/resume/score.ts` line for line —
@@ -157,6 +157,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | The match-score formula (weights, alignment points, primary-stack cap) | `src/resume/score.ts` (ADR 0012) — mirrored in `src/web/public/score.mjs`, parity test `src/web/score.test.ts` |
 | What counts as primary stack / sibling-tech rules (prompt side) | `src/resume/prompts.ts:MATCH_SYSTEM` steps 3-4 — guard-tested in `prompts.test.ts` |
 | ask_user confirmations (CandidateFact rows, instant re-score) | `src/resume/facts.ts` (pure) + `src/web/routes/facts.ts` (POST /facts), managed on `/resumes` |
+| Anti-hallucination gate for generated prose (pass/warn/block) | `src/resume/fact-check.ts:factCheck` (pure, ADR 0020) — sources arrive as arguments, `store.ts` loads them |
 | "In another resume" evidence hints | `src/resume/store.ts:listOtherResumeSkills` → `facts.ts:annotateElsewhere` |
 | ATS parse warnings ("What the ATS sees") | `src/resume/parse-warnings.ts`, rendered on `/resumes/:id` |
 | Version delta (gained/lost keywords, component moves) | `src/resume/diff.ts:diffMatches`, rendered in `resume-match-card.tsx` |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -393,7 +393,21 @@ external project, copy-check before merge.
       again, gate written down (list-completeness assertion)
 - [ ] F5 status-transition ledger + funnel/calibration stats — v0.7.0
 - [ ] F6 follow-up cadence with pin/retire/auto-seed in the stale digest — v0.8.0
-- [ ] F7 fact gate (anti-hallucination pure module) — v0.9.0
+- [x] F7 fact gate (anti-hallucination pure module) — no tag of its own
+      (branch `fact-gate`, ADR 0020). Ships untagged with F8 per
+      release-discipline's pure-module rule: no route, no column, no toggle,
+      nothing a user can observe. Re-analysis on live data changed the
+      design: all 4 confirmed `CandidateFact` rows are bare tool terms, so
+      the metric side is sourced entirely from resume text and facts can only
+      support a *tool* claim — while the 4 `denied` rows became a hard block
+      the plan never proposed. The plan's headline `16,181` separator case has
+      zero occurrences in our corpus; the 7 spelled-out numerals it never
+      mentions do, so priority inverted. NFKC measured insufficient (it leaves
+      `–`, `—`, `’` — the only non-ASCII we have). Zero Cyrillic in 3 resumes
+      and 771 job descriptions, so "EN + UA" narrowed to: percent/currency
+      script-agnostic, count nouns and history triggers EN-only, non-Latin
+      sentences degrade `pass → warn`. Measured 0.75ms median on a 285-word
+      letter vs the real 6004-char resume — the 50ms budget is 66x over
 - [ ] F8 cover letter generation (job + company analysis, gated by F7) — v0.10.0
 - [ ] F9 golden-eval harness for the AI engine chain — v0.11.0
 - [ ] F10 fetchers wave 2: Getro/Consider/a16z, Arbeitsagentur, Teamtailor,

--- a/docs/adr/0020-fact-gate-blocks-fabrication-not-imprecision.md
+++ b/docs/adr/0020-fact-gate-blocks-fabrication-not-imprecision.md
@@ -1,0 +1,98 @@
+# 0020 — The fact gate blocks fabrication, not imprecision
+
+**Status:** Accepted (2026-08-31)
+
+## Context
+
+Cover letters (F8) and, later, AI edit suggestions in the target editor
+generate prose that a recruiter reads as the candidate's own claims. Gotcha
+11 already cost us once: a scoring prompt without an explicit hard cap
+averaged its way to a flattering number. A generation prompt without a
+deterministic check does the same with facts — an invented "40%" reads
+exactly like a real one.
+
+Measured on our own data before designing (2026-08-31):
+
+- **`CandidateFact` carries no numbers.** 8 rows (4 confirmed, 4 denied),
+  every one a bare tool term (`nginx`, `stripe`, `varnish`). The model is
+  `term/status/note`. So the metric side of the gate is sourced entirely
+  from resume text; facts can only ever support a *tool* assertion — and a
+  `denied` row is the one signal that contradicts the resume outright.
+- **Noise dominates the numeric surface.** 59 digit-bearing spans in the
+  6004-char resume, ~19 of them real claims. The rest are years
+  (`2009`–`2024`), tool versions (`PHP 7`, `v1.5`, `HTML5`, `EC2`, `p95`),
+  big-O (`O(N2log2N)`), a ZIP (`78758`) and a phone in two formats
+  (`267-5544`, `267 5544`). "Any digit is a claim" makes the gate fire on
+  its own contact line.
+- **The plan's headline normalization example does not occur.** Zero
+  thousands separators in our texts; the only regex hit is `267 554` —
+  a fragment of the phone number. Meanwhile 7 spelled-out numerals do
+  occur (`four developers`, `three parts`, `zero downtime`), which the plan
+  never mentions. A digit-only extractor blocks "mentored 4 developers"
+  against a resume that says "four".
+- **NFKC is necessary but not sufficient.** It leaves `–`, `—` and `’`
+  untouched — the exact non-ASCII characters our resumes contain (`∙` ×10,
+  `–` ×7, `’` ×4). Dash and quote folding are separate explicit steps.
+- **No Ukrainian exists yet.** 0 of 3 resumes and 0 of 771 job descriptions
+  contain Cyrillic, so the plan's "EN + UA extraction" has no fixture behind
+  it.
+
+## Decision
+
+`src/resume/fact-check.ts` is a pure module (no Prisma, no I/O — sources
+arrive as arguments; `store.ts` loads them). It extracts claims from the
+generated text and from the sources through **one** normalization pipeline
+and returns `pass | warn | block` plus the claims behind the verdict.
+
+**It is a fabrication detector, not a precision auditor.** Every ambiguous
+case resolves toward *not blocking*. A gate that fires on truthful text
+teaches the user to click through it, at which point it protects nothing.
+Concretely:
+
+| Situation | Verdict | Why |
+|---|---|---|
+| Value absent from every source | `block` | the thing the gate exists for |
+| `denied` CandidateFact term asserted | `block` | user said outright they lack it |
+| Employer / title asserted with a history trigger, absent from sources | `block` | plan acceptance criterion |
+| `10 years` vs source `10+ years` | supported | `+` is hedging, not a different number |
+| `40 min` vs source bare `4` | supported only when one side has no unit | unit drift is phrasing |
+| `40%` vs source `40 min` | unsupported | both carry units, and they differ |
+| count noun differs (`200 million users` vs `…registered users`) | supported | value carries the claim, not the noun |
+| Numeric span the extractor cannot classify | `warn` + "N claims could not be checked" | unchecked must never look like checked-and-clean |
+
+Normalization applies identically to both sides: NFKC → dash fold → quote
+fold → bullet fold → block-level breaks become sentence boundaries →
+lowercase; then per-number canonicalization (contact/URL spans stripped
+first, then spelled-out numerals, magnitude suffixes, and group-structured
+thousands separators). Allowlist entries (`allowMetrics` / `allowFacts`)
+run through the same pipeline, so an entry that can never match is
+detectable rather than silently inert.
+
+**Language scope, stated honestly:** percent, currency and bare-number
+extraction is script-agnostic and works in any language; count nouns and
+the employer/title triggers are English-only. A sentence that is mostly
+non-Latin marks its numbers `unchecked`, degrading `pass → warn`. The gate
+never reports "clean" for text it cannot read.
+
+## Consequences
+
+✅ F8 can regenerate against quoted violations instead of showing an
+   unverified letter; every later generation surface reuses one seam.
+✅ The 4 `denied` facts finally do work — they contradict generation.
+✅ Pure and unit-testable; no schema, no UI, no toggle in this feature.
+❌ Tool assertions are checked only against the CandidateFact vocabulary —
+   we do not classify arbitrary words as tools. A fabricated tool the user
+   has never been asked about passes.
+❌ The bias toward not blocking lets a true number be reused under a
+   different unit when one side is unitless.
+❌ A four-state provenance model on `CandidateFact` (`verified / supported /
+   derived-unverified / cannot-confirm`) is **deferred**: it needs a schema
+   change F7 deliberately avoids, and our 8 bare-term rows show no
+   population to model. Revisit when facts feed generation beyond F8.
+
+## When to revisit
+
+A real letter blocked on a truthful claim (tighten the extractor, never the
+verdict), or the first non-English resume entering the corpus — at which
+point the `unchecked` counter is already the measurement of how much that
+language costs us.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0017 — Starter-pack entries pin a hand-verified board](./0017-starter-packs-pin-verified-boards.md)
 - [0018 — Cross-listing is annotated, never merged](./0018-simhash-annotates-never-merges.md)
 - [0019 — Source health is a per-company streak; `empty` resets it but does not prove health](./0019-source-health-streaks.md)
+- [0020 — The fact gate blocks fabrication, not imprecision](./0020-fact-gate-blocks-fabrication-not-imprecision.md)
 
 ## When to write a new one
 

--- a/src/resume/fact-check.test.ts
+++ b/src/resume/fact-check.test.ts
@@ -143,6 +143,9 @@ test('a captured employer run keeps no dangling connector', () => {
   const r = check('I mentored four engineers at Northwind Freight and drove the rewrite.', [FIXTURE_RESUME]);
   assert.equal(r.verdict, 'pass', r.reasons.join(' | '));
   assert.ok(r.claims.some((c) => c.kind === 'employer' && c.text === 'Northwind Freight'));
+  // "At OGD Solutions I processed …" captured "OGD Solutions I" and blocked.
+  const pronoun = check('At Northwind Freight I rebuilt the pricing cache.', [FIXTURE_RESUME]);
+  assert.equal(pronoun.verdict, 'pass', pronoun.reasons.join(' | '));
 });
 
 test('magnitude suffixes and words resolve to the same value', () => {
@@ -185,6 +188,21 @@ test('TITLE_NOUNS is what makes an "as a …" span a claim', () => {
   assert.equal(check('As a result, deploys got faster.', [FIXTURE_RESUME]).verdict, 'pass');
 });
 
+test('a sentence-initial trigger is still a history claim', () => {
+  // /i on the whole regex would have relaxed [A-Z] too, making every lowercase
+  // word after "at" read as a company.
+  assert.equal(check('At Stripe Financial I led delivery.', [FIXTURE_RESUME]).verdict, 'block');
+  assert.equal(check('As a Principal Architect I owned the rewrite.', [FIXTURE_RESUME]).verdict, 'block');
+  assert.equal(check('I tuned the cache for the edge tier.', [FIXTURE_RESUME]).verdict, 'pass');
+});
+
+test('a paraphrased title is supported word by word', () => {
+  const sources = ['Senior Backend PHP Engineer at Northwind Freight.'];
+  assert.equal(check('I worked as a senior backend engineer.', sources).verdict, 'pass');
+  // A company name is an identity, so it still has to match as one unit.
+  assert.equal(check('I worked at Northwind Airlines.', sources).verdict, 'block');
+});
+
 test('REAL letter against REAL resume does not block', () => {
   const r = factCheck({ text: REAL_LETTER, sources: [REAL_RESUME], addressee: 'HS GovTech', facts: FACTS });
   assert.equal(r.verdict, 'pass', r.reasons.join(' | '));
@@ -214,6 +232,12 @@ test('a confirmed fact supports a tool the resume never spells out', () => {
   const r = factCheck({ text: 'I wired up Stripe billing.', sources: [FIXTURE_RESUME], facts: FACTS });
   assert.equal(r.verdict, 'pass');
   assert.ok(r.claims.some((c) => c.kind === 'tool' && c.from === 'fact'));
+});
+
+test('a fact term with regex metacharacters is matched literally', () => {
+  const facts: FactLike[] = [{ term: 'c++', status: 'denied', note: null }];
+  assert.equal(factCheck({ text: 'I write C++ daily.', sources: [FIXTURE_RESUME], facts }).verdict, 'block');
+  assert.equal(factCheck({ text: 'I write Go daily.', sources: [FIXTURE_RESUME], facts }).verdict, 'pass');
 });
 
 // ------------------------------------------------- deliberate non-strictness
@@ -255,6 +279,10 @@ test('an inert allowlist entry is reported, not silently ignored', () => {
   const r = factCheck({ text: LETTER_WITHOUT_NUMBER, sources: [FIXTURE_RESUME], allowMetrics: ['  '] });
   assert.deepEqual(r.inertAllowlist, ['  ']);
   assert.ok(r.reasons.some((x) => x.includes('can never match')));
+  // An allowMetrics entry with no number canonicalizes to a term and looks
+  // valid, but nothing in the metric path will ever consult it.
+  const noNumber = factCheck({ text: LETTER_WITHOUT_NUMBER, sources: [FIXTURE_RESUME], allowMetrics: ['Acme Corp'] });
+  assert.deepEqual(noNumber.inertAllowlist, ['Acme Corp']);
 });
 
 test('an allowlisted employer passes', () => {

--- a/src/resume/fact-check.test.ts
+++ b/src/resume/fact-check.test.ts
@@ -1,0 +1,305 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { canonicalizeAllowEntry, factCheck, normalizeText, TITLE_NOUNS } from './fact-check';
+import type { FactLike } from './facts';
+
+/*
+ * Fixtures marked REAL are verbatim from our own database (Resume rows 1 and
+ * 2, read 2026-08-31) — they are the regression that matters: the gate must
+ * never block the letter Nazar actually sent against the resume he actually
+ * has.
+ */
+
+/** REAL — excerpt of Resume id=1, the numbers and shapes measured for ADR 0020. */
+const REAL_RESUME = `Nazar Boyko
+Senior Software Engineer
+Austin, Texas, 78758 ∙ boyko.nazar@gmail.com ∙ +1 (612) 267-5544 ∙ linkedin.com/in/nazar-boyko
+
+Senior full-stack engineer (10+ years) shipping production Laravel/React systems end-to-end. Led platforms supporting $10M+ ARR with 99.9% uptime.
+
+V Shred | Austin, Texas, US ∙ Remote
+Senior Software Engineer | Dec. 2024 – Present
+- Combined Snyk/Dependabot with Claude AI to detect vulnerabilities, reducing risks by 40%+.
+- Engineered a centralized, multi-gateway payment error-handling platform (Braintree, Adyen), increasing successful transactions by 15–20%.
+- Built and deployed a cross-platform notification system that boosted mobile DAU by 200%.
+Technology Stack: PHP, Laravel, Phalcon, Typescript, React, Cypress, MySQL, S3, EC2, RDS.
+
+Vodwork (Aylo project) | Hopkins, Minnesota, US ∙ Remote
+Senior Full-Stack Engineer | Jan. 2021 – Dec. 2024
+- Reduced the complexity of the system, cutting costs by hundreds of thousands of dollars annually.
+- Integrated Windsurf (Opus 4.6) and Claude App, reducing development time by 30 - 40%.
+- Decreased the data logs storing algorithm (space complexity) from O(N2log2N) to O(N).
+
+PROBEGIN B.V. | Lelystad, Netherlands ∙ Hybrid
+Senior PHP Engineer / Team Lead | Sep. 2019 – Jan. 2021
+- Led a high-load CRM using PostgreSQL, Lumen and Vue.js, achieving a 40% reduction in response time.
+- Guided and mentored four developers, fostering growth and collaborative teamwork.
+
+OGD Solutions | Lviv, Ukraine ∙ On-site
+Senior Laravel Developer | Sep. 2018 – Sep. 2019
+- Processed data from a global survey of nearly 200 million registered users.
+- Divided a substantial database into three parts for different clients.`;
+
+/** REAL — Resume id=2 verbatim: a cover letter Nazar actually sent. */
+const REAL_LETTER = `Hi HS GovTech Team,
+I’m excited to apply for the Full Stack Developer position. I’ve spent the past several years
+building and maintaining large-scale SaaS and data-driven platforms, mainly with PHP,
+TypeScript, and React, and I really enjoy turning complex systems into clean, reliable, and
+user-friendly solutions.
+What I like about HS GovTech is your mission - helping government agencies modernize their
+workflows and deliver better public services. I’d love to contribute to that by bringing my
+experience in scalable backend design, API development, and modern front-end work to your
+team.
+Thank you for considering my application - I’d be happy to chat anytime.
+Best,
+Nazar Boyko
+Senior Software Engineer
+www.nazarboyko.com
++1 (612) 267 5544
+boyko.nazar@gmail.com`;
+
+/** Purpose-built pair for the acceptance criterion: the source has no 40%. */
+const FIXTURE_RESUME = `Dana Reyes
+Backend Engineer
+- Cut checkout latency by 25% by reworking the pricing cache at Northwind Freight.
+- Migrated 16,181 legacy invoices to the new billing service with zero downtime.
+- Mentored four engineers through the platform rewrite.`;
+
+const LETTER_WITH_INVENTED = `Dear team,
+I reworked the pricing cache and cut checkout latency by 40%.
+I also migrated 16,181 legacy invoices with zero downtime.`;
+
+const LETTER_WITHOUT_NUMBER = `Dear team,
+I reworked the pricing cache and cut checkout latency substantially.
+I also migrated 16,181 legacy invoices with zero downtime.`;
+
+const FACTS: FactLike[] = [
+  { term: 'nginx', status: 'confirmed', note: null },
+  { term: 'stripe', status: 'confirmed', note: null },
+  { term: 'varnish', status: 'denied', note: null },
+  { term: 'fastly cdn', status: 'denied', note: null },
+];
+
+const check = (text: string, sources: string[], extra: Record<string, unknown> = {}) =>
+  factCheck({ text, sources, ...extra });
+
+// ------------------------------------------------------------- normalization
+
+test('folds the three non-ASCII characters our resumes actually contain', () => {
+  // Measured: NFKC leaves all three alone, so they need explicit folding.
+  assert.equal(normalizeText('15–20%'), '15-20%');
+  assert.equal(normalizeText('I’m'), "I'm");
+  assert.equal(normalizeText('Austin ∙ Texas'), 'Austin ; Texas');
+  assert.equal(normalizeText('a   b\nc'), 'a b\nc');
+});
+
+test('NFKC still handles what it is good at', () => {
+  assert.equal(normalizeText('２M'), '2M');
+  assert.equal(normalizeText('16 181'), '16 181');
+});
+
+test('block boundaries stop two bullets gluing into one phantom claim', () => {
+  // "…by 30\n- Rebuilt 12 pipelines" must not read as a 30-12 range.
+  const r = check('- Improved throughput by 30\n- Rebuilt 12 pipelines', ['Improved throughput by 30. Rebuilt 12 pipelines.']);
+  assert.equal(r.verdict, 'pass');
+});
+
+test('separator variants canonicalize to the same claim', () => {
+  for (const written of ['16,181', '16 181', '16181', '16 181']) {
+    const r = check(`Migrated ${written} invoices.`, ['Migrated 16181 invoices.']);
+    assert.equal(r.verdict, 'pass', written);
+  }
+});
+
+test('a phone number is not a claim, and yields no ghost thousands', () => {
+  // The only separator-shaped match in our corpus is "267 554" inside a phone.
+  const r = check('Reach me at +1 (612) 267-5544 or +1 (612) 267 5544.', ['no numbers here']);
+  assert.equal(r.verdict, 'pass');
+  assert.deepEqual(r.claims, []);
+});
+
+test('years, tool versions and big-O are not quantities', () => {
+  const r = check(
+    'From 2019 to 2022 I shipped PHP 7 and Vue.js 2 on EC2, cutting O(N2log2N) to O(N).',
+    ['nothing quantitative at all'],
+  );
+  assert.equal(r.verdict, 'pass');
+});
+
+test('spelled-out numerals match their digits', () => {
+  // 7 occurrences in our corpus, versus 0 thousands separators.
+  assert.equal(check('I mentored 4 developers.', ['Guided and mentored four developers.']).verdict, 'pass');
+  assert.equal(check('Guided three teams.', ['Guided 3 teams.']).verdict, 'pass');
+});
+
+test('an article-like "one" is not a count claim', () => {
+  // "split one database into three parts" false-blocked until this was fixed.
+  assert.equal(check('I split one database into three parts.', [FIXTURE_RESUME + '\nSplit that database into three parts.']).verdict, 'pass');
+  assert.equal(check('I led one of the platform teams.', [FIXTURE_RESUME]).verdict, 'pass');
+});
+
+test('a captured employer run keeps no dangling connector', () => {
+  // "at PROBEGIN and drove" captured "PROBEGIN and" and blocked a true claim.
+  const r = check('I mentored four engineers at Northwind Freight and drove the rewrite.', [FIXTURE_RESUME]);
+  assert.equal(r.verdict, 'pass', r.reasons.join(' | '));
+  assert.ok(r.claims.some((c) => c.kind === 'employer' && c.text === 'Northwind Freight'));
+});
+
+test('magnitude suffixes and words resolve to the same value', () => {
+  assert.equal(check('Served 2M requests a day.', ['Served 2 million requests a day.']).verdict, 'pass');
+  assert.equal(check('Retired 40,000 lines.', ['Retired 40k LOC.']).verdict, 'pass');
+});
+
+// ----------------------------------------------------------------- verdicts
+
+test('an invented metric blocks', () => {
+  const r = check(LETTER_WITH_INVENTED, [FIXTURE_RESUME]);
+  assert.equal(r.verdict, 'block');
+  assert.ok(r.reasons.some((x) => x.includes('40%')), r.reasons.join(' | '));
+});
+
+test('the same letter without the number passes', () => {
+  assert.equal(check(LETTER_WITHOUT_NUMBER, [FIXTURE_RESUME]).verdict, 'pass');
+});
+
+test('a supported metric passes', () => {
+  assert.equal(check('I cut checkout latency by 25%.', [FIXTURE_RESUME]).verdict, 'pass');
+});
+
+test('an employer absent from the resume blocks', () => {
+  const r = check('I led the payments platform at Northwind Freight.', [FIXTURE_RESUME]);
+  assert.equal(r.verdict, 'pass');
+  const bad = check('I led the payments platform at Stripe Financial.', [FIXTURE_RESUME]);
+  assert.equal(bad.verdict, 'block');
+  assert.ok(bad.reasons.some((x) => x.includes('Stripe Financial')), bad.reasons.join(' | '));
+});
+
+test('a title never held blocks, a real one passes', () => {
+  assert.equal(check('I worked as a Backend Engineer.', [FIXTURE_RESUME]).verdict, 'pass');
+  assert.equal(check('I worked as a Principal Architect.', [FIXTURE_RESUME]).verdict, 'block');
+});
+
+test('TITLE_NOUNS is what makes an "as a …" span a claim', () => {
+  assert.ok(TITLE_NOUNS.includes('engineer'));
+  // "as a result" carries no role noun and must not be read as a claim.
+  assert.equal(check('As a result, deploys got faster.', [FIXTURE_RESUME]).verdict, 'pass');
+});
+
+test('REAL letter against REAL resume does not block', () => {
+  const r = factCheck({ text: REAL_LETTER, sources: [REAL_RESUME], addressee: 'HS GovTech', facts: FACTS });
+  assert.equal(r.verdict, 'pass', r.reasons.join(' | '));
+});
+
+test('the addressee is not a claim about the past', () => {
+  const named = factCheck({ text: 'I want to build this at HS GovTech.', sources: [FIXTURE_RESUME], addressee: 'HS GovTech' });
+  assert.equal(named.verdict, 'pass');
+  const unnamed = factCheck({ text: 'I want to build this at HS GovTech.', sources: [FIXTURE_RESUME] });
+  assert.equal(unnamed.verdict, 'block');
+});
+
+// -------------------------------------------------------------------- facts
+
+test('a denied fact term blocks even though nothing else is wrong', () => {
+  const r = factCheck({ text: 'I tuned Varnish for the edge tier.', sources: [FIXTURE_RESUME], facts: FACTS });
+  assert.equal(r.verdict, 'block');
+  assert.ok(r.reasons.some((x) => x.includes('cannot claim')), r.reasons.join(' | '));
+});
+
+test('resume text outranks a stale denial, exactly as applyFacts does', () => {
+  const r = factCheck({ text: 'I tuned Varnish for the edge tier.', sources: ['Ran Varnish in front of the API.'], facts: FACTS });
+  assert.equal(r.verdict, 'pass');
+});
+
+test('a confirmed fact supports a tool the resume never spells out', () => {
+  const r = factCheck({ text: 'I wired up Stripe billing.', sources: [FIXTURE_RESUME], facts: FACTS });
+  assert.equal(r.verdict, 'pass');
+  assert.ok(r.claims.some((c) => c.kind === 'tool' && c.from === 'fact'));
+});
+
+// ------------------------------------------------- deliberate non-strictness
+
+test('"10 years" against a resume saying "10+ years" is not a fabrication', () => {
+  assert.equal(check('I have 10 years of experience.', [REAL_RESUME]).verdict, 'pass');
+});
+
+test('a unitless source figure supports a unit, but two different units do not', () => {
+  assert.equal(check('It now takes 4 minutes.', ['cut invoice generation from 40 min to 4']).verdict, 'pass');
+  assert.equal(check('I made it 40% faster.', ['cut invoice generation from 40 min to 4']).verdict, 'block');
+});
+
+test('a vague magnitude cannot be sharpened into a figure', () => {
+  assert.equal(check('Saved hundreds of thousands of dollars.', [REAL_RESUME]).verdict, 'pass');
+  assert.equal(check('Saved $400,000 a year.', [REAL_RESUME]).verdict, 'block');
+});
+
+// ---------------------------------------------------------------- allowlist
+
+test('an allowlisted metric passes and is labelled as allowed', () => {
+  const r = factCheck({ text: LETTER_WITH_INVENTED, sources: [FIXTURE_RESUME], allowMetrics: ['40%'] });
+  assert.equal(r.verdict, 'pass');
+  assert.ok(r.claims.some((c) => c.status === 'allowed' && c.from === 'allowlist'));
+});
+
+test('an allowlist entry written in another surface form still matches', () => {
+  // The bug class the gate exists to catch: an entry that never matches.
+  for (const entry of ['40 percent', '40%', 'improved conversion by 40%']) {
+    const r = factCheck({ text: LETTER_WITH_INVENTED, sources: [FIXTURE_RESUME], allowMetrics: [entry] });
+    assert.equal(r.verdict, 'pass', entry);
+  }
+});
+
+test('an inert allowlist entry is reported, not silently ignored', () => {
+  assert.equal(canonicalizeAllowEntry('40%'), 'pct:40');
+  assert.equal(canonicalizeAllowEntry('Acme Corp'), 'acme corp');
+  assert.equal(canonicalizeAllowEntry('   '), null);
+  const r = factCheck({ text: LETTER_WITHOUT_NUMBER, sources: [FIXTURE_RESUME], allowMetrics: ['  '] });
+  assert.deepEqual(r.inertAllowlist, ['  ']);
+  assert.ok(r.reasons.some((x) => x.includes('can never match')));
+});
+
+test('an allowlisted employer passes', () => {
+  const r = factCheck({ text: 'I led delivery at Stripe Financial.', sources: [FIXTURE_RESUME], allowFacts: ['Stripe Financial'] });
+  assert.equal(r.verdict, 'pass');
+});
+
+// ----------------------------------------------------------------- coverage
+
+test('unreadable count claims downgrade pass to warn, never a silent pass', () => {
+  const r = check('Я скоротив час обробки на 30 хвилин і навчив 4 інженерів.', [FIXTURE_RESUME]);
+  assert.equal(r.verdict, 'warn');
+  assert.equal(r.unchecked, 2);
+  assert.ok(r.reasons.some((x) => x.includes('could not be checked')), r.reasons.join(' | '));
+});
+
+test('percent survives outside Latin script, so an invented one still blocks', () => {
+  const r = check('Я скоротив затримку оформлення на 40%.', [FIXTURE_RESUME]);
+  assert.equal(r.verdict, 'block');
+});
+
+test('a supported percent in Ukrainian passes', () => {
+  const r = check('Я скоротив затримку оформлення на 25%.', [FIXTURE_RESUME]);
+  assert.equal(r.verdict, 'pass');
+});
+
+// -------------------------------------------------------------- performance
+
+test('a full letter checks well inside the 50ms budget', () => {
+  // F8 specifies 250-350 word letters; our largest stored resume is 6004 chars.
+  const source = Array.from({ length: 4 }, () => REAL_RESUME).join('\n');
+  const letter = Array.from({ length: 14 }, (_, i) =>
+    `In my last role I cut latency by 25% and moved 16,181 invoices with zero downtime, mentoring four engineers along the way (${i}).`,
+  ).join('\n');
+  assert.ok(letter.split(/\s+/).length >= 250, 'fixture letter is letter-sized');
+  assert.ok(source.length >= 6000, 'source is our largest-resume sized');
+
+  const runs = 50;
+  const times: number[] = [];
+  for (let i = 0; i < runs; i++) {
+    const t = performance.now();
+    factCheck({ text: letter, sources: [source], facts: FACTS, addressee: 'HS GovTech' });
+    times.push(performance.now() - t);
+  }
+  times.sort((a, b) => a - b);
+  const median = times[Math.floor(runs / 2)] as number;
+  assert.ok(median < 50, `median ${median.toFixed(2)}ms exceeds the 50ms budget`);
+});

--- a/src/resume/fact-check.ts
+++ b/src/resume/fact-check.ts
@@ -107,7 +107,7 @@ export function normalizeText(raw: string): string {
     .replace(/[‘’‛ʼ´`]/g, "'")
     .replace(/[“”„]/g, '"')
     .replace(/[•∙·●▪]/g, ' ; ')
-    .replace(/[   ]/g, ' ');
+    .replace(/[^\S\n]+/g, ' ');
 }
 
 /** Contact data is not evidence — strip it before any number is parsed. */
@@ -119,13 +119,20 @@ function maskContacts(s: string): string {
     .replace(/\+?\d{0,3}[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/g, ' ');
 }
 
-/** Tokens whose digits identify a thing, not a quantity. */
+/**
+ * Tokens whose digits identify a thing, not a quantity: big-O, `v1.5`,
+ * letter-glued forms (`EC2`, `HTML5`, `p95`) and anything year-shaped.
+ * Masking every year costs us the rare four-digit count ("2000 users");
+ * leaving them in costs a false block on every letter saying "since 2021".
+ * A spaced version (`PHP 7`) is not masked — it survives as a bare number
+ * and bare numbers do not block.
+ */
 function maskNonQuantities(s: string): string {
   return s
     .replace(/\bO\([^)]*\)/g, ' ')
     .replace(/\bv\d+(?:\.\d+)*\b/gi, ' ')
     .replace(/\b[A-Za-z]+\d[\w.*]*/g, ' ')
-    .replace(/\b(?:19|20)\d{2}\b(?!\s+[a-z])/g, ' ');
+    .replace(/\b(?:19|20)\d{2}\b/g, ' ');
 }
 
 /** Block boundaries, so two bullets never glue into one phantom claim. */
@@ -168,8 +175,12 @@ interface RawClaim {
 }
 
 const NUM = String.raw`\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?`;
-const WORD_NUM = Object.keys(SMALL_NUMBERS).join('|');
+// "one" is an article's cousin far more often than a quantity ("split one
+// database", "one of the teams"), and claiming it asserts nothing anyway.
+const WORD_NUM = Object.keys(SMALL_NUMBERS).filter((w) => w !== 'one').join('|');
 const MAG = `hundred|thousand|million|billion|k|m|b`;
+/** Function words after a number do not make it a count of anything. */
+const NOT_A_NOUN = `and|or|to|of|the|an|in|on|at|for|with|by|from|as|is|are|was|were|but|that|this|it|its|per|than|into|out|up|down|over|under`;
 
 /**
  * Ordered most-specific first; each match is blanked out of the segment so a
@@ -201,7 +212,7 @@ const PATTERNS: Array<{ unit: UnitClass; re: RegExp; values: (m: RegExpExecArray
   },
   {
     unit: 'count',
-    re: new RegExp(String.raw`\b(${NUM}|${WORD_NUM})\+?\s?(${MAG})?\s+[a-z][a-z-]+`, 'gi'),
+    re: new RegExp(String.raw`\b(${NUM}|${WORD_NUM})\+?\s?(${MAG})?\s+(?!(?:${NOT_A_NOUN})\b)[a-z][a-z-]+`, 'gi'),
     values: (m) => [scale(m[1], m[2])].filter(isValue),
   },
   {
@@ -267,6 +278,11 @@ interface RawAssertion {
  * written to is not one — measured on a real letter of ours, the addressee
  * appears in the second person ("your mission"), never under these triggers.
  */
+/** A captured run keeps neither trailing punctuation nor a dangling connector. */
+function trimRun(raw: string | undefined): string {
+  return (raw ?? '').trim().replace(/(?:[.,;:'-]+|\s+(?:of|and|&))+$/i, '');
+}
+
 function extractAssertions(normalized: string, addressee: string | null): RawAssertion[] {
   const out: RawAssertion[] = [];
   const skip = new Set(NOT_AN_EMPLOYER);
@@ -274,14 +290,14 @@ function extractAssertions(normalized: string, addressee: string | null): RawAss
   const addresseeKey = addressee ? canonicalTerm(addressee) : null;
 
   for (const m of normalized.matchAll(EMPLOYER_TRIGGER)) {
-    const name = (m[1] ?? '').trim();
+    const name = trimRun(m[1]);
     const key = canonicalTerm(name);
     if (!key || key === addresseeKey) continue;
     if (key.split(/\s+/).every((w) => skip.has(w))) continue;
     out.push({ kind: 'employer', text: name, canonical: key });
   }
   for (const m of normalized.matchAll(TITLE_TRIGGER)) {
-    const role = (m[1] ?? '').trim();
+    const role = trimRun(m[1]);
     const key = canonicalTerm(role);
     if (!TITLE_NOUNS.some((n) => key.split(/[\s/]+/).includes(n))) continue;
     out.push({ kind: 'title', text: role, canonical: key });
@@ -367,8 +383,11 @@ export function factCheck(input: FactCheckInput): FactCheckResult {
     }
   };
 
+  // A unitless number asserts almost nothing ("PHP 7", "one of 3 teams") but
+  // would false-block constantly, so on the generated side it is not a claim.
+  // Sources still index theirs, where they widen support (ADR 0020).
   const { claims: metrics, unchecked } = extractMetrics(normalized);
-  for (const m of metrics) {
+  for (const m of metrics.filter((c) => c.unit !== 'bare')) {
     const canonical = keyOf(m.unit, m.value);
     if (metricSupported(m, src)) add({ kind: 'metric', text: m.text, canonical, status: 'supported', from: 'source' });
     else if (metricSupported(m, allowedMetrics)) add({ kind: 'metric', text: m.text, canonical, status: 'allowed', from: 'allowlist' });

--- a/src/resume/fact-check.ts
+++ b/src/resume/fact-check.ts
@@ -73,8 +73,11 @@ const NOT_AN_EMPLOYER = new Set([
   'scale', 'least', 'most', 'work', 'home', 'first', 'all',
 ]);
 
-const EMPLOYER_TRIGGER = /\b(?:at|for|joined|left)\s+((?:[A-Z][\w&'.-]*)(?:\s+(?:[A-Z][\w&'.-]*|of|and|&)){0,3})/g;
-const TITLE_TRIGGER = /\bas\s+an?\s+((?:[A-Za-z][\w-]*)(?:[\s/]+[A-Za-z][\w-]*){0,4})/g;
+// The trigger's own case is spelled out rather than set with the /i flag: /i
+// would also relax `[A-Z]`, and then every lowercase word after "at" reads as
+// a company. A letter opening "At Vodwork I led …" still has to be caught.
+const EMPLOYER_TRIGGER = /\b(?:[Aa]t|[Ff]or|[Jj]oined|[Ll]eft)\s+((?:[A-Z][\w&'.-]*)(?:\s+(?:[A-Z][\w&'.-]*|of|and|&)){0,3})/g;
+const TITLE_TRIGGER = /\b[Aa]s\s+an?\s+((?:[A-Za-z][\w-]*)(?:[\s/]+[A-Za-z][\w-]*){0,4})/g;
 
 const SMALL_NUMBERS: Record<string, number> = {
   zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7,
@@ -158,9 +161,8 @@ function nonLatinDominant(seg: string): boolean {
  * of a phone number (ADR 0020).
  */
 function parseNumber(token: string): number | null {
-  const t = token.replace(/\+$/, '');
-  if (/^\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?$/.test(t)) return Number(t.replace(/[,\s]/g, ''));
-  if (/^\d+(?:\.\d+)?$/.test(t)) return Number(t);
+  if (/^\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?$/.test(token)) return Number(token.replace(/[,\s]/g, ''));
+  if (/^\d+(?:\.\d+)?$/.test(token)) return Number(token);
   return null;
 }
 
@@ -233,11 +235,7 @@ function isValue<T>(v: T | null): v is T {
 function scale(token: string | undefined, magnitude?: string): number | null {
   if (!token) return null;
   const t = token.replace(/\+$/, '');
-  const base = /^[\d,.\s]+$/.test(t)
-    ? (/^\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?$/.test(t)
-      ? Number(t.replace(/[,\s]/g, ''))
-      : (/^\d+(?:\.\d+)?$/.test(t) ? Number(t) : null))
-    : (SMALL_NUMBERS[t.toLowerCase()] ?? null);
+  const base = parseNumber(t) ?? SMALL_NUMBERS[t.toLowerCase()] ?? null;
   if (base === null) return null;
   const mag = magnitude ? MAGNITUDES[magnitude.toLowerCase()] : undefined;
   return mag ? base * mag : base;
@@ -274,15 +272,19 @@ interface RawAssertion {
 }
 
 /**
+ * A captured run keeps no trailing punctuation, connector, or one-letter word:
+ * "At OGD Solutions I processed …" is a claim about OGD Solutions, not about
+ * "OGD Solutions I".
+ */
+function trimRun(raw: string | undefined): string {
+  return (raw ?? '').trim().replace(/(?:[.,;:'-]+|\s+(?:of|and|&|[A-Za-z]))+$/i, '');
+}
+
+/**
  * Only claims about the writer's own history. Naming the company being
  * written to is not one — measured on a real letter of ours, the addressee
  * appears in the second person ("your mission"), never under these triggers.
  */
-/** A captured run keeps neither trailing punctuation nor a dangling connector. */
-function trimRun(raw: string | undefined): string {
-  return (raw ?? '').trim().replace(/(?:[.,;:'-]+|\s+(?:of|and|&))+$/i, '');
-}
-
 function extractAssertions(normalized: string, addressee: string | null): RawAssertion[] {
   const out: RawAssertion[] = [];
   const skip = new Set(NOT_AN_EMPLOYER);
@@ -366,8 +368,10 @@ export function factCheck(input: FactCheckInput): FactCheckResult {
   const allowedFacts = new Set(
     (input.allowFacts ?? []).map(canonicalizeAllowEntry).filter((k): k is string => k !== null),
   );
-  const inertAllowlist = [...(input.allowMetrics ?? []), ...(input.allowFacts ?? [])]
-    .filter((e) => canonicalizeAllowEntry(e) === null);
+  const inertAllowlist = [
+    ...(input.allowMetrics ?? []).filter((e) => extractMetrics(normalizeText(e)).claims.length === 0),
+    ...(input.allowFacts ?? []).filter((e) => canonicalizeAllowEntry(e) === null),
+  ];
   const sourceText = canonicalTerm(normalizeText(input.sources.join('\n')));
 
   const claims: FactClaim[] = [];
@@ -395,7 +399,13 @@ export function factCheck(input: FactCheckInput): FactCheckResult {
   }
 
   for (const a of extractAssertions(normalized, input.addressee ?? null)) {
-    if (mentions(sourceText, a.canonical)) add({ ...a, status: 'supported', from: 'source' });
+    // A title is a description, so every word of it need only appear somewhere
+    // ("senior backend engineer" against "Senior Backend PHP Engineer"). A
+    // company name is an identity and must match as one unit.
+    const supported = a.kind === 'title'
+      ? a.canonical.split(/[\s/]+/).every((w) => mentions(sourceText, w))
+      : mentions(sourceText, a.canonical);
+    if (supported) add({ ...a, status: 'supported', from: 'source' });
     else if (allowedFacts.has(a.canonical)) add({ ...a, status: 'allowed', from: 'allowlist' });
     else add({ ...a, status: 'unsupported' });
   }

--- a/src/resume/fact-check.ts
+++ b/src/resume/fact-check.ts
@@ -1,0 +1,408 @@
+import type { FactLike } from './facts';
+import { canonicalTerm } from './facts';
+
+/*
+ * Deterministic fact gate (ADR 0020). Generated prose in, verdict out — no
+ * AI, no I/O, no Prisma: sources arrive as arguments, store.ts loads them.
+ *
+ * It is a FABRICATION detector, not a precision auditor. Every ambiguous
+ * case resolves toward not blocking: a gate that fires on truthful text
+ * teaches the user to click through it, and then it protects nothing.
+ *
+ * Pure: tested in fact-check.test.ts.
+ */
+
+export type FactVerdict = 'pass' | 'warn' | 'block';
+export type ClaimKind = 'metric' | 'employer' | 'title' | 'tool';
+export type ClaimStatus = 'supported' | 'unsupported' | 'allowed';
+/** How a value is qualified. `bare` cross-matches any class of the same value. */
+export type UnitClass = 'pct' | 'money' | 'count' | 'magnitude' | 'bare';
+
+export interface FactClaim {
+  kind: ClaimKind;
+  /** The span as written in the checked text. */
+  text: string;
+  /** Matching key — both sides of the check are canonicalized identically. */
+  canonical: string;
+  status: ClaimStatus;
+  /** Where support came from, when there is any. */
+  from?: 'source' | 'fact' | 'allowlist';
+}
+
+export interface FactCheckInput {
+  /** The generated text under test. */
+  text: string;
+  /** Grounded text: resume, match summary, stored verification evidence. */
+  sources: string[];
+  /** CandidateFact rows — confirmed terms support, denied terms contradict. */
+  facts?: FactLike[];
+  /** The company being written to: naming it is not a claim about the past. */
+  addressee?: string | null;
+  allowMetrics?: string[];
+  allowFacts?: string[];
+}
+
+export interface FactCheckResult {
+  verdict: FactVerdict;
+  claims: FactClaim[];
+  /** Count-shaped spans the extractor could not read (never a silent pass). */
+  unchecked: number;
+  /** Allowlist entries that canonicalize to nothing, and so protect nothing. */
+  inertAllowlist: string[];
+  /** One line per problem, quotable straight into a regeneration prompt. */
+  reasons: string[];
+}
+
+/** Role nouns that make an "as a …" span a claim about the writer's history. */
+export const TITLE_NOUNS = [
+  'engineer', 'developer', 'architect', 'lead', 'manager', 'designer',
+  'analyst', 'scientist', 'director', 'consultant', 'administrator',
+  'specialist', 'programmer', 'devops', 'sre',
+] as const;
+
+/**
+ * Capitalized words that follow a history trigger without naming an employer.
+ * `with` is deliberately not a trigger: "built with PHP" is a tool statement,
+ * and tool claims are bounded to the CandidateFact vocabulary (ADR 0020).
+ */
+const NOT_AN_EMPLOYER = new Set([
+  'january', 'february', 'march', 'april', 'may', 'june', 'july', 'august',
+  'september', 'october', 'november', 'december', 'present', 'today',
+  'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday',
+  'i', 'the', 'a', 'an', 'this', 'that', 'your', 'my', 'our', 'it', 'we',
+  'scale', 'least', 'most', 'work', 'home', 'first', 'all',
+]);
+
+const EMPLOYER_TRIGGER = /\b(?:at|for|joined|left)\s+((?:[A-Z][\w&'.-]*)(?:\s+(?:[A-Z][\w&'.-]*|of|and|&)){0,3})/g;
+const TITLE_TRIGGER = /\bas\s+an?\s+((?:[A-Za-z][\w-]*)(?:[\s/]+[A-Za-z][\w-]*){0,4})/g;
+
+const SMALL_NUMBERS: Record<string, number> = {
+  zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7,
+  eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12, thirteen: 13,
+  fourteen: 14, fifteen: 15, sixteen: 16, seventeen: 17, eighteen: 18,
+  nineteen: 19, twenty: 20, thirty: 30, forty: 40, fifty: 50, sixty: 60,
+  seventy: 70, eighty: 80, ninety: 90,
+};
+const MAGNITUDES: Record<string, number> = {
+  hundred: 100, thousand: 1_000, million: 1_000_000, billion: 1_000_000_000,
+  k: 1_000, m: 1_000_000, b: 1_000_000_000,
+};
+/** Plural magnitude words carry a claim with no resolvable number of its own. */
+const VAGUE_MAGNITUDES = ['hundreds', 'thousands', 'millions', 'billions'];
+
+/** A sentence this far into another script cannot be read for count nouns. */
+const NON_LATIN_SHARE = 0.3;
+
+// ---------------------------------------------------------------- normalize
+
+/**
+ * One pipeline, applied identically to both sides. NFKC alone is not enough:
+ * measured on our own resumes, it leaves `–`, `—` and `’` untouched — the
+ * only non-ASCII characters they actually contain (ADR 0020).
+ */
+export function normalizeText(raw: string): string {
+  return raw
+    .normalize('NFKC')
+    .replace(/[‐-―−﹘﹣－]/g, '-')
+    .replace(/[‘’‛ʼ´`]/g, "'")
+    .replace(/[“”„]/g, '"')
+    .replace(/[•∙·●▪]/g, ' ; ')
+    .replace(/[   ]/g, ' ');
+}
+
+/** Contact data is not evidence — strip it before any number is parsed. */
+function maskContacts(s: string): string {
+  return s
+    .replace(/\b[\w.+-]+@[\w-]+\.[\w.-]+\b/g, ' ')
+    .replace(/\b(?:https?:\/\/|www\.)\S+/g, ' ')
+    .replace(/\b[\w-]+\.(?:com|net|org|io|dev|co)\b\S*/g, ' ')
+    .replace(/\+?\d{0,3}[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/g, ' ');
+}
+
+/** Tokens whose digits identify a thing, not a quantity. */
+function maskNonQuantities(s: string): string {
+  return s
+    .replace(/\bO\([^)]*\)/g, ' ')
+    .replace(/\bv\d+(?:\.\d+)*\b/gi, ' ')
+    .replace(/\b[A-Za-z]+\d[\w.*]*/g, ' ')
+    .replace(/\b(?:19|20)\d{2}\b(?!\s+[a-z])/g, ' ');
+}
+
+/** Block boundaries, so two bullets never glue into one phantom claim. */
+function segments(s: string): string[] {
+  return s
+    .split(/\n+|(?<=[.;!?])\s+/)
+    .map((x) => x.trim())
+    .filter(Boolean);
+}
+
+function nonLatinDominant(seg: string): boolean {
+  const letters = seg.match(/\p{L}/gu);
+  if (!letters || letters.length < 8) return false;
+  const latin = seg.match(/\p{Script=Latin}/gu)?.length ?? 0;
+  return (letters.length - latin) / letters.length >= NON_LATIN_SHARE;
+}
+
+// ------------------------------------------------------------------ numbers
+
+/**
+ * Thousands separators only when the token is fully group-structured. Measured
+ * why: the one separator-shaped match in our corpus is `267 554`, a fragment
+ * of a phone number (ADR 0020).
+ */
+function parseNumber(token: string): number | null {
+  const t = token.replace(/\+$/, '');
+  if (/^\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?$/.test(t)) return Number(t.replace(/[,\s]/g, ''));
+  if (/^\d+(?:\.\d+)?$/.test(t)) return Number(t);
+  return null;
+}
+
+function keyOf(unit: UnitClass, value: number | string): string {
+  return `${unit}:${value}`;
+}
+
+interface RawClaim {
+  unit: UnitClass;
+  value: number | string;
+  text: string;
+}
+
+const NUM = String.raw`\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?`;
+const WORD_NUM = Object.keys(SMALL_NUMBERS).join('|');
+const MAG = `hundred|thousand|million|billion|k|m|b`;
+
+/**
+ * Ordered most-specific first; each match is blanked out of the segment so a
+ * looser pattern cannot claim the same span twice (`15-20%` is a range, not
+ * a bare 15 followed by a percent).
+ */
+const PATTERNS: Array<{ unit: UnitClass; re: RegExp; values: (m: RegExpExecArray) => Array<number | string> }> = [
+  {
+    unit: 'pct',
+    re: new RegExp(String.raw`(${NUM})\s*-\s*(${NUM})\s*%`, 'gi'),
+    values: (m) => [scale(m[1]), scale(m[2])].filter(isValue),
+  },
+  {
+    unit: 'money',
+    re: new RegExp(String.raw`[$€£]\s?(${NUM})\+?\s?(${MAG})?\b`, 'gi'),
+    values: (m) => [scale(m[1], m[2])].filter(isValue),
+  },
+  {
+    unit: 'pct',
+    re: new RegExp(String.raw`\b(${NUM}|${WORD_NUM})\+?\s?(?:%|percent\b)`, 'gi'),
+    values: (m) => [scale(m[1])].filter(isValue),
+  },
+  // A vague magnitude carries no number of its own, so it matches only the
+  // same phrase — a letter cannot sharpen "hundreds of thousands" into a figure.
+  {
+    unit: 'magnitude',
+    re: new RegExp(String.raw`\b(${VAGUE_MAGNITUDES.join('|')})(?:\s+of\s+(${VAGUE_MAGNITUDES.join('|')}))?\b`, 'gi'),
+    values: (m) => [[m[1], m[2]].filter(Boolean).join('-of-').toLowerCase()],
+  },
+  {
+    unit: 'count',
+    re: new RegExp(String.raw`\b(${NUM}|${WORD_NUM})\+?\s?(${MAG})?\s+[a-z][a-z-]+`, 'gi'),
+    values: (m) => [scale(m[1], m[2])].filter(isValue),
+  },
+  {
+    unit: 'bare',
+    re: new RegExp(String.raw`\b(${NUM}|${WORD_NUM})\+?\s?(${MAG})?\b`, 'gi'),
+    values: (m) => [scale(m[1], m[2])].filter(isValue),
+  },
+];
+
+/** Units that survive outside Latin script — `%` and `$` need no vocabulary. */
+const SCRIPT_AGNOSTIC: UnitClass[] = ['pct', 'money'];
+
+function isValue<T>(v: T | null): v is T {
+  return v !== null;
+}
+
+/** A numeric token, spelled-out numeral, or either scaled by a magnitude. */
+function scale(token: string | undefined, magnitude?: string): number | null {
+  if (!token) return null;
+  const t = token.replace(/\+$/, '');
+  const base = /^[\d,.\s]+$/.test(t)
+    ? (/^\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?$/.test(t)
+      ? Number(t.replace(/[,\s]/g, ''))
+      : (/^\d+(?:\.\d+)?$/.test(t) ? Number(t) : null))
+    : (SMALL_NUMBERS[t.toLowerCase()] ?? null);
+  if (base === null) return null;
+  const mag = magnitude ? MAGNITUDES[magnitude.toLowerCase()] : undefined;
+  return mag ? base * mag : base;
+}
+
+/** Extract claims segment by segment; report spans we could not read. */
+function extractMetrics(normalized: string): { claims: RawClaim[]; unchecked: number } {
+  const claims: RawClaim[] = [];
+  let unchecked = 0;
+  for (const seg of segments(maskNonQuantities(maskContacts(normalized)))) {
+    const blind = nonLatinDominant(seg);
+    const chars = [...seg];
+    for (const { unit, re, values } of PATTERNS) {
+      // A count noun we cannot read must surface as unchecked, never as clean.
+      if (blind && !SCRIPT_AGNOSTIC.includes(unit)) continue;
+      for (const m of chars.join('').matchAll(re)) {
+        const vals = values(m as RegExpExecArray);
+        if (vals.length === 0) continue;
+        for (const value of vals) claims.push({ unit, value, text: m[0].trim() });
+        chars.fill(' ', m.index, m.index + m[0].length);
+      }
+    }
+    if (blind) unchecked += (chars.join('').match(/\d+/g) ?? []).length;
+  }
+  return { claims, unchecked };
+}
+
+// --------------------------------------------------------------- assertions
+
+interface RawAssertion {
+  kind: 'employer' | 'title';
+  text: string;
+  canonical: string;
+}
+
+/**
+ * Only claims about the writer's own history. Naming the company being
+ * written to is not one — measured on a real letter of ours, the addressee
+ * appears in the second person ("your mission"), never under these triggers.
+ */
+function extractAssertions(normalized: string, addressee: string | null): RawAssertion[] {
+  const out: RawAssertion[] = [];
+  const skip = new Set(NOT_AN_EMPLOYER);
+  if (addressee) for (const w of addressee.toLowerCase().split(/\s+/)) skip.add(w);
+  const addresseeKey = addressee ? canonicalTerm(addressee) : null;
+
+  for (const m of normalized.matchAll(EMPLOYER_TRIGGER)) {
+    const name = (m[1] ?? '').trim();
+    const key = canonicalTerm(name);
+    if (!key || key === addresseeKey) continue;
+    if (key.split(/\s+/).every((w) => skip.has(w))) continue;
+    out.push({ kind: 'employer', text: name, canonical: key });
+  }
+  for (const m of normalized.matchAll(TITLE_TRIGGER)) {
+    const role = (m[1] ?? '').trim();
+    const key = canonicalTerm(role);
+    if (!TITLE_NOUNS.some((n) => key.split(/[\s/]+/).includes(n))) continue;
+    out.push({ kind: 'title', text: role, canonical: key });
+  }
+  return out;
+}
+
+// ----------------------------------------------------------------- matching
+
+/** Source values by number, so a bare source figure supports any unit class. */
+function indexSources(sources: string[]): { keys: Set<string>; values: Set<string> } {
+  const keys = new Set<string>();
+  const values = new Set<string>();
+  for (const raw of sources) {
+    for (const c of extractMetrics(normalizeText(raw)).claims) {
+      keys.add(keyOf(c.unit, c.value));
+      if (c.unit !== 'magnitude') values.add(String(c.value));
+    }
+  }
+  return { keys, values };
+}
+
+/**
+ * Supported when the same value is present under the same unit, or when one
+ * of the two sides carries no unit at all — unit drift is a phrasing choice,
+ * inventing the number is not (ADR 0020).
+ */
+function metricSupported(claim: RawClaim, src: { keys: Set<string>; values: Set<string> }): boolean {
+  if (src.keys.has(keyOf(claim.unit, claim.value))) return true;
+  if (claim.unit === 'magnitude') return false;
+  if (claim.unit === 'bare') return src.values.has(String(claim.value));
+  return src.keys.has(keyOf('bare', claim.value));
+}
+
+/**
+ * Run an allowlist entry through the same extractor, so an entry that can
+ * never match is detectable instead of silently inert — the bug class this
+ * gate exists to catch. Returns null when the entry yields no claim at all.
+ */
+export function canonicalizeAllowEntry(entry: string): string | null {
+  const first = extractMetrics(normalizeText(entry)).claims[0];
+  if (first) return keyOf(first.unit, first.value);
+  const term = canonicalTerm(normalizeText(entry));
+  return term.length > 0 ? term : null;
+}
+
+/** Whole-word containment on two strings already put through the pipeline. */
+function mentions(haystack: string, needle: string): boolean {
+  if (!needle) return false;
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(String.raw`(?<![\p{L}\p{N}])${escaped}(?![\p{L}\p{N}])`, 'u').test(haystack);
+}
+
+// ------------------------------------------------------------------ verdict
+
+/**
+ * Check generated prose against the sources it is supposed to be grounded in.
+ * Sources arrive already loaded — this module never touches Prisma.
+ */
+export function factCheck(input: FactCheckInput): FactCheckResult {
+  const normalized = normalizeText(input.text);
+  const src = indexSources(input.sources);
+  // Allowed metrics are indexed exactly like sources, so an entry written in
+  // another surface form still matches the claim it was meant to cover.
+  const allowedMetrics = indexSources(input.allowMetrics ?? []);
+  const allowedFacts = new Set(
+    (input.allowFacts ?? []).map(canonicalizeAllowEntry).filter((k): k is string => k !== null),
+  );
+  const inertAllowlist = [...(input.allowMetrics ?? []), ...(input.allowFacts ?? [])]
+    .filter((e) => canonicalizeAllowEntry(e) === null);
+  const sourceText = canonicalTerm(normalizeText(input.sources.join('\n')));
+
+  const claims: FactClaim[] = [];
+  const reasons: string[] = [];
+  const seen = new Set<string>();
+  const add = (c: FactClaim, reason?: string) => {
+    const dedupe = `${c.kind}|${c.canonical}`;
+    if (seen.has(dedupe)) return;
+    seen.add(dedupe);
+    claims.push(c);
+    if (c.status === 'unsupported') {
+      reasons.push(reason ?? `${c.kind} "${c.text}" is not in the resume or confirmed facts`);
+    }
+  };
+
+  const { claims: metrics, unchecked } = extractMetrics(normalized);
+  for (const m of metrics) {
+    const canonical = keyOf(m.unit, m.value);
+    if (metricSupported(m, src)) add({ kind: 'metric', text: m.text, canonical, status: 'supported', from: 'source' });
+    else if (metricSupported(m, allowedMetrics)) add({ kind: 'metric', text: m.text, canonical, status: 'allowed', from: 'allowlist' });
+    else add({ kind: 'metric', text: m.text, canonical, status: 'unsupported' });
+  }
+
+  for (const a of extractAssertions(normalized, input.addressee ?? null)) {
+    if (mentions(sourceText, a.canonical)) add({ ...a, status: 'supported', from: 'source' });
+    else if (allowedFacts.has(a.canonical)) add({ ...a, status: 'allowed', from: 'allowlist' });
+    else add({ ...a, status: 'unsupported' });
+  }
+
+  // Facts are the only support for a tool claim, and the only contradiction:
+  // a denied term is the user saying outright they cannot claim it. Resume
+  // text still outranks a stale denial, exactly as facts.ts:applyFacts does.
+  const body = canonicalTerm(normalized);
+  for (const f of input.facts ?? []) {
+    const term = canonicalTerm(f.term);
+    if (!mentions(body, term)) continue;
+    if (f.status === 'confirmed') {
+      add({ kind: 'tool', text: f.term, canonical: term, status: 'supported', from: 'fact' });
+    } else if (f.status === 'denied' && !mentions(sourceText, term) && !allowedFacts.has(term)) {
+      add({ kind: 'tool', text: f.term, canonical: term, status: 'unsupported' },
+        `tool "${f.term}" is marked as one you cannot claim`);
+    }
+  }
+
+  if (unchecked > 0) reasons.push(`${unchecked} claim${unchecked === 1 ? '' : 's'} could not be checked`);
+  for (const e of inertAllowlist) reasons.push(`allowlist entry "${e}" can never match anything`);
+
+  const verdict: FactVerdict = claims.some((c) => c.status === 'unsupported')
+    ? 'block'
+    : unchecked > 0
+      ? 'warn'
+      : 'pass';
+  return { verdict, claims, unchecked, inertAllowlist, reasons };
+}


### PR DESCRIPTION
F7 from [the plan §8](docs/feature-expansion-plan.md). A pure module that
diffs generated prose against the resume it is supposed to be grounded in,
so F8's cover letters — and later the target editor's AI suggestions —
cannot invent a metric, an employer, a title or a tool.

No schema, no route, no UI, no toggle. `src/resume/fact-check.ts` +
`fact-check.test.ts` + ADR 0020 + docs.

## Tag decision — F7 ships untagged, with F8

The plan lists F7 as v0.9.0 and §0.1 step 7 would make it v0.8.0 in actual
integration order. Neither applies: `release-discipline` has a line for
exactly this case — *"pure-module prerequisite invisible to the user (e.g.
F7 fact gate before F8) — may skip its own tag and be tagged with the
feature that surfaces it"*.

F7 has **no user-visible surface at all**: nothing to click, nothing to
observe, no behaviour change in either container. A release whose "What's
new" section is empty is noise in the changelog. So: **no tag for this
merge**; the gate ships inside **F8's v0.8.0**, whose release notes will
credit it. No release-notes draft here — there is no release.

Nothing to rebuild. The worker never imports `src/resume/` (ADR 0008) and
the web container gains no reachable code path until F8 wires it in, so
the running `app` and `web` images stay valid on v0.7.0.

## Re-analysis changed the design (measured, not assumed)

Every query was read-only; nothing was written to the database.

**1. `CandidateFact` carries no numbers.** 8 rows — 4 confirmed, 4 denied —
and every one is a bare tool term (`nginx`, `stripe`, `varnish`). So the
plan's "resume text + confirmed CandidateFact" source pair is really
*resume text carries everything*, and facts can only ever support a **tool**
claim. The flip side the plan never proposed: the 4 `denied` rows are a hard
**block** — the user saying outright they cannot claim that term. Resume
text still outranks a stale denial, exactly as `facts.ts:applyFacts` does.

**2. Noise dominates the numeric surface.** 59 digit-bearing spans in the
6004-char resume; ~19 are real claims. The rest are years (2009–2024), tool
versions (`PHP 7`, `v1.5`, `HTML5`, `EC2`, `p95`), big-O `O(N2log2N)`, a ZIP,
and a phone in two different formats. "Any digit is a claim" fires on the
contact line.

**3. The plan's headline normalization example does not occur.** Zero
thousands separators in our corpus — the only separator-shaped regex hit is
`267 554`, *inside the phone number*. Meanwhile 7 spelled-out numerals do
occur (`four developers`, `three parts`, `zero downtime`), which the plan
never mentions: a digit-only extractor blocks "mentored 4 developers"
against a resume that says "four". Priority inverted; both are handled.

**4. NFKC is necessary but not sufficient.** Measured: it leaves `–`, `—`
and `’` untouched — the exact non-ASCII our resumes contain (`∙`×10, `–`×7,
`’`×4). Dash, quote and bullet folding are separate explicit steps.

**5. Ukrainian: scope narrowed honestly rather than shipped untested.**
0 of 3 resumes and 0 of 771 job descriptions contain Cyrillic. So instead of
the plan's unfixtured "EN + UA": percent/currency extraction is
script-agnostic (an invented `40%` in Ukrainian **does** block), count nouns
and history triggers are English-only, and a non-Latin-dominant sentence
marks its numbers `unchecked`, degrading `pass → warn`. The gate never
reports "clean" for text it cannot read. Both halves have fixtures.

**6. Improvement candidate — deferred with reason.** The four-state
provenance model on `CandidateFact` needs a schema change F7 deliberately
avoids, and our 8 bare-term rows show no `derived-unverified` population to
model. The existing two states already serve the gate. Trigger to revisit is
the plan's own: facts feeding generation beyond F8.

## Design

`factCheck(input)` → `pass | warn | block` + the claims behind it. Pure: no
Prisma, no I/O — sources arrive as arguments, `store.ts` loads them
(CLAUDE.md resume-module rule).

It is a **fabrication detector, not a precision auditor** (ADR 0020). Every
ambiguous case resolves toward not blocking, because a gate that fires on
truthful text teaches the user to click through it:

- `10 years` against a resume saying `10+ years` — supported; `+` is hedging.
- unit drift when one side is unitless (`4` vs `4 minutes`) — supported;
  two *different* units (`40%` vs `40 min`) — not.
- a number with no unit and no noun (`PHP 7`) — not a claim at all.
- `hundreds of thousands` cannot be sharpened into `$400,000`.

Allowlist entries are indexed through the same extractor, so `40 percent`
covers a `40%` claim — and an entry that can never match is reported in
`inertAllowlist` instead of sitting there silently useless, which is the
same bug class the gate exists to catch.

## Verification

`lint:types` + `npm test` green: **598 tests, 0 failures** (35 new).
Pure module, so per the testing-gate matrix there is no rebuild, no smoke
run and no screenshot to report — the unit suite and the benchmark *are* the
verification. Fixtures marked REAL in the test file are verbatim from
`Resume` rows 1 and 2, so the suite pins the case that matters: the letter
Nazar actually sent must not block against the resume he actually has.

Acceptance, all asserted:

| Criterion | Result |
|---|---|
| Invented "40%" in a letter | `block`, reason names the span |
| Same letter, number removed | `pass` |
| Employer absent from resume | `block` |
| Allowlist exception, incl. another surface form | `pass` |
| Separator variants `16,181` = `16 181` = `16181` | equal |
| Unreadable count spans | `warn` + "2 claims could not be checked" |
| **< 50 ms on a full letter** | **0.75 ms median, 0.97 ms max over 500 runs** |

The timing figure is a 285-word letter (F8 specifies 250–350) checked
against the real 6004-char resume plus all 8 `CandidateFact` rows: 16 claims
extracted, all supported, 0 unchecked. That is **66× inside** the budget, so
the criterion was never in doubt — the number is here because "fast" is not
a measurement.

Independent implementation: nothing was copied from any external project;
a copy-check across `~/main` found no comparable module.

## Pre-merge review (code-review-expert, applied)

Six findings fixed on the branch before this PR:

- **P1** `parseNumber` was dead code duplicating `scale()`'s inline parsing —
  the two would have drifted. `scale` now calls it.
- **P1** Title support was exact-phrase, so "as a senior backend engineer"
  blocked against "Senior Backend PHP Engineer". Titles now match word by
  word; a *company* name stays an exact unit, since it is an identity.
- **P1** An `allowMetrics` entry with no number canonicalized to a bare term
  and looked valid while protecting nothing. Inertness is now judged per
  list, by what each list actually consults.
- **P1** Sentence-initial `At Vodwork …` / `As a …` was invisible to the
  triggers. Fixed by spelling out the trigger's case — the `/i` flag would
  have relaxed `[A-Z]` too, making every lowercase word after "at" read as a
  company (caught by the suite when I tried it).
- **P1** `At OGD Solutions I processed …` captured "OGD Solutions I" and
  blocked a true claim. Captured runs now drop a trailing one-letter word.
- **P2** The `extractAssertions` docblock had drifted onto `trimRun`.

Four earlier bugs were caught by the fixtures themselves during
implementation and have regression tests: a proper-noun version mask that ate
`Migrated 16,`, a dangling `and` in captured employer runs, `one database`
read as a count, and bare numbers blocking on years and tool versions.

### Follow-ups (P2/P3, not blocking)

- **P2** A spaced product version followed by a noun (`React 18 components`)
  reads as a count and blocks. The mask that would catch it also ate
  `Migrated 16,181` and `Served 2 million`, so it was dropped rather than
  patched; no fixture of ours exhibits the shape. Revisit if F8 output shows
  it.
- **P2** Tool claims are checked only against the `CandidateFact` vocabulary
  — a fabricated tool the user has never been asked about passes. Widening
  this needs a tool lexicon, which is F8+ territory.
- **P3** `mentions()` compiles a RegExp per fact per call (8 facts → 8
  compiles). Invisible at 0.75 ms; worth caching if the fact table grows.
- **P3** Masking every year-shaped token loses the rare four-digit count
  (`2000 users`). Deliberate: leaving years in false-blocks every letter that
  says "since 2021".

## References

- [ADR 0020](docs/adr/0020-fact-gate-blocks-fabrication-not-imprecision.md)
- [Plan §8](docs/feature-expansion-plan.md), [TASKS §7](docs/TASKS.md)
