### PR TITLE
Make the no-Docker path work as documented

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,8 +59,11 @@ MIN_SALARY_USD=0
 # --- Dashboard (web service) -----------------------------------------------
 # Port the Hono server listens on (inside the container).
 WEB_PORT=4747
-# Host interface to bind to inside the container. 0.0.0.0 is fine because
-# docker-compose binds the published port to 127.0.0.1 only.
-WEB_HOST=0.0.0.0
-# Optional Basic Auth: "username:password". Empty = no auth (safe for localhost).
+# Interface the dashboard binds to. Loopback by default: run without Docker
+# and 0.0.0.0 would put an unauthenticated dashboard — jobs, resumes, settings,
+# the Telegram form — on every network you join. docker-compose overrides this
+# to 0.0.0.0 for the container, where the published port is already limited to
+# 127.0.0.1. Change it here only with WEB_BASIC_AUTH set.
+WEB_HOST=127.0.0.1
+# Optional Basic Auth: "username:password". Empty = no auth (safe for loopback).
 WEB_BASIC_AUTH=

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The stack is plain Node + Postgres, so a local setup is first-class:
 
 ```bash
 docker compose up -d postgres   # or any Postgres 16 you already have
-cp .env.example .env            # DATABASE_URL=postgresql://jobhunter:jobhunter@localhost:5432/jobhunter
+cp .env.example .env            # then point DATABASE_URL at that Postgres
 npm install
 npx prisma migrate deploy
 npm run seed
@@ -104,6 +104,20 @@ npm run seed
 npm run dev                     # the cron worker
 npm run dev:web                 # the dashboard → http://localhost:4747
 ```
+
+`DATABASE_URL` is the only line you must set — with an existing Postgres,
+use a role and database you already have. Everything else in `.env.example`
+works as shipped, engines included: the dashboard starts without any AI
+credential and the AI tab shows you which engines are usable, so you can
+pick one there instead of guessing up front.
+
+Run both commands from the repository root — the dashboard serves its
+browser modules from `src/web/public/` relative to the working directory.
+
+`WEB_HOST` defaults to `127.0.0.1` here on purpose. The dashboard has no
+authentication unless you set `WEB_BASIC_AUTH`, so bind it wider only
+together with that. (Under Docker, compose sets `0.0.0.0` for the
+container and publishes the port on loopback only.)
 
 CLI engines (claude / gemini / codex) are simpler locally: install them
 globally, log in once in your terminal, and the probe on the AI tab turns

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,10 @@ services:
     environment:
       DATABASE_URL: postgresql://jobhunter:jobhunter@postgres:5432/jobhunter
       NODE_ENV: production
+      # Inside the container this must be 0.0.0.0 or the published port cannot
+      # reach it. Safe here, and only here: the port below is loopback-only.
+      # .env keeps 127.0.0.1 so a no-Docker run is not exposed by default.
+      WEB_HOST: 0.0.0.0
     ports:
       # Bind to localhost only — never expose dashboard publicly.
       - "127.0.0.1:4747:4747"

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ConfigSchema } from './config';
+
+const MINIMAL = { DATABASE_URL: 'postgresql://u@localhost:5432/db' };
+
+test('a bare DATABASE_URL is enough to boot', () => {
+  const r = ConfigSchema.safeParse(MINIMAL);
+  assert.ok(r.success, JSON.stringify(r.error?.issues));
+  assert.equal(r.data.AI_PROVIDER, 'anthropic_api');
+  assert.equal(r.data.WEB_PORT, 4747);
+});
+
+test('a missing engine credential does not fail the process', () => {
+  // The dashboard is where the credential gets fixed, so it has to start.
+  // /settings reports the unusable engine; the provider factory throws only
+  // when that engine is actually selected (ADR 0013/0014).
+  const r = ConfigSchema.safeParse({ ...MINIMAL, AI_PROVIDER: 'anthropic_api', ANTHROPIC_API_KEY: '' });
+  assert.ok(r.success, 'an empty ANTHROPIC_API_KEY must not be a config error');
+});
+
+test('DATABASE_URL is the one thing genuinely required', () => {
+  const r = ConfigSchema.safeParse({});
+  assert.equal(r.success, false);
+  assert.ok(r.error?.issues.some((i) => i.path[0] === 'DATABASE_URL'));
+});
+
+test('the shipped bind default is loopback, not every interface', () => {
+  // .env.example must not put an unauthenticated dashboard on the LAN;
+  // docker-compose overrides WEB_HOST to 0.0.0.0 inside the container.
+  assert.equal(ConfigSchema.safeParse(MINIMAL).data?.WEB_HOST, '127.0.0.1');
+});
+
+test('rejects an out-of-range concurrency and an unknown provider', () => {
+  assert.equal(ConfigSchema.safeParse({ ...MINIMAL, AI_CONCURRENCY: '99' }).success, false);
+  assert.equal(ConfigSchema.safeParse({ ...MINIMAL, AI_PROVIDER: 'nope' }).success, false);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,17 +34,31 @@ const ConfigSchema = z.object({
   MIN_FIT_SCORE: z.coerce.number().int().min(0).max(100).default(70),
   MIN_SALARY_USD: z.coerce.number().int().min(0).default(0),
   WEB_PORT: z.coerce.number().int().min(1).max(65535).default(4747),
-  WEB_HOST: z.string().default('0.0.0.0'),
+  // Loopback by default: an unauthenticated dashboard must never land on a
+  // network because a .env was missing. docker-compose sets 0.0.0.0 for the
+  // container, whose published port is loopback-only; a bare `docker run`
+  // needs `-e WEB_HOST=0.0.0.0` for the same reason.
+  WEB_HOST: z.string().default('127.0.0.1'),
   WEB_BASIC_AUTH: z
     .string()
     .optional()
     .transform((v) => (v && v.length > 0 ? v : undefined)),
-}).refine(
-  (c) => c.AI_PROVIDER !== 'anthropic_api' || (c.ANTHROPIC_API_KEY ?? '').length > 0,
-  { path: ['ANTHROPIC_API_KEY'], message: 'required when AI_PROVIDER=anthropic_api' },
-);
+});
+
+/*
+ * A missing engine credential is NOT a config error. The engine chain resolves
+ * at runtime from the database with .env as fallback (ADR 0013/0014), so an
+ * unusable engine belongs on /settings → "AI engine", where the probe already
+ * reports `set ANTHROPIC_API_KEY in .env` and the provider factory throws with
+ * the same message if it is ever selected. Failing the whole process here used
+ * to take down the dashboard — the one place the credential can be fixed —
+ * which is why `cp .env.example .env` could not even reach the UI.
+ */
 
 export type Config = z.infer<typeof ConfigSchema>;
+
+/** Exported for config.test.ts; loadConfig runs it against process.env at import. */
+export { ConfigSchema };
 
 function loadConfig(): Config {
   const parsed = ConfigSchema.safeParse(process.env);

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,10 +2,16 @@ import 'dotenv/config';
 import { z } from 'zod';
 import { AI_PROVIDER_IDS } from './ai-engine';
 
-const ConfigSchema = z.object({
+export const ConfigSchema = z.object({
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
   // Default AI backend; /settings → "AI engine" can override it at runtime.
   AI_PROVIDER: z.enum(AI_PROVIDER_IDS).default('anthropic_api'),
+  // Optional on purpose, even when AI_PROVIDER selects it. The engine chain
+  // resolves at runtime from the database with .env as fallback (ADR 0013/0014):
+  // /settings → "AI engine" reports `set ANTHROPIC_API_KEY in .env` and the
+  // provider factory throws the same message if this engine is ever used.
+  // Failing the process here took down the dashboard — the one place the
+  // credential can be set — so `cp .env.example .env` could not reach the UI.
   ANTHROPIC_API_KEY: z.string().optional(),
   CLAUDE_MODEL: z.string().default('claude-haiku-4-5-20251001'),
   // Resume scan + resume-vs-job comparison: a few calls a day where judgment
@@ -45,20 +51,7 @@ const ConfigSchema = z.object({
     .transform((v) => (v && v.length > 0 ? v : undefined)),
 });
 
-/*
- * A missing engine credential is NOT a config error. The engine chain resolves
- * at runtime from the database with .env as fallback (ADR 0013/0014), so an
- * unusable engine belongs on /settings → "AI engine", where the probe already
- * reports `set ANTHROPIC_API_KEY in .env` and the provider factory throws with
- * the same message if it is ever selected. Failing the whole process here used
- * to take down the dashboard — the one place the credential can be fixed —
- * which is why `cp .env.example .env` could not even reach the UI.
- */
-
 export type Config = z.infer<typeof ConfigSchema>;
-
-/** Exported for config.test.ts; loadConfig runs it against process.env at import. */
-export { ConfigSchema };
 
 function loadConfig(): Config {
   const parsed = ConfigSchema.safeParse(process.env);


### PR DESCRIPTION
Verifies the documented no-Docker path end to end, on a clean clone against a
real local Postgres 16, and fixes what it broke on.

## Method

`git clone` into an empty directory, `cp .env.example .env`, then the README's
"Running without Docker" steps verbatim against a throwaway database in a
host Postgres 16.15 (not the compose one — no production data was touched).
The test database was dropped and the clone deleted afterwards.

## What was broken

**P0 — the dashboard was on the LAN, unauthenticated.** `WEB_HOST` defaulted
to `0.0.0.0` in *both* the zod schema and `.env.example`, whose comment
justified it with "docker-compose binds the published port to 127.0.0.1
only" — true under Docker, and only there. Following the README's local
steps put the whole dashboard (jobs, resume text, cover letters, settings,
the Telegram token form) on every network the machine joins, with no auth
unless `WEB_BASIC_AUTH` is set. Verified: `http://10.0.0.173:4848/jobs` → 200
from the LAN address.

Fixed in both places, so a missing `.env` cannot re-expose it. `docker-compose`
now sets `WEB_HOST: 0.0.0.0` in the `web` service's `environment:` block —
the same override it already uses for `DATABASE_URL`, and verified with
`docker compose config` that it still wins over `env_file`. A bare
`docker run` needs `-e WEB_HOST=0.0.0.0`; that is stated where the default
is defined.

**P1 — `cp .env.example .env` could not start anything.** The example ships
`AI_PROVIDER=anthropic_api` with an empty `ANTHROPIC_API_KEY`, and a
`.refine()` turned that into a fatal config error. Every entry point died —
`npm run seed`, the worker, and the dashboard, which is the one place that
credential is meant to be set. That contradicts ADR 0013/0014: the engine
chain resolves at runtime from the database with `.env` as fallback.

The boot check was also redundant. `ai-provider.ts` already throws the same
message if that engine is actually selected, and `/settings → AI engine`
already reports `set ANTHROPIC_API_KEY in .env` — verified present in the
rendered page after the fix.

**P2 — the local README section under-documented itself.** It never mentioned
adding an AI engine (the Docker quick start does), and never said the
commands must run from the repository root — `serveStatic` resolves
`./src/web/public` against the working directory, so the dashboard's browser
modules 404 from anywhere else.

## What already worked

Worth recording, since the answer to "does this run without Docker" is now
mostly yes:

| Step | Result |
|---|---|
| `npm install` on a clean clone | fine — the `npm warn allow-scripts` noise is harmless here; the Prisma client generates and the engines ship in the package |
| `npx prisma migrate deploy` | 36 migrations applied to an empty database |
| `npm run seed` | 39 upserts |
| `npm run build` | clean |
| `node dist/index.js` (worker) | init ran migrate deploy, seeded, bootstrapped the default profile, registered all 6 crons |
| `node dist/web/server.js` | `/`, `/jobs`, `/companies`, `/settings`, `/resumes`, `/discovery`, `/runs`, `/letter`, `/target` all 200 |
| `/static/*.mjs` | `target.mjs`, `score.mjs`, `settings-models.mjs` all 200 |
| `npm run lint:types` + `npm test` | green, 683 tests on the fresh install |

Node 26.4 against `engines: >=22`, Postgres 16.15 against the required 16.

## Verification

- `lint:types` + `npm test` green; **688 tests**, +5 covering the config schema
  (a missing credential must not fail validation; the shipped bind default is
  loopback; `DATABASE_URL` is the one genuinely required value).
- Re-ran the clean install with the fixes: the dashboard **boots with
  `.env.example` copied verbatim and no API key**, logs `host: "127.0.0.1"`,
  answers 200 on loopback, and the LAN address is refused.
- `docker compose config` confirms the `web` service still resolves
  `WEB_HOST: 0.0.0.0`; no rebuild was run and no container was restarted.

## Behaviour change to note

Anyone running locally **without** `WEB_HOST` in their `.env` moves from
`0.0.0.0` to `127.0.0.1` and loses LAN access to the dashboard. That is the
point of the fix; set `WEB_HOST` explicitly together with `WEB_BASIC_AUTH` if
you want it back. Docker installs are unaffected.

## Follow-ups (not in this PR)

- `package.json` still says `0.2.1` while the latest tag is `v0.9.0`. The
  release-discipline skill says nothing about `package.json`, so this is a
  question rather than a fix: should the version track the tag?
- `tsc` compiles `*.test.ts` into `dist/`, so the Docker image ships the test
  suite. Excluding them from the build would also drop them from
  `tsc --noEmit`, which is a worse trade; a second tsconfig is the only clean
  fix and did not seem worth the file.
- `serveStatic({ root: './src/web/public' })` is working-directory relative.
  Documented for now; resolving it from `__dirname` would need the Dockerfile
  copy target to move too.

## Release notes draft — v0.10.0

**The dashboard no longer binds to every network by default.** Running the
project without Docker used to put an unauthenticated dashboard — jobs,
resume text, cover letters, settings — on whatever network the machine was
joined to. It now listens on loopback unless you say otherwise; Docker
installs are unchanged, since compose already published the port on localhost
only.

**A fresh install starts without an AI key.** Copying `.env.example` and
running anything used to fail with `ANTHROPIC_API_KEY: required`, including
the dashboard where that key is configured. The dashboard now starts with no
credential at all and the AI engine tab tells you which engines are usable, so
you can pick one there instead of guessing before the first boot.

The "Running without Docker" section of the README was verified step by step
on a clean clone and now says what it actually takes.

Suggested tag (runtime behaviour changed, not a follow-up to F12):

    git tag -a v0.10.0 -m "safe local defaults" && git push origin v0.10.0
