### PR TITLE
Apply-link flags instead of a job trust score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-08-31
+
+### Added
+- **Apply-link flags (ADR 0023).** Postings whose apply link cannot be applied
+  through are tagged at ingest: `apply-url-missing` (a fetched row with no
+  URL), `apply-url-unusable` (unparseable, or a scheme a browser cannot open a
+  posting with), `apply-url-shortened` (a destination-hiding redirector) and
+  `apply-url-not-an-application` (a host that cannot serve one — a YouTube
+  video, a LinkedIn company page, a Telegram handle). The tags join the
+  classifier's own in `Job.redFlags`, so they appear on `/jobs/:id` and in the
+  Telegram alert with no new UI and no schema change.
+- `backfill-apply-link-flags` annotates already-stored rows without spending
+  an AI call. Additive and idempotent; `--dry-run` reads only.
+
+### Changed
+- The plan's trust *score* was dropped after measuring its four penalties on
+  all 814 stored jobs. Three would have been wrong: the `http://` penalty
+  marks 22.7% of the corpus and every one of those rows is Block's own
+  Greenhouse-served careers domain, which redirects to https; the missing-URL
+  penalty only ever hits jobs pasted by hand; and the company↔apply-domain
+  mismatch produces either nothing, 26 rows that are false by construction, or
+  302 (37%) depending on a string-matching detail — with a non-Latin-name
+  exemption that protects zero rows. ADR 0023 records the measurements.
+
 ## [0.10.0] — 2026-08-31
 
 ### Security
@@ -387,6 +411,7 @@ commit history.
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
 [Unreleased]: https://github.com/nazboyko/job-hunter/compare/v0.10.0...HEAD
+[0.11.0]: https://github.com/nazboyko/job-hunter/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/nazboyko/job-hunter/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/nazboyko/job-hunter/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/nazboyko/job-hunter/compare/v0.7.0...v0.8.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,9 @@
 ## File rules
 - Each fetcher returns `NormalizedJob[]` — never writes to DB directly.
 - `filter.ts` is pure — no I/O.
+- `apply-link.ts` is pure — no I/O. It flags apply links, never rejects a
+  row, and the company name is deliberately not an input (ADR 0023).
+  `withApplyLinkFlags` is called at every site that persists `redFlags`.
 - `classifier.ts` (and `classifier-prefilter.ts`) build prompts and parse
   replies; the only thing that talks to the AI is `ai-provider.ts` — no DB.
   Engine choice (provider + models) resolves per call via `ai-runtime.ts`
@@ -135,6 +138,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Pure helpers (parsing, hashing, masking) | `src/text-utils.ts` |
 | Near-duplicate detection across sources (SimHash, Hamming) | `src/fingerprint.ts` (ADR 0018); wired in `jobs/process-jobs.ts` |
 | Per-source health (error→status, failure streak, quiet/silent) | `src/fetchers/source-health.ts` (pure, ADR 0019); recorded by the wrapper in `fetchers/index.ts:runAllFetchers` |
+| Apply-link flags (missing / unusable / shortened / not-an-application) | `src/apply-link.ts` (pure, ADR 0023); merged into `Job.redFlags` at all three persist paths |
 | Stable id for a feed row with no id of its own | `src/text-utils.ts:feedItemKey` (URL key → text key → null, never `''`) |
 | The cron list (6 schedules) | `src/index.ts:registerCron` |
 | What runs on container boot | `src/init.ts` |
@@ -422,6 +426,7 @@ Always:
 | psql into the DB | `docker compose exec postgres psql -U jobhunter -d jobhunter` |
 | Re-clean stored descriptions (rows with leftover markup) | `docker compose exec app node dist/scripts/backfill-descriptions.js --dry-run`, then without the flag |
 | Fingerprint existing jobs + link cross-listings | `docker compose exec app node dist/scripts/backfill-fingerprints.js --dry-run`, then without the flag |
+| Flag apply links on already-stored jobs | `docker compose exec app node dist/scripts/backfill-apply-link-flags.js --dry-run`, then without the flag |
 | Re-pull descriptions from the boards (structure lost) | `docker compose exec app node dist/scripts/refetch-descriptions.js --dry-run`, then without the flag |
 | Migrate after a schema change | `DATABASE_URL=… npx prisma migrate dev --name <name>` |
 | Re-classify everything against the active profile | UI: `/settings` → "Re-classify all jobs" |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -447,6 +447,28 @@ external project, copy-check before merge.
       model" slot (role `cover`, empty inherits resume); edits autosave
       (Save button becomes the no-JS fallback); PDF/DOCX became labelled
       "Save as" buttons
+- [x] F13 job trust score — v0.11.0 (branch `trust-score`, ADR 0023).
+      Re-analysis killed the score: measured on all 814 stored jobs, three of
+      the plan's four penalties are wrong for our data. `http://` marks 22.7%
+      of the corpus and all 185 rows are one host, `block.xyz`, whose
+      `absolute_url` Greenhouse itself serves and which 301s to https; the
+      missing-URL penalty hits only `MANUAL` rows (all 13, pasted by hand, 0
+      fetched); the company↔apply-domain mismatch yields 0 / 26 / 302 (37%)
+      depending on a string-matching detail, the 26 being 100% `HN_HIRING`
+      and false by construction — an HN posting's company row IS the
+      aggregator, the same trap ADR 0018 named. The non-Latin exemption
+      protects 0 rows: the only non-ASCII company names are our own
+      `WeWorkRemotely ·` rows and the character is a middle dot. Underneath,
+      the premise fails too — every classic scam marker (Telegram/WhatsApp
+      apply, application fee, crypto, "no experience needed", free-email
+      contact) returns 0/814, because ADR 0005 keeps us out of the venues
+      where those postings live. So F13 ships as four apply-link flags in
+      `Job.redFlags` (no score, no schema, no badge, no migration), each true
+      by definition rather than tuned — which is what makes a 0 firing rate
+      acceptable here. Fires on 2/814: a YouTube video and a LinkedIn company
+      page, both from HN comments, both true positives for what the flag
+      claims. `forms.gle` deliberately excluded — it announces its
+      destination, and our single occurrence is a legitimate HN posting
 - [ ] F9 golden-eval harness for the AI engine chain — v0.11.0
 - [ ] F10 fetchers wave 2: Getro/Consider/a16z, Arbeitsagentur, Teamtailor,
       Personio, Jobvite, Gem, join.com — v0.12.0

--- a/docs/adr/0023-apply-link-flags-not-a-trust-score.md
+++ b/docs/adr/0023-apply-link-flags-not-a-trust-score.md
@@ -1,0 +1,121 @@
+# 0023 — Trust is a handful of apply-link flags, not a score, because our corpus has nothing to score
+
+**Status:** Accepted (2026-08-31)
+
+## Context
+
+F13 (feature-expansion-plan.md §14) proposed a `scoreTrust(job)` starting at
+100 and subtracting: −40/−50 for a missing or invalid apply URL, −25 for a
+shortener, −15 for a company↔apply-domain mismatch with an ATS allowlist and
+a non-Latin-name exemption; the result stored as `trustScore`/`trustFlags`
+and shown as a badge.
+
+Every one of those penalties was measured against our 814 stored jobs before
+any code was written, and three of the four are wrong for our data.
+
+**The http penalty would mark 22.7% of the corpus, always wrongly.** All 185
+non-https rows are one host, `block.xyz`, and Greenhouse's own board API is
+what serves it: `"absolute_url":"http://block.xyz/careers/jobs/…"`. The host
+answers `301 → https://block.xyz/…` and then `200`. The scheme is a stale
+string in Block's Greenhouse configuration, not a property of the posting.
+
+**The missing-URL penalty would only ever hit the operator.** All 13 rows
+with an empty URL are `AtsType.MANUAL` — jobs pasted through `/jobs/new`,
+which stores an empty URL by design. Zero *fetched* rows lack a URL.
+
+**The mismatch rule has no calibration point at all.** Implemented three ways:
+
+| Variant | Hits | What they are |
+| --- | --- | --- |
+| ATS allowlist + aggregator exemption | **0** | nothing to flag |
+| ATS allowlist only (the plan as written) | **26** | 100% `HN_HIRING` |
+| Strict company-name-in-domain | **302 (37%)** | 185 block.xyz + every aggregator on its own feed |
+
+The 26 are false by construction: an HN posting's `Company` row is the
+synthetic aggregator `HN Who is Hiring`, so its apply host is *always* some
+other domain. That is the same trap ADR 0018 documented for same-company
+SimHash matches. The 22 with non-HN hosts are Brandfetch, Nango, PermitFlow,
+Gem, Kula, Featurebase — all real employers.
+
+**The non-Latin exemption protects zero rows.** The only two non-ASCII
+company names are `WeWorkRemotely · Back-End` and `· Full-Stack`, and the
+character is a middle dot in our own synthetic row names. There is no
+Cyrillic, CJK, Greek or Arabic in the `Company` table.
+
+**The shortener rule cannot be calibrated: n = 1.** The single hit is
+`forms.gle` on job 1030 — Sitewire, posted on HN by its head of engineering
+with a salary band and equity. A Google Form is not a destination-hiding
+redirector; it announces what it is.
+
+Underneath all of it, the premise itself does not hold. Across all 814
+descriptions, every classic scam marker returns **zero**: Telegram/WhatsApp
+apply instructions, `t.me`/`wa.me` handles, application fees, crypto
+payment, "no experience needed", free-email contact addresses. Positive
+controls pass (`engineer` 547, `bitcoin` 186 — Block is a bitcoin company),
+so the zeros are real. ADR 0005 is why: we do not fetch from the venues
+where scam postings live, and the curated two-tier coverage model is itself
+the filter.
+
+What did measure real is narrower and different in kind — **links you cannot
+apply through**: job 945's apply URL is a YouTube video, job 956's is a
+LinkedIn company page. Two rows, both genuine, both from HN comments.
+
+## Decision
+
+No score, no schema. `src/apply-link.ts` is pure and exports
+`checkApplyLink({ url, pasted }): string[]` plus `withApplyLinkFlags`, and
+the tags join the model's own in `Job.redFlags` — the array that already
+renders as a danger `TagRow` on `/jobs/:id` and already travels in the
+Telegram alert. F12's `prompt-injection-attempt` set the precedent; these
+are the first flags produced by *code* rather than by the model, so they
+describe the posting's metadata where the model's describe its content.
+
+| Tag | Fires when | Corpus |
+| --- | --- | --- |
+| `apply-url-missing` | empty URL on a **fetched** row | 0 |
+| `apply-url-unusable` | unparseable, or a non-http(s) scheme | 0 |
+| `apply-url-shortened` | destination-hiding redirector (`bit.ly`, `t.co`, …) | 0 |
+| `apply-url-not-an-application` | host that cannot serve an application (`youtube.com`, `linkedin.com`, `t.me`, …) | 2 |
+
+Three penalties are **dropped outright**: the http scheme, the company↔domain
+mismatch, and with it the non-Latin exemption — which becomes structural
+rather than conditional, because the company name is not an input to this
+module at all. `forms.gle` is deliberately absent from the shortener list.
+
+Every remaining rule is **true by definition rather than tuned to a
+threshold**. That is what makes a flag firing zero times acceptable here and
+not evidence of a mis-set constant: there is no constant. A `bit.ly` link
+genuinely hides where it goes and a video page genuinely cannot take a
+submission, whether or not either has appeared yet. Host matching is on a
+domain boundary, never a substring, so `mylinkedin.com` is not LinkedIn.
+
+Flags only, never a filter: nothing here rejects, hides, reorders or
+rewrites a row, in keeping with ADR 0018's "annotate, never merge" and
+ADR 0012's "the model judges evidence, code owns the verdict".
+
+The merge happens at all three paths that persist `redFlags` — ingest,
+re-classify, classify-one — through one shared helper; a merge in only some
+of them would drop the tags at the next re-classification.
+
+## Consequences
+
+✅ No migration, no columns, no badge to design: the tags surface everywhere
+red flags already surface. Cost stays proportional to a signal that fires on
+0.2% of the corpus. The dropped penalties are pinned by regression fixtures,
+so nobody re-adds the http rule without a failing test.
+❌ A trust *level* cannot be sorted or filtered on, and a job whose only
+problem is its apply link looks like a job with a stack mismatch — both are
+red flags. Accepted: inventing a rank for two rows would be false precision.
+❌ Three of the four rules are unexercised by real data. They are preventive,
+in the same sense as ADR 0018's URL-key discipline, and are honestly labelled
+as such rather than presented as measured.
+
+## When to revisit
+
+When the corpus stops being curated: F14 starter packs widen it, and HN
+Who-is-hiring plus manual pastes are already the two uncurated intake
+channels — the two real hits came from HN. Re-measure the flag rates once
+packs have landed, and if scam markers appear at all, that is the moment to
+reconsider a score with something to score. Reconsider the company↔domain
+mismatch only with a per-posting employer name (HN descriptions carry one in
+a `Company:` line), never against the aggregator's `Company` row.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,8 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0019 — Source health is a per-company streak; `empty` resets it but does not prove health](./0019-source-health-streaks.md)
 - [0020 — The fact gate blocks fabrication, not imprecision](./0020-fact-gate-blocks-fabrication-not-imprecision.md)
 - [0021 — Cover letters generate from stored inputs only](./0021-cover-letters-stored-inputs-only.md)
+- [0022 — Fences make untrusted text data, and an attempt evidence](./0022-prompt-fences-for-untrusted-text.md)
+- [0023 — Trust is apply-link flags, not a score](./0023-apply-link-flags-not-a-trust-score.md)
 
 ## When to write a new one
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-hunter",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Self-hosted AI job hunter: monitors 16 ATS / aggregator sources, classifies postings with Claude against your profile, verifies ghost jobs, matches your resume, alerts via Telegram.",
   "license": "MIT",

--- a/src/apply-link.test.ts
+++ b/src/apply-link.test.ts
@@ -1,0 +1,224 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  APPLY_LINK_FLAGS,
+  APPLY_URL_MISSING,
+  APPLY_URL_NOT_AN_APPLICATION,
+  APPLY_URL_SHORTENED,
+  APPLY_URL_UNUSABLE,
+  checkApplyLink,
+  withApplyLinkFlags,
+} from './apply-link';
+
+/** Fetched row unless a case says otherwise — pasted rows are the exception. */
+const fetched = (url: string) => checkApplyLink({ url, pasted: false });
+const pasted = (url: string) => checkApplyLink({ url, pasted: true });
+
+describe('apply-url-missing', () => {
+  const cases: [string, string, string[]][] = [
+    ['empty on a fetched row', '', [APPLY_URL_MISSING]],
+    ['whitespace on a fetched row', '   ', [APPLY_URL_MISSING]],
+    ['tab and newline on a fetched row', '\t\n', [APPLY_URL_MISSING]],
+  ];
+  for (const [name, url, expected] of cases) {
+    test(name, () => assert.deepEqual(fetched(url), expected));
+  }
+
+  test('a pasted row with no URL is not flagged', () => {
+    // All 13 URL-less rows in the corpus are MANUAL: /jobs/new stores an
+    // empty URL by design, so flagging it would only ever hit the operator.
+    assert.deepEqual(pasted(''), []);
+    assert.deepEqual(pasted('   '), []);
+  });
+
+  test('a pasted row with a bad URL is still flagged', () => {
+    // The exemption covers absence, not content.
+    assert.deepEqual(pasted('javascript:alert(1)'), [APPLY_URL_UNUSABLE]);
+  });
+});
+
+describe('apply-url-unusable', () => {
+  const cases: [string, string][] = [
+    ['not a URL at all', 'apply by email'],
+    ['scheme only', 'https://'],
+    ['javascript scheme', 'javascript:alert(1)'],
+    ['data scheme', 'data:text/html,<p>hi</p>'],
+    ['mailto scheme', 'mailto:jobs@example.com'],
+    ['ftp scheme', 'ftp://example.com/jobs'],
+    ['file scheme', 'file:///etc/passwd'],
+  ];
+  for (const [name, url] of cases) {
+    test(name, () => assert.deepEqual(fetched(url), [APPLY_URL_UNUSABLE]));
+  }
+
+  test('an unusable URL reports only that flag', () => {
+    // No point telling the user a link is shortened when it cannot be opened.
+    assert.deepEqual(fetched('javascript:location="bit.ly/x"'), [
+      APPLY_URL_UNUSABLE,
+    ]);
+  });
+});
+
+describe('apply-url-shortened', () => {
+  const cases: [string, string][] = [
+    ['bit.ly', 'https://bit.ly/3xYz'],
+    ['tinyurl', 'https://tinyurl.com/abc'],
+    ['t.co', 'https://t.co/abc'],
+    ['goo.gl', 'https://goo.gl/maps/x'],
+    ['lnkd.in', 'https://lnkd.in/eXaMple'],
+    ['is.gd', 'https://is.gd/abc'],
+    ['subdomain of a shortener', 'https://a.bit.ly/3xYz'],
+    ['uppercase host', 'https://BIT.LY/3xYz'],
+    ['http scheme', 'http://bit.ly/3xYz'],
+  ];
+  for (const [name, url] of cases) {
+    test(name, () => assert.deepEqual(fetched(url), [APPLY_URL_SHORTENED]));
+  }
+
+  const notShortened: [string, string][] = [
+    ['a host merely ending in the name', 'https://notbit.ly.example.com/jobs'],
+    ['a host containing the name', 'https://mybit.lyric.com/jobs'],
+    ['a path containing the name', 'https://example.com/bit.ly/jobs'],
+    // Deliberate: a Google Form states its own destination and hides
+    // nothing. Our single corpus occurrence is a legitimate HN posting.
+    ['forms.gle', 'https://forms.gle/diVa5ScKJLYnW7u38'],
+  ];
+  for (const [name, url] of notShortened) {
+    test(`${name} is not a shortener`, () => assert.deepEqual(fetched(url), []));
+  }
+});
+
+describe('apply-url-not-an-application', () => {
+  const cases: [string, string][] = [
+    ['a YouTube video', 'https://www.youtube.com/watch?v=djsPTbs7R_w'],
+    ['a youtu.be link', 'https://youtu.be/djsPTbs7R_w'],
+    ['a LinkedIn company page', 'https://www.linkedin.com/company/tyce/jobs/'],
+    ['a Facebook page', 'https://facebook.com/somecompany'],
+    ['an X profile', 'https://x.com/somecompany'],
+    ['a Telegram handle', 'https://t.me/somerecruiter'],
+    ['a WhatsApp link', 'https://wa.me/15551234567'],
+    ['a Discord invite', 'https://discord.gg/abcdef'],
+  ];
+  for (const [name, url] of cases) {
+    test(name, () =>
+      assert.deepEqual(fetched(url), [APPLY_URL_NOT_AN_APPLICATION]),
+    );
+  }
+
+  const fine: [string, string][] = [
+    ['a lookalike host', 'https://mylinkedin.com/jobs/1'],
+    ['the name in the path', 'https://example.com/youtube.com/jobs'],
+    ['a real ATS board', 'https://jobs.lever.co/spotify/abc'],
+  ];
+  for (const [name, url] of fine) {
+    test(`${name} is fine`, () => assert.deepEqual(fetched(url), []));
+  }
+
+  test('LinkedIn’s own shortener reports only that it is shortened', () => {
+    // `lnkd.in` resolves to linkedin.com, but only over the network. This
+    // module reads the host string and nothing else, so it states the fact
+    // it has — the link hides its destination — and does not infer the rest.
+    assert.deepEqual(fetched('https://lnkd.in/eXaMple'), [APPLY_URL_SHORTENED]);
+  });
+});
+
+describe('non-Latin company names', () => {
+  // The plan asked for a company↔apply-domain mismatch rule with a
+  // non-Latin-name exemption. Measured on our corpus that rule produced
+  // either nothing or 37% false positives, so it was dropped — which makes
+  // the exemption structural rather than conditional: the company name is
+  // not an input, so no name can change any verdict. These cases pin that.
+  const names = ['Ромашка', '株式会社テスト', 'Ελλάδα ΑΕ', 'شركة', 'Acme Inc'];
+
+  test('a company name cannot reach this module', () => {
+    // If a name parameter were ever added, this call stops compiling.
+    const link = { url: 'https://acme.example.com/jobs/1', pasted: false };
+    assert.deepEqual(checkApplyLink(link), []);
+    assert.deepEqual(Object.keys(link).sort(), ['pasted', 'url']);
+  });
+
+  test('every verdict is identical whatever the company is called', () => {
+    // The names below are carried alongside, exactly as a caller would hold
+    // them, and never influence the result.
+    for (const name of names) {
+      assert.deepEqual(fetched('https://acme.example.com/jobs/1'), [], name);
+      assert.deepEqual(
+        fetched('https://www.youtube.com/watch?v=x'),
+        [APPLY_URL_NOT_AN_APPLICATION],
+        name,
+      );
+    }
+  });
+});
+
+describe('corpus regressions', () => {
+  // Fixtures taken from the 814 stored jobs, pinning the penalties this
+  // feature deliberately does not apply (ADR 0023).
+  test('Block’s http careers domain is not a flag', () => {
+    // 185 rows — Greenhouse itself serves this absolute_url, and the host
+    // 301s to https and answers 200. The scheme is Block’s config, not a
+    // property of the posting.
+    assert.deepEqual(
+      fetched('http://block.xyz/careers/jobs/4667604008?gh_jid=4667604008'),
+      [],
+    );
+  });
+
+  test('an aggregator listing on its own domain is not a flag', () => {
+    // The plan’s mismatch rule fired on 26 HN rows, all false: an HN job’s
+    // company row is the aggregator, so its apply host is always different.
+    assert.deepEqual(fetched('https://brandfetch.com'), []);
+    assert.deepEqual(fetched('https://nango.dev'), []);
+    assert.deepEqual(fetched('https://jobicy.com/jobs/x'), []);
+  });
+
+  test('a bare company root is not a flag', () => {
+    // Inconvenient, not untrustworthy — 7 corpus rows, all real employers.
+    assert.deepEqual(fetched('https://permitflow.com'), []);
+  });
+});
+
+describe('withApplyLinkFlags', () => {
+  const link = { url: 'https://www.youtube.com/watch?v=x', pasted: false };
+
+  test('appends to the model’s flags, preserving their order', () => {
+    assert.deepEqual(withApplyLinkFlags(['stack-mismatch', 'low-pay'], link), [
+      'stack-mismatch',
+      'low-pay',
+      APPLY_URL_NOT_AN_APPLICATION,
+    ]);
+  });
+
+  test('returns the model’s flags unchanged when the link is fine', () => {
+    const clean = { url: 'https://jobs.lever.co/spotify/abc', pasted: false };
+    assert.deepEqual(withApplyLinkFlags(['no-salary-listed'], clean), [
+      'no-salary-listed',
+    ]);
+  });
+
+  test('does not duplicate a tag the model already emitted', () => {
+    assert.deepEqual(
+      withApplyLinkFlags([APPLY_URL_NOT_AN_APPLICATION], link),
+      [APPLY_URL_NOT_AN_APPLICATION],
+    );
+  });
+
+  test('does not mutate the caller’s array', () => {
+    const model = ['stack-mismatch'];
+    withApplyLinkFlags(model, link);
+    assert.deepEqual(model, ['stack-mismatch']);
+  });
+
+  test('works from an empty model list', () => {
+    assert.deepEqual(withApplyLinkFlags([], link), [
+      APPLY_URL_NOT_AN_APPLICATION,
+    ]);
+  });
+});
+
+test('every exported flag is kebab-case and unique', () => {
+  assert.equal(new Set(APPLY_LINK_FLAGS).size, APPLY_LINK_FLAGS.length);
+  for (const flag of APPLY_LINK_FLAGS) {
+    assert.match(flag, /^[a-z]+(-[a-z]+)*$/, flag);
+  }
+});

--- a/src/apply-link.ts
+++ b/src/apply-link.ts
@@ -111,7 +111,7 @@ function onDomain(host: string, domains: readonly string[]): boolean {
  * company↔domain mismatch rule; measured on our corpus it produced either
  * nothing or 37% false positives, and its non-Latin-name exemption would
  * have protected zero rows. Leaving the name out makes the exemption
- * structural — a company called "Ромашка" or "株式会社テスト" is scored
+ * structural — a company called "Ромашка" or "株式会社テスト" is treated
  * exactly like any other, because its name never reaches this code.
  */
 export function checkApplyLink(link: ApplyLink): string[] {

--- a/src/apply-link.ts
+++ b/src/apply-link.ts
@@ -1,0 +1,147 @@
+/**
+ * Apply-link checks: cheap, ingest-time annotation of postings you cannot
+ * actually apply through. Pure — no DB, no HTTP, no config.
+ *
+ * Every rule here is true by definition rather than tuned to a threshold,
+ * which is deliberate: our corpus contains no scam postings to calibrate
+ * against (ADR 0023 records the measurement). A shortener genuinely hides
+ * its destination and a video page genuinely cannot take an application,
+ * whether or not either has appeared yet.
+ *
+ * Flags only — nothing here rejects, hides or rewrites a row. The output
+ * joins the model's own tags in `Job.redFlags`.
+ */
+
+/** Kebab-case to match the existing red-flag vocabulary ("stack-mismatch", …). */
+export const APPLY_URL_MISSING = 'apply-url-missing';
+export const APPLY_URL_UNUSABLE = 'apply-url-unusable';
+export const APPLY_URL_SHORTENED = 'apply-url-shortened';
+export const APPLY_URL_NOT_AN_APPLICATION = 'apply-url-not-an-application';
+
+/** Every tag this module can produce, for the UI legend and the guard test. */
+export const APPLY_LINK_FLAGS = [
+  APPLY_URL_MISSING,
+  APPLY_URL_UNUSABLE,
+  APPLY_URL_SHORTENED,
+  APPLY_URL_NOT_AN_APPLICATION,
+] as const;
+
+/**
+ * Destination-hiding redirectors only. `forms.gle` is deliberately absent:
+ * a Google Form announces exactly what it is, and the single occurrence in
+ * our corpus is a small company on HN collecting applications legitimately.
+ * A one-row category is not a rule we can calibrate (ADR 0023).
+ */
+const SHORTENER_HOSTS = [
+  'bit.ly',
+  'tinyurl.com',
+  't.co',
+  'goo.gl',
+  'ow.ly',
+  'buff.ly',
+  'rebrand.ly',
+  'is.gd',
+  'cutt.ly',
+  'shorturl.at',
+  'lnkd.in',
+  'rb.gy',
+  'tiny.cc',
+];
+
+/**
+ * Hosts that cannot serve a job application, whatever the path. A posting
+ * whose apply link lands here leaves you with nothing to submit — measured
+ * twice in our corpus, both from HN comments (a YouTube video and a
+ * LinkedIn company page).
+ */
+const NOT_AN_APPLICATION_HOSTS = [
+  'youtube.com',
+  'youtu.be',
+  'linkedin.com',
+  'facebook.com',
+  'twitter.com',
+  'x.com',
+  'instagram.com',
+  'tiktok.com',
+  't.me',
+  'wa.me',
+  'discord.gg',
+];
+
+export interface ApplyLink {
+  url: string;
+  /**
+   * True for rows the user pasted by hand (`AtsType.MANUAL`). A pasted job
+   * legitimately has no URL — that is how `/jobs/new` stores it — so the
+   * missing-URL flag would fire on the user's own input and nothing else.
+   */
+  pasted: boolean;
+}
+
+/**
+ * Host of an http(s) URL, lowercased and without `www.`; null when the URL
+ * is unusable as an apply link (unparseable, or a scheme a browser cannot
+ * open a posting with).
+ */
+function applyHost(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  const host = parsed.hostname.toLowerCase().replace(/^www\./, '');
+  return host.length > 0 ? host : null;
+}
+
+/**
+ * Host match on a domain boundary, never a substring: `mylinkedin.com` is
+ * not LinkedIn and `notbit.ly.example.com` is not a shortener.
+ */
+function onDomain(host: string, domains: readonly string[]): boolean {
+  return domains.some((d) => host === d || host.endsWith(`.${d}`));
+}
+
+/**
+ * Tags for one posting's apply link. Empty array when the link is fine,
+ * which is the overwhelmingly common case.
+ *
+ * The company name is deliberately not an input. The plan proposed a
+ * company↔domain mismatch rule; measured on our corpus it produced either
+ * nothing or 37% false positives, and its non-Latin-name exemption would
+ * have protected zero rows. Leaving the name out makes the exemption
+ * structural — a company called "Ромашка" or "株式会社テスト" is scored
+ * exactly like any other, because its name never reaches this code.
+ */
+export function checkApplyLink(link: ApplyLink): string[] {
+  const url = link.url.trim();
+  if (url.length === 0) return link.pasted ? [] : [APPLY_URL_MISSING];
+
+  const host = applyHost(url);
+  if (host === null) return [APPLY_URL_UNUSABLE];
+
+  const flags: string[] = [];
+  if (onDomain(host, SHORTENER_HOSTS)) flags.push(APPLY_URL_SHORTENED);
+  if (onDomain(host, NOT_AN_APPLICATION_HOSTS)) {
+    flags.push(APPLY_URL_NOT_AN_APPLICATION);
+  }
+  return flags;
+}
+
+/**
+ * The model's red flags plus this module's, de-duplicated and with the
+ * model's order preserved. One helper because three call sites persist
+ * `redFlags` — ingest, re-classify and classify-one — and a merge done in
+ * only two of them silently drops the tags on the next re-classification.
+ */
+export function withApplyLinkFlags(
+  modelFlags: readonly string[],
+  link: ApplyLink,
+): string[] {
+  const merged = [...modelFlags];
+  for (const flag of checkApplyLink(link)) {
+    if (!merged.includes(flag)) merged.push(flag);
+  }
+  return merged;
+}

--- a/src/jobs/classify-existing.ts
+++ b/src/jobs/classify-existing.ts
@@ -1,4 +1,4 @@
-import { JobStatus, type Job } from '@prisma/client';
+import { AtsType, JobStatus, type Job } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../logger';
 import { classifyJob } from '../classifier';
@@ -6,6 +6,7 @@ import { getActiveProfile } from '../profiles';
 import { getSettings } from '../settings';
 import { parsePriorityRules } from '../priority-rules';
 import { applyPriorityFloor } from './process-jobs';
+import { withApplyLinkFlags } from '../apply-link';
 
 /**
  * Classifies one stored job against the active profile and writes the
@@ -16,7 +17,7 @@ import { applyPriorityFloor } from './process-jobs';
  * Returns false when there is no active profile or the classifier failed.
  */
 export async function classifyExistingJob(
-  job: Job & { company: { name: string } },
+  job: Job & { company: { name: string; atsType: AtsType } },
   opts: { keepStatus: boolean },
 ): Promise<boolean> {
   const profile = await getActiveProfile();
@@ -61,7 +62,10 @@ export async function classifyExistingJob(
       salaryMin: c.salary_min_usd,
       salaryMax: c.salary_max_usd,
       techMatch: c.tech_match,
-      redFlags: c.red_flags,
+      redFlags: withApplyLinkFlags(c.red_flags, {
+        url: job.url,
+        pasted: job.company.atsType === AtsType.MANUAL,
+      }),
       summary: c.summary,
       status,
       priorityRulesApplied: priority.applied.map((r) => r.label),

--- a/src/jobs/manual-job.ts
+++ b/src/jobs/manual-job.ts
@@ -75,7 +75,7 @@ export async function createManualJob(
       postedAt: new Date(),
       status: JobStatus.SAVED,
     },
-    include: { company: { select: { name: true } } },
+    include: { company: { select: { name: true, atsType: true } } },
   });
   const classified =
     opts.classify === false ? false : await classifyExistingJob(job, { keepStatus: true });

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -4,6 +4,7 @@ import { config } from '../config';
 import { logger } from '../logger';
 import { createLimiter } from '../concurrency';
 import { passesBaseFilter } from '../filter';
+import { withApplyLinkFlags } from '../apply-link';
 import { classifyJob } from '../classifier';
 import { sendTelegramAlert } from '../notifier';
 import { applyPriorityFloor, parsePriorityRules } from '../priority-rules';
@@ -321,7 +322,10 @@ function buildJobData(
     salaryMin: c.salary_min_usd,
     salaryMax: c.salary_max_usd,
     techMatch: c.tech_match,
-    redFlags: c.red_flags,
+    // `pasted: false` is an invariant, not an assumption: a MANUAL company's
+    // fetchOne returns [], so a pasted row never reaches this loop. Pasted
+    // jobs get their flags from classify-existing.ts instead.
+    redFlags: withApplyLinkFlags(c.red_flags, { url: job.url, pasted: false }),
     summary: c.summary,
     status,
     priorityRulesApplied,

--- a/src/jobs/reclassify-job.ts
+++ b/src/jobs/reclassify-job.ts
@@ -1,4 +1,4 @@
-import { JobStatus } from '@prisma/client';
+import { AtsType, JobStatus } from '@prisma/client';
 import { prisma } from '../db';
 import { config } from '../config';
 import { logger } from '../logger';
@@ -9,6 +9,7 @@ import { getActiveProfile } from '../profiles';
 import { getSettings } from '../settings';
 import { parsePriorityRules } from '../priority-rules';
 import { applyPriorityFloor } from './process-jobs';
+import { withApplyLinkFlags } from '../apply-link';
 import type { CronStats } from './cron-run';
 
 const RECLASSIFY_BATCH_SIZE = 50;
@@ -56,7 +57,7 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
         status: { not: JobStatus.APPLIED },
         id: { gt: lastId },
       },
-      include: { company: { select: { name: true } } },
+      include: { company: { select: { name: true, atsType: true } } },
       orderBy: { id: 'asc' },
       take: RECLASSIFY_BATCH_SIZE,
     });
@@ -140,7 +141,10 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
           salaryMin: c.salary_min_usd,
           salaryMax: c.salary_max_usd,
           techMatch: c.tech_match,
-          redFlags: c.red_flags,
+          redFlags: withApplyLinkFlags(c.red_flags, {
+            url: j.url,
+            pasted: j.company.atsType === AtsType.MANUAL,
+          }),
           summary: c.summary,
           status: targetStatus,
           priorityRulesApplied: appliedLabels,

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -102,6 +102,16 @@ describe('formatJobMessage', () => {
     );
   });
 
+  it('escapes the hyphens in apply-link flags', () => {
+    // Every red flag is kebab-case and MarkdownV2 treats "-" as reserved, so
+    // one unescaped hyphen makes Telegram reject the whole alert.
+    const msg = formatJobMessage({
+      ...base,
+      redFlags: ['stack-mismatch', 'apply-url-not-an-application'],
+    });
+    assert.match(msg, /Flags: stack\\-mismatch, apply\\-url\\-not\\-an\\-application/);
+  });
+
   it('escapes the cross-listed company name', () => {
     // Parentheses, dots and hyphens all need escaping in MarkdownV2 — an
     // unescaped one makes Telegram reject the entire message.

--- a/src/scripts/backfill-apply-link-flags.ts
+++ b/src/scripts/backfill-apply-link-flags.ts
@@ -1,0 +1,86 @@
+import { AtsType } from '@prisma/client';
+import { logger } from '../logger';
+import { prisma } from '../db';
+import { APPLY_LINK_FLAGS, checkApplyLink } from '../apply-link';
+
+/*
+ * One-shot backfill for F13 (ADR 0023): annotate stored postings whose apply
+ * link cannot be applied through. Without it the flags only appear on jobs
+ * fetched or re-classified from now on, and a full re-classify costs AI calls
+ * this backfill does not.
+ *
+ * Additive and idempotent — a tag is appended to Job.redFlags only when it is
+ * absent, no other field is touched, and no row is hidden, merged or deleted.
+ * Safe to re-run. --dry-run reads only.
+ *
+ * Usage: node dist/scripts/backfill-apply-link-flags.js [--dry-run]
+ */
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main(): Promise<void> {
+  const jobs = await prisma.job.findMany({
+    select: {
+      id: true,
+      title: true,
+      url: true,
+      redFlags: true,
+      company: { select: { name: true, atsType: true } },
+    },
+    orderBy: { id: 'asc' },
+  });
+
+  const perFlag = new Map<string, number>(APPLY_LINK_FLAGS.map((f) => [f, 0]));
+  let flagged = 0;
+  let updated = 0;
+
+  for (const job of jobs) {
+    const flags = checkApplyLink({
+      url: job.url,
+      pasted: job.company.atsType === AtsType.MANUAL,
+    });
+    if (flags.length === 0) continue;
+    flagged++;
+    for (const flag of flags) perFlag.set(flag, (perFlag.get(flag) ?? 0) + 1);
+
+    const missing = flags.filter((f) => !job.redFlags.includes(f));
+    logger.info(
+      {
+        jobId: job.id,
+        title: job.title,
+        company: job.company.name,
+        url: job.url,
+        flags,
+        alreadyPresent: missing.length === 0,
+      },
+      'backfill-apply-link-flags: flagged',
+    );
+    if (missing.length === 0) continue;
+
+    updated++;
+    if (!DRY_RUN) {
+      await prisma.job.update({
+        where: { id: job.id },
+        data: { redFlags: [...job.redFlags, ...missing] },
+      });
+    }
+  }
+
+  logger.info(
+    {
+      total: jobs.length,
+      flagged,
+      updated,
+      ...Object.fromEntries(perFlag),
+      dryRun: DRY_RUN,
+    },
+    'backfill-apply-link-flags: done',
+  );
+}
+
+main()
+  .catch((err) => {
+    logger.error({ err }, 'backfill-apply-link-flags: failed');
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -432,7 +432,7 @@ jobsRoute.get('/jobs/:id/cover/:letterId/file/:fmt', async (c) => {
   if (!letter || letter.jobId !== id) return c.text('Not found', 404);
   const job = await prisma.job.findUnique({
     where: { id },
-    include: { company: { select: { name: true, atsType: true } } },
+    include: { company: { select: { name: true } } },
   });
   if (!job) return c.text('Not found', 404);
 

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -262,7 +262,7 @@ jobsRoute.post('/jobs/:id/reclassify', async (c) => {
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const job = await prisma.job.findUnique({
     where: { id },
-    include: { company: { select: { name: true } } },
+    include: { company: { select: { name: true, atsType: true } } },
   });
   if (!job) return c.text('Not found', 404);
   try {
@@ -432,7 +432,7 @@ jobsRoute.get('/jobs/:id/cover/:letterId/file/:fmt', async (c) => {
   if (!letter || letter.jobId !== id) return c.text('Not found', 404);
   const job = await prisma.job.findUnique({
     where: { id },
-    include: { company: { select: { name: true } } },
+    include: { company: { select: { name: true, atsType: true } } },
   });
   if (!job) return c.text('Not found', 404);
 


### PR DESCRIPTION
F13 from the expansion plan (§14), reshaped by the pre-integration
measurement. The plan wanted a `scoreTrust(job)` with four penalties, stored
as `trustScore`/`trustFlags` and shown as a badge. Measured against all 814
stored jobs, three of the four penalties are wrong for our data and the
premise underneath them does not hold, so this ships four apply-link flags in
`Job.redFlags` instead — no score, no columns, no migration, no new UI.

[ADR 0023](docs/adr/0023-apply-link-flags-not-a-trust-score.md) carries the
full reasoning.

## What the measurement found

**The `http://` penalty would mark 22.7% of the corpus and be wrong every
time.** All 185 non-https rows are one host, `block.xyz`, and Greenhouse's own
board API is what serves it — `"absolute_url":"http://block.xyz/careers/jobs/…"`.
The host answers `301 → https://block.xyz/…` then `200`. The scheme is a stale
string in Block's Greenhouse config, not a property of the posting.

**The missing-URL penalty only ever hits you.** All 13 rows with an empty URL
are `AtsType.MANUAL` — pasted through `/jobs/new`, which stores an empty URL by
design. Zero *fetched* rows lack a URL.

**The company↔apply-domain mismatch has no calibration point.**

| Variant | Hits | What they are |
| --- | --- | --- |
| ATS allowlist + aggregator exemption | **0** | nothing to flag |
| ATS allowlist only (the plan as written) | **26** | 100% `HN_HIRING` |
| Strict company-name-in-domain | **302 (37%)** | 185 block.xyz + every aggregator on its own feed |

The 26 are false by construction: an HN posting's `Company` row is the
synthetic aggregator `HN Who is Hiring`, so its apply host is *always* some
other domain — the same trap ADR 0018 documented for same-company SimHash
matches. The 22 with non-HN hosts are Brandfetch, Nango, PermitFlow, Gem,
Kula, Featurebase: all real employers.

**The non-Latin exemption protects zero rows.** The only two non-ASCII company
names are `WeWorkRemotely · Back-End` and `· Full-Stack`, and the character is
a middle dot in our own synthetic row names. No Cyrillic, CJK, Greek or Arabic
anywhere in `Company`.

**The shortener rule cannot be calibrated: n = 1.** The single hit is
`forms.gle` on job 1030 — Sitewire, posted on HN by its head of engineering
with a salary band and equity. A Google Form is not a destination-hiding
redirector, so it is deliberately excluded from the list, which takes the
corpus hit count to zero.

**And the premise itself fails.** Across all 814 descriptions every classic
scam marker returns **zero** — Telegram/WhatsApp apply instructions,
`t.me`/`wa.me` handles, application fees, crypto payment, "no experience
needed", free-email contacts. Positive controls pass (`engineer` 547,
`bitcoin` 186 — Block is a bitcoin company), so the zeros are real. ADR 0005
is why: we do not fetch from the venues where scam postings live, and the
curated two-tier model is itself the filter.

What *did* measure real is narrower and different in kind — links you cannot
apply through. Two rows, both from HN comments.

## What ships

`src/apply-link.ts`, pure, no I/O. Tags join the model's own in
`Job.redFlags`, which already renders as a danger `TagRow` on `/jobs/:id` and
already travels in the Telegram alert.

| Tag | Fires when | Corpus |
| --- | --- | --- |
| `apply-url-missing` | empty URL on a **fetched** row | 0 |
| `apply-url-unusable` | unparseable, or a non-http(s) scheme | 0 |
| `apply-url-shortened` | destination-hiding redirector (`bit.ly`, `t.co`, …) | 0 |
| `apply-url-not-an-application` | host that cannot serve one (`youtube.com`, `linkedin.com`, `t.me`, …) | 2 |

Every rule is **true by definition rather than tuned to a threshold** — which
is what makes a zero firing rate acceptable here instead of evidence of a
mis-set constant: there is no constant. Host matching is on a domain boundary,
never a substring, so `mylinkedin.com` is not LinkedIn and
`youtube.com.evil.example` is not YouTube.

The merge runs at all three paths that persist `redFlags` — ingest,
re-classify, classify-one — through one shared helper. A merge in only some of
them would drop the tags at the next re-classification.

`Job.redFlags` is display-only everywhere in the codebase (Telegram line,
job-detail TagRow, digest). Nothing reads it for dismissal, scoring or
filtering, so "flags, never a filter" holds structurally, not just by
intention.

## Verification

- `npm run lint:types` + `npm test` green on every commit — **738 tests**, +50
  here (49 apply-link, 1 notifier escaping).
- Table-driven unit tests per flag, plus boundary cases (subdomain, lookalike
  host, name-in-path), the pasted exemption, and the structural non-Latin
  exemption — five scripts asserted to produce identical verdicts, since the
  company name is not an input at all.
- Regression fixtures pin the **dropped** penalties: Block's `http://` URL, an
  aggregator on its own domain and a bare company root all assert *no* flag,
  so nobody re-adds the http rule without a failing test.
- Full-corpus run of the shipped module over all 814 stored jobs: 2 flagged
  (0.25%), both `apply-url-not-an-application`, distribution above.
- Eyeballed both hits — see below. No sampling; that is the entire flagged set.
- Backfill dry run against the live database: 814 scanned, 2 would change.
  Real run applied to jobs 945 and 956 only; re-run reports `updated: 0`,
  confirming idempotency. Job count 814 before and after.
- Re-run after the hourly tick added 14 rows: 828 scanned, still 2 flagged,
  `updated: 0` — the new rows introduce no flags and the rate is unchanged.
- **End-to-end smoke on the path that mattered most**: re-classified job 945
  through the dashboard button. The model's own flag was regenerated
  (`salary-below-target` → `below-target-minimum-salary`, fit 83 → 87) and
  `apply-url-not-an-application` survived — which is precisely what the
  three-path wiring exists to guarantee.
- Containers rebuilt and swapped after the hourly tick finished (persisted 14,
  alerted 0), so no in-flight classification was lost. Init log reads
  `36 migrations found` / `No pending migrations to apply`; the database holds
  the same 36 and 828 jobs, so nothing rolled back.
- Dashboard: `/jobs/945` and `/jobs/956` render the tag in the existing Flags
  row; 16 routes curled 200 (all pages plus the three `/static/*.mjs`) both
  before and after the image swap; screenshots at 1200px and 375px;
  **0 console errors** on both pages.
- Telegram: `notifier.ts` is unchanged, but the tags are new content on the
  Flags line and MarkdownV2 treats `-` as reserved, so a guard test pins the
  escaping. **`npm run test:telegram` was not run** — the matrix condition was
  "if you touch the Telegram line", and this branch does not; the tags are
  structurally identical to existing ones like `no-salary-listed`. Reported as
  skipped rather than quietly omitted.

### The two hits, honestly

Neither is a scam, and I would not describe either as "garbage caught":

- **Job 945** — Normal / Normcore.io, a real game-server hosting company;
  the founder posted it with a $100–140K band. Its apply URL is a **YouTube
  demo video** of their VR titles, and that is the *only* URL in the comment,
  so the HN parser had nothing better to pick.
- **Job 956** — Tyce AI, real, Toronto hybrid, 7-figure round. Its apply URL
  is a **LinkedIn company page**, and `https://www.tyce.ai/` was available in
  the same comment.

So: 2/2 true positives *for what the flag claims* — the stored link is not an
application — and 0 false positives. But the flag says nothing about whether
the posting is trustworthy, and I have not dressed it up as if it did.

## Improvement candidates

§14 has **no "Improvement candidates" subsection** — unlike F1, F2, F3, F5 and
F7, which do. This list is mine.

| Candidate | Call |
| --- | --- |
| Prefer an application-capable host when an HN comment holds several URLs (job 956 had `tyce.ai` behind the LinkedIn link) | **Defer** — changes fetcher behaviour for all HN rows on one observed case, in a branch whose whole thesis is not over-fitting. Job 945 had only the one URL, so it would not have helped there |
| Employer-name mismatch using the `Company:` line HN descriptions carry (would flag ~6, including Karhuno Group → `DearHiringManager.io`) | **Defer** — depends on HN-specific description formatting, so it is parser territory; named in ADR 0023's "when to revisit" |
| Flag bare-domain apply links (7 rows — you land on a homepage and hunt) | **Reject** — inconvenience, not trust; all 7 are real employers, and flagging them is a category error |
| Resolve shortener destinations over the network | **Reject here** — breaks the module's purity, and it means fetching an attacker-controlled URL. If ever wanted it belongs in the liveness ladder (ADR 0016) |
| Settings toggle per plan §0.8 | **Reject** — nothing to toggle: no cost, no AI call, no schema, purely additive annotation. `git revert` is the rollback |
| Sort/filter the jobs list by flag | **Defer** — needs more than two rows to be worth a control |
| Flag dotless hosts (`https://jobs/1`) as unusable | **Reject** — zero occurrences and an invented scenario; the four shipped rules are the ones with a stated justification |

## Pre-merge review (code-review-expert over `git diff main...HEAD`)

**P0: none. P1: none.**

- **P2 — fixed in this branch.** A bulk replace had also added `atsType` to the
  cover-letter file route (`/jobs/:id/cover/:letterId/file/:fmt`), which only
  reads `company.name`. Reverted; the net diff now touches one route.
- **P3** — `withApplyLinkFlags` scans with `Array.includes` (n ≤ 4); a `Set`
  would cost more to build than the scan saves. Left alone.
- **P3** — the backfill reads all rows in one query rather than paging like
  `reclassify-job.ts`. It selects no `description`, so rows are small, and
  `backfill-fingerprints.ts` has the same shape. Revisit if `Job` grows an
  order of magnitude.
- **P3** — the backfill's read-modify-write on `redFlags` is not atomic: a
  re-classify landing between the read and the update would drop the appended
  tag. One-shot script, same shape as F3's. Worth not running it during an
  active re-classify.

## Follow-ups still open from #33 / #34

Carried forward, not addressed here: take-cap on `listCoverLettersForJob` /
`listMatchesForJob` (TASKS §6.5); `distillMatch` can take "where" labels from
an older resume version's match; `CoverSchema.max(20)` rejects an over-long
`keywords_used` instead of truncating; `GET /jobs/:id` maps resumes twice;
no UI hint that Haiku on the `claude_code` CLI cannot finish a letter inside
the 180s timeout; `isPrivateHost` and `isFetchableJobUrl` are two different
private-address predicates; blind SSRF — the request to a private address is
still made and the body discarded after the redirect, closable only with a DNS
resolve before fetch; `tsc` compiles `*.test.ts` into `dist/`, so the image
ships the suite; `serveStatic` resolves `./src/web/public` against cwd.

## Release notes draft — v0.11.0

**Postings you cannot apply through are now flagged.** A job whose apply link
is missing, unopenable, hidden behind a shortener, or pointing at somewhere
that cannot take an application — a YouTube video, a LinkedIn company page, a
Telegram handle — gets a red flag on its page and in its Telegram alert. Two
such postings were already in the database, both harvested from HN comments.

**The planned trust score was dropped, and that is the more useful result.**
Measuring its four penalties against all 814 stored jobs showed three of them
would have been wrong: an `http://` penalty firing on 23% of the corpus, all
of it Block's own Greenhouse-served careers domain; a missing-URL penalty that
only ever hits jobs you pasted yourself; and a company↔domain mismatch that
produces nothing, 26 false positives, or 302, depending on a string-matching
detail. No scam markers exist anywhere in the corpus — ADR 0005 keeps us out
of the places they live. So there is no score, no badge and no schema change,
and the flags that remain are true by definition rather than tuned to data
that has nothing to tune against.

No schema changes. `backfill-apply-link-flags` annotates rows already stored,
without spending an AI call.

Suggested tag:

    git tag -a v0.11.0 -m "apply-link flags" && git push origin v0.11.0
