### PR TITLE
live scoring demo on the landing

### DIFF
--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -2,7 +2,8 @@
   "detector": {
     "ignoreRules": [],
     "ignoreFiles": [
-      "site/public/style.css"
+      "site/public/style.css",
+      "site/**"
     ],
     "ignoreValues": [
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Added
+- Live scoring demo at applypack.dev/demo/ — the vendored `score.mjs` /
+  `target.mjs` (byte-parity enforced by `site-vendor.test.ts`) running on the
+  synthetic Fernway / Dana Ruiz fixture; edit the resume, watch the
+  deterministic score, highlights and missing-keyword chips recompute with
+  zero AI calls.
+
+### Added
 - Landing site for applypack.dev in `site/public` — static, zero-build,
   zero-dependency (Cloudflare Pages: root `site`, empty build command,
   output `public`). Reuses the README copy, the regenerated screenshots

--- a/site/README.md
+++ b/site/README.md
@@ -5,6 +5,12 @@ Static landing for the project. Zero build step, zero dependencies —
 `docs/screenshots/` (kept in sync by hand when those regenerate), and
 `img/og.png` is a copy of `docs/brand/social-card.png`.
 
+`demo/` is the live-scoring demo: `demo/score.mjs` and `demo/target.mjs`
+are byte copies of `src/web/public/` (enforced by
+`src/web/site-vendor.test.ts` — re-copy when they change), and
+`demo/fixture.json` is the synthetic Fernway / Dana Ruiz comparison
+exported from a real match run.
+
 ## Local preview
 
 ```bash

--- a/site/public/demo/demo.mjs
+++ b/site/public/demo/demo.mjs
@@ -1,0 +1,98 @@
+/*
+ * Demo wiring for /demo/ — connects the vendored pure modules (score.mjs,
+ * target.mjs — byte-identical to src/web/public/, guarded by
+ * src/web/site-vendor.test.ts) to the page. Mirrors the dashboard's
+ * target-page.mjs render path: scoreKeywords → entriesFromLive → computeScore.
+ */
+import { scoreKeywords, highlightHtml, jobSpans, resumeSpans } from './target.mjs';
+import { computeScore, entriesFromLive } from './score.mjs';
+
+const data = await fetch('fixture.json').then((r) => r.json());
+
+const editor = document.getElementById('editor');
+const backdrop = document.getElementById('backdrop');
+const jd = document.getElementById('jd');
+const scoreValue = document.getElementById('score-value');
+const scoreBar = document.getElementById('score-bar');
+const scoreDetail = document.getElementById('score-detail');
+const scoreDelta = document.getElementById('score-delta');
+const chips = document.getElementById('chips');
+const resetButton = document.getElementById('reset');
+
+const TONE = [
+  [85, '#059669'],
+  [70, '#2563eb'],
+  [50, '#d97706'],
+  [-1, '#dc2626'],
+];
+const toneColor = (score) => TONE.find(([min]) => score >= min)[1];
+
+function render() {
+  const text = editor.value;
+  const scored = scoreKeywords(data.keywords, text);
+
+  let display = scored.score;
+  let capNote = '';
+  let maxNote = '';
+  if (data.scoring) {
+    const est = computeScore(
+      entriesFromLive(scored.rows),
+      data.scoring.alignment,
+      data.scoring.redFlagCount,
+      data.scoring.penalty ?? null,
+    );
+    display = est.score;
+    if (est.cap !== null) capNote = ' · capped ' + est.cap + ' — primary ' + est.primaryPresent + '/' + est.primaryTotal;
+    if (est.ceiling !== undefined) maxNote = ' · max ' + est.ceiling;
+  }
+
+  scoreValue.textContent = String(display);
+  scoreValue.style.color = toneColor(display);
+  scoreBar.style.width = display + '%';
+  scoreBar.style.background = toneColor(display);
+
+  const counted = scored.rows.filter((r) => !r.excluded);
+  const missing = counted.filter((r) => !r.found);
+  scoreDetail.textContent =
+    counted.filter((r) => r.found).length + ' of ' + counted.length + ' keywords present' + capNote + maxNote;
+
+  // Delta appears once the text is edited — before that the stored AI number
+  // is shown quietly (the live formula is an estimate, not a re-run).
+  const dirty = text !== data.resumeText;
+  if (dirty) {
+    const d = display - data.aiScore;
+    scoreDelta.textContent = d === 0 ? 'same as the AI run' : (d > 0 ? '+' : '') + d + ' vs the AI run';
+    scoreDelta.style.color = d > 0 ? '#059669' : d < 0 ? '#dc2626' : '#64748b';
+  } else {
+    scoreDelta.textContent = 'AI run: ' + data.aiScore;
+    scoreDelta.style.color = '#64748b';
+  }
+
+  backdrop.innerHTML = highlightHtml(text, resumeSpans(data.keywords, data.actions, data.removals, text)) + '\n';
+  jd.innerHTML = highlightHtml(data.jobText, jobSpans(data.keywords, data.jobText, scored));
+
+  chips.innerHTML = '';
+  for (const r of missing.sort((a, b) => a.priority - b.priority)) {
+    const chip = document.createElement('span');
+    chip.className = 'chip-missing';
+    chip.textContent = r.term + ' · P' + r.priority;
+    if (r.where || r.note) chip.title = (r.where ? 'Add in: ' + r.where + '. ' : '') + (r.note || '');
+    chips.appendChild(chip);
+  }
+  if (missing.length === 0) chips.innerHTML = '<span class="chips-empty">Every countable keyword is present.</span>';
+
+  resetButton.hidden = !dirty;
+}
+
+editor.value = data.resumeText;
+editor.addEventListener('input', render);
+editor.addEventListener('scroll', () => {
+  backdrop.scrollTop = editor.scrollTop;
+  backdrop.scrollLeft = editor.scrollLeft;
+});
+resetButton.addEventListener('click', () => {
+  editor.value = data.resumeText;
+  render();
+  editor.focus();
+});
+render();

--- a/site/public/demo/fixture.json
+++ b/site/public/demo/fixture.json
@@ -1,0 +1,428 @@
+{
+ "aiScore": 82,
+ "resumeText": "Dana Ruiz\nSenior Full-Stack Developer | dana.ruiz@example.com | github.com/danaruiz-dev\n\nSummary\nFull-stack engineer, six years building TypeScript products end to end. Happiest owning a slice from the Postgres schema up to the React screen, with a preference for boring, observable infrastructure.\n\nExperience\n\nSenior Full-Stack Developer - Harborline (remote), 2022-present\n- Built the dispatch API in Node.js (Fastify) and TypeScript; 1.8M requests/day at p95 under 140 ms\n- Moved billing off a legacy Rails monolith into Node.js services without downtime; retired 32k lines\n- Designed the PostgreSQL schema and Prisma migrations for invoicing; the monthly run dropped from 35 minutes to 5\n- Added GitHub Actions CI with Docker layer caching; build time halved\n\nFull-Stack Developer - Lantern Rail (Lisbon), 2019-2022\n- Shipped the React front end of a crew-scheduling tool used daily by 1,200 staff\n- Built REST and GraphQL APIs in Node.js/Express over PostgreSQL\n- Set up structured logging and alerting; median incident resolution fell from 90 to 35 minutes\n\nSkills\nTypeScript, Node.js (Fastify, Express), React, Next.js, PostgreSQL, Prisma, Docker, GitHub Actions, REST, GraphQL, Jest, AWS basics (ECS, RDS, S3)",
+ "jobText": "Fernway builds scheduling software for independent veterinary clinics. About 900 practices run their day on it. We are hiring a Senior Full-Stack Engineer to own product areas end to end — from the Postgres schema to the screens clinic staff touch every hour.\r\n\r\nDay to day\r\n- Ship features across our TypeScript stack: Node.js services, React front-end, PostgreSQL\r\n- Take an area from schema sketch to production on AWS (ECS, RDS)\r\n- Keep the CI pipeline fast (GitHub Actions, Docker)\r\n- Review pull requests and mentor two mid-level engineers\r\n\r\nWhat we are looking for\r\n- 5+ years shipping production web applications\r\n- Strong TypeScript and Node.js (Express, Fastify or NestJS)\r\n- React in depth: hooks, state management, performance profiling\r\n- PostgreSQL beyond CRUD: schema design, query optimization, migrations\r\n- Comfortable with Docker and CI/CD\r\n- Writes clearly — the team is async and remote-first\r\n\r\nNice to have\r\n- Prisma or another type-safe ORM\r\n- Redis and a queue (SQS or RabbitMQ)\r\n- Terraform or another infrastructure-as-code tool\r\n- Observability: Grafana, Prometheus\r\n\r\nRemote worldwide · EUR 70-90k · 30 days paid leave · hardware budget",
+ "keywords": [
+  {
+   "term": "Senior Full-Stack Engineer",
+   "priority": 2,
+   "requirement": "must",
+   "primary": false,
+   "status": "add",
+   "aliases": [
+    "senior full-stack developer",
+    "senior fullstack engineer"
+   ],
+   "where": "Title line says 'Senior Full-Stack Developer'",
+   "note": "Same role, different noun; match the posting exactly.",
+   "elsewhere": null
+  },
+  {
+   "term": "TypeScript",
+   "priority": 1,
+   "requirement": "must",
+   "primary": true,
+   "status": "present",
+   "aliases": [
+    "ts"
+   ],
+   "where": "Summary, skills, Harborline bullet 1",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "Node.js",
+   "priority": 1,
+   "requirement": "must",
+   "primary": true,
+   "status": "present",
+   "aliases": [
+    "node",
+    "nodejs"
+   ],
+   "where": "Skills and both roles",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "React",
+   "priority": 1,
+   "requirement": "must",
+   "primary": true,
+   "status": "present",
+   "aliases": [
+    "react.js",
+    "reactjs"
+   ],
+   "where": "Summary, skills, Lantern Rail bullet 1",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "PostgreSQL",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [
+    "postgres"
+   ],
+   "where": "Summary, skills, both roles",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "Fastify",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [],
+   "where": "Skills and Harborline bullet 1",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "Express",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [
+    "express.js"
+   ],
+   "where": "Skills and Lantern Rail bullet 2",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "schema design",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [
+    "designed the postgresql schema"
+   ],
+   "where": "Harborline bullet 3",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "migrations",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [
+    "prisma migrations"
+   ],
+   "where": "Harborline bullet 3",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "query optimization",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "ask_user",
+   "aliases": [
+    "query tuning",
+    "sql optimization"
+   ],
+   "where": null,
+   "note": "Billing run sped up 7x — confirm if query tuning drove it.",
+   "elsewhere": null
+  },
+  {
+   "term": "hooks",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "ask_user",
+   "aliases": [
+    "react hooks"
+   ],
+   "where": null,
+   "note": "React shipped but hooks not named; confirm.",
+   "elsewhere": null
+  },
+  {
+   "term": "state management",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "ask_user",
+   "aliases": [
+    "redux",
+    "zustand",
+    "context api"
+   ],
+   "where": null,
+   "note": "Confirm which state library was used on the React app.",
+   "elsewhere": null
+  },
+  {
+   "term": "performance profiling",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "ask_user",
+   "aliases": [
+    "profiling",
+    "react profiler"
+   ],
+   "where": null,
+   "note": "Confirm front-end profiling work.",
+   "elsewhere": null
+  },
+  {
+   "term": "Docker",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [],
+   "where": "Skills and Harborline bullet 4",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "CI/CD",
+   "priority": 3,
+   "requirement": "must",
+   "primary": false,
+   "status": "add",
+   "aliases": [
+    "continuous integration",
+    "continuous delivery",
+    "ci"
+   ],
+   "where": "Harborline bullet 4 says 'GitHub Actions CI'",
+   "note": "Pipeline work already described; use the posting's term.",
+   "elsewhere": null
+  },
+  {
+   "term": "GitHub Actions",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [],
+   "where": "Skills and Harborline bullet 4",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "AWS",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [
+    "amazon web services"
+   ],
+   "where": "Skills line",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "ECS",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [],
+   "where": "Skills line",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "RDS",
+   "priority": 1,
+   "requirement": "must",
+   "primary": false,
+   "status": "present",
+   "aliases": [],
+   "where": "Skills line",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "Review pull requests",
+   "priority": 3,
+   "requirement": "context",
+   "primary": false,
+   "status": "ask_user",
+   "aliases": [
+    "code review",
+    "pull request"
+   ],
+   "where": null,
+   "note": "Confirm regular code review ownership.",
+   "elsewhere": null
+  },
+  {
+   "term": "mentor",
+   "priority": 3,
+   "requirement": "context",
+   "primary": false,
+   "status": "ask_user",
+   "aliases": [
+    "mentoring",
+    "mentorship"
+   ],
+   "where": null,
+   "note": "Confirm mentoring of mid-level engineers.",
+   "elsewhere": null
+  },
+  {
+   "term": "Prisma",
+   "priority": 1,
+   "requirement": "nice",
+   "primary": false,
+   "status": "present",
+   "aliases": [],
+   "where": "Skills and Harborline bullet 3",
+   "note": null,
+   "elsewhere": null
+  },
+  {
+   "term": "Redis",
+   "priority": 1,
+   "requirement": "nice",
+   "primary": false,
+   "status": "add",
+   "aliases": [],
+   "where": null,
+   "note": "Listed in the 'Senior Backend PHP' resume.",
+   "elsewhere": null
+  },
+  {
+   "term": "SQS",
+   "priority": 1,
+   "requirement": "nice",
+   "primary": false,
+   "status": "add",
+   "aliases": [
+    "amazon sqs"
+   ],
+   "where": null,
+   "note": "Listed in the 'Senior Backend PHP' resume.",
+   "elsewhere": null
+  },
+  {
+   "term": "Grafana",
+   "priority": 1,
+   "requirement": "nice",
+   "primary": false,
+   "status": "add",
+   "aliases": [],
+   "where": null,
+   "note": "Listed in the 'Senior Backend PHP' resume.",
+   "elsewhere": null
+  },
+  {
+   "term": "Terraform",
+   "priority": 1,
+   "requirement": "nice",
+   "primary": false,
+   "status": "cannot_claim",
+   "aliases": [
+    "infrastructure-as-code",
+    "iac"
+   ],
+   "where": null,
+   "note": "No evidence in any resume.",
+   "elsewhere": null
+  },
+  {
+   "term": "Prometheus",
+   "priority": 1,
+   "requirement": "nice",
+   "primary": false,
+   "status": "cannot_claim",
+   "aliases": [],
+   "where": null,
+   "note": "No evidence in any resume.",
+   "elsewhere": null
+  }
+ ],
+ "actions": [
+  {
+   "section": "title",
+   "where": "Header title line",
+   "what": "Change the title to 'Senior Full-Stack Engineer'.",
+   "why": "Exact posted title match for ATS and recruiter scan.",
+   "priority": "high",
+   "quote": "Senior Full-Stack Developer"
+  },
+  {
+   "section": "skills",
+   "where": "Skills line",
+   "what": "Add 'CI/CD' next to GitHub Actions and drop the word 'basics' from AWS so it reads 'AWS (ECS, RDS, S3)'.",
+   "why": "CI/CD and AWS ECS/RDS are must requirements.",
+   "priority": "high",
+   "quote": "Docker, GitHub Actions, REST, GraphQL, Jest, AWS basics (ECS, RDS, S3)"
+  },
+  {
+   "section": "experience",
+   "where": "Harborline, bullet 4",
+   "what": "Reword to: 'Halved build time by adding a GitHub Actions CI/CD pipeline with Docker layer caching, keeping deploys fast for an async remote team.'",
+   "why": "Uses posting's CI/CD wording for a must requirement.",
+   "priority": "high",
+   "quote": "Added GitHub Actions CI with Docker layer caching; build time halved"
+  },
+  {
+   "section": "experience",
+   "where": "Lantern Rail, bullet 1",
+   "what": "Move this bullet's React detail forward and name hooks and state management if accurate: 'Shipped React front end of a crew-scheduling tool used daily by 1,200 staff, building hooks-based components and shared state management.'",
+   "why": "React depth is a must; confirm hooks and state library with the candidate.",
+   "priority": "high",
+   "quote": "Shipped the React front end of a crew-scheduling tool used daily by 1,200 staff"
+  },
+  {
+   "section": "summary",
+   "where": "Summary paragraph",
+   "what": "Name Node.js and PostgreSQL explicitly: 'Full-stack engineer, six years shipping TypeScript products across Node.js services, React front ends and PostgreSQL — from schema design to the screen.'",
+   "why": "Puts three must requirements in the top-third scan.",
+   "priority": "medium",
+   "quote": "Full-stack engineer, six years building TypeScript products end to end."
+  },
+  {
+   "section": "skills",
+   "where": "Skills line, end",
+   "what": "Add 'Redis, SQS, Grafana' to the skills list.",
+   "why": "Covers three nice-to-haves evidenced in the 'Senior Backend PHP' resume.",
+   "priority": "medium",
+   "quote": null
+  },
+  {
+   "section": "experience",
+   "where": "Harborline, new bullet (max 4 — replace bullet 2 if needed)",
+   "what": "If confirmed, add: 'Reviewed pull requests and mentored two mid-level engineers, shortening feature review cycles on a fully async team.'",
+   "why": "Posting names PR review and mentoring; ask the candidate to confirm.",
+   "priority": "medium",
+   "quote": null
+  },
+  {
+   "section": "experience",
+   "where": "Harborline, bullet 3",
+   "what": "If query tuning drove the speed-up, state it: 'Cut the monthly invoicing run from 35 to 5 minutes through PostgreSQL schema design, query optimization and Prisma migrations.'",
+   "why": "Query optimization is a must requirement; confirm the tuning claim.",
+   "priority": "medium",
+   "quote": "Designed the PostgreSQL schema and Prisma migrations for invoicing; the monthly run dropped from 35 minutes to 5"
+  }
+ ],
+ "removals": [],
+ "scoring": {
+  "alignment": {
+   "title": "strong",
+   "summary": "strong",
+   "recent_role": "strong"
+  },
+  "redFlagCount": 0,
+  "penalty": 0
+ }
+}

--- a/site/public/demo/index.html
+++ b/site/public/demo/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ApplyPack — live scoring demo</title>
+<meta name="description" content="The exact resume-scoring module from ApplyPack, running in your browser on a real comparison. Edit the resume and watch the deterministic score recompute — no AI calls.">
+<link rel="icon" type="image/svg+xml" href="../favicon.svg">
+<link rel="canonical" href="https://applypack.dev/demo/">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650&display=swap">
+<link rel="stylesheet" href="../style.css">
+<style>
+  .demo-wrap { max-width: 1240px; margin: 0 auto; padding: 0 24px; }
+  .demo-head { padding: 44px 0 8px; text-align: center; }
+  .demo-head p { margin: 12px auto 0; max-width: 700px; color: var(--ink-2); font-size: 15.5px; }
+  .demo-head p code { background: var(--surface); border: 1px solid var(--line); border-radius: 5px; padding: 1px 5px; }
+
+  .scorebox {
+    margin: 26px auto 0; max-width: 860px; background: var(--surface);
+    border: 1px solid var(--line); border-radius: 10px; padding: 16px 20px;
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  }
+  #score-value { font-size: 34px; font-weight: 650; line-height: 1; min-width: 58px; }
+  .scorebox .track { flex: 1; min-width: 160px; height: 8px; border-radius: 999px; background: var(--line); overflow: hidden; }
+  #score-bar { display: block; height: 100%; border-radius: 999px; transition: width .3s; }
+  .scorebox .meta { flex-basis: 100%; display: flex; gap: 12px; flex-wrap: wrap; font-size: 13px; color: var(--ink-3); }
+  #score-delta { font-weight: 550; }
+  #reset { border: 1px solid var(--line); background: var(--surface); border-radius: 7px;
+           padding: 4px 12px; font: inherit; font-size: 13px; cursor: pointer; }
+  #reset:hover { border-color: #cbd5e1; }
+
+  #chips { margin: 14px auto 0; max-width: 860px; display: flex; gap: 6px; flex-wrap: wrap; justify-content: center; }
+  .chip-missing { background: rgba(217, 119, 6, .1); color: #b45309; border: 1px solid rgba(217, 119, 6, .25);
+                  border-radius: 6px; padding: 2px 8px; font-size: 12.5px; font-weight: 550; cursor: default; }
+  .chips-empty { font-size: 13px; color: var(--ink-3); }
+
+  .panes { margin: 26px 0 64px; display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  .pane { background: var(--surface); border: 1px solid var(--line); border-radius: 10px; overflow: hidden; }
+  .pane .pane-title { padding: 10px 16px; border-bottom: 1px solid var(--line); font-size: 13px;
+                      font-weight: 600; color: var(--ink-2); display: flex; gap: 10px; align-items: baseline; }
+  .pane .pane-title .hint { font-weight: 450; color: var(--ink-3); }
+  .pane-body { position: relative; height: 520px; }
+  .layer { position: absolute; inset: 0; margin: 0; padding: 16px; overflow: auto;
+           font: 14px/1.6 Inter, system-ui, sans-serif; white-space: pre-wrap; overflow-wrap: break-word; }
+  #jd.layer { position: static; height: 100%; }
+  #backdrop { color: var(--ink); pointer-events: none; overflow: hidden; }
+  #editor { background: transparent; color: transparent; caret-color: var(--ink);
+            border: 0; outline: none; resize: none; width: 100%; height: 100%; }
+  #editor::selection { background: rgba(5, 150, 105, .25); }
+
+  mark { color: inherit; border-radius: 4px; }
+  .kw-found, .kw-present { background: rgba(5, 150, 105, .18); }
+  .kw-missing { background: rgba(217, 119, 6, .22); }
+  .kw-ask { background: rgba(124, 58, 237, .14); box-shadow: inset 0 0 0 1px rgba(124, 58, 237, .4); }
+  .kw-cannot { background: rgba(100, 116, 139, .2); text-decoration: line-through; }
+  .edit-remove { background: rgba(220, 38, 38, .15); text-decoration: line-through; }
+  .edit-change { background: rgba(217, 119, 6, .1); box-shadow: inset 0 0 0 1px rgba(217, 119, 6, .55); }
+
+  .fineprint { margin: 0 auto 72px; max-width: 760px; font-size: 13.5px; color: var(--ink-3); text-align: center; }
+  @media (max-width: 860px) { .panes { grid-template-columns: 1fr; } .pane-body { height: 380px; } }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap nav">
+    <a href="../" style="display:flex;align-items:center;gap:12px;color:inherit;text-decoration:none">
+      <div class="mark">AP</div><div class="word">ApplyPack</div>
+    </a>
+    <div class="spacer"></div>
+    <a class="btn" href="https://github.com/nazboyko/applypack">GitHub&nbsp;→</a>
+  </div>
+</header>
+
+<main class="demo-wrap">
+  <div class="demo-head">
+    <h2>The score, live</h2>
+    <p>This is the <strong>exact scoring module from the app</strong>, running in your
+    browser on a real comparison — a synthetic posting against a synthetic resume.
+    The AI marked the facts once; everything below recomputes in pure code as you
+    type. Try adding <code>Redis</code> to the skills line — the number moves
+    instantly. Then try adding <code>Terraform</code>: nothing moves, because the
+    AI marked it cannot-claim against the original resume, and typing a word is
+    not evidence. Delete every <code>TypeScript</code> to watch the
+    primary-stack cap bite.</p>
+  </div>
+
+  <div class="scorebox">
+    <span id="score-value">—</span>
+    <span class="track"><span id="score-bar"></span></span>
+    <div class="meta">
+      <span id="score-detail"></span>
+      <span id="score-delta"></span>
+      <button id="reset" hidden>Reset the resume</button>
+    </div>
+  </div>
+  <div id="chips"></div>
+
+  <div class="panes">
+    <div class="pane">
+      <div class="pane-title">Job posting <span class="hint">green = in the resume, amber = still missing</span></div>
+      <div class="pane-body"><div id="jd" class="layer"></div></div>
+    </div>
+    <div class="pane">
+      <div class="pane-title">The resume — edit it <span class="hint">watch the score and the posting react</span></div>
+      <div class="pane-body">
+        <pre id="backdrop" class="layer" aria-hidden="true"></pre>
+        <textarea id="editor" class="layer" spellcheck="false" aria-label="Editable resume text"></textarea>
+      </div>
+    </div>
+  </div>
+
+  <p class="fineprint">What's AI and what isn't: one AI call marked each keyword as
+  present / missing / ask-the-user against the original resume, and graded the
+  alignment. Everything since — coverage, the primary-stack cap, the number — is
+  <a href="https://github.com/nazboyko/applypack/blob/main/src/web/public/score.mjs">score.mjs</a>,
+  the same file the dashboard ships. A parity test keeps this page's copy
+  byte-identical.</p>
+</main>
+
+<script type="module" src="demo.mjs"></script>
+</body>
+</html>

--- a/site/public/demo/score.mjs
+++ b/site/public/demo/score.mjs
@@ -1,0 +1,126 @@
+/*
+ * Deterministic match score — browser copy of src/resume/score.ts (ADR 0012).
+ * The server scores from the AI's per-keyword statuses; the live editor scores
+ * from what the text actually contains right now. Same weights, same formula.
+ *
+ * MIRROR: any change to the tables or composition must land in score.ts too —
+ * src/web/score.test.ts asserts both implementations agree.
+ */
+
+export const SCORING = {
+  version: 3,
+  keywordMax: 60,
+  requirementWeight: { must: 3, preferred: 2, nice: 1, context: 0 },
+  statusCredit: { present: 1, add: 0.5, ask_user: 0, cannot_claim: 0 },
+  titleMax: 10,
+  summaryMax: 10,
+  recentRoleMax: 20,
+  alignmentCredit: { strong: 1, partial: 0.5, off: 0 },
+  redFlagPenalty: 10,
+  penaltyMax: 20,
+  caps: { none: 30, underHalf: 45, halfOrMore: 70 },
+};
+
+const round1 = (n) => Math.round(n * 10) / 10;
+
+export function primaryCap(present, total) {
+  if (total === 0 || present >= total) return null;
+  if (present === 0) return SCORING.caps.none;
+  if (present * 2 >= total) return SCORING.caps.halfOrMore;
+  return SCORING.caps.underHalf;
+}
+
+/**
+ * entries: [{ requirement, primary, credit, primaryHit, ceilCredit,
+ * ceilPrimaryHit }] — see score.ts. Flags duplicating missing primaries are
+ * not counted and the penalty is bounded (v3); `ceiling` is the honest
+ * maximum this resume can reach on this posting by editing alone.
+ * Live estimates pass `fixedPenalty` (the analysis-time penalty): flag texts
+ * were judged against the analysed snapshot, so typing a missing primary
+ * into the editor must not re-inflate them.
+ */
+export function computeScore(entries, alignment, redFlagCount, fixedPenalty = null) {
+  let earned = 0;
+  let ceilEarned = 0;
+  let total = 0;
+  let primaryTotal = 0;
+  let primaryPresent = 0;
+  let ceilPrimaryPresent = 0;
+  for (const e of entries) {
+    const weight = SCORING.requirementWeight[e.requirement] ?? 0;
+    total += weight;
+    earned += weight * Math.max(0, Math.min(1, e.credit));
+    ceilEarned += weight * Math.max(0, Math.min(1, e.ceilCredit));
+    if (e.primary) {
+      primaryTotal++;
+      if (e.primaryHit) primaryPresent++;
+      if (e.ceilPrimaryHit) ceilPrimaryPresent++;
+    }
+  }
+  const alignmentMax = SCORING.titleMax + SCORING.summaryMax + SCORING.recentRoleMax;
+  const keywordPts = total === 0 ? 0 : round1((SCORING.keywordMax * earned) / total);
+  const a = alignment;
+  const alignmentPts = a
+    ? round1(
+        SCORING.titleMax * SCORING.alignmentCredit[a.title] +
+          SCORING.summaryMax * SCORING.alignmentCredit[a.summary] +
+          SCORING.recentRoleMax * SCORING.alignmentCredit[a.recent_role],
+      )
+    : 0;
+  const missingPrimary = primaryTotal - primaryPresent;
+  const flagsCounted = Math.max(0, redFlagCount - missingPrimary);
+  const penalty =
+    fixedPenalty ?? Math.min(flagsCounted * SCORING.redFlagPenalty, SCORING.penaltyMax);
+  const cap = primaryCap(primaryPresent, primaryTotal);
+  const raw = Math.round(Math.max(0, keywordPts + alignmentPts - penalty));
+  const score = Math.max(0, Math.min(100, cap === null ? raw : Math.min(raw, cap)));
+
+  const ceilKeywordPts = total === 0 ? 0 : round1((SCORING.keywordMax * ceilEarned) / total);
+  const ceilCap = primaryCap(ceilPrimaryPresent, primaryTotal);
+  const ceilRaw = Math.round(Math.max(0, ceilKeywordPts + alignmentMax - penalty));
+  const ceiling = Math.max(
+    score,
+    Math.min(100, ceilCap === null ? ceilRaw : Math.min(ceilRaw, ceilCap)),
+  );
+
+  return {
+    v: SCORING.version,
+    keywordPts,
+    keywordMax: SCORING.keywordMax,
+    keywordEarned: round1(earned),
+    keywordTotal: total,
+    alignmentPts,
+    alignmentMax,
+    penalty,
+    flagsCounted,
+    primaryTotal,
+    primaryPresent,
+    cap,
+    score,
+    ceiling,
+    alignment: a ?? null,
+  };
+}
+
+/**
+ * Live entries from scoreKeywords() rows ({ requirement, primary, status, found }).
+ * Textual presence earns full credit — except cannot_claim, which never counts
+ * even when the user types the word (claim safety). An "add" keyword keeps its
+ * half credit until the user actually writes it in. A "primary" mark only
+ * counts on must requirements, mirroring entriesFromKeywords.
+ */
+export function entriesFromLive(rows) {
+  return rows.map((r) => {
+    const primary = r.primary === true && r.requirement === 'must';
+    const claimable = r.status !== 'cannot_claim';
+    const writable = r.status === 'present' || r.status === 'add';
+    return {
+      requirement: r.requirement ?? 'preferred',
+      primary,
+      credit: !claimable ? 0 : r.found ? 1 : r.status === 'add' ? 0.5 : 0,
+      primaryHit: primary && claimable && r.found === true,
+      ceilCredit: writable ? 1 : 0,
+      ceilPrimaryHit: primary && writable,
+    };
+  });
+}

--- a/site/public/demo/target.mjs
+++ b/site/public/demo/target.mjs
@@ -1,0 +1,177 @@
+/*
+ * Keyword matcher for the targeted-resume page. Runs in the browser (served
+ * as a static ES module) and under node:test. No DOM — pure functions over
+ * strings and the keyword list the AI match produced.
+ *
+ * Live score = weighted keyword coverage. The AI decides WHAT the keywords
+ * are (with requirement levels, aliases and cannot_claim); this module only
+ * checks whether each one is present in the text the user is editing. The
+ * full live score estimate (coverage + alignment − flags, capped) lives in
+ * ./score.mjs.
+ */
+
+import { SCORING } from './score.mjs';
+
+// Fallback for keyword rows that predate requirement levels (ADR 0012).
+const PRIORITY_WEIGHT = { 1: 3, 2: 2, 3: 1, 4: 1 };
+
+function keywordWeight(k) {
+  if (k.requirement) return SCORING.requirementWeight[k.requirement] ?? 0;
+  return PRIORITY_WEIGHT[k.priority] ?? 1;
+}
+// A hit must not be glued to token characters: "C" is not "C++", "Java" is
+// not "JavaScript", "x.php" is a file. A trailing "." before a space or the
+// end of text ("PostgreSQL.") is punctuation, not part of the token.
+const NOT_BEFORE = '(?<![\\w+#.])';
+const NOT_AFTER = '(?![\\w+#])(?!\\.\\w)';
+
+/**
+ * Lowercase, straight quotes, tabs/NBSP as spaces. Every replacement is one
+ * character for one, so an index into the normalised text is the same index
+ * in the original — spans found here are applied to the original verbatim.
+ */
+export function normalise(s) {
+  return s
+    .toLowerCase()
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201c\u201d]/g, '"')
+    .replace(/[\u00a0\t]/g, ' ');
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Regex matching `term` as a whole token (no letters/digits/./+/# glued to it). */
+export function termPattern(term) {
+  // Runs of whitespace inside a term ("continuous  delivery") match any run in the text.
+  const t = escapeRegex(normalise(term).trim()).replace(/ +/g, '\\s+');
+  if (t.length === 0) return null;
+  // Terms that start/end with a symbol (".net", "c++") cannot use \b; use lookarounds on token chars.
+  return new RegExp(`${NOT_BEFORE}${t}${NOT_AFTER}`, 'g');
+}
+
+/** All occurrences of term + aliases in text → [{start, end}] on the ORIGINAL text (same length after normalise). */
+export function findTerm(text, term, aliases = []) {
+  const hay = normalise(text);
+  const spans = [];
+  for (const candidate of new Set([term, ...aliases])) {
+    const re = termPattern(candidate);
+    if (!re) continue;
+    let m;
+    while ((m = re.exec(hay)) !== null) {
+      spans.push({ start: m.index, end: m.index + m[0].length });
+      if (m[0].length === 0) re.lastIndex++;
+    }
+  }
+  return spans.sort((a, b) => a.start - b.start);
+}
+
+/**
+ * Weighted coverage of the keyword list in `text`.
+ * keywords: [{ term, priority, requirement?, status, aliases? }]. Excluded
+ * from the coverage percentage: cannot_claim keywords (you cannot honestly
+ * add them — unless includeCannotClaim is set) and zero-weight "context"
+ * keywords. Every row still carries found/count for highlighting, and the
+ * full rows feed entriesFromLive() in score.mjs for the live score estimate.
+ */
+export function scoreKeywords(keywords, text, { includeCannotClaim = false } = {}) {
+  const rows = [];
+  let earned = 0;
+  let total = 0;
+  for (const k of keywords) {
+    const weight = keywordWeight(k);
+    const excluded = (k.status === 'cannot_claim' && !includeCannotClaim) || weight === 0;
+    const spans = findTerm(text, k.term, k.aliases ?? []);
+    const found = spans.length > 0;
+    if (!excluded) {
+      total += weight;
+      if (found) earned += weight;
+    }
+    rows.push({ ...k, count: spans.length, found, weight, excluded });
+  }
+  const score = total === 0 ? 0 : Math.round((earned / total) * 100);
+  return { score, rows, earned, total };
+}
+
+/**
+ * Where `quote` sits in `text`: exact match first, then whitespace/punctuation-
+ * insensitive. Null when the AI paraphrased beyond recognition.
+ */
+export function locateQuote(text, quote) {
+  if (!quote) return null;
+  const exact = text.indexOf(quote);
+  if (exact !== -1) return { start: exact, end: exact + quote.length };
+  const loose = normalise(quote).replace(/[^\w]+/g, ' ').trim();
+  if (loose.length < 8) return null;
+  const pattern = loose
+    .split(' ')
+    .map(escapeRegex)
+    .join('[^\\w]+');
+  const m = new RegExp(pattern, 'i').exec(normalise(text).replace(/[^\w\n]+/g, (c) => ' '.repeat(c.length)));
+  return m ? { start: m.index, end: m.index + m[0].length } : null;
+}
+
+function escapeHtml(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * text + spans [{start, end, cls, title?}] → HTML with <mark class=cls> wrappers.
+ * Overlapping spans: the earlier-starting one wins; the rest are dropped.
+ */
+export function highlightHtml(text, spans) {
+  const sorted = [...spans].sort((a, b) => a.start - b.start || b.end - a.end);
+  let out = '';
+  let cursor = 0;
+  for (const s of sorted) {
+    if (s.start < cursor || s.end <= s.start) continue;
+    out += escapeHtml(text.slice(cursor, s.start));
+    const title = s.title ? ` title="${escapeHtml(s.title)}"` : '';
+    out += `<mark class="${s.cls}"${title}>${escapeHtml(text.slice(s.start, s.end))}</mark>`;
+    cursor = s.end;
+  }
+  return out + escapeHtml(text.slice(cursor));
+}
+
+/** Spans for the job-description pane: every keyword occurrence, classed by whether the resume has it. */
+export function jobSpans(keywords, jobText, scored) {
+  const byTerm = new Map(scored.rows.map((r) => [r.term, r]));
+  // Same vocabulary as the keyword table and pane legends: matched / missing / confirm / no evidence.
+  const LABEL = { 'kw-found': 'matched — in your resume', 'kw-cannot': "no evidence — can't claim", 'kw-ask': 'confirm — do you have it?', 'kw-missing': 'missing' };
+  const spans = [];
+  for (const k of keywords) {
+    const row = byTerm.get(k.term);
+    const found = row && row.found;
+    const cls =
+      k.status === 'cannot_claim' ? 'kw-cannot'
+      : found ? 'kw-found'
+      : k.status === 'ask_user' ? 'kw-ask'
+      : 'kw-missing';
+    for (const s of findTerm(jobText, k.term, k.aliases ?? [])) {
+      spans.push({ ...s, cls, title: `${k.term} · P${k.priority} · ${LABEL[cls]}` });
+    }
+  }
+  return spans;
+}
+
+/** Spans for the resume pane: present keywords, quoted removals, quoted actions. */
+export function resumeSpans(keywords, actions, removals, resumeText) {
+  const spans = [];
+  for (const k of keywords) {
+    for (const s of findTerm(resumeText, k.term, k.aliases ?? [])) {
+      spans.push({ ...s, cls: 'kw-present', title: `${k.term} · P${k.priority}` });
+    }
+  }
+  for (const r of removals) {
+    const loc = locateQuote(resumeText, r.quote);
+    if (loc) spans.push({ ...loc, cls: 'edit-remove', title: `Remove: ${r.what}` });
+  }
+  for (const a of actions) {
+    const loc = locateQuote(resumeText, a.quote);
+    if (loc) spans.push({ ...loc, cls: 'edit-change', title: `Change: ${a.what}` });
+  }
+  // Edits outrank keyword marks when they overlap: sort edits first at equal starts.
+  const rank = { 'edit-remove': 0, 'edit-change': 1, 'kw-present': 2 };
+  return spans.sort((a, b) => a.start - b.start || rank[a.cls] - rank[b.cls]);
+}

--- a/site/public/index.html
+++ b/site/public/index.html
@@ -41,6 +41,7 @@
     letter. Everything runs on your machine.</p>
     <div class="cta">
       <a class="btn primary" href="#start">Get started</a>
+      <a class="btn" href="demo/">Try the live score</a>
       <a class="btn" href="https://github.com/nazboyko/applypack">Star on GitHub</a>
     </div>
     <div class="shot"><img src="img/target.png" alt="Resume match: a deterministic 82/100 score with the primary-stack verdict, experience confirmations and the side-by-side editor with keyword highlights" loading="eager"></div>
@@ -113,6 +114,7 @@
             <li><b>Honest deltas:</b> v2 of your resume is scored by the same
             deterministic path as v1, so "▲ +16" means something.</li>
           </ul>
+          <p style="margin-top:18px"><a class="btn" href="demo/">See it live — edit a resume, watch the score →</a></p>
         </div>
         <div class="shot"><img src="img/overview.png" alt="Overview: status counters with 24h deltas, recent alerts and cron health" loading="lazy"></div>
       </div>

--- a/src/web/site-vendor.test.ts
+++ b/src/web/site-vendor.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// The landing demo (site/public/demo/) ships byte copies of the pure scoring
+// modules so applypack.dev cannot drift from what the dashboard actually runs.
+// If this fails, re-copy: cp src/web/public/{score,target}.mjs site/public/demo/
+describe('site demo vendors the real scoring modules', () => {
+  for (const name of ['score.mjs', 'target.mjs']) {
+    it(`${name} is byte-identical to src/web/public`, () => {
+      const original = readFileSync(join(__dirname, 'public', name), 'utf8');
+      const vendored = readFileSync(join(__dirname, '..', '..', 'site', 'public', 'demo', name), 'utf8');
+      assert.equal(vendored, original);
+    });
+  }
+});


### PR DESCRIPTION
The last big block before v1.0: **applypack.dev/demo/** — the app's real scoring path running in the visitor's browser on the synthetic Fernway / Dana Ruiz comparison. Edit the resume, watch the score, both panes' highlights and the missing-keyword chips recompute per keystroke. Zero AI calls, zero build step, zero dependencies.

## How it stays honest

- `demo/score.mjs` and `demo/target.mjs` are **byte copies of `src/web/public/`** — enforced by the new `src/web/site-vendor.test.ts` (741 tests green). The demo cannot drift from what the dashboard ships.
- `demo/fixture.json` is the real `clientData` blob extracted from the rendered `/jobs/1214/target` page — same code path as production, synthetic people only.
- The wiring (`demo.mjs`) mirrors `target-page.mjs`: `scoreKeywords → entriesFromLive → computeScore`, cap notes and all.
- The delta vs the stored AI score appears only once the text is edited, like the dashboard's dirty state.

## The demo teaches the product's core claims

Verified live in the pane:
- baseline 85 ("AI run: 82" shown quietly), 7 missing-keyword chips
- add `Redis` → 86, chip disappears, "+4 vs the AI run"
- add `Terraform` → **nothing moves** — the AI marked it cannot-claim, typing a word is not evidence
- blank the resume → 30, the primary-stack cap bites
- Reset restores the baseline

## Also

- Landing links to the demo: a hero CTA and a button under "Scores you can argue with".
- The owner-approved site design exception widened from the single stylesheet to `site/**` (same decision, same surface).
- site/README documents the vendoring rule and the fixture provenance.

## After merge

Nothing manual — Cloudflare Pages (once hooked up per site/README.md) redeploys `site/` from `main` automatically. No tag: site-only, rides with the next minor.