### PR TITLE
bump to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-09-01
+
+First stable release: the whole arc — find → verify → tailor → apply →
+track — is deployed, documented and demonstrated at
+[applypack.dev](https://applypack.dev).
+
 ### Added
 - Live scoring demo at applypack.dev/demo/ — the vendored `score.mjs` /
   `target.mjs` (byte-parity enforced by `site-vendor.test.ts`) running on the
   synthetic Fernway / Dana Ruiz fixture; edit the resume, watch the
   deterministic score, highlights and missing-keyword chips recompute with
   zero AI calls.
-
-### Added
 - Landing site for applypack.dev in `site/public` — static, zero-build,
   zero-dependency (Cloudflare Pages: root `site`, empty build command,
   output `public`). Reuses the README copy, the regenerated screenshots
@@ -446,7 +450,8 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
-[Unreleased]: https://github.com/nazboyko/applypack/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/nazboyko/applypack/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/nazboyko/applypack/compare/v0.11.1...v1.0.0
 [0.11.1]: https://github.com/nazboyko/applypack/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/nazboyko/applypack/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/nazboyko/applypack/compare/v0.9.0...v0.10.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "0.11.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "0.11.1",
+      "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "0.11.1",
+  "version": "1.0.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",


### PR DESCRIPTION
Version + changelog for the first stable release. Everything on the launch checklist is done and verified live: applypack.dev serves the landing and the /demo/ scorer (executed in a real browser against production — 85/16-of-23/7 chips), SECURITY.md + private vulnerability reporting enabled, CODE_OF_CONDUCT, social preview card, regenerated screenshots.

No code changes — `package.json` / lockfile / CHANGELOG only. The two Unreleased entries (landing site, live demo) fold into [1.0.0].

## After merge (Nazar)

```
git tag -a v1.0.0 -m "first stable release" <merge-sha> && git push origin v1.0.0
```

I'll create the GitHub release from the notes below once the tag exists.

## Release notes (v1.0.0 — first stable release)

## What's new
- The whole arc ships: find (22 sources) → verify (ghost-job checklist) → tailor (deterministic resume scoring + targeted editor) → apply (fact-gated cover letters) → track (kanban + stale nudges).
- **applypack.dev** is live, with a browser demo of the real scoring module at /demo/ — edit the resume, watch the score; adding a word the AI marked cannot-claim moves nothing.
- 5 swappable AI backends with auto-failover; your data stays in your own Postgres.

## Schema
- no schema changes since v0.11.1

## Verification
- 741 tests green; production site + demo exercised in a real browser

## References
- PR #40 (landing), PR #41 (demo), this PR