### PR TITLE
launch: draft the Show HN / r/selfhosted / awesome-selfhosted pack

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -534,8 +534,10 @@ and shadcn/ui are all React-runtime. What we lift instead:
 
 ## 9. Launch & distribution (v1.0.0 shipped 2026-09-01 — this is what's left)
 
-- [ ] Draft the launch pack: Show HN title + first comment, r/selfhosted post,
-  awesome-selfhosted PR. Demo link (applypack.dev/demo/) leads every text.
+- [x] Draft the launch pack — [docs/launch/](./launch/) (2026-08-31): Show HN
+  title + first comment, r/selfhosted post, awesome-selfhosted YAML entry.
+  Demo link (applypack.dev/demo/) leads every text. awesome-selfhosted's
+  4-month rule sets the earliest submission at 2026-12-28.
 - [ ] Pick the day (Tue–Thu, US-morning), submit, stay in the comments ~6h.
 - [ ] `www.applypack.dev` custom domain in Cloudflare Pages (one click, Nazar).
 - [ ] Measurement posts on the site, one every ~2 weeks, each from a paid-for

--- a/docs/launch/awesome-selfhosted-pr.md
+++ b/docs/launch/awesome-selfhosted-pr.md
@@ -1,0 +1,67 @@
+# awesome-selfhosted PR — draft, DO NOT submit before 2026-12-28
+
+> Their CONTRIBUTING requires the first release to be older than 4
+> months. ApplyPack v0.1.0 shipped 2026-08-28, so the earliest
+> submission day is 2026-12-28. Their guidelines threaten bans for
+> machine-generated contributions that break the rules: Nazar reviews
+> this draft and submits it by hand from his own account.
+
+ApplyPack fits the list as a job-search console that checks 22 sources
+hourly and keeps every AI report in the user's own Postgres; the live
+scoring demo at https://applypack.dev/demo/ goes into the entry's
+`demo_url`. Format below was checked against their CONTRIBUTING.md and a
+live entry (`software/gitea.yml`) on 2026-08-31.
+
+## Where it goes
+
+The rendered list is generated from a data repo. The PR adds ONE file to
+https://github.com/awesome-selfhosted/awesome-selfhosted-data:
+
+- File: `software/applypack.yml` (kebab-case name, their convention)
+- Branch: `add-applypack`
+- Commit message and PR title: `add ApplyPack`
+
+Fields like `stargazers_count`, `updated_at`, `current_release` and
+`commit_history` are CI-maintained; a submission carries only the fields
+in the entry below.
+
+## Section (tag)
+
+`Automation` — "Automation software designed to reduce human
+intervention in processes". No jobs/career/recruitment tag exists
+(checked the full `tags/` inventory 2026-08-31), and
+`human-resources-management-hrm` is employer-side software, which
+ApplyPack is not. The Automation tag hosts personal monitor-and-act
+agents, which is what the worker is. Their own fallback rule
+(`Miscellaneous` when nothing fits) stays available if maintainers
+disagree.
+
+## The entry (`software/applypack.yml`)
+
+```yaml
+name: ApplyPack
+website_url: https://applypack.dev
+source_code_url: https://github.com/nazboyko/applypack
+demo_url: https://applypack.dev/demo/
+description: Job-search console that watches company ATS boards and job feeds, scores postings against your profile using your own AI accounts, verifies ghost jobs and tracks applications, with Telegram alerts.
+licenses:
+  - MIT
+platforms:
+  - Nodejs
+  - Docker
+tags:
+  - Automation
+```
+
+Description is 197 chars and avoids "self-hosted" / "open-source" /
+"free" per their rules. `demo_url` points at the live scoring demo, one
+real module of the app; if maintainers read `demo_url` as
+full-application-only, drop the field rather than argue.
+
+## Pre-submit checklist
+
+- [ ] Date is 2026-12-28 or later (4 months since v0.1.0)
+- [ ] Re-read their CONTRIBUTING.md for rule drift since 2026-08-31
+- [ ] Repo shows recent commits (their dormancy bar: 6–12 months)
+- [ ] Demo and applypack.dev both load
+- [ ] Submit from Nazar's GitHub account, not from an agent

--- a/docs/launch/reddit-selfhosted.md
+++ b/docs/launch/reddit-selfhosted.md
@@ -1,0 +1,61 @@
+# r/selfhosted — draft for manual posting
+
+> Draft only, posted by hand from Nazar's account; the text discloses
+> authorship. Re-check the subreddit's current self-promotion rules on
+> posting day.
+
+## Title
+
+```
+ApplyPack: self-hosted job-hunt console – watches the boards, scores your resume without flattery, pings Telegram (MIT)
+```
+
+## Body
+
+I'm looking for a job and got tired of being the cron job myself:
+refresh the boards, read every posting, realize it's the wrong stack or
+quietly country-locked. So I built the console I wanted. It watches the
+boards, and my Telegram only rings when a posting clears my fit
+threshold. Resume, profile and every AI report stay in my Postgres. The
+scoring part runs live in your browser, no signup:
+https://applypack.dev/demo/
+
+What it does:
+
+* Checks 22 sources hourly: ten ATS vendors (Greenhouse, Lever, Ashby,
+  Workable, SmartRecruiters, Recruitee, Breezy, BambooHR, Pinpoint,
+  Rippling) on company boards you pick, eleven aggregators, and the
+  monthly HN "Who is hiring" thread
+* An AI classifier reads each full description against your profile.
+  "Remote · Germany" is not a US-remote match, and "full-stack" in a
+  title is not a stack match; both rules exist because both burned me
+* Resume-vs-posting scoring where the model marks facts and
+  deterministic code computes the number, so a Laravel resume can't
+  sweet-talk its way to 85 against a Node.js posting
+* Ghost-job verification: a web-search checklist returns
+  legit / suspicious / fake with evidence URLs
+* Cover letters behind a fact gate (a claim must exist in your resume or
+  your confirmed facts to reach the letter), exported to PDF / DOCX
+* A small application tracker with a "gone quiet for two weeks" nudge
+
+Self-hosting details, since that's why we're here:
+
+* `docker compose up -d` brings up Postgres 16, a cron worker and a
+  dashboard. The dashboard binds to 127.0.0.1; put your own proxy in
+  front if you want it off-box
+* No accounts, no telemetry, no phone-home. Outbound traffic goes to
+  the job boards and to whichever AI backend you configure
+* AI is the one running cost, and you pick the meter: Claude Code /
+  Gemini / Codex CLIs ride subscriptions you already pay ($0 extra),
+  the Anthropic API costs about $0.001 per classified job ($2–10/month
+  at 5–10 matching jobs a day; prompt caching covers ~90% of the system
+  prompt), or point the OpenAI-compatible engine at Ollama / LM Studio
+  and pay nothing. Engines chain with automatic failover
+* Official public APIs and RSS only. No LinkedIn / Indeed / Glassdoor /
+  Workday scraping; an ADR in the repo draws that line. For anything
+  uncovered you paste the posting by hand, and the HN parser harvests
+  company boards into a review queue
+
+Single-user by design, MIT. Repo:
+https://github.com/nazboyko/applypack. Setup for every AI engine, local
+and Docker, is in docs/ai-engines.md.

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -1,0 +1,69 @@
+# Show HN — draft for manual posting
+
+> Draft only. Nothing in `docs/launch/` gets published by automation;
+> Nazar submits by hand. Per TASKS §9: pick a Tue–Thu, US morning,
+> stay in the comments for ~6 hours after submitting.
+
+## Submission
+
+- **URL:** https://applypack.dev/demo/ (the live scoring demo leads;
+  the first comment carries the repo link)
+- **Title** (77 chars, HN limit 80):
+
+```
+Show HN: ApplyPack – self-hosted job search where AI marks facts, code scores
+```
+
+Alternates if the primary reads flat on the day:
+
+```
+Show HN: ApplyPack – watch job boards, score resumes honestly, self-hosted    (74)
+Show HN: A resume scorer the model can't flatter, from my self-hosted job hunt (78)
+```
+
+## First comment (post right after submitting)
+
+I'm mid job hunt. The boards were eating my evenings: every promising
+"Senior Engineer" listing took three minutes of reading to reveal a wrong
+stack, a wrong country, or a ghost posting. ApplyPack does that reading
+for me, on my own machine, and I run it for my own search every day.
+
+The submission link (https://applypack.dev/demo/) is the app's actual
+scoring module compiled for the browser, on a synthetic resume and
+posting. My first version let the model output the score, and it graded a
+Laravel/Vue resume 82/100 against a Node.js/React posting. Credit leaked
+through sibling tech: Vue read as close enough to React, PHP as close
+enough to Node. So I split the jobs. The model only marks facts per
+keyword (present, add, cannot_claim; must-have or nice; primary stack or
+not), and TypeScript computes the number, with a hard cap when the
+posting's primary stack is missing. Same resume after the split: 10/100
+against that Node posting, 92/100 against a Laravel one.
+
+You can feel it in the demo. Type Redis into the skills line and the
+score moves on the next keystroke. Type Terraform and nothing moves: the
+model marked it cannot-claim against the original resume, and typing a
+word is not evidence. Delete TypeScript to watch the primary-stack cap
+bite.
+
+Scoring is one corner of the console. A worker checks 22 sources hourly
+(Greenhouse, Lever, Ashby and seven more ATS vendors on boards you pick,
+eleven aggregators, the monthly HN "Who is hiring" thread), a classifier
+reads each posting against your profile, and Telegram pings you above
+your fit threshold. A ghost-job check runs a web-search checklist and
+returns legit / suspicious / fake with evidence URLs. A cover-letter
+writer sits behind a fact gate: a metric that appears in neither your
+resume nor your confirmed facts never reaches the letter.
+
+Stack: TypeScript strict, Postgres, two containers behind docker compose,
+dashboard bound to 127.0.0.1. AI is bring-your-own with failover: Claude
+Code / Gemini / Codex CLIs riding subscriptions you already pay for, the
+Anthropic API, or any OpenAI-compatible endpoint, including a local
+model. One honest caveat: consumer-subscription terms don't explicitly
+cover a background service, so the README tells you to read yours before
+making a subscription the primary engine. Sources are official public
+APIs and RSS only; no LinkedIn, Indeed or Workday scraping, and
+docs/adr/0005 says why. MIT.
+
+Repo: https://github.com/nazboyko/applypack. If you want to argue with
+the scoring weights, the decision record is docs/adr/0012 and it is a
+two-minute read.


### PR DESCRIPTION
TASKS §9: the launch pack as reviewable drafts in `docs/launch/`. Nothing is published; all three are for manual posting by Nazar.

- **show-hn.md** — submission URL is the live demo, title 77/80 chars + two alternates, and the author's first comment: the 82→10 scoring story (ADR 0012), the Terraform cannot-claim trick, stack and source-policy notes, plus the subscription-ToS caveat HN would raise anyway.
- **reddit-selfhosted.md** — r/selfhosted post: what it does, compose/localhost/no-telemetry details, and the one running cost stated plainly (~$0.001 per classified job on the API path, $0 on subscription CLIs, free with local models).
- **awesome-selfhosted-pr.md** — ready `software/applypack.yml` for the awesome-selfhosted-data repo (format checked against their CONTRIBUTING.md and a live entry on 2026-08-31; tag `Automation`, platforms `Nodejs`/`Docker`, description 197 chars without their banned words). **Blocked until 2026-12-28**: their 4-month first-release rule; v0.1.0 shipped 2026-08-28. Pre-submit checklist included.

Each text leads with https://applypack.dev/demo/ and carries one measured number (82→10, $0.001/job, 22 sources).

Review: code-review-expert pass done (docs-only); two P2 wording fixes applied in place (ToS caveat sentence, precise ban wording). No open follow-ups.

## Release notes

Docs-only (launch drafts); no runtime change, no tag per release-discipline's pure-docs rule.
