### PR TITLE
quick fixes: interrupted cron runs, verdict badge + filter, site deploy docs

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -17,17 +17,22 @@ exported from a real match run.
 python3 -m http.server 8901 --bind 127.0.0.1 --directory site/public
 ```
 
-## Deploy (Cloudflare Pages, one-time hookup)
+## Deploy (Cloudflare Worker with static assets)
 
-1. Cloudflare dashboard → Workers & Pages → Create → Pages →
-   Connect to Git → pick `nazboyko/applypack`.
-2. Build settings:
-   - **Root directory**: `site`
-   - **Build command**: *(leave empty)*
-   - **Build output directory**: `public`
-3. After the first deploy: Custom domains → add `applypack.dev`
-   (the domain is already on Cloudflare, so this is one click).
-4. Optional: Settings → Builds → **Build watch paths** → include
-   `site/*` so app-only commits don't trigger site deploys.
+The site is NOT a Cloudflare Pages project. It runs as a Cloudflare
+**Worker** that serves `site/public` as static assets:
 
-Every push to `main` that touches `site/` then redeploys automatically.
+- Worker URL: https://applypack.boyko-nazar.workers.dev
+- Custom domains on the Worker: `applypack.dev` and `www.applypack.dev`
+
+The Worker's configuration lives in the Cloudflare dashboard
+(Workers & Pages → the applypack worker) — there is deliberately no
+`wrangler.toml` in this repo. Build settings there:
+
+- **Root directory**: `site`
+- **Build command**: *(empty — nothing to build)*
+- **Assets directory**: `public`
+
+Deploys ship from the Worker's git connection (Workers Builds) on
+pushes to `main`; check Deployments in the dashboard if a push doesn't
+show up on the domain within a couple of minutes.

--- a/site/README.md
+++ b/site/README.md
@@ -25,14 +25,13 @@ The site is NOT a Cloudflare Pages project. It runs as a Cloudflare
 - Worker URL: https://applypack.boyko-nazar.workers.dev
 - Custom domains on the Worker: `applypack.dev` and `www.applypack.dev`
 
-The Worker's configuration lives in the Cloudflare dashboard
-(Workers & Pages → the applypack worker) — there is deliberately no
-`wrangler.toml` in this repo. Build settings there:
+The Worker itself is configured by [`wrangler.jsonc`](../wrangler.jsonc)
+at the repo root (assets-only: `site/public`, no script). The Cloudflare
+dashboard (Workers & Pages → applypack) keeps the rest: the git
+connection (Workers Builds) and the custom domains.
 
-- **Root directory**: `site`
-- **Build command**: *(empty — nothing to build)*
-- **Assets directory**: `public`
-
-Deploys ship from the Worker's git connection (Workers Builds) on
-pushes to `main`; check Deployments in the dashboard if a push doesn't
-show up on the domain within a couple of minutes.
+Deploys ship from that git connection: a push to `main` deploys; a push
+to any other branch only uploads a preview version (`npx wrangler
+versions upload`, visible as a "Workers Builds" check on PRs). Check
+Deployments in the dashboard if a push doesn't show up on the domain
+within a couple of minutes.

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { CronRunStatus } from '@prisma/client';
 import { config } from './config';
 import { prisma } from './db';
 import { logger } from './logger';
@@ -19,12 +20,35 @@ export async function init(): Promise<void> {
   logger.info('init: pinging database');
   await prisma.$queryRaw`SELECT 1`;
 
+  await failInterruptedCronRuns();
+
   logger.info('init: seeding companies');
   const seeded = await runSeed();
   logger.info(seeded, 'init: seed complete');
 
   await bootstrapDefaultProfile();
   await bootstrapTelegramFromEnv();
+}
+
+/**
+ * A RUNNING CronRun at worker boot is a run the previous process died
+ * under (issue #18) — only this process starts cron jobs, so nothing can
+ * legitimately be RUNNING before registerCron. The one near-miss is a
+ * web-owned reclassify-all in flight during a worker restart; its final
+ * update still lands and overwrites this verdict.
+ */
+async function failInterruptedCronRuns(): Promise<void> {
+  const stale = await prisma.cronRun.updateMany({
+    where: { status: CronRunStatus.RUNNING },
+    data: {
+      status: CronRunStatus.FAILED,
+      finishedAt: new Date(),
+      errorMessage: 'interrupted',
+    },
+  });
+  if (stale.count > 0) {
+    logger.warn({ count: stale.count }, 'init: marked interrupted cron runs FAILED');
+  }
 }
 
 /**

--- a/src/web/pages/jobs-list.tsx
+++ b/src/web/pages/jobs-list.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'hono/jsx';
 import type { JobStatus } from '@prisma/client';
 import { Layout } from '../layout';
 import {
+  Badge,
   Button,
   Card,
   FitBadge,
@@ -15,6 +16,7 @@ import {
   Tr,
 } from '../ui';
 import { formatDateShort, formatRelative, formatSalary } from '../format';
+import { VERDICT_TONE } from './verification-card';
 
 interface JobRow {
   id: number;
@@ -29,6 +31,7 @@ interface JobRow {
   postedAt: Date;
   techMatch: string[];
   company: { name: string };
+  verifications: { verdict: string }[];
 }
 
 export interface JobsListProps {
@@ -41,6 +44,7 @@ export interface JobsListProps {
     minFit: string;
     q: string;
     sort: string;
+    verified: string;
   };
 }
 
@@ -72,7 +76,10 @@ export const JobsListPage: FC<JobsListProps> = ({
   const to = Math.min(total, page * pageSize);
   const pageHref = (p: number) => buildQuery({ ...filters, page: p });
   const hasFilters =
-    filters.q.length > 0 || filters.status.length > 0 || filters.minFit.length > 0;
+    filters.q.length > 0 ||
+    filters.status.length > 0 ||
+    filters.minFit.length > 0 ||
+    filters.verified.length > 0;
 
   return (
     <Layout title="Jobs" active="jobs" fill>
@@ -87,7 +94,7 @@ export const JobsListPage: FC<JobsListProps> = ({
       />
 
       <div class="mb-4 flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2">
-        <nav aria-label="Status filter" class="flex flex-wrap items-center gap-1">
+        <nav aria-label="Job filters" class="flex flex-wrap items-center gap-1">
           {STATUS_OPTIONS.map((o) => {
             const active = filters.status === o.value;
             return (
@@ -104,10 +111,24 @@ export const JobsListPage: FC<JobsListProps> = ({
               </a>
             );
           })}
+          <span class="mx-1 h-4 w-px bg-line" aria-hidden="true" />
+          <a
+            href={buildQuery({ ...filters, verified: filters.verified ? '' : '1' })}
+            aria-current={filters.verified ? 'true' : undefined}
+            title="Only jobs with an “Is this job real?” verdict"
+            class={`rounded-md border px-2.5 py-1 text-[13px] transition-colors duration-150 ${
+              filters.verified
+                ? 'border-line-strong bg-surface-overlay font-medium text-ink'
+                : 'border-transparent text-ink-muted hover:bg-surface-overlay/70 hover:text-ink'
+            }`}
+          >
+            Verified
+          </a>
         </nav>
 
         <form method="get" action="/jobs" class="ml-auto flex flex-wrap items-center gap-2">
           <input type="hidden" name="status" value={filters.status} />
+          <input type="hidden" name="verified" value={filters.verified} />
           <Input
             type="search"
             name="q"
@@ -221,6 +242,15 @@ export const JobsListPage: FC<JobsListProps> = ({
                         </Td>
                         <Td class="whitespace-nowrap">
                           <StatusBadge status={j.status} />
+                          {j.verifications[0] && (
+                            <div class="mt-1">
+                              <Badge
+                                tone={VERDICT_TONE[j.verifications[0].verdict] ?? 'neutral'}
+                              >
+                                {j.verifications[0].verdict}
+                              </Badge>
+                            </div>
+                          )}
                         </Td>
                         <Td
                           class="whitespace-nowrap text-right text-[13px] text-ink-faint"

--- a/src/web/pages/verification-card.tsx
+++ b/src/web/pages/verification-card.tsx
@@ -29,7 +29,7 @@ const LIVENESS_VIEW: Record<string, { label: string; tone: Tone }> = {
 const codeLabel = (code: string): string =>
   LIVENESS_CODE_LABEL[code as LivenessCode] ?? code;
 
-const VERDICT_TONE: Record<string, Tone> = { legit: 'ok', suspicious: 'warn', fake: 'danger' };
+export const VERDICT_TONE: Record<string, Tone> = { legit: 'ok', suspicious: 'warn', fake: 'danger' };
 const RECOMMENDATION_VIEW: Record<string, { label: string; tone: Tone }> = {
   apply: { label: 'worth applying', tone: 'ok' },
   caution: { label: 'apply with caution', tone: 'warn' },

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -68,6 +68,10 @@ const ListQuerySchema = z.object({
   sort: z
     .enum(['fetchedAt_desc', 'fitScore_desc', 'postedAt_desc', 'title_asc'])
     .default('fetchedAt_desc'),
+  verified: z
+    .string()
+    .optional()
+    .transform((v) => (v === '1' ? '1' : '')),
 });
 
 const StatusBodySchema = z.object({
@@ -83,11 +87,12 @@ jobsRoute.get('/jobs', async (c) => {
     minFit: c.req.query('minFit'),
     q: c.req.query('q'),
     sort: c.req.query('sort'),
+    verified: c.req.query('verified'),
   });
   if (!parsed.success) {
     return c.text('Invalid query', 400);
   }
-  const { page, status, minFit, q, sort } = parsed.data;
+  const { page, status, minFit, q, sort, verified } = parsed.data;
 
   const where: Prisma.JobWhereInput = {};
   if (status) {
@@ -103,6 +108,9 @@ jobsRoute.get('/jobs', async (c) => {
       { description: { contains: q, mode: 'insensitive' } },
     ];
   }
+  if (verified) {
+    where.verifications = { some: {} };
+  }
 
   const orderBy = sortToOrderBy(sort);
 
@@ -112,7 +120,14 @@ jobsRoute.get('/jobs', async (c) => {
       orderBy,
       skip: (page - 1) * PAGE_SIZE,
       take: PAGE_SIZE,
-      include: { company: { select: { name: true } } },
+      include: {
+        company: { select: { name: true } },
+        verifications: {
+          select: { verdict: true },
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+        },
+      },
     }),
     prisma.job.count({ where }),
   ]);
@@ -128,6 +143,7 @@ jobsRoute.get('/jobs', async (c) => {
         minFit,
         q,
         sort,
+        verified,
       }}
     />,
   );

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,13 @@
+// Cloudflare Worker config for the applypack.dev site — assets-only, no
+// Worker script. Workers Builds runs wrangler from the repo root on git
+// pushes (`versions upload` for branches, deploy for main), and this file
+// is what wrangler reads; without it every build fails with "Missing
+// entry-point". Custom domains (applypack.dev, www) and the git
+// connection live in the Cloudflare dashboard.
+{
+  "name": "applypack",
+  "compatibility_date": "2026-08-28",
+  "assets": {
+    "directory": "./site/public"
+  }
+}


### PR DESCRIPTION
Three small fixes, one branch.

**Issue #18 — interrupted cron runs.** `init()` (worker-only; the web process never calls it) marks every `RUNNING` CronRun as `FAILED` / `errorMessage='interrupted'` with `finishedAt` set, before seeding. Rationale in a code comment: only the worker starts cron jobs, so nothing can legitimately be RUNNING at its boot; the one near-miss (web-owned reclassify-all during a worker restart) self-heals because the web's final update overwrites the verdict.
Smoke run: inserted a fake `RUNNING` row (id 937, startedAt −30 min) via psql → `docker compose build app && up -d app` → boot log shows `init: marked interrupted cron runs FAILED`, the row reads `FAILED / interrupted / finishedAt set`, `/runs` renders it (200). Test row deleted afterwards.

**Issue #21 — verification verdict on /jobs.** The list query includes each job's latest `JobVerification.verdict`; rows render a small tone badge (`legit` ok / `suspicious` warn / `fake` danger — `VERDICT_TONE` exported from verification-card, same map as the detail page) under the status badge. A **Verified** pill after the status pills (divider between facets, `aria-current` when active, keyboard-reachable anchor) filters to `verifications: { some: {} }`; the search form carries it via a hidden input; the nav label became "Job filters".
Verified per testing-gate: web container rebuilt; `/jobs` 200; `/jobs?verified=1` returns exactly the 4 verified jobs (3 `legit`, 1 `suspicious` badges); checked at 1200 px and 375 px in the browser pane, 0 console errors. Screenshots reviewed live in-session; none attached — grab `/jobs?verified=1` if the PR needs one.

**site/README.md.** The deploy section described a Cloudflare Pages hookup that never happened; the site actually runs as a Cloudflare **Worker** serving `site/public` as static assets (applypack.boyko-nazar.workers.dev + custom domains `applypack.dev`, `www.applypack.dev`), configured in the dashboard with no wrangler file in the repo. **One assumption to double-check on merge:** the doc says deploys ship from the Worker's git connection (Workers Builds) on pushes to `main` — correct that line if you deploy the Worker some other way.

Notes:
- TASKS §9 still says "`www.applypack.dev` custom domain in Cloudflare Pages (one click)" — already true in reality (domain live on the Worker). Left untouched here because PR #44 edits the same §9 block; tick it after both merge.
- Review pass done (code-review-expert): no P0–P2; one P3 left as-is (the Verified pill inlines the same class string as the status pills, matching the local idiom).

Closes #18. Closes #21.

## Release notes

Fix + small UI feature, no schema change. Fold into the next minor (F5's tag) per release-discipline, or `v1.0.1` if F5 slips past a deploy.

---

**Workers Builds failure — diagnosed and fixed in this branch.** The check's build log showed the deploy command `npx wrangler versions upload` running from the repo root with no wrangler config anywhere: `✘ Missing entry-point to Worker script or to assets directory`. So the git connection exists (README assumption confirmed), it just had nothing to read. Fix: `wrangler.jsonc` at the repo root (assets-only — name `applypack`, assets `site/public`), plus the README section rewritten to match (config in the repo, dashboard keeps the git connection + domains). Branch pushes upload a preview version; `main` deploys.
