### PR TITLE
stage ledger: append-only funnel history + stats on /applications

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -400,7 +400,26 @@ external project, copy-check before merge.
       `<title>Plaid Jobs</title>`, offices SF/NYC/London/Seattle/Raleigh)
       and Pleo at `ASHBY:pleo` (37 jobs), both identity-verified live;
       company rows re-pointed by hand via /companies
-- [ ] F5 status-transition ledger + funnel/calibration stats — v0.7.0
+- [x] F5 status-transition ledger + funnel/calibration stats — v1.1.0
+      (branch `stage-ledger`, ADR 0024). Tag is v1.1.0, not the plan's
+      v0.7.0 (post-1.0 numbering). Re-analysis corrected the plan: the
+      "single write path" is really TWO web routes (the tracking-card
+      POST and the pipelineStage='applied' seeding inside the status
+      route) and the worker never writes stages — inbox status churn
+      (762 of 834 rows are DISMISSED) stays out of the ledger;
+      `JobStatusEvent` renamed `JobStageEvent` (collides with the
+      orthogonal JobStatus enum); backfill measured tiny and clean —
+      exactly 3 funnel rows, all 'applied', with real user-entered
+      appliedAt dates, done as SQL inside the migration; with 3
+      applications every rate sits under the n=5 floor, so the honest
+      empty state ("— (n=0, need 5)") is the whole launch experience,
+      not an edge case; cleanup-job could cascade-delete the funnel
+      history of an applied-then-DISMISSED job — it now skips jobs with
+      a pipelineStage. Fit bands kept as planned (live inbox:
+      12/15/13/29 per band). Deferred: assessment event type (0 data),
+      per-source channel yield (today Greenhouse×2 + Jobicy×1, floor
+      n≥8), per-hop occurredOn date picker (stage hops date to the
+      write day; appliedAt edits write correction events)
 - [ ] F6 follow-up cadence with pin/retire/auto-seed in the stale digest — v0.8.0
 - [x] F7 fact gate (anti-hallucination pure module) — no tag of its own
       (branch `fact-gate`, ADR 0020). Ships untagged with F8 per

--- a/docs/adr/0024-append-only-stage-ledger.md
+++ b/docs/adr/0024-append-only-stage-ledger.md
@@ -1,0 +1,77 @@
+# 0024 — Funnel history is an append-only stage ledger, written only where stages are written
+
+**Status:** Accepted (2026-08-31)
+
+## Context
+
+F5 (feature-expansion-plan §6) wants funnel/velocity/calibration stats,
+which need transitions, not snapshots. Re-analysis against the code and
+the live DB (834 jobs) corrected the plan on four points:
+
+- The plan's "single write path" is really **two**: `POST
+  /jobs/:id/application` (any stage, including clearing to null, with a
+  backdatable `appliedAt`) and the `pipelineStage='applied'` seeding
+  inside `POST /jobs/:id/status`. Both are web routes. The worker writes
+  only inbox `status` (NEW/ALERTED/DISMISSED in bulk — 762 of 834 rows
+  are DISMISSED machine states), never `pipelineStage`, and
+  reclassify explicitly excludes APPLIED. So the ledger records
+  **pipelineStage transitions**; inbox churn stays out (that telemetry
+  is F15's).
+- The plan's name `JobStatusEvent` collides with the orthogonal
+  `JobStatus` inbox enum — renamed **`JobStageEvent`**.
+- Backfill is tiny and clean: exactly 3 funnel rows, all at `applied`,
+  all with user-entered `appliedAt` (2026-04-29/30). Fit scores 32, 92,
+  15 — the user applies across the whole score range, so the plan's
+  bands (<60/60–74/75–84/≥85) need no retuning (live inbox: 12/15/13/29
+  per band).
+- With 3 applications, every rate sits under the n=5 floor: the honesty
+  rules ("— (n=3, need 5)", null not 0) are the **entire initial
+  screen**, not an edge case — the cards ship with explicit empty-state
+  copy.
+- `cleanup-job` deletes DISMISSED jobs after 30 days; a job with a
+  funnel history can be DISMISSED later, which would cascade-delete its
+  ledger. Currently 0 such rows, but the hole is real.
+
+## Decision
+
+- `JobStageEvent(id, jobId FK cascade, fromStage?, toStage?, occurredOn
+  DATE, recordedAt, source)` — append-only, no update route. `source`:
+  `ui | backfill | correction` (strings, like `pipelineStage` itself;
+  F17 adds `reply`). `toStage=null` records a stage cleared from the
+  tracking card (`source=correction`).
+- Events are written **in the same `$transaction` as the stage update**,
+  at both write sites, via one helper (`src/web/stage-events.ts`). A
+  form resubmit that does not change the stage writes nothing; editing
+  `appliedAt` with an existing `applied` event writes a
+  `correction` event carrying the new date.
+- `occurredOn`: the form's `appliedAt` day for `applied`, else the
+  write day. Day-math uses the latest non-backfill event per (job,
+  stage); `source=backfill` rows never enter day-math.
+- The migration is hand-written (gotcha 7) and backfills one
+  `source=backfill` event per job with a `pipelineStage`, dated
+  `appliedAt` when present.
+- `cleanup-job` gains `pipelineStage: null` in its delete filter — an
+  application's history is never garbage-collected.
+- Analytics are pure functions in `src/web/stats.ts` (fixture-tested):
+  monotone funnel fold (an `offer` event implies screen/tech/onsite were
+  reached), per-hop medians with right-censoring counts and same-day
+  hops excluded-but-counted, applied→rejected tracked apart from
+  applied→offer, in-flight rows out of every rate, n<5 renders null.
+  Cards live on `/applications`. Channel yield (n≥8 floor) deferred:
+  today's channels are Greenhouse×2 + Jobicy×1.
+
+## Consequences
+
+✅ "Rejected after three interviews" and "rejected instantly" become
+different histories; time-in-stage and calibration are computable from
+day one; future features (F6 cadence, F17 replies) append to the same
+table.
+❌ Two write sites to keep honest (guarded by one shared helper); pre-F5
+stage history is unrecoverable beyond the 3 backfilled rows; stats stay
+mostly "need 5" until real volume exists.
+
+## When to revisit
+
+If a third stage write site appears (F17 replies, bulk actions), or if
+correction events grow beyond date fixes — then consider moving stage
+writes behind a single service function instead of a route-level helper.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0021 — Cover letters generate from stored inputs only](./0021-cover-letters-stored-inputs-only.md)
 - [0022 — Fences make untrusted text data, and an attempt evidence](./0022-prompt-fences-for-untrusted-text.md)
 - [0023 — Trust is apply-link flags, not a score](./0023-apply-link-flags-not-a-trust-score.md)
+- [0024 — Funnel history is an append-only stage ledger](./0024-append-only-stage-ledger.md)
 
 ## When to write a new one
 

--- a/prisma/migrations/20260901040000_add_stage_events/migration.sql
+++ b/prisma/migrations/20260901040000_add_stage_events/migration.sql
@@ -1,0 +1,25 @@
+-- F5 (ADR 0024): append-only funnel ledger. Additive: a new table plus a
+-- backfill snapshot — one source=backfill event per job that already has
+-- a pipelineStage, dated appliedAt when known (the stats module keeps
+-- backfill rows out of day-math, so a reconstructed date cannot poison
+-- velocity medians).
+CREATE TABLE "JobStageEvent" (
+    "id" SERIAL NOT NULL,
+    "jobId" INTEGER NOT NULL,
+    "fromStage" TEXT,
+    "toStage" TEXT,
+    "occurredOn" DATE NOT NULL,
+    "recordedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "source" TEXT NOT NULL,
+
+    CONSTRAINT "JobStageEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "JobStageEvent_jobId_recordedAt_idx" ON "JobStageEvent"("jobId", "recordedAt");
+
+ALTER TABLE "JobStageEvent" ADD CONSTRAINT "JobStageEvent_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "Job"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+INSERT INTO "JobStageEvent" ("jobId", "fromStage", "toStage", "occurredOn", "source")
+SELECT "id", NULL, "pipelineStage", COALESCE("appliedAt"::date, CURRENT_DATE), 'backfill'
+FROM "Job"
+WHERE "pipelineStage" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,7 @@ model Job {
   resumeMatches ResumeMatch[]
   verifications JobVerification[]
   coverLetters  CoverLetter[]
+  stageEvents   JobStageEvent[]
 
   @@unique([companyId, externalId])
   @@index([status, fetchedAt])
@@ -399,6 +400,24 @@ model CoverLetter {
   createdAt        DateTime @default(now())
 
   @@index([jobId, createdAt])
+}
+
+// F5 (ADR 0024): append-only funnel history — one row per pipelineStage
+// transition, written in the same $transaction as the stage update (the
+// two web write sites only; the worker never writes stages). Never
+// updated; rows leave only via the job's cascade, and cleanup-job skips
+// jobs that have a pipelineStage.
+model JobStageEvent {
+  id         Int      @id @default(autoincrement())
+  jobId      Int
+  job        Job      @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  fromStage  String?
+  toStage    String? // null = stage cleared from the tracking card
+  occurredOn DateTime @db.Date // real-world event day; recordedAt is the write time
+  recordedAt DateTime @default(now())
+  source     String // ui | backfill | correction (F17 adds reply)
+
+  @@index([jobId, recordedAt])
 }
 
 // Phase 8.2: ghost-job / scam check of one posting, done with web search.

--- a/src/jobs/cleanup-job.ts
+++ b/src/jobs/cleanup-job.ts
@@ -12,9 +12,12 @@ export async function runCleanupJob(): Promise<{ stats: CronStats }> {
   const cutoff = new Date(Date.now() - RETENTION_DAYS * DAY_MS);
   logger.info({ cutoff: cutoff.toISOString() }, 'cleanup-job: start');
 
+  // pipelineStage: null — an application's funnel history (and its F5
+  // ledger, which cascades with the job) is never garbage-collected.
   const result = await prisma.job.deleteMany({
     where: {
       status: JobStatus.DISMISSED,
+      pipelineStage: null,
       fetchedAt: { lt: cutoff },
     },
   });

--- a/src/web/pages/applications.tsx
+++ b/src/web/pages/applications.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
 import { Empty, FitBadge, PageHeader } from '../ui';
 import { formatRelative } from '../format';
+import { FunnelStatsSection, type FunnelStatsProps } from './funnel-stats';
 
 const STAGES = ['applied', 'screen', 'tech', 'onsite', 'offer', 'rejected', 'ghosted'] as const;
 type Stage = (typeof STAGES)[number];
@@ -40,16 +41,18 @@ interface ApplicationCard {
 export interface ApplicationsProps {
   byStage: Record<Stage, ApplicationCard[]>;
   applicationTrackingEnabled: boolean;
+  stats: FunnelStatsProps | null;
 }
 
 export const ApplicationsPage: FC<ApplicationsProps> = ({
   byStage,
   applicationTrackingEnabled,
+  stats,
 }) => {
   const totalCount = STAGES.reduce((sum, s) => sum + (byStage[s]?.length ?? 0), 0);
 
   return (
-    <Layout title="Applications" active="applications" fill={applicationTrackingEnabled}>
+    <Layout title="Applications" active="applications">
       <PageHeader
         title="Applications"
         meta={applicationTrackingEnabled ? `${totalCount} in the funnel` : undefined}
@@ -71,6 +74,7 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
           to see your funnel here.
         </Empty>
       ) : (
+        <>
         <div class="flex min-h-0 min-w-0 flex-1 items-stretch gap-3 overflow-x-auto pb-1">
           {STAGES.map((stage) => {
             const items = byStage[stage] ?? [];
@@ -127,6 +131,8 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
             );
           })}
         </div>
+        {stats && <FunnelStatsSection {...stats} />}
+        </>
       )}
     </Layout>
   );

--- a/src/web/pages/funnel-stats.tsx
+++ b/src/web/pages/funnel-stats.tsx
@@ -1,0 +1,176 @@
+/** @jsxImportSource hono/jsx */
+import type { FC } from 'hono/jsx';
+import { Badge, Card, Hint, SectionTitle } from '../ui';
+import type { Tone } from '../format';
+import type { Calibration, Funnel, HopStats } from '../stats';
+import { MIN_RATE_N } from '../stats';
+
+// F5 (ADR 0024): funnel / velocity / calibration cards on /applications.
+// The math lives in src/web/stats.ts; this file only renders it, and the
+// "need 5" phrasing is the deliberate face of the null-not-zero rule.
+
+export interface FunnelStatsProps {
+  funnel: Funnel;
+  hops: HopStats[];
+  calibration: Calibration;
+}
+
+const HOP_LABEL: Record<string, string> = {
+  applied: 'Applied',
+  screen: 'Screen',
+  tech: 'Tech',
+  onsite: 'Onsite',
+  offer: 'Offer',
+  rejected: 'Rejected',
+};
+
+const VERDICT_VIEW: Record<Calibration['verdict'], { label: string; tone: Tone; note: string }> = {
+  separating: {
+    label: 'separating',
+    tone: 'ok',
+    note: 'Higher fit bands reach interviews more often — the score is earning its keep.',
+  },
+  flat: {
+    label: 'flat',
+    tone: 'warn',
+    note: 'Interview rates barely differ across fit bands.',
+  },
+  inverted: {
+    label: 'inverted',
+    tone: 'danger',
+    note: 'Lower fit bands out-interview higher ones — worth re-checking the profile.',
+  },
+  insufficient: {
+    label: 'not enough data',
+    tone: 'neutral',
+    note: `A band needs ${MIN_RATE_N} resolved outcomes before its rate counts.`,
+  },
+};
+
+const rate = (value: number | null, resolved: number): string =>
+  value === null ? `— (n=${resolved}, need ${MIN_RATE_N})` : `${Math.round(value * 100)}%`;
+
+export const FunnelStatsSection: FC<FunnelStatsProps> = ({
+  funnel,
+  hops,
+  calibration,
+}) => {
+  const applied = funnel.rows[0]?.everReached ?? 0;
+  if (applied === 0) {
+    return (
+      <section aria-labelledby="funnel-stats" class="mt-6">
+        <h2 id="funnel-stats" class="sr-only">
+          Funnel stats
+        </h2>
+        <Hint>
+          Funnel, velocity and calibration stats appear here once an
+          application moves through stages — every stage change is now
+          kept as history.
+        </Hint>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-labelledby="funnel-stats" class="mt-6">
+      <h2 id="funnel-stats" class="sr-only">
+        Funnel stats
+      </h2>
+      <div class="grid gap-4 xl:grid-cols-3">
+        <Card>
+          <SectionTitle>Ever reached</SectionTitle>
+          <ul class="mt-3 space-y-2">
+            {funnel.rows.map((r) => (
+              <li class="flex items-center gap-3">
+                <span class="w-16 shrink-0 text-[13px] text-ink-muted">
+                  {HOP_LABEL[r.stage] ?? r.stage}
+                </span>
+                <span class="h-2 flex-1 overflow-hidden rounded-full bg-line" aria-hidden="true">
+                  <span
+                    class="block h-full rounded-full bg-accent"
+                    style={`width:${r.everReached === 0 ? 0 : Math.max(2, Math.round((r.everReached / applied) * 100))}%`}
+                  />
+                </span>
+                <span class="w-8 shrink-0 text-right text-sm tabular-nums text-ink">
+                  {r.everReached}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <p class="mt-3 text-[13px] text-ink-faint">
+            rejected {funnel.rejected} · ghosted {funnel.ghosted} · in flight{' '}
+            {funnel.inFlight}
+          </p>
+          <Hint class="mt-2">
+            A declined offer still counts as an offer — the fold is by the
+            furthest stage ever reached.
+          </Hint>
+        </Card>
+
+        <Card>
+          <SectionTitle>Days per hop</SectionTitle>
+          <ul class="mt-3 divide-y divide-line">
+            {hops.map((h) => (
+              <li class="flex items-baseline justify-between gap-3 py-1.5">
+                <span class="text-[13px] text-ink-muted">
+                  {HOP_LABEL[h.from] ?? h.from} → {HOP_LABEL[h.to] ?? h.to}
+                </span>
+                <span class="text-right text-sm tabular-nums text-ink">
+                  {h.medianDays === null ? '—' : `${h.medianDays}d median`}
+                  <span class="ml-2 text-xs text-ink-faint">
+                    n={h.n}
+                    {h.sameDay > 0 ? ` · ${h.sameDay} same-day` : ''}
+                    {h.censored > 0 ? ` · ${h.censored} waiting` : ''}
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ul>
+          <Hint class="mt-2">
+            Medians use real event days only — backfilled history carries
+            no dates, and same-day hops are counted but not averaged.
+          </Hint>
+        </Card>
+
+        <Card>
+          <div class="flex items-center justify-between gap-2">
+            <SectionTitle>Does fit predict interviews?</SectionTitle>
+            <Badge tone={VERDICT_VIEW[calibration.verdict].tone}>
+              {VERDICT_VIEW[calibration.verdict].label}
+            </Badge>
+          </div>
+          <table class="mt-3 w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs text-ink-faint">
+                <th class="py-1 font-medium">Fit band</th>
+                <th class="py-1 text-right font-medium">In funnel</th>
+                <th class="py-1 text-right font-medium">Interviews</th>
+                <th class="py-1 text-right font-medium">Offers</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-line">
+              {calibration.bands.map((b) => (
+                <tr>
+                  <td class="py-1.5 text-ink-muted">{b.label}</td>
+                  <td class="py-1.5 text-right tabular-nums text-ink">{b.applied}</td>
+                  <td class="py-1.5 text-right tabular-nums text-ink">
+                    {rate(b.interviewRate, b.interviewResolved)}
+                  </td>
+                  <td class="py-1.5 text-right tabular-nums text-ink">
+                    {rate(b.offerRate, b.offerResolved)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p class="mt-2 text-[13px] text-ink-faint">
+            {VERDICT_VIEW[calibration.verdict].note}
+            {calibration.unknownFit > 0
+              ? ` ${calibration.unknownFit} funnel job${calibration.unknownFit === 1 ? ' has' : 's have'} no fit score.`
+              : ''}
+          </p>
+        </Card>
+      </div>
+    </section>
+  );
+};

--- a/src/web/routes/applications.tsx
+++ b/src/web/routes/applications.tsx
@@ -4,6 +4,8 @@ import { z } from 'zod';
 import { prisma } from '../../db';
 import { getSettings } from '../../settings';
 import { ApplicationsPage } from '../pages/applications';
+import { appliedDateCorrection, stageChangeEvent } from '../stage-events';
+import { calibration, funnel, groupByJob, velocity } from '../stats';
 
 const STAGE_VALUES = [
   'applied',
@@ -73,9 +75,36 @@ applicationsRoute.get('/applications', async (c) => {
     <ApplicationsPage
       byStage={byStage}
       applicationTrackingEnabled={settings.applicationTrackingEnabled}
+      stats={settings.applicationTrackingEnabled ? await loadFunnelStats() : null}
     />,
   );
 });
+
+// F5 (ADR 0024): fold the ledger into funnel / velocity / calibration.
+async function loadFunnelStats() {
+  const events = await prisma.jobStageEvent.findMany({
+    orderBy: { recordedAt: 'asc' },
+  });
+  const eventJobIds = [...new Set(events.map((e) => e.jobId))];
+  const fitRows = eventJobIds.length
+    ? await prisma.job.findMany({
+        where: { id: { in: eventJobIds } },
+        select: { id: true, fitScore: true },
+      })
+    : [];
+  const fitById = new Map(fitRows.map((j) => [j.id, j.fitScore]));
+  const histories = groupByJob(events);
+  return {
+    funnel: funnel(histories.values()),
+    hops: velocity(histories.values()),
+    calibration: calibration(
+      [...histories].map(([jobId, history]) => ({
+        fitScore: fitById.get(jobId) ?? null,
+        history,
+      })),
+    ),
+  };
+}
 
 applicationsRoute.post('/jobs/:id/application', async (c) => {
   const id = Number(c.req.param('id'));
@@ -100,15 +129,28 @@ applicationsRoute.post('/jobs/:id/application', async (c) => {
 
   const stageValue =
     pipelineStage && pipelineStage.length > 0 ? pipelineStage : null;
+  const appliedAtValue =
+    appliedAt && appliedAt.length > 0 && !Number.isNaN(Date.parse(appliedAt))
+      ? new Date(appliedAt)
+      : null;
 
-  await prisma.job.update({
+  const current = await prisma.job.findUnique({
+    where: { id },
+    select: { pipelineStage: true, appliedAt: true },
+  });
+  if (!current) return c.text('Not found', 404);
+
+  // F5 (ADR 0024): ledger row in the same transaction as the stage write.
+  // A stage change wins; otherwise an appliedAt edit corrects the apply day.
+  const event =
+    stageChangeEvent(id, current.pipelineStage, stageValue, appliedAtValue, new Date()) ??
+    appliedDateCorrection(id, stageValue, current.appliedAt, appliedAtValue);
+
+  const update = prisma.job.update({
     where: { id },
     data: {
       pipelineStage: stageValue,
-      appliedAt:
-        appliedAt && appliedAt.length > 0 && !Number.isNaN(Date.parse(appliedAt))
-          ? new Date(appliedAt)
-          : null,
+      appliedAt: appliedAtValue,
       recruiterContact:
         recruiterContact && recruiterContact.trim().length > 0
           ? recruiterContact.trim()
@@ -119,6 +161,11 @@ applicationsRoute.post('/jobs/:id/application', async (c) => {
           : null,
     },
   });
+  if (event) {
+    await prisma.$transaction([update, prisma.jobStageEvent.create({ data: event })]);
+  } else {
+    await update;
+  }
 
   return c.redirect(`/jobs/${id}`, 303);
 });

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -46,6 +46,7 @@ import { factCheck } from '../../resume/fact-check';
 import { buildLetterDocx, DOCX_MIME } from '../../resume/docx-write';
 import { buildLetterPdf } from '../../resume/pdf-write';
 import { setCoverAngles } from '../../settings';
+import { stageChangeEvent, type StageEventData } from '../stage-events';
 
 const PAGE_SIZE = 50;
 
@@ -241,6 +242,7 @@ jobsRoute.post('/jobs/:id/status', async (c) => {
   // When the user marks a job APPLIED and tracking is on, seed the funnel
   // so it shows up on /applications immediately. Don't overwrite existing
   // pipelineStage / appliedAt — user may have backdated them.
+  let seedEvent: StageEventData | null = null;
   if (parsed.data.status === 'APPLIED') {
     const settings = await getSettings();
     if (settings.applicationTrackingEnabled) {
@@ -248,12 +250,21 @@ jobsRoute.post('/jobs/:id/status', async (c) => {
         where: { id },
         select: { pipelineStage: true, appliedAt: true },
       });
-      if (!current?.pipelineStage) data.pipelineStage = 'applied';
+      if (current && !current.pipelineStage) {
+        data.pipelineStage = 'applied';
+        // F5 (ADR 0024): the seeding is a funnel entry — ledger it.
+        seedEvent = stageChangeEvent(id, null, 'applied', current.appliedAt, new Date());
+      }
       if (!current?.appliedAt) data.appliedAt = new Date();
     }
   }
 
-  await prisma.job.update({ where: { id }, data });
+  const update = prisma.job.update({ where: { id }, data });
+  if (seedEvent) {
+    await prisma.$transaction([update, prisma.jobStageEvent.create({ data: seedEvent })]);
+  } else {
+    await update;
+  }
   return c.redirect(`/jobs/${id}`, 303);
 });
 

--- a/src/web/stage-events.test.ts
+++ b/src/web/stage-events.test.ts
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { appliedDateCorrection, dateOnly, stageChangeEvent } from './stage-events';
+
+const NOW = new Date('2026-08-31T22:15:30.000Z');
+const APPLIED = new Date('2026-04-30T09:00:00.000Z');
+
+test('dateOnly keeps the UTC day and drops the time', () => {
+  assert.equal(dateOnly(NOW).toISOString(), '2026-08-31T00:00:00.000Z');
+});
+
+test('unchanged stage writes nothing', () => {
+  assert.equal(stageChangeEvent(1, null, null, null, NOW), null);
+  assert.equal(stageChangeEvent(1, 'applied', 'applied', APPLIED, NOW), null);
+});
+
+test('a move into applied is dated by the backdatable appliedAt', () => {
+  const e = stageChangeEvent(1, null, 'applied', APPLIED, NOW);
+  assert.deepEqual(e, {
+    jobId: 1,
+    fromStage: null,
+    toStage: 'applied',
+    occurredOn: new Date('2026-04-30T00:00:00.000Z'),
+    source: 'ui',
+  });
+});
+
+test('a move into applied without a date falls back to today', () => {
+  const e = stageChangeEvent(1, null, 'applied', null, NOW);
+  assert.equal(e?.occurredOn.toISOString(), '2026-08-31T00:00:00.000Z');
+});
+
+test('other hops are dated today, not by appliedAt', () => {
+  const e = stageChangeEvent(2, 'applied', 'tech', APPLIED, NOW);
+  assert.equal(e?.toStage, 'tech');
+  assert.equal(e?.source, 'ui');
+  assert.equal(e?.occurredOn.toISOString(), '2026-08-31T00:00:00.000Z');
+});
+
+test('clearing the stage is a correction with toStage null', () => {
+  const e = stageChangeEvent(3, 'screen', null, null, NOW);
+  assert.equal(e?.toStage, null);
+  assert.equal(e?.source, 'correction');
+});
+
+test('appliedAt edits correct the apply day only when something changed', () => {
+  assert.equal(appliedDateCorrection(1, null, null, APPLIED), null);
+  assert.equal(appliedDateCorrection(1, 'applied', APPLIED, null), null);
+  assert.equal(
+    appliedDateCorrection(1, 'applied', APPLIED, new Date('2026-04-30T23:59:00Z')),
+    null,
+  );
+
+  const e = appliedDateCorrection(1, 'tech', APPLIED, new Date('2026-05-02T08:00:00Z'));
+  assert.deepEqual(e, {
+    jobId: 1,
+    fromStage: null,
+    toStage: 'applied',
+    occurredOn: new Date('2026-05-02T00:00:00.000Z'),
+    source: 'correction',
+  });
+
+  const first = appliedDateCorrection(1, 'applied', null, APPLIED);
+  assert.equal(first?.occurredOn.toISOString(), '2026-04-30T00:00:00.000Z');
+});

--- a/src/web/stage-events.ts
+++ b/src/web/stage-events.ts
@@ -1,0 +1,64 @@
+// F5 (ADR 0024). Pure builders for JobStageEvent rows; the two routes that
+// write pipelineStage put these in the same $transaction as the Job update.
+
+export type StageEventSource = 'ui' | 'backfill' | 'correction';
+
+export interface StageEventData {
+  jobId: number;
+  fromStage: string | null;
+  toStage: string | null;
+  occurredOn: Date;
+  source: StageEventSource;
+}
+
+/** The ledger stores days, not instants (occurredOn is a DATE column). */
+export function dateOnly(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+/**
+ * The event for an actual stage change, or null when nothing changed —
+ * a tracking-card resubmit that only edits notes must not append history.
+ * Clearing the stage is recorded as toStage=null, source=correction.
+ * For a move into 'applied' the event day is the (backdatable) appliedAt.
+ */
+export function stageChangeEvent(
+  jobId: number,
+  fromStage: string | null,
+  toStage: string | null,
+  appliedAt: Date | null,
+  now: Date,
+): StageEventData | null {
+  if (fromStage === toStage) return null;
+  return {
+    jobId,
+    fromStage,
+    toStage,
+    occurredOn: dateOnly(toStage === 'applied' && appliedAt ? appliedAt : now),
+    source: toStage === null ? 'correction' : 'ui',
+  };
+}
+
+/**
+ * The correction row for an appliedAt edit while the stage stays put:
+ * the apply-day changed, so day-math needs a fresh 'applied' date. Null
+ * when there is nothing to correct (stage empty, date unset or equal).
+ */
+export function appliedDateCorrection(
+  jobId: number,
+  stage: string | null,
+  oldAppliedAt: Date | null,
+  newAppliedAt: Date | null,
+): StageEventData | null {
+  if (stage === null || newAppliedAt === null) return null;
+  if (oldAppliedAt && dateOnly(oldAppliedAt).getTime() === dateOnly(newAppliedAt).getTime()) {
+    return null;
+  }
+  return {
+    jobId,
+    fromStage: null,
+    toStage: 'applied',
+    occurredOn: dateOnly(newAppliedAt),
+    source: 'correction',
+  };
+}

--- a/src/web/stats.test.ts
+++ b/src/web/stats.test.ts
@@ -1,0 +1,189 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  calibration,
+  foldJob,
+  funnel,
+  groupByJob,
+  velocity,
+  type StageEventRow,
+} from './stats';
+
+let seq = 0;
+const ev = (
+  jobId: number,
+  toStage: string | null,
+  occurredOn: string,
+  source: 'ui' | 'backfill' | 'correction' = 'ui',
+): StageEventRow => ({
+  jobId,
+  toStage,
+  occurredOn: new Date(`${occurredOn}T00:00:00.000Z`),
+  recordedAt: new Date(2026, 0, 1, 0, 0, ++seq),
+  source,
+});
+
+test('foldJob: a cleared stage voids the run before it', () => {
+  const h = foldJob([
+    ev(1, 'offer', '2026-05-01'), // mis-click
+    ev(1, null, '2026-05-01', 'correction'),
+    ev(1, 'applied', '2026-05-02'),
+  ]);
+  assert.equal(h.maxRank, 0); // the offer is gone
+  assert.equal(h.dates.has('offer'), false);
+});
+
+test('foldJob: backfill rows reach stages but carry no dates', () => {
+  const h = foldJob([ev(2, 'screen', '2026-05-01', 'backfill')]);
+  assert.equal(h.maxRank, 1);
+  assert.equal(h.dates.size, 0);
+});
+
+test('foldJob: terminal comes from the last event only', () => {
+  const rejectedThenMoved = foldJob([
+    ev(3, 'applied', '2026-05-01'),
+    ev(3, 'rejected', '2026-05-03'),
+  ]);
+  assert.equal(rejectedThenMoved.terminal, 'rejected');
+
+  const stillGoing = foldJob([
+    ev(4, 'applied', '2026-05-01'),
+    ev(4, 'screen', '2026-05-03'),
+  ]);
+  assert.equal(stillGoing.terminal, null);
+});
+
+test('funnel: ever-reached is monotone and terminals are counted', () => {
+  const rows = [
+    ev(1, 'offer', '2026-05-10'), // implies applied..onsite
+    ev(2, 'applied', '2026-05-01'),
+    ev(2, 'rejected', '2026-05-05'),
+    ev(3, 'applied', '2026-05-01'),
+  ];
+  const f = funnel(groupByJob(rows).values());
+  assert.deepEqual(
+    f.rows.map((r) => [r.stage, r.everReached]),
+    [
+      ['applied', 3],
+      ['screen', 1],
+      ['tech', 1],
+      ['onsite', 1],
+      ['offer', 1],
+    ],
+  );
+  assert.equal(f.rejected, 1);
+  assert.equal(f.ghosted, 0);
+  assert.equal(f.inFlight, 2);
+});
+
+test('velocity: median over positive-day hops, same-day counted apart', () => {
+  const rows = [
+    ev(1, 'applied', '2026-05-01'),
+    ev(1, 'screen', '2026-05-04'), // 3 days
+    ev(2, 'applied', '2026-05-01'),
+    ev(2, 'screen', '2026-05-08'), // 7 days
+    ev(3, 'applied', '2026-05-01'),
+    ev(3, 'screen', '2026-05-01'), // same-day: excluded, counted
+  ];
+  const hops = velocity(groupByJob(rows).values());
+  const applied2screen = hops.find((h) => h.from === 'applied' && h.to === 'screen')!;
+  assert.equal(applied2screen.medianDays, 5);
+  assert.equal(applied2screen.n, 2);
+  assert.equal(applied2screen.sameDay, 1);
+});
+
+test('velocity: waiting jobs are censored, terminal jobs are not', () => {
+  const rows = [
+    ev(1, 'applied', '2026-05-01'), // waiting for screen
+    ev(2, 'applied', '2026-05-01'),
+    ev(2, 'rejected', '2026-05-02'), // resolved without screen
+  ];
+  const hops = velocity(groupByJob(rows).values());
+  const applied2screen = hops.find((h) => h.to === 'screen')!;
+  assert.equal(applied2screen.censored, 1);
+  assert.equal(applied2screen.medianDays, null);
+
+  const applied2rejected = hops.find((h) => h.to === 'rejected')!;
+  assert.equal(applied2rejected.n, 1);
+  assert.equal(applied2rejected.medianDays, 1);
+});
+
+test('velocity: backfill-only in-flight jobs still count as waiting', () => {
+  const rows = [ev(1, 'applied', '2026-04-30', 'backfill')];
+  const hops = velocity(groupByJob(rows).values());
+  const applied2screen = hops.find((h) => h.to === 'screen')!;
+  assert.equal(applied2screen.censored, 1);
+  assert.equal(applied2screen.n, 0);
+});
+
+test('velocity: a negative span from a crossed correction is dropped', () => {
+  const rows = [
+    ev(1, 'applied', '2026-05-10'),
+    ev(1, 'screen', '2026-05-04'), // "before" applying — bad data
+  ];
+  const hops = velocity(groupByJob(rows).values());
+  const applied2screen = hops.find((h) => h.to === 'screen')!;
+  assert.equal(applied2screen.n, 0);
+  assert.equal(applied2screen.sameDay, 0);
+  assert.equal(applied2screen.medianDays, null);
+});
+
+const jobWith = (
+  fitScore: number | null,
+  events: StageEventRow[],
+): { fitScore: number | null; history: ReturnType<typeof foldJob> } => ({
+  fitScore,
+  history: foldJob(events),
+});
+
+test('calibration: below MIN_RATE_N the rate is null, not 0', () => {
+  const jobs = [
+    jobWith(90, [ev(1, 'applied', '2026-05-01'), ev(1, 'screen', '2026-05-03')]),
+    jobWith(92, [ev(2, 'applied', '2026-05-01'), ev(2, 'rejected', '2026-05-03')]),
+  ];
+  const c = calibration(jobs);
+  const top = c.bands.find((b) => b.label === '≥85')!;
+  assert.equal(top.applied, 2);
+  assert.equal(top.interviewResolved, 2);
+  assert.equal(top.interviewRate, null);
+  assert.equal(c.verdict, 'insufficient');
+});
+
+test('calibration: in-flight jobs stay out of the denominator', () => {
+  const resolved = Array.from({ length: 5 }, (_, i) =>
+    jobWith(90, [
+      ev(100 + i, 'applied', '2026-05-01'),
+      ev(100 + i, i < 3 ? 'screen' : 'rejected', '2026-05-05'),
+    ]),
+  );
+  const waiting = jobWith(90, [ev(200, 'applied', '2026-05-01')]);
+  const c = calibration([...resolved, waiting]);
+  const top = c.bands.find((b) => b.label === '≥85')!;
+  assert.equal(top.applied, 6);
+  assert.equal(top.interviewResolved, 5);
+  assert.equal(top.interviewRate, 3 / 5);
+});
+
+test('calibration: verdict compares the lowest and highest known bands', () => {
+  const mk = (fit: number, id: number, interviewed: boolean) =>
+    jobWith(fit, [
+      ev(id, 'applied', '2026-05-01'),
+      ev(id, interviewed ? 'screen' : 'rejected', '2026-05-05'),
+    ]);
+  const low = Array.from({ length: 5 }, (_, i) => mk(40, 300 + i, i < 1)); // 20%
+  const high = Array.from({ length: 5 }, (_, i) => mk(90, 400 + i, i < 4)); // 80%
+  assert.equal(calibration([...low, ...high]).verdict, 'separating');
+  assert.equal(calibration([...high.map((j) => ({ ...j, fitScore: 40 })), ...low.map((j) => ({ ...j, fitScore: 90 }))]).verdict, 'inverted');
+
+  const flat = [...low, ...low.map((j, i) => jobWith(90, [
+    ev(500 + i, 'applied', '2026-05-01'),
+    ev(500 + i, i < 1 ? 'screen' : 'rejected', '2026-05-05'),
+  ]))];
+  assert.equal(calibration(flat).verdict, 'flat');
+});
+
+test('calibration: jobs without a fit score are counted aside', () => {
+  const c = calibration([jobWith(null, [ev(1, 'applied', '2026-05-01')])]);
+  assert.equal(c.unknownFit, 1);
+  assert.equal(c.bands.every((b) => b.applied === 0), true);
+});

--- a/src/web/stats.ts
+++ b/src/web/stats.ts
@@ -1,0 +1,246 @@
+// F5 (ADR 0024). Pure funnel / velocity / calibration math over
+// JobStageEvent rows. The honesty rules are code, not captions:
+// backfill rows never enter day-math, in-flight jobs never enter rates,
+// and a rate under MIN_RATE_N is null — a small count is an anecdote.
+
+export const STAGE_ORDER = ['applied', 'screen', 'tech', 'onsite', 'offer'] as const;
+export type RankedStage = (typeof STAGE_ORDER)[number];
+export const TERMINAL_STAGES = ['rejected', 'ghosted'] as const;
+export type TerminalStage = (typeof TERMINAL_STAGES)[number];
+
+export const MIN_RATE_N = 5;
+/** Interview = any human process: screen or beyond. */
+export const INTERVIEW_RANK = 1;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface StageEventRow {
+  jobId: number;
+  toStage: string | null;
+  occurredOn: Date;
+  recordedAt: Date;
+  source: string; // ui | backfill | correction
+}
+
+interface JobHistory {
+  maxRank: number; // -1 when no ranked stage reached
+  terminal: TerminalStage | null; // from the last event
+  /** Latest non-backfill occurredOn per stage name (ranked or terminal). */
+  dates: Map<string, Date>;
+}
+
+const rankOf = (stage: string | null): number =>
+  stage === null ? -1 : STAGE_ORDER.indexOf(stage as RankedStage);
+
+/**
+ * Fold one job's events into its history. Events after the last
+ * toStage=null win: a cleared stage voids the mis-entered run before it.
+ */
+export function foldJob(events: StageEventRow[]): JobHistory {
+  const sorted = [...events].sort(
+    (a, b) => a.recordedAt.getTime() - b.recordedAt.getTime(),
+  );
+  const lastClear = sorted.reduce(
+    (acc, e, i) => (e.toStage === null ? i : acc),
+    -1,
+  );
+  const live = sorted.slice(lastClear + 1);
+
+  let maxRank = -1;
+  const dates = new Map<string, Date>();
+  for (const e of live) {
+    if (e.toStage === null) continue;
+    maxRank = Math.max(maxRank, rankOf(e.toStage));
+    if (e.source !== 'backfill') dates.set(e.toStage, e.occurredOn);
+  }
+  const last = live[live.length - 1];
+  const terminal =
+    last && (TERMINAL_STAGES as readonly string[]).includes(last.toStage ?? '')
+      ? (last.toStage as TerminalStage)
+      : null;
+  return { maxRank, terminal, dates };
+}
+
+export function groupByJob(rows: StageEventRow[]): Map<number, JobHistory> {
+  const byJob = new Map<number, StageEventRow[]>();
+  for (const r of rows) {
+    const list = byJob.get(r.jobId);
+    if (list) list.push(r);
+    else byJob.set(r.jobId, [r]);
+  }
+  return new Map([...byJob].map(([id, events]) => [id, foldJob(events)]));
+}
+
+// ---------------------------------------------------------------- funnel
+
+export interface FunnelRow {
+  stage: RankedStage;
+  everReached: number;
+}
+
+export interface Funnel {
+  rows: FunnelRow[];
+  rejected: number;
+  ghosted: number;
+  inFlight: number;
+}
+
+/** "Ever reached" is monotone: an offer event implies screen/tech/onsite. */
+export function funnel(histories: Iterable<JobHistory>): Funnel {
+  const all = [...histories].filter((h) => h.maxRank >= 0 || h.terminal !== null);
+  const rows = STAGE_ORDER.map((stage, rank) => ({
+    stage,
+    everReached: all.filter((h) => h.maxRank >= rank).length,
+  }));
+  return {
+    rows,
+    rejected: all.filter((h) => h.terminal === 'rejected').length,
+    ghosted: all.filter((h) => h.terminal === 'ghosted').length,
+    inFlight: all.filter((h) => h.terminal === null).length,
+  };
+}
+
+// -------------------------------------------------------------- velocity
+
+export interface HopStats {
+  from: string;
+  to: string;
+  medianDays: number | null;
+  n: number;
+  sameDay: number; // 0-day hops: excluded from the median, counted here
+  censored: number; // reached `from`, still waiting for `to`
+}
+
+const median = (xs: number[]): number | null => {
+  if (xs.length === 0) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 === 1 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
+};
+
+function hop(histories: JobHistory[], from: string, to: string): HopStats {
+  const days: number[] = [];
+  let sameDay = 0;
+  let censored = 0;
+  for (const h of histories) {
+    const a = h.dates.get(from);
+    const b = h.dates.get(to);
+    if (a && b) {
+      const d = Math.round((b.getTime() - a.getTime()) / DAY_MS);
+      if (d === 0) sameDay++;
+      else if (d > 0) days.push(d);
+      // d < 0: a backdated correction crossed itself — not a real duration
+    } else if (
+      // Counting the still-waiting needs no dates, so backfill-only
+      // histories censor too — only durations demand real event days.
+      rankOf(from) >= 0 &&
+      rankOf(to) >= 0 &&
+      h.maxRank >= rankOf(from) &&
+      h.maxRank < rankOf(to) &&
+      h.terminal === null
+    ) {
+      censored++;
+    }
+  }
+  return { from, to, medianDays: median(days), n: days.length, sameDay, censored };
+}
+
+/**
+ * Consecutive funnel hops, plus applied→rejected and applied→offer kept
+ * apart — a mixed "days to terminal" number reads grim and means nothing.
+ */
+export function velocity(histories: Iterable<JobHistory>): HopStats[] {
+  const all = [...histories];
+  const hops: HopStats[] = [];
+  for (let i = 0; i < STAGE_ORDER.length - 1; i++) {
+    hops.push(hop(all, STAGE_ORDER[i]!, STAGE_ORDER[i + 1]!));
+  }
+  hops.push(hop(all, 'applied', 'rejected'));
+  return hops;
+}
+
+// ----------------------------------------------------------- calibration
+
+export const FIT_BANDS = [
+  { label: '<60', min: 0, max: 59 },
+  { label: '60–74', min: 60, max: 74 },
+  { label: '75–84', min: 75, max: 84 },
+  { label: '≥85', min: 85, max: 100 },
+] as const;
+
+export interface BandStats {
+  label: string;
+  applied: number;
+  /** null when the resolved count is under MIN_RATE_N. */
+  interviewRate: number | null;
+  interviewResolved: number;
+  offerRate: number | null;
+  offerResolved: number;
+}
+
+export type CalibrationVerdict = 'separating' | 'flat' | 'inverted' | 'insufficient';
+
+export interface Calibration {
+  bands: BandStats[];
+  verdict: CalibrationVerdict;
+  unknownFit: number;
+}
+
+/**
+ * A job enters a rate only once its outcome is known: it reached the
+ * milestone, or it ended (rejected/ghosted) without it. Still-waiting
+ * jobs are excluded — counting them either way biases the number.
+ */
+function rate(histories: JobHistory[], milestoneRank: number): {
+  rate: number | null;
+  resolved: number;
+} {
+  const reached = histories.filter((h) => h.maxRank >= milestoneRank);
+  const endedWithout = histories.filter(
+    (h) => h.maxRank < milestoneRank && h.terminal !== null,
+  );
+  const resolved = reached.length + endedWithout.length;
+  return {
+    rate: resolved >= MIN_RATE_N ? reached.length / resolved : null,
+    resolved,
+  };
+}
+
+export function calibration(
+  jobs: Array<{ fitScore: number | null; history: JobHistory }>,
+): Calibration {
+  const inFunnel = jobs.filter(
+    (j) => j.history.maxRank >= 0 || j.history.terminal !== null,
+  );
+  const unknownFit = inFunnel.filter((j) => j.fitScore === null).length;
+
+  const bands: BandStats[] = FIT_BANDS.map((band) => {
+    const members = inFunnel
+      .filter(
+        (j) =>
+          j.fitScore !== null && j.fitScore >= band.min && j.fitScore <= band.max,
+      )
+      .map((j) => j.history);
+    const interview = rate(members, INTERVIEW_RANK);
+    const offer = rate(members, rankOf('offer'));
+    return {
+      label: band.label,
+      applied: members.length,
+      interviewRate: interview.rate,
+      interviewResolved: interview.resolved,
+      offerRate: offer.rate,
+      offerResolved: offer.resolved,
+    };
+  });
+
+  const known = bands.filter((b) => b.interviewRate !== null);
+  let verdict: CalibrationVerdict = 'insufficient';
+  if (known.length >= 2) {
+    const first = known[0]!.interviewRate!;
+    const last = known[known.length - 1]!.interviewRate!;
+    if (last - first > 0.1) verdict = 'separating';
+    else if (first - last > 0.1) verdict = 'inverted';
+    else verdict = 'flat';
+  }
+  return { bands, verdict, unknownFit };
+}


### PR DESCRIPTION
F5 per the §7 process: re-analysis on live data BEFORE code, findings recorded in [ADR 0024](docs/adr/0024-append-only-stage-ledger.md) and the TASKS §7 bullet.

## What the re-analysis changed

- The plan's "single write path" is really **two web routes**: the tracking-card POST (any stage, clearable, backdatable `appliedAt`) and the `pipelineStage='applied'` seeding inside the status route. The worker writes only inbox `status` (762 of 834 rows are machine DISMISSED churn) and never touches stages — so the ledger records **pipelineStage transitions** and inbox noise stays out (that's F15's telemetry).
- `JobStatusEvent` → **`JobStageEvent`**: the plan's name collides with the orthogonal `JobStatus` inbox enum.
- Backfill measured tiny and clean: **3 funnel rows, all `applied`, all with real user-entered dates** (2026-04-29/30) — done as SQL inside the migration, `source=backfill`, excluded from day-math by the stats module.
- With 3 applications, **every rate sits under the n=5 floor**: the honesty rules are the entire launch experience, so the cards ship with explicit "— (n=0, need 5)" rendering and an empty-state hint.
- Latent data-loss hole: `cleanup-job` deletes old DISMISSED jobs, and a job with funnel history can be DISMISSED later — cascade would erase its ledger. **cleanup now skips jobs with a `pipelineStage`** (0 such rows today; preventive).
- Fit bands kept as planned — live inbox distribution across `<60/60–74/75–84/≥85` is 12/15/13/29.
- Deferred with reasons: `assessment` event type (0 data), per-source channel yield (channels today: Greenhouse×2 + Jobicy×1 vs the n≥8 floor), per-hop date picker (hops date to the write day; `appliedAt` edits write `correction` events).

## What shipped

- **Schema** (hand-written migration, gotcha 7): `JobStageEvent(jobId FK cascade, fromStage?, toStage?, occurredOn DATE, recordedAt, source)` + backfill INSERT.
- **Writes**: pure builders in `src/web/stage-events.ts` (tested); both routes write the event in the **same `$transaction`** as the stage update. A notes-only resubmit writes nothing; clearing the stage writes `source=correction, toStage=null` (fold voids the run before it); an `appliedAt` edit writes a dated `correction`.
- **Stats** (`src/web/stats.ts`, pure, 12 fixture tests): monotone "ever reached" fold, per-hop medians with same-day excluded-but-counted and right-censoring counts (censoring needs no dates, so backfill-only histories still count as waiting), applied→rejected kept apart from applied→offer, in-flight rows out of every rate, n<5 ⇒ null (never 0).
- **Cards on `/applications`**: Ever reached, Days per hop, "Does fit predict interviews?" with a `separating / flat / inverted / not enough data` verdict badge. Definition pinned in code: "interview" = screen or beyond (`INTERVIEW_RANK` in stats.ts) — rename the column if you'd rather count from tech.

## Verification (testing-gate)

- `lint:types` + 760/760 tests green.
- Migration applied via container boot (`migrate deploy`); backfill produced exactly the 3 expected rows with real dates.
- Route smoke on job 28 through the live dashboard: stage change → **exactly one** `ui` event; notes-only resubmit → zero; `appliedAt` edit → dated `correction`; clear → `toStage=null` correction. Smoke rows deleted afterwards, job restored byte-identical.
- Web rebuilt; `/applications` 200; checked at 1200px and 375px, 0 console errors ("3 waiting" renders on applied→screen from censoring).

## Release notes (draft for the tag)

v1.1.0 — status-transition ledger. Every pipeline-stage change is history now: an append-only `JobStageEvent` row per transition, written transactionally at both web write sites, with the current funnel backfilled. `/applications` gained funnel, days-per-hop and fit-calibration cards whose honesty rules are code: backfilled dates never enter medians, in-flight applications never enter rates, and a rate below n=5 renders as "need 5", not as a number. ADR 0024.
