### PR TITLE
Honor pause mid-run: stop fetch/classify/alert within seconds of pausing

### DIFF
--- a/src/cancellation.test.ts
+++ b/src/cancellation.test.ts
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { makeLatchingProbe } from './cancellation';
+
+function fakeClock(start = 0) {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+test('reads on first call and returns the value', async () => {
+  const clock = fakeClock();
+  let reads = 0;
+  const probe = makeLatchingProbe(
+    async () => {
+      reads++;
+      return false;
+    },
+    5000,
+    clock.now,
+  );
+  assert.equal(await probe(), false);
+  assert.equal(reads, 1);
+});
+
+test('throttles reads inside the interval', async () => {
+  const clock = fakeClock();
+  let reads = 0;
+  const probe = makeLatchingProbe(
+    async () => {
+      reads++;
+      return false;
+    },
+    5000,
+    clock.now,
+  );
+  await probe();
+  clock.advance(4999);
+  assert.equal(await probe(), false);
+  assert.equal(reads, 1);
+  clock.advance(1);
+  assert.equal(await probe(), false);
+  assert.equal(reads, 2);
+});
+
+test('latches true and stops reading', async () => {
+  const clock = fakeClock();
+  const answers = [false, true, false];
+  let reads = 0;
+  const probe = makeLatchingProbe(
+    async () => {
+      const v = answers[reads] ?? false;
+      reads++;
+      return v;
+    },
+    5000,
+    clock.now,
+  );
+  assert.equal(await probe(), false);
+  clock.advance(5000);
+  assert.equal(await probe(), true);
+  // Latched: no further reads even after the interval, and a later false
+  // from the source could not un-latch it anyway.
+  clock.advance(60_000);
+  assert.equal(await probe(), true);
+  assert.equal(reads, 2);
+});
+
+test('throttled calls between reads return the last value, not a read', async () => {
+  const clock = fakeClock();
+  let reads = 0;
+  const probe = makeLatchingProbe(
+    async () => {
+      reads++;
+      return reads >= 2;
+    },
+    1000,
+    clock.now,
+  );
+  assert.equal(await probe(), false);
+  assert.equal(await probe(), false); // same tick — throttled
+  assert.equal(reads, 1);
+  clock.advance(1000);
+  assert.equal(await probe(), true);
+  assert.equal(reads, 2);
+});

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -1,0 +1,25 @@
+/**
+ * Wraps an async boolean probe (e.g. "is fetching paused?") so long loops
+ * can poll it every iteration without hammering the source: the underlying
+ * read runs at most once per `minIntervalMs`, and once it answers true the
+ * probe latches — later calls return true without reading again. A latched
+ * run stays aborted even if the flag flips back mid-run; the next cron tick
+ * picks the new value up.
+ */
+export function makeLatchingProbe(
+  read: () => Promise<boolean>,
+  minIntervalMs: number,
+  now: () => number = Date.now,
+): () => Promise<boolean> {
+  let latched = false;
+  let lastReadAt: number | null = null;
+
+  return async () => {
+    if (latched) return true;
+    const t = now();
+    if (lastReadAt !== null && t - lastReadAt < minIntervalMs) return false;
+    lastReadAt = t;
+    if (await read()) latched = true;
+    return latched;
+  };
+}

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -41,7 +41,9 @@ export interface FetcherResult {
   companyName: string;
 }
 
-export async function runAllFetchers(): Promise<FetcherResult[]> {
+export async function runAllFetchers(
+  isCancelled?: () => Promise<boolean>,
+): Promise<FetcherResult[]> {
   const settings = await getSettings();
   const disabled = toAtsTypes(settings.disabledSources);
   if (disabled.length > 0) {
@@ -57,8 +59,17 @@ export async function runAllFetchers(): Promise<FetcherResult[]> {
   });
 
   const out: FetcherResult[] = [];
+  let done = 0;
 
   for (const company of companies) {
+    if (isCancelled && (await isCancelled())) {
+      logger.warn(
+        { done, remaining: companies.length - done },
+        'fetchers: aborted (fetching paused mid-run)',
+      );
+      break;
+    }
+    done++;
     let status: FetchStatus;
     try {
       const jobs = await fetchOne(company);

--- a/src/jobs/fetch-job.ts
+++ b/src/jobs/fetch-job.ts
@@ -3,6 +3,7 @@ import { runAllFetchers } from '../fetchers';
 import { getActiveProfile } from '../profiles';
 import { getSettings } from '../settings';
 import { recordCandidatesFromText } from '../discovery';
+import { makeFetchPauseProbe } from './fetch-pause';
 import { processNormalizedJobs, type ProcessStats } from './process-jobs';
 import type { CronStats } from './cron-run';
 
@@ -29,7 +30,11 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     'fetch-job: using active profile',
   );
 
-  const fetched = await runAllFetchers();
+  // Pausing on /settings must also stop a tick that is already running —
+  // every long phase below polls this probe and aborts within seconds.
+  const paused = makeFetchPauseProbe();
+
+  const fetched = await runAllFetchers(paused);
   logger.info({ count: fetched.length }, 'fetch-job: total fetched');
 
   // Phase 7.5 — universal ATS-URL discovery from any fetched job's URL
@@ -44,6 +49,7 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
   if (settings.discoveryEnabled) {
     const sourceTag = `fetch-${new Date().toISOString().slice(0, 7)}`;
     for (const { job, companyName } of fetched) {
+      if (await paused()) break;
       const text = `${job.url}\n${job.description}`;
       const recorded = await recordCandidatesFromText(text, sourceTag, {
         name: null,
@@ -55,6 +61,24 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     if (candidates > 0) {
       logger.info({ candidates }, 'fetch-job: discovery harvested candidates');
     }
+  }
+
+  if (await paused()) {
+    const durationMs = Date.now() - started;
+    logger.warn(
+      { fetched: fetched.length, durationMs },
+      'fetch-job: aborted before classify (fetching paused mid-run)',
+    );
+    return {
+      stats: {
+        profile: profile.name,
+        aborted: 1,
+        reason: 'paused-mid-run',
+        fetched: fetched.length,
+        candidatesRecorded: candidates,
+        durationMs,
+      },
+    };
   }
 
   const inner: ProcessStats = {
@@ -69,8 +93,10 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     alertFailed: 0,
     priorityBoosted: 0,
     crossListed: 0,
+    abortedMidRun: 0,
+    skippedByPause: 0,
   };
-  await processNormalizedJobs(fetched, profile, classifierMode, inner);
+  await processNormalizedJobs(fetched, profile, classifierMode, inner, paused);
 
   const durationMs = Date.now() - started;
   const stats: CronStats = {

--- a/src/jobs/fetch-pause.ts
+++ b/src/jobs/fetch-pause.ts
@@ -1,0 +1,18 @@
+import { makeLatchingProbe } from '../cancellation';
+import { getSettings } from '../settings';
+
+/** How often a long-running tick re-reads the pause flag from the DB. */
+export const PAUSE_RECHECK_MS = 5_000;
+
+/**
+ * Probe for "did the user pause fetching while this tick was running?".
+ * The /settings toggle writes fetchingEnabled immediately (gotcha 9); the
+ * jobs pass this probe into every long phase so a pause takes effect
+ * within seconds instead of at the next tick.
+ */
+export function makeFetchPauseProbe(): () => Promise<boolean> {
+  return makeLatchingProbe(
+    async () => !(await getSettings()).fetchingEnabled,
+    PAUSE_RECHECK_MS,
+  );
+}

--- a/src/jobs/hn-hiring-job.ts
+++ b/src/jobs/hn-hiring-job.ts
@@ -5,6 +5,7 @@ import { fetchHnHiring, findLatestHiringThread } from '../fetchers/hn-hiring';
 import { getActiveProfile } from '../profiles';
 import { getSettings } from '../settings';
 import { recordCandidatesFromText } from '../discovery';
+import { makeFetchPauseProbe } from './fetch-pause';
 import { processNormalizedJobs, type ProcessStats } from './process-jobs';
 import type { CronStats } from './cron-run';
 
@@ -57,6 +58,10 @@ export async function runHnHiringJob(): Promise<{ stats: CronStats }> {
   const fetched = await fetchHnHiring(company.id);
   const items = fetched.map((job) => ({ job, companyName: HN_COMPANY_NAME }));
 
+  // Same mid-run pause handling as runFetchJob: the classify loop below can
+  // run for many minutes, and a pause on /settings must stop it.
+  const paused = makeFetchPauseProbe();
+
   // Phase 4.2 — harvest ATS company candidates from comment URLs.
   // Each fetched job already carries the cleaned comment text in
   // `description`, so we re-scan it for greenhouse / lever / ashby URLs.
@@ -65,6 +70,7 @@ export async function runHnHiringJob(): Promise<{ stats: CronStats }> {
     const sourceTag = `hn-${new Date().toISOString().slice(0, 7)}`; // hn-2026-04
     const thread = await findLatestHiringThread().catch(() => null);
     for (const j of fetched) {
+      if (await paused()) break;
       const recorded = await recordCandidatesFromText(j.description, sourceTag, {
         name: null,
         sourceUrl: thread
@@ -91,8 +97,10 @@ export async function runHnHiringJob(): Promise<{ stats: CronStats }> {
     alertFailed: 0,
     priorityBoosted: 0,
     crossListed: 0,
+    abortedMidRun: 0,
+    skippedByPause: 0,
   };
-  await processNormalizedJobs(items, profile, settings.classifierMode, inner);
+  await processNormalizedJobs(items, profile, settings.classifierMode, inner, paused);
 
   const durationMs = Date.now() - started;
   const stats: CronStats = {

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -5,7 +5,7 @@ import { logger } from '../logger';
 import { createLimiter } from '../concurrency';
 import { passesBaseFilter } from '../filter';
 import { withApplyLinkFlags } from '../apply-link';
-import { classifyJob } from '../classifier';
+import { classifyJob, type ClassifyOutcome } from '../classifier';
 import { sendTelegramAlert } from '../notifier';
 import { applyPriorityFloor, parsePriorityRules } from '../priority-rules';
 import {
@@ -40,6 +40,10 @@ export interface ProcessStats {
   alertFailed: number;
   priorityBoosted: number;
   crossListed: number;
+  /** 1 when the run stopped early because fetching was paused mid-run. */
+  abortedMidRun: number;
+  /** Classifications scheduled but discarded by the mid-run abort. */
+  skippedByPause: number;
 }
 
 /** How far back the cross-listing scan looks. */
@@ -55,14 +59,23 @@ export async function processNormalizedJobs(
   profile: Profile,
   classifierMode: 'single' | 'two_stage',
   stats: ProcessStats,
+  isCancelled?: () => Promise<boolean>,
 ): Promise<void> {
   const priorityRules = parsePriorityRules(profile.priorityRules);
+
+  // Once true, queued classify thunks below become no-ops, so an abort
+  // stops the AI spend, not just the persist/alert loop.
+  let cancelled = false;
 
   // `seen` catches the same posting twice in one fetch: the sequential loop
   // used to see it in the DB, now both copies would be classified together.
   const candidates: FetchResult[] = [];
   const seen = new Set<string>();
   for (const item of items) {
+    if (isCancelled && (await isCancelled())) {
+      cancelled = true;
+      break;
+    }
     if (!passesBaseFilter(item.job, profile)) {
       stats.filterRejected++;
       continue;
@@ -74,6 +87,11 @@ export async function processNormalizedJobs(
     }
     seen.add(key);
     candidates.push(item);
+  }
+  if (cancelled) {
+    stats.abortedMidRun = 1;
+    logger.warn('process-jobs: aborted before classify (fetching paused mid-run)');
+    return;
   }
 
   // Fingerprints of everything ingested in the dedup window, read once for
@@ -87,9 +105,14 @@ export async function processNormalizedJobs(
   const limit = createLimiter(config.AI_CONCURRENCY);
   const pending = candidates.map((item) => ({
     ...item,
-    outcome: limit(() =>
-      classifyJob(buildClassifyInput(item.job, item.companyName), profile, classifierMode),
-    ),
+    outcome: limit(async (): Promise<ClassifyOutcome> => {
+      if (cancelled) return { result: null, preFiltered: false };
+      return classifyJob(
+        buildClassifyInput(item.job, item.companyName),
+        profile,
+        classifierMode,
+      );
+    }),
   }));
   if (pending.length > 0) {
     logger.info(
@@ -98,7 +121,22 @@ export async function processNormalizedJobs(
     );
   }
 
+  let consumed = 0;
   for (const { job, companyName, outcome } of pending) {
+    if (isCancelled && (await isCancelled())) {
+      cancelled = true;
+      stats.abortedMidRun = 1;
+      stats.skippedByPause = pending.length - consumed;
+      logger.warn(
+        { consumed, skipped: pending.length - consumed },
+        'process-jobs: aborted mid-run (fetching paused); discarding unconsumed classifications',
+      );
+      // In-flight classifications (≤ AI_CONCURRENCY) finish in the
+      // background and are discarded; swallow their rejections.
+      void Promise.allSettled(pending.map((p) => p.outcome));
+      break;
+    }
+    consumed++;
     const { result: classification, preFiltered } = await outcome;
     if (preFiltered) {
       stats.preFiltered++;


### PR DESCRIPTION
Fixes #51.

Pausing "Job fetching" on /settings only prevented the *next* tick from starting — a tick already in flight kept fetching, classifying (AI spend) and sending Telegram alerts for its whole runtime. During the blank-profile incident (#50) that meant 23 alerts and 118+ classifications *after* the pause, stoppable only by killing the container.

## Change

- **`src/cancellation.ts`** (new, pure, tested): `makeLatchingProbe(read, minIntervalMs)` — throttles an async boolean probe to one read per interval and latches once it answers true. A latched run stays aborted even if the flag flips back; the next tick reads fresh state.
- **`src/jobs/fetch-pause.ts`** (new): `makeFetchPauseProbe()` — the probe bound to `!settings.fetchingEnabled`, re-read at most every 5s.
- Checkpoints in every long phase, all aborting gracefully with honest stats (`reason: paused-mid-run`, `abortedMidRun`, `skippedByPause`):
  - `runAllFetchers` — between sources (skipped sources get no health write, per ADR 0019 semantics: no attempt, no streak change);
  - discovery harvest loops in both jobs — between items;
  - `processNormalizedJobs` — in the dedupe loop and before consuming each classification. Queued classify thunks become no-ops via a shared `cancelled` flag, so the abort stops AI spend, not just persist/alert; ≤ AI_CONCURRENCY in-flight calls finish in the background and are discarded (`Promise.allSettled` swallows their rejections).

An earlier draft added a boot janitor for orphaned RUNNING CronRun rows — dropped after finding `init.ts:failInterruptedCronRuns` (#18) already does exactly that.

## Verification

- `npm run lint:types` + `npm test` green (764 tests, incl. 4 new for the probe: first read, throttle boundary, latch, throttled return value).
- Live smoke in Docker: enabled fetching, started `fetch-once`, flipped the pause flag 12s in → run aborted **1.5s later** between sources (`done: 10, remaining: 63`), skipped classification entirely, 0 new Job rows, 0 alerts, CronRun stats `{"reason": "paused-mid-run", "aborted": 1, "fetched": 1141}`.
- Not live-smoked: the abort *inside* the classify loop (same probe + break pattern; exercising it live would burn AI calls and risk alerts against the currently-active blank profile from #50). Covered by types + review.

## Follow-ups (P2/P3 from pre-merge review)

- **P2**: on abort, results of in-flight classifications are discarded; those jobs are re-fetched and re-classified next tick (double spend of ≤ AI_CONCURRENCY calls per abort). Consuming completed in-flight results before breaking wasn't worth the complexity.
- **P3**: the skipped-thunk sentinel `{result: null, preFiltered: false}` would count as `classifyFailed` if future code ever consumed skipped outcomes (unreachable today — the loop breaks first).

## Release notes (draft)

Fold into the next release (v1.2.0 changelog, alongside the untagged #48 items):

> **Pause now stops in-flight runs.** Pausing Job fetching takes effect within seconds even mid-tick: fetchers, discovery and the classify/alert loop all abort gracefully, record `paused-mid-run` in run stats, and stop AI spend and Telegram alerts immediately.
