### PR TITLE
release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-09-01
+
+### Fixed
+- **Pausing "Job fetching" now stops an in-flight tick within seconds**
+  (#51, #52). The flag used to be read once at tick start, so a running
+  tick kept fetching, classifying (AI spend) and sending Telegram alerts
+  until it finished. Every long phase — fetchers, discovery harvest, the
+  classify/alert loop — now polls the flag through a throttled latching
+  probe (`makeLatchingProbe`, one read per 5s) and aborts gracefully,
+  recording `paused-mid-run` in the run stats on `/runs`.
+
+### Added
+- "Ready to apply" cue on the targeted-resume view: at a match score of
+  85+ the card says so explicitly — stop polishing, send it (#48).
+
+### Changed
+- The paste-posting-vs-resume flow is named **Compare** in the nav and on
+  its start page (was "Target") (#48).
+- Match history lists (per job and per resume) are capped to the 50
+  newest entries; re-runs no longer grow them without bound (#48).
+
 ## [1.1.0] — 2026-09-01
 
 ### Added
@@ -477,7 +498,8 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
-[Unreleased]: https://github.com/nazboyko/applypack/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/nazboyko/applypack/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/nazboyko/applypack/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/nazboyko/applypack/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/nazboyko/applypack/compare/v0.11.1...v1.0.0
 [0.11.1]: https://github.com/nazboyko/applypack/compare/v0.11.0...v0.11.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",


### PR DESCRIPTION
Version bump + changelog for **v1.2.0**, folding the two untagged merges (#48, #52) per release discipline — the tagged commit must carry the version in `package.json` and the `CHANGELOG.md` entry.

## v1.2.0 contents
- **Fixed**: pausing "Job fetching" stops an in-flight tick within seconds — fetchers, discovery and the classify/alert loop poll the flag and abort gracefully, recording `paused-mid-run` in run stats (#51, #52)
- **Added**: "Ready to apply" cue at match score 85+ on the targeted view (#48)
- **Changed**: nav flow renamed to **Compare**; match history lists capped at 50 newest (#48)
- **Schema**: no changes

## After merge (I'll run these on your "merged")
```
git tag -a v1.2.0 -m "pause honored mid-run + compare polish" <merge-sha>
git push origin v1.2.0
gh release create v1.2.0 --title "v1.2.0 — pause honored mid-run" --notes <drafted>
```