### PR TITLE
Analysis plans: TASKS §11-13 (onboarding, /resumes, /target)

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -711,3 +711,103 @@ triage lands** — one branch (`applications-board`), one PR, ordered:
 Also: `.claude/skills/ui-review/SKILL.md` still says "dark-only" — stale
 since the 2026-08-28 light redesign (PR #12); fix the skill context line
 when next touching it.
+
+## 11. Onboarding wizard + profile simplification + multi-resume search (analysis 2026-08-31)
+
+Full plan: [docs/onboarding-plan.md](./onboarding-plan.md). **Analysis
+only — nothing implemented yet** (written from a parallel session; do not
+start without checking §10's status first).
+
+Driver: users don't find where to create a profile or upload a resume;
+no way to verify the pipeline works from the UI; target persona for
+first-run is a non-technical user. Critical path decided by owner:
+connect AI → prove search works → build profile from a resume;
+Telegram explicitly optional.
+
+- [ ] `profile-tab-quickwins` — reorder Profile tab around the journey,
+      kill top "Re-classify all", placeholders, conditional rules hint,
+      `advancedOpen` fix, inline upload in the Fill card
+- [ ] `fetch-now` — "Fetch now" button + `{classify: false}` seam +
+      background run (reclassify pattern) + progress page
+- [ ] `welcome-wizard` — `/welcome` 4-step first-run flow
+      (AI → test search → resume → first matches), redirect while
+      `AppSettings.setupCompletedAt` null, skip link, Overview chip;
+      ~4 clicks + one file pick end-to-end
+- [ ] `ai-key-in-db` — paste API key in UI, DB-stored, masked
+      (**ADR**: extends 0013 + secrets policy; TelegramTarget precedent)
+- [ ] `profile-resume-link` — `Profile.resumeId` + one-click "Create
+      profile from this resume"
+- [ ] `multi-profile-search` — multiple active profiles, union base
+      filter, **one** classifier call returning per-profile scores,
+      `JobScore` table, per-profile alert routing (**ADR**)
+- [ ] `applied-resume` — record which resume (+ text snapshot) a job was
+      applied with; surface in stale digest
+
+## 12. /resumes overhaul + on-demand resume strength review (analysis 2026-08-31)
+
+Full plan: [docs/resumes-plan.md](./resumes-plan.md). **Analysis only —
+nothing implemented** (written from a parallel session: browser audit of
+the live page at desktop + 375px, plus code verification; do not start
+without checking §10/§11 status first).
+
+Driver: `/resumes` shows inventory, not effectiveness — no per-resume
+match signal, upload & scan freezes the browser ~60 s (double-submit
+creates duplicates), and at 375px the action buttons sit behind
+horizontal scroll. New feature (owner request): an **on-demand** "is this
+resume strong?" review — per-dimension grades with evidence, prioritized
+make-it-stronger advice so the candidate reads like a top professional,
+metric *asks* instead of invented numbers (ADR 0020 stance). Never
+auto-run on upload; discoverable as a real card with an explainer, not an
+icon; progress visible step-by-step via the target-run registry pattern.
+
+- [ ] `resumes-page-p0` — async upload/replace/rescan via the run
+      registry, mobile row fix (Delete off hub rows, responsive columns —
+      needs a small `Table` th-class extension), delete-confirm mentions
+      cover letters, `primarySkills` column, Matches/`FitBadge` column
+- [ ] `resume-strength` — fenced `REVIEW_SYSTEM` (grades only — the model
+      never outputs the score; pure `review-score.ts` applies hard caps,
+      gotcha-11 guard test) + `ResumeReview` table + detail card + hub
+      column + run-page `review` step (**ADR**: new AI call site + table)
+- [ ] `resume-strength-loop` — metric asks → user answers → re-run
+      deltas; version-over-version strength trend
+- [ ] quick wins ride along where touched: facts add/flip on `/resumes`
+      (existing `POST /facts` covers it), rename route, version badge in
+      hub, grouped per-job score history (`diff.ts`)
+
+## 13. /target compare speed (30-40 s) + keyword-matcher accuracy (analysis 2026-08-31)
+
+Full plan: [docs/target-plan.md](./target-plan.md). **Analysis only —
+nothing implemented** (written from a parallel session; do not start
+without checking §10–§12 status first — §12's async-upload item overlaps
+the `/resumes` sync-scan finding, planned there, referenced here).
+
+Driver: a fresh-resume compare takes ~3 min (owner target: 30-40 s), and
+the JD pane skips important posting words. Verified causes: one
+2.5-4 k-token Opus match call dominates; classify and scan sit on the
+critical path although match reads neither (`{classify:false}` seam
+already exists); parse-retry silently doubles a step; highlights show
+ONLY AI-listed keywords through a literal matcher (soft cap ~25,
+non-verbatim terms render nowhere, aliases model-dependent, no
+plural/separator tolerance, `previousKeywords` makes a missed term
+sticky). Speed strategy: instant no-AI check against the stored frame
+(the live-editor machinery already does it), keywords-only fast AI mode,
+Sonnet bench for the resume role — not "make Opus stream faster".
+
+- [ ] `target-speed-p0` — classify off the critical path (parallel,
+      `{classify:false}`), scan → background on reupload, memoize
+      identical (job, resumeText) re-runs, honest `STEP_VIEW` copy +
+      per-step ms logging
+- [ ] `keyword-matcher-v2` — persist-time verbatim guard, deterministic
+      alias table (`keyword-aliases.ts`, pure), plural + separator
+      tolerance in `termPattern`, tiered keyword budget (all must/
+      preferred always listed); table-driven tests
+- [ ] `target-instant-check` — reupload → parse-only dirty draft in the
+      target editor (~2-5 s, zero AI), "Re-analyze" upgrades on demand
+- [ ] `match-fast-mode` — keywords-only prompt variant (score-complete
+      subset, ~¼ output tokens) + `bench:resume` Sonnet-vs-Opus decision
+      (**PROMPT_VERSION bump**; possibly ADR)
+- [ ] `keyword-priority-ui` — per-keyword user overrides (re-level /
+      exclude / add own term) via existing `updateMatchScoring`, visual
+      weight for must+primary misses, posting-frequency tiebreaker
+- [ ] (only if still short of target) `match-split-frame` — per-job cached
+      keyword frame + statuses-only judge call (**ADR**)

--- a/docs/onboarding-plan.md
+++ b/docs/onboarding-plan.md
@@ -1,0 +1,323 @@
+# Onboarding & profile simplification plan
+
+> Drafted 2026-08-31 from a live UI review of `/settings?tab=profile` and
+> `/` (desktop + 375px) plus a source pass over `src/web/pages/settings.tsx`,
+> `overview.tsx`, `resumes.tsx`, `src/profiles.ts`, `src/init.ts`,
+> `src/resume/profile-draft.ts`, `src/resume/pick.ts` and the Prisma schema.
+> Backlog tick: [TASKS.md §11](./TASKS.md). Pairs with
+> [CLAUDE.md](../CLAUDE.md), the testing-gate / commit-discipline skills and
+> the ADR register in [docs/adr](./adr/).
+>
+> **Status: analysis only.** Nothing here is implemented. Constants
+> (batch caps, source subsets, timings) are starting hypotheses to
+> re-measure at implementation time.
+
+**Who this is for.** The target user of the wizard is explicitly
+non-technical — a manager who can install Docker by following a README but
+has never edited a config file and does not know what a "classifier" is.
+Every screen must survive the test: *would a person who has never seen a
+terminal understand what to click next?*
+
+---
+
+## 0. What the analysis found
+
+### 0.1 The onboarding hole (P0)
+
+- There is **no onboarding in the product**. The "first fifteen minutes"
+  live only in the README. A fresh install lands on `/` showing four
+  zeros, "No alerted jobs yet", cron rows saying "never ran" and a
+  "Pipeline paused" badge with no explanation of *why* it is paused or
+  what to do next (`src/web/pages/overview.tsx` has no first-run branch).
+- There is **no way to verify the pipeline works from the UI**. No
+  "fetch now" button exists anywhere (`Discovery` has "Run now"; fetch
+  does not). A new user either waits up to an hour for cron or runs
+  `docker compose exec … fetch-once.js` — which the target persona will
+  never do.
+- The resume → profile loop spans **two pages with a silent wait**:
+  warning on the Profile tab links to `/resumes`, upload there, wait ~1
+  min for the scan with no pointer back, return to `/settings?tab=profile`
+  by memory, pick the resume, "Fill from resume", review, "Save profile".
+  6–7 steps; this is precisely where users report getting lost.
+
+### 0.2 The Profile tab itself (P0/P1)
+
+- **Wrong order for the main journey.** The first screen is profile CRUD
+  chrome (select + Activate + "+ New profile" + "Re-classify all jobs").
+  The violet "Re-classify all jobs" — a paid AI action, useless at 0 jobs —
+  is the most colourful button a brand-new user sees. On 375px the real
+  first action ("Fill from a resume") is 1.5 screens down; the tab is
+  2.8 viewports closed, ~3.3 with Advanced open.
+- **Three identical-looking chip fields with load-bearing semantics**
+  (required stack vs role types vs nice-to-have). The split is critical
+  for the classifier (CLAUDE.md gotcha 8) so it must stay — but visually
+  the fields differ only by fine print, and users cannot tell where
+  "full-stack" goes vs "php".
+- **Save-model contradiction.** The page header promises "changes save
+  the moment you click", the profile editor is a submit-form with an
+  "Unsaved changes" indicator.
+- **Priority rules** (`LABEL | techs,csv | regions,csv | MIN_FIT`) plus an
+  always-rendered warn paragraph is the single most intimidating block on
+  the page, shown even when the textarea is empty.
+- **Advanced auto-opens for most real users**: the `advancedOpen`
+  condition includes `minSalaryUsd > 0`, and `init.ts` seeds salary from
+  `.env` — so the block is permanently open and the page permanently long.
+- **"Other profiles" table duplicates the activate select** — two UI
+  mechanisms for one concept on one page.
+
+Functionally no profile field is dead weight — every one feeds
+`buildSystemPrompt` or `passesBaseFilter`. The fix is presentation and
+sequencing, not the data model.
+
+### 0.3 Multi-resume reality (P1)
+
+Users have 3+ resumes (backend / full-stack / QA) and want **all**
+directions hunted at once, choosing the resume per application:
+
+- Any number of resumes is supported and `pickResumeForJob`
+  (`src/resume/pick.ts`) already preselects the best one per job — the
+  "choose at application time" half exists.
+- But the **search is single-track**: one `AppSettings.activeProfileId`;
+  fetch/HN/re-classify all score against one profile. Hunting three
+  directions today means either one union-profile (muddy scores — exactly
+  what gotchas 8/11 guard against) or manually switching profiles and
+  re-classifying everything. Both are bad.
+- `Job` records `appliedAt/pipelineStage/notes` but **not which resume
+  was sent**. "Upload new version" replaces resume bytes and text in
+  place, so a bare foreign key would lie after an update; the snapshot
+  pattern already exists in `ResumeMatch.resumeText`.
+
+---
+
+## 1. Wizard design principles
+
+1. **One screen — one action.** Each step has a single primary button.
+   Everything else is a quiet "skip" link.
+2. **Detect, don't ask.** Every step first checks the DB/env and
+   auto-completes if the condition is already met. Steps are **derived
+   from data**, never stored as a step counter: engine detected? jobs
+   exist? profile has stack/roleTypes? a classified run finished?
+3. **Plain human copy.** No "classifier", "ATS", "fit score" on wizard
+   screens — "we read every job and score how well it matches you",
+   "match score". Terminology stays in Settings for power users.
+4. **Show real numbers fast.** The wow moment is live: "312 jobs found
+   from 14 sources in 40s", then "18 match you — here are the top 5".
+5. **Never spend AI before AI is connected and never classify against a
+   blank profile** (that is why fetching ships paused — keep honouring it).
+6. **Skippable for experts.** "Skip setup" marks setup complete;
+   everything remains reachable through Settings as today. The wizard is
+   sugar over existing flows, not a new source of truth.
+7. **Existing primitives only** (`src/web/ui.tsx`, flash, confirm,
+   no-JS-safe forms). Progress pages reuse the compare-run pattern.
+
+## 2. First-run wizard — `/welcome`
+
+**Entry:** `GET /` redirects to `/welcome` while
+`AppSettings.setupCompletedAt IS NULL`. Any other page keeps working (no
+lock-in). "Skip setup" sets the flag; Overview shows a small "Finish
+setup →" chip while any step is incomplete (flag set or not).
+
+**Schema:** one nullable column `AppSettings.setupCompletedAt DateTime?`.
+Hand-written migration (gotcha 7). Nothing else is stored — see
+principle 2.
+
+### Step 1 — Connect AI
+
+- Auto-detect engines exactly as `/settings?tab=ai` does. If at least one
+  engine probes `ok`: run one tiny live test call on entry (same code as
+  the Test button), show "✓ Claude connected" and auto-advance. Zero
+  clicks for the README-follower who set one `.env` line.
+- If none detected: per-engine plain-language cards ("I have a Claude
+  subscription" / "I have a Gemini key — free tier works" / "OpenAI or
+  compatible"), each with the exact `.env` line to paste and a "Check
+  again" button. This is the weakest step for the non-technical persona
+  until Phase B lands:
+- **Phase B (separate stage, ADR required):** paste the API key directly
+  into the wizard/Settings, stored in the DB, masked like Telegram bot
+  tokens. Precedent: `TelegramTarget` tokens already live in DB rows and
+  CLAUDE.md's secrets rule carves that exception explicitly; ADR 0013
+  already resolves engine config DB-row-first with `.env` fallback. The
+  ADR extends both to per-engine keys. Dashboard binds to 127.0.0.1 by
+  default, which bounds the exposure. Until then the wizard shows the
+  `.env` path honestly.
+
+### Step 2 — Test the search (no AI, no profile needed)
+
+The user's core question — *"does job search actually work?"* — answered
+before any configuration, because this step spends no AI:
+
+- One button: **"Run a test search"**. It fetches from the enabled
+  sources, dedupes and stores jobs with `status NEW, fitScore null`,
+  **classification explicitly skipped** (new `{ classify: false }` seam
+  through `jobs/process-jobs.ts` — today a blank profile would send every
+  job to the AI, which is the expensive accident the pause exists to
+  prevent).
+- Runs in the web process as a background run with an in-flight guard and
+  `recordCronRun('fetch-test', …)` — the exact pattern of
+  `POST /settings/reclassify` (`src/web/routes/settings.tsx:710`) — with a
+  live progress page (auto-refresh, `src/web/target-runs.ts` pattern)
+  showing sources ticking as they answer.
+- Result screen: "✓ **312 jobs** found from **14 sources** in 40s. The
+  search works — now let's find the ones that match *you*." Counts come
+  from the run's `CronStats`.
+- Failure is honest: which sources answered, which errored, with a plain
+  retry. (Zero jobs from all sources ⇒ likely no network — say so.)
+- This button is **not wizard-only**: the same run gets a permanent home
+  as "Fetch now" on `/runs` (or Overview), closing the standalone P0 gap
+  for existing users too.
+
+### Step 3 — Your profile (from a resume)
+
+- One card: **"Upload your resume"** (file input; `.pdf .docx .md .txt`,
+  same accept-list as `/resumes`). Under it a quiet link: "no file handy?
+  answer three questions instead".
+- On upload: create the Resume row (first upload becomes default — logic
+  unchanged), run the scan with a progress page, then show a
+  plain-language summary card built from the existing
+  `buildProfileDraft` (ADR 0015 machinery, unchanged):
+  > "Looks like you're a **Senior Backend Engineer** — main tools
+  > **PHP, Laravel, MySQL**, plus 12 more skills. We'll hunt for senior
+  > backend roles using these."
+  Buttons: **"Yes, that's me — start matching"** (applies the draft to
+  the active profile and saves — one click, ADR 0015's
+  review-before-save is honoured because nothing persisted until this
+  click) and "Let me adjust" (jumps to `/settings?tab=profile` with the
+  draft rendered, today's flow).
+- The three-question fallback (no resume): main technologies (chips),
+  role words (chips), seniority (pills) — writes the same profile fields,
+  defaults for the rest. Nothing else is asked; regions/salary/etc. stay
+  defaults and live in Settings.
+- Auto-completes if the active profile already has stack or role types.
+
+### Step 4 — First matches
+
+- One button: **"Score the jobs we found"**. Classifies the stored
+  unscored jobs against the fresh profile using the existing re-classify
+  machinery, **capped to the most recent ~100** by `fetchedAt` (constant
+  to measure: cost vs wow; the rest catches up on the next cron ticks).
+  Same background-run + progress pattern as step 2.
+- Result screen: "**18 of 100** look like a match. Top 5:" — five rows
+  (title, company, match score) linking to `/jobs/:id`. Then one closing
+  action: **"Start the hourly watch"** → `setFetchingEnabled(true)`,
+  `setupCompletedAt = now()`, redirect to `/` with a flash.
+- Telegram is a quiet card on this final screen — "Want new matches on
+  your phone? Set up Telegram later in Settings → Notifications" — a
+  link, not a step. (Per product decision: Telegram is skippable;
+  AI + proven search + profile are the critical path.)
+- Auto-completes if a classified job already exists (returning user).
+
+**Click budget:** README-follower with a key in `.env`: step 1 = 0 clicks,
+step 2 = 1, step 3 = file pick + 1, step 4 = 2. **~4 clicks + one file
+pick** from install to watching real scored matches.
+
+## 3. Profile tab restructure
+
+Independent of the wizard; ships first as quick wins + one reorder.
+
+Quick wins (each < 1h):
+
+1. Remove the standalone "Re-classify all jobs" button from the top row —
+   "Save & re-classify" at the form foot already covers it.
+2. Real example placeholders in the three chip editors ("php, laravel,
+   mysql…" / "backend, full-stack…" / "docker, aws…") instead of three
+   identical "Add and press Enter…".
+3. Render the priority-rules warn hint only when rules are non-empty;
+   wrap the whole rules editor in its own nested `<details>`.
+4. Drop `minSalaryUsd > 0` (and `telegramTargetId`) from the
+   `advancedOpen` condition — notes/cities/rules only.
+5. Fix the header copy contradiction for this tab (the profile editor is
+   submit-to-save; say so, or scope the "saves on click" line to toggles).
+6. Overview: the "Pipeline paused" badge gains one explanatory line —
+   "paused on fresh install so a blank profile doesn't waste AI credit"
+   — linking to the wizard/checklist.
+
+Reorder (one PR):
+
+- Section order becomes: contextual warning (if any) → **Fill from a
+  resume** (now also accepting a direct file upload when no resumes
+  exist, killing the two-page round trip) → **profile editor** →
+  compact management row (select + Activate + New + Delete) at the
+  bottom. Drop the "Other profiles" table — the select is the one
+  mechanism.
+- Group the three chip fields under one "What are we hunting for?"
+  sub-heading with a two-line legend (languages/frameworks → required;
+  job-title words → role types) so the distinction is explained once,
+  not three times in fine print.
+
+## 4. Multi-resume search
+
+### Stage A — resume-linked profiles (small, no ADR)
+
+- `Profile.resumeId Int?` — "this search hunts jobs I'd apply to with
+  this resume". Hand-written migration.
+- One-click **"Create profile from this resume"** on `/resumes/:id` and
+  in the wizard's step 3 for second/third resumes: upload → scan →
+  draft → save as a *new linked profile* (activation unchanged).
+- Job page preselect: winning profile's resume when the link exists,
+  `pickResumeForJob` fallback otherwise.
+
+### Stage B — parallel search across active profiles (the big one, ADR)
+
+- Multiple **active** profiles replace the single `activeProfileId`
+  (keep it as "primary" for defaults, add `Profile.active Boolean`).
+- Base filter passes a job if **any** active profile admits it (pure
+  union — free).
+- **One classifier call per job, not N:** the prompt describes every
+  active profile; structured output returns
+  `[{ profileId, fitScore, fitReasons }]`. New table
+  `JobScore (jobId × profileId, fitScore, reasons…)`; `Job.fitScore`
+  keeps best-of for list sorting. AI spend stays ~flat (output grows,
+  calls don't). Prompt-cache-friendly: profiles are stable across a tick.
+- Alerts: one alert per job with the best profile named
+  ("Backend 87 · QA 41"); `Profile.telegramTargetId` **already exists**,
+  so each direction can notify its own chat with zero new schema.
+- UI: profile filter chips on `/jobs`; per-profile score row on
+  `/jobs/:id`; per-profile `minFitScore` gates its own alerts.
+- ADR covers: schema (JobScore, active flag), single-call multi-profile
+  prompt contract, alert routing, migration of existing `fitScore` rows.
+- Re-measure before building: prompt-size growth vs the two-stage
+  prefilter; cap on simultaneous active profiles (hypothesis: 5).
+
+### Stage C — remember the resume you applied with (small)
+
+- On "Mark applied": a resume select (preselected from the match card /
+  winning profile) writing `Job.appliedResumeId + appliedResumeVersion +
+  appliedResumeText` (text snapshot — bytes are replaced in place on
+  version bumps, so a bare FK would lie; `ResumeMatch.resumeText` is the
+  proven pattern).
+- Stale digest and the job page can then say "applied with Senior
+  Backend v3".
+
+## 5. Stage breakdown
+
+One feature = one branch = one PR = one tag (release-discipline).
+Verification per testing-gate; dashboard changes mean rebuild + curl +
+1200/768/375 screenshots + 0 console errors; schema changes mean
+hand-written migrations verified through a container rebuild.
+
+| # | Branch | Scope | Schema | ADR | Key verification |
+|---|--------|-------|--------|-----|------------------|
+| 1 | `profile-tab-quickwins` | §3 quick wins + reorder, inline upload in Fill card | — | — | dashboard matrix; profile save round-trip; chip editor no-JS path |
+| 2 | `fetch-now` | "Fetch now" button + `{classify: false}` seam + background run + progress page (standalone value) | — | — | smoke `fetch:once`; run visible on `/runs`; unscored jobs stored; dashboard matrix |
+| 3 | `welcome-wizard` | `/welcome` steps 1–4, redirect, skip, Overview chip | `setupCompletedAt` | — | migration via container rebuild; full wizard walkthrough on a wiped DB (docker volume rm) at 1200/375; every step's auto-complete branch |
+| 4 | `ai-key-in-db` | per-engine API key in DB, masked; wizard step 1 upgrade | engine-key column/JSON | **yes** (extends 0013 + secrets policy) | probe/test with DB key and with `.env` fallback; key never logged; masked render |
+| 5 | `profile-resume-link` | Stage A | `Profile.resumeId` | — | create-from-resume flow; preselect unit test in `pick.test.ts` scope |
+| 6 | `multi-profile-search` | Stage B | `JobScore`, `Profile.active` | **yes** | prompt/parser unit tests; live smoke on 2 profiles; alert routing test send; jobs-list filters |
+| 7 | `applied-resume` | Stage C | 3 columns on `Job` | — | mark-applied round-trip; digest line render test |
+
+Order rationale: 1–3 are the user-facing pain in the report and need no
+policy decisions; 4 unblocks the truly non-technical persona; 5–7 build
+the multi-resume story on top of a wizard that can then onboard several
+resumes in one sitting.
+
+## 6. Open decisions
+
+- Step-2 source subset: all enabled sources vs a fast-aggregator subset
+  (RemoteOK/Remotive answer in seconds; per-company boards add minutes).
+  Hypothesis: all enabled, with the progress page making the wait fun.
+- Step-4 classification cap (hypothesis 100 — measure cost/latency on
+  Haiku 4.5 two-stage vs single).
+- Whether "Fetch now" lives on `/runs`, Overview, or both.
+- Wizard copy voice pass (stop-slop skill) once screens exist.
+- Whether step 3 should offer multi-upload immediately or defer extra
+  resumes to `/resumes` until stage 5 lands.

--- a/docs/resumes-plan.md
+++ b/docs/resumes-plan.md
@@ -1,0 +1,243 @@
+# /resumes: page overhaul + on-demand resume strength review
+
+> **Analysis only — nothing implemented.** Written 2026-08-31 from a parallel
+> session (browser audit of the live page at desktop + 375px, plus code
+> verification) while `backlog-triage` was checked out with uncommitted work.
+> Do not start without checking §10/§11 status in [TASKS.md](./TASKS.md) first.
+> Companion TASKS.md section: §12.
+
+Two parts. **Part A** is a findings audit of the existing `/resumes` hub and
+`/resumes/:id` detail page. **Part B** is the design for the one genuinely new
+feature the owner asked for: an **on-demand "is this resume strong?" review**
+with visible progress and concrete make-it-stronger advice.
+
+---
+
+## Part A — /resumes page audit (verified 2026-08-31)
+
+### A.0 Facts established (don't re-derive)
+
+- `POST /resumes` awaits `scanResume` (~60 s AI call) before redirecting
+  ([routes/resumes.tsx](../src/web/routes/resumes.tsx) `POST /resumes`). The
+  browser sits on a frozen form; the submit button is never disabled, so a
+  second click creates a duplicate resume **and** a second AI call. Same
+  synchronous shape in `/resumes/:id/replace`, `/rescan` and `/draft`.
+- The async pattern already exists and is in daily use:
+  [target-runs.ts](../src/web/target-runs.ts) (in-memory registry, typed
+  `RunStep` union) + the polled progress page
+  [target-run.tsx](../src/web/pages/target-run.tsx) with per-step icons and
+  the violet rotating activity line (§6.2). Used by `/target`,
+  `/jobs/:id/match` and target re-upload — but not by resume upload/scan.
+- At 375px the hub table (`min-w-[52rem]` + `overflow-x-auto`) shows only
+  Name and a truncated Headline; Skills, Scanned and **both action buttons
+  are behind horizontal scroll** — effectively unreachable on a phone.
+- The `Table` primitive renders `th` from `columns: (string | JSX)[]`;
+  there is no way to put a responsive class on the `th` itself, so hiding
+  columns per breakpoint needs a small primitive extension
+  (`columns: {label, class}[]` or similar). A finding against the system,
+  recorded honestly.
+- Deleting a resume cascades `ResumeMatch` **and** `CoverLetter` (including
+  the user's manual `editedText`); the confirm says
+  "Delete this resume and its comparisons?" — letters are not mentioned.
+- The hub Skills column shows the first 6 of ~85 scanned `skills`; on the
+  two real resumes both rows read `php, go, javascript, typescript, sql…`
+  — zero differentiation. `Resume.primarySkills` (the 2–5 core stack,
+  [schema.prisma](../prisma/schema.prisma)) exists and is unused here.
+- No effectiveness signal on the hub: `ResumeMatch` holds count / latest /
+  best `matchScore` per resume (one `groupBy`), none surfaced.
+- `Resume.version` is shown on the detail header but not in the hub rows.
+- `POST /facts` ([routes/facts.ts](../src/web/routes/facts.ts)) already
+  accepts an arbitrary `term + decision + note + back` — a manual
+  "add fact" form and a status-flip button need **no new backend**.
+  Today a wrong answer can only be Forgotten, then the user waits for some
+  future comparison to re-ask.
+- There is no rename route — the name is fixed at upload forever, while a
+  resume on v5 is often no longer what its v1 name says.
+- `listOtherResumeSkills` (store.ts) already computes cross-resume skill
+  evidence; `CoverLetter` rows relate to `resumeId` but are reachable only
+  through each job's page.
+
+### A.1 Findings, prioritized
+
+| # | P | Finding | Fix (existing primitives) |
+|---|---|---------|---------------------------|
+| 1 | P0 | Upload & scan blocks the browser ~60 s, double-submit unguarded | Reuse the run registry: create resume → redirect to a run page (`steps: ['scan']`) → `resultUrl: /resumes/:id`. Same for replace/rescan. Add a `scan` label to the run-page step map if missing |
+| 2 | P0 | 375px row: actions + 3 of 5 columns off-screen | Remove Delete from hub rows entirely (it lives on the detail page; destructive actions shouldn't be one click from a list). Hide Headline/Skills below `sm:` — needs the `Table` th-class extension above. Result: Name / Scanned / Set default fits with no scroll |
+| 3 | P1 | Delete confirm understates blast radius (letters silently lost) | Confirm text mentions cover letters; ideally interpolate counts ("…, 12 comparisons and 3 letters") |
+| 4 | P1 | Skills column doesn't differentiate resumes | Show `primarySkills` as `Tag`s first, rest as `+N` |
+| 5 | P1 | No performance signal per resume | "Matches" column: count + best/latest score as `FitBadge` (number + meter, reads without colour) |
+| 6 | P2 | Version invisible in hub | `Badge tone="info"` `v{N}` next to the name, as on the detail header |
+| 7 | P2 | Facts: can't add or flip | Inline add form + per-row flip button over the existing `POST /facts` upsert |
+| 8 | P2 | No rename | `POST /resumes/:id/rename` + inline form on the detail header |
+| 9 | P3 | Polish | Filename mono line desktop-only (or `title` attr); facts grouped confirmed-first + `updatedAt` ("confirmed 2w ago"); absolute date in `title` on relative dates; `tabindex="0"` on the horizontal-scroll container |
+
+### A.2 Feature candidates beyond the strength review
+
+- **Score history per job across versions.** The detail hint already promises
+  "the history below shows how the score moves between versions", but
+  Comparisons is a flat list. Group by job, show `61 → 78` progressions
+  (data: `resumeVersion` + `createdAt`; deltas via
+  [diff.ts](../src/resume/diff.ts)). Closes the compare → edit → re-check
+  loop that is the product's core.
+- **Cover letters section on `/resumes/:id`** (job, tone, date, gate
+  verdict) — also makes the delete blast radius visible.
+- **Cross-resume skill diff** ("only in this resume / missing vs default")
+  from `listOtherResumeSkills` — answers "which resume do I send when the
+  posting wants X".
+- **"Fill profile from this resume" link on the detail page** — the flow
+  exists (ADR 0015) but is discoverable only via Settings and a one-time
+  flash line.
+- **Duplicate-upload guard**: sha256 over `original`, warn
+  "identical to v3 of Senior Backend PHP". Cheap; pairs with finding #1's
+  double-submit risk.
+
+---
+
+## Part B — On-demand resume strength review
+
+### B.1 Product intent (owner's requirements, 2026-08-31)
+
+1. Answer **"is this resume strong?"** and **"how do I make it stronger?"**
+   — the outcome the owner named: the candidate should read like the best
+   hire and a professional at their craft.
+2. **Strictly on-demand.** Never auto-run on upload; upload keeps its
+   current single scan. The review is a button the user presses.
+3. **Discoverable.** A real card with an explainer and a visible CTA — the
+   owner explicitly ruled out "an icon at the top nobody notices".
+4. **Visible progress.** While the review runs, show *what is being
+   checked*, step by step — the run-page pattern, not a spinner.
+
+### B.2 Relationship to what already exists (no duplication)
+
+| Existing | What it covers | What the review adds |
+|----------|----------------|----------------------|
+| `scan.ts` + `SCAN_SYSTEM` issues | Mechanical hygiene, job-agnostic: headings order, date formats, bullet counts, buzzwords, contact line, length, parser-breaking layout | A *judged rubric*: per-dimension grades with evidence, an overall strength score, prioritized rewrite advice, asks for missing metrics |
+| `parse-warnings.ts` | Deterministic ATS parseability of the extracted text | Feeds the review run as a free pre-step (no AI) |
+| `match.ts` / `score.ts` | Resume **vs one posting** | The review is deliberately job-agnostic — "strong for your role type", not "fits this job". Card copy must state this split ("to check against a posting, use Resume match on a job page") |
+| Detail card "Issues to fix (any job)" | Renders the scan's issues | Once a review exists for the current version, its advice list **subsumes** this card — one advice surface, not two competing lists |
+
+### B.3 Design decisions
+
+1. **The model never outputs the overall number** (ADR 0012, gotchas 8/11 —
+   every scoring prompt without hard caps inflates). The prompt marks
+   per-dimension **grades** (`strong | ok | weak`, each with 1–2 verbatim
+   evidence quotes); a pure `review-score.ts` maps grades → 0–100 with
+   hard caps in code (e.g. impact/quantification `weak` → cap 55; two or
+   more `weak` dimensions → cap 45 — exact caps tuned on the two real
+   resumes at implementation time). Unit-tested like `score.test.ts`, with
+   a gotcha-11-style guard: a duties-only, zero-numbers resume must not
+   score high.
+2. **Rubric dimensions** (each graded, each with evidence):
+   - *First impression* — headline + summary: does a recruiter know in 10
+     seconds who this is and at what level?
+   - *Impact & quantification* — achievements vs duties; numbers, outcomes
+     (revenue, cost, speed, reliability, users, time saved).
+   - *Seniority signal* — scope, ownership, leadership, decisions; does the
+     language match the claimed level?
+   - *Clarity & structure* — density, section order, bullet quality, length
+     (parse-warnings results injected as deterministic context).
+   - *Role-type keyword coverage* — against the resume's own scanned
+     `roleTypes` (job-agnostic), not against any posting.
+   - *Red flags* — clichés, weak verbs, buzzword stuffing, unexplained
+     gaps *as presented* (never speculating about the person).
+3. **Honesty boundary — "look like the best professional" ≠ invent facts.**
+   The pitch is achieved by *reframing and quantifying what the text
+   already supports*, never by fabrication (the same stance as the letter
+   gate, ADR 0020/0021). Concretely: advice items may (a) rewrite using
+   only facts present in the resume, or (b) carry an explicit
+   `ask: "how many users / what % / team size?"` instead of an invented
+   number. Example rewrites in advice run through `factCheck` before
+   persisting; a blocked rewrite degrades to the ask form.
+4. **Prompt discipline**: new `REVIEW_SYSTEM` builder in
+   [prompts.ts](../src/resume/prompts.ts) with its own `PROMPT_VERSION`
+   stamp; fenced via `fence()` (ADR 0022 — the registry test
+   `prompt-fence-registry.test.ts` will fail CI until it is covered).
+   Tool-free (ADR 0009). Web-only (ADR 0008) — the worker never imports it.
+5. **Storage**: new `ResumeReview` table mirroring `ResumeMatch`
+   conventions — `resumeId`, `resumeVersion`, `model`, `promptVersion`,
+   `grades Json`, `advice Json`, `strengths Json`, `asks Json`,
+   `breakdown Json` (deterministic, from `review-score.ts`), `createdAt`.
+   One row per run (keep history) → strength trend across versions comes
+   free. Hand-written migration (gotcha 7).
+6. **Engine/model**: reuse the `resume` role in the engine chain initially;
+   add a per-engine `review` slot only if quality demands it (the
+   cover-letter precedent: empty inherits).
+7. **Cost honesty in copy**: "one AI call, ~1–2 min"; counted in `aiUsage`.
+8. **ADR required at implementation** (adr-writer triggers: new AI call
+   site + new table): scope, rubric-caps rationale, the asks-not-inventions
+   rule.
+
+### B.4 UX
+
+- **`/resumes/:id` — "Resume strength" card** (the discoverability
+  requirement):
+  - *Before the first run*: an explainer state, not an `Empty` one-liner —
+    what the review checks (the six dimensions, in plain words), what the
+    user gets (score + prioritized advice), the cost line, and a violet
+    **"Run strength review"** button (violet = AI action, DESIGN.md).
+  - *After*: overall score in the `FitBadge` number+meter style;
+    per-dimension rows (grade badge + one-line why + evidence quote);
+    prioritized advice list (issue → why it matters → how to fix →
+    example rewrite *or* metric ask); "strengths to keep" so the user
+    doesn't edit away what works; meta "reviewed v3 · 2d ago" + Re-run.
+  - *Staleness*: when `resume.version > review.resumeVersion`, a warn
+    badge — "review is for v3, resume is at v5 — re-run".
+- **Hub surfacing** (`/resumes`): a Strength column — score badge when
+  reviewed, otherwise a quiet "not reviewed" link to the detail card. The
+  upload success flash gains one sentence pointing at the review. **No
+  auto-run anywhere.**
+- **Progress** (the visible-steps requirement): the same run registry —
+  extend the `RunStep` union with `review`; steps render as
+  `Extract ✓ → ATS checks ✓ → Strength review … → Save`, and the violet
+  activity line rotates through the rubric dimensions ("checking impact &
+  quantification…", "checking seniority signal…") exactly like §6.2's
+  prompt-checklist rotation. Terminal state redirects to the detail card
+  with a flash.
+- **Metric-ask loop** (phase 3): advice asks render the existing
+  ask_user-style confirm UI; answers persist (a `CandidateFact` note or a
+  review-local answer store — decide at implementation) and a Re-run folds
+  them into rewrites. This is how "best professional" is reached honestly:
+  the numbers come from the user, the wording from the model.
+
+### B.5 Phasing (one feature = one branch = one PR)
+
+1. **`resumes-page-p0`** — Part A #1–#5: async upload/replace/rescan via
+   the run registry, mobile row fix (+ `Table` th-class extension),
+   delete-confirm blast radius, `primarySkills` column, Matches column.
+   P2/P3 items ride along only where the diff already touches them.
+2. **`resume-strength`** — Part B MVP: `REVIEW_SYSTEM` + zod schema + pure
+   reply parser + pure `review-score.ts` caps + `ResumeReview` migration +
+   run-page step + detail card + hub column + ADR.
+3. **`resume-strength-loop`** — metric asks → answers → re-run deltas;
+   version-over-version strength trend on the detail page (pairs naturally
+   with A.2's grouped score history).
+
+### B.6 Verification matrix (testing-gate)
+
+- **Pure**: reply-parser test; `review-score` cap tests including the
+  duties-only guard; fence registry test picks up the new builder
+  automatically.
+- **Schema**: hand-written migration, reviewed before `migrate dev`.
+- **Dashboard**: rebuild; screenshots 375 / 768 / 1200 of hub, detail card
+  (both states), run page; a live run against both real resumes — sanity:
+  the two should NOT land on the same score if the rubric discriminates.
+- **Prompt quality**: one weak-vs-strong gold fixture pair through
+  `bench:resume`-style smoke only if prompt iteration proves necessary
+  (§F9 reasoning — don't build eval infrastructure ahead of need).
+
+### B.7 Risks / open questions
+
+- **Grade inflation** is the known failure mode of every scoring prompt in
+  this repo (gotchas 8, 11) — the caps live in code and get a guard test,
+  or the feature ships flattery instead of advice.
+- **Advice hallucination**: the asks-not-inventions rule plus `factCheck`
+  on example rewrites; manual spot-check on the live resumes before PR.
+- **Overlap with the scan's issues card**: resolved by subsumption (B.2) —
+  decide the exact rendering when building the card, but never show two
+  competing advice lists.
+- **In-memory runs**: a web restart forgets an in-flight review (accepted
+  behaviour for /target already — ADR 0003 philosophy, no queue).
+- **Tone**: advice must stay recruiter-practical ("state the outcome of
+  the migration in numbers"), not generic career-coach filler; the
+  stop-slop pass applies to the card copy and the prompt's advice style
+  rules.

--- a/docs/target-plan.md
+++ b/docs/target-plan.md
@@ -1,0 +1,344 @@
+# /target compare flow: speed (30-40 s target) + keyword-matching accuracy
+
+> **Analysis only — nothing implemented.** Written 2026-08-31 from a parallel
+> session (full source pass over the compare pipeline: `src/web/routes/target.tsx`,
+> `jobs.tsx`, `src/resume/{match,scan,prompts,score}.ts`, `src/web/public/{target,score,target-page}.mjs`,
+> `src/ai-{runtime,provider}.ts`, `src/jobs/{manual-job,posting-extract,classify-existing}.ts`)
+> while `backlog-triage` was checked out with uncommitted work from other
+> sessions. Do not start without checking §10–§12 status in
+> [TASKS.md](./TASKS.md) first. Companion TASKS.md section: §13.
+>
+> All latency numbers below are **starting hypotheses** — the code paths and
+> serialization are verified facts, the seconds are estimates to re-measure
+> (see §2.3) before and after each change.
+
+Two asks from the owner:
+
+- **A. Speed.** A compare should land in **30-40 s**. Today a fresh-resume
+  compare takes ~3 min. Find what can be cached after the first run, what can
+  run in parallel, what can be skipped — including a "keywords only, don't
+  rewrite my bullets" mode.
+- **B. Accuracy.** Some important words from the posting are never
+  highlighted. Audit the matcher end-to-end, add keyword prioritization,
+  cross-check against current resume-vs-JD best practice.
+
+---
+
+## 1. The pipeline as written (facts established — don't re-derive)
+
+Four entry points share the same building blocks:
+
+| Entry point | Steps (serial, in order) | Where |
+| --- | --- | --- |
+| `POST /target` (new compare) | resolve resume inline → **[extract] → classify → match** | [routes/target.tsx](../src/web/routes/target.tsx) |
+| `POST /jobs/:id/target/reupload`, named resume | **scan → match** | [routes/jobs.tsx](../src/web/routes/jobs.tsx) `reupload` |
+| `POST /jobs/:id/target/reupload`, scratch resume · `POST /jobs/:id/match` (Compare / Re-analyze) | **match** only | same file |
+| `POST /resumes` (upload on /resumes) | **scan**, fully synchronous — browser sits on the frozen form | [routes/resumes.tsx](../src/web/routes/resumes.tsx); already covered by §12 / [resumes-plan.md](./resumes-plan.md), not re-planned here |
+
+Per-step facts:
+
+| Step | Call | Role → default model | maxTokens (out) | Notes |
+| --- | --- | --- | --- | --- |
+| extract | `extractPostingFacts` | classifier → **Haiku 4.5** | 250 | Only when company/title/location left empty; reads first 6 000 chars |
+| classify | `createManualJob` → `classifyExistingJob` | classifier → Haiku 4.5 | 600 | **Two calls** when `classifierMode = two_stage` (prefilter 100 tok + full 600 tok). Re-pasting the identical posting dedupes → classify skipped |
+| scan | `scanResume` | resume → **Opus 5** (`CLAUDE_MODEL_RESUME` default `claude-opus-5`) | 3 000 | 5-min timeout, `PARSE_ATTEMPTS = 2` |
+| match | `matchResumeToJob` | resume → **Opus 5** | **8 000** | 5-min timeout, `PARSE_ATTEMPTS = 2`. Input ≈ 30 000 resume chars + 15 000 posting chars + ~2.5 k-token system prompt ≈ **~15 k input tokens**; real output ~2.5-4 k tokens (≤25 keywords × {term, aliases, where, note} + ≤10 actions with ≤200-char quotes + ≤8 removals with quotes + gates + strengths + cautions) |
+
+Independence facts (the levers everything in §3 stands on):
+
+- **`match` never reads the classification.** The fit score feeds the jobs
+  list / job card, not the compare result. `createManualJob` already has a
+  `{classify: false}` seam — the cover-letter flow uses it (F8.3).
+- **`match` never reads the scan.** The scan feeds `/resumes/:id`, `pick.ts`
+  preselection, profile drafts, and `listOtherResumeSkills` *for other
+  resumes' future matches* — never the match that runs next to it.
+- **The keyword frame is already half-cached.** `matchResumeToJob` loads the
+  latest match of the same job and passes up to 40 `previousKeywords`
+  (term + priority + requirement + primary) so re-runs reuse the frame and
+  scores stay comparable. But the model still re-reads the full posting and
+  re-emits every keyword row — the cache saves *stability*, not *time*.
+- **A parse failure silently doubles a step.** Both scan and match retry the
+  identical prompt once on schema mismatch (`PARSE_ATTEMPTS = 2`); on Opus
+  that is +1-2.5 min of invisible tail latency.
+- **Engine choice dominates constants.** `anthropic_api` is one HTTPS call
+  with a prompt-cached system block. `claude_code` spawns a process per call
+  with ~5 k tokens of CLI system prompt and no cross-call reuse
+  ([ai-provider.ts](../src/ai-provider.ts) docstring) — add ~10-30 s *per
+  call*; a two-stage first compare is then **4 serial CLI spawns**
+  (extract + prefilter + classify + match).
+- The run registry ([target-runs.ts](../src/web/target-runs.ts)) is solid —
+  polling page, per-step icons. Its copy undersells reality: `STEP_VIEW`
+  promises "about a minute" for scan and match; the reupload menu says
+  "about 2 minutes"; on Opus + CLI both are optimistic.
+
+## 2. Where the ~3 minutes go
+
+### 2.1 Latency model
+
+Interactive wall time ≈ Σ over serial calls of
+(*provider overhead* + *input processing* + **output tokens ÷ output speed**).
+Output tokens dominate: match emits 2.5-4 k tokens and Opus streams roughly
+25-50 tok/s, so **the match call alone is ~60-160 s on Opus** regardless of
+everything else. Sonnet-class output speed (~2-3×) puts the same call at
+~30-70 s; Haiku-class at ~20-40 s.
+
+### 2.2 Scenario estimates (hypotheses; API engine vs claude_code CLI)
+
+| Scenario | Serial chain today | est. API/Opus | est. CLI/Opus |
+| --- | --- | --- | --- |
+| First compare on /target (fields empty, two-stage on) | extract → prefilter → classify → match | ~90-200 s | **~150-300 s** ← the reported "~3 min" |
+| Re-upload new version of a named resume | scan → match | ~100-250 s | ~150-300 s |
+| Re-analyze / Compare (match only) | match | ~60-160 s | ~90-200 s |
+
+### 2.3 Measure before optimizing
+
+`resume: matched` already logs `ms`. Add the same `ms` field to the
+scan / extract / classify log lines and log a per-stage delta in
+`updateRun` (`stageAt` already exists) — one log pass over a week of real
+runs replaces every estimate above. No schema change.
+
+---
+
+## 3. Speed plan
+
+### 3.1 P0 — same calls, different order (no prompt, no schema changes)
+
+1. **Take classify off the critical path on /target.**
+   `createManualJob({ classify: false })`, then run `classifyExistingJob`
+   fire-and-forget *in parallel* with `matchResumeToJob`. The compare result
+   never shows the fit score; the job card gets it a minute later. The run
+   page drops the classify step (or marks it "in background").
+   Saves the full classify leg: ~5-40 s API, ~20-90 s CLI/two-stage.
+2. **Take scan off the critical path on reupload.** In the named-resume
+   branch start `matchResumeToJob` immediately and let `scanResume` finish in
+   the background (`void` + logged failure). Known cost: `Resume.skills`
+   stays one version stale until the background scan lands (affects only
+   *other* resumes' "elsewhere" hints and /resumes display; `scannedAt:
+   null` already marks it). Saves ~40-90 s.
+3. **Memoize identical work.** Before calling the AI, if the latest
+   `ResumeMatch` for (jobId, resumeId) has `resumeText` identical to the
+   input text (and the same `PROMPT_VERSION`), return the stored row and
+   flash "unchanged since the last analysis" (with a "re-run anyway"
+   escape). Kills the double-submit / back-button / re-paste full-price
+   re-run. A plain string compare — no schema change.
+4. **Honest progress copy.** `STEP_VIEW` durations from measured p50/p90
+   (§2.3), per-step elapsed seconds on the run page. Perceived speed counts;
+   "about a minute" that takes three reads as broken.
+
+P0 alone turns the first-compare chain into a single match-length wait
+(~60-160 s on Opus). Not 30-40 s yet — that needs P1.
+
+### 3.2 P1 — the fast lanes the owner asked for
+
+5. **Instant check, zero AI (the "тільки перевірити ключові слова" mode).**
+   Everything needed already exists in the browser: the target editor
+   re-scores any text against the stored keyword frame live
+   (`target.mjs` + `score.mjs`, same formula as the server). Missing is only
+   the entry point: today "Re-upload resume" *forces* a full AI run.
+   Add a parse-only path: upload → `extractResumeText` (pure, <1 s) →
+   render `/jobs/:id/target` with the new text loaded as a **dirty draft**
+   over the previous match's frame — live estimate, missing-keyword chips
+   and highlights appear in **~2-5 s**, and "Re-analyze with AI" (already on
+   the page) upgrades it to an official score on demand. Also covers
+   "new resume vs already-analyzed job" on /target when the posting dedupes
+   to an existing job with a match.
+   *Limit to be honest about:* textual presence can verify `present`, but
+   only the AI can judge `add` / `ask_user` / `cannot_claim` for a *new*
+   resume, so the estimate inherits the previous resume's statuses — label
+   it "estimate vs the frame from &lt;date&gt;", exactly like the live
+   editor does today.
+6. **Fast AI mode — keywords-only prompt.** A `MATCH_SYSTEM` variant that
+   returns only `summary` (one line), `alignment`, `red_flags`,
+   `hard_requirements`, `keywords` — **no actions, no removals, no
+   strengths/cautions**. That is the score-complete subset
+   (`scoreMatch` needs exactly keywords + alignment + flag count) at ~¼ of
+   the output tokens → ~20-40 s even on Opus, ~10-20 s on Sonnet.
+   Suggestions become a lazy second call ("Get suggestions" on the target
+   page) that reuses the stored keyword frame. Needs: prompt variant +
+   schema subset in `prompts.ts`, a `mode` flag on `matchResumeToJob`,
+   `PROMPT_VERSION` handling, guard tests (gotcha 11 rules must survive in
+   the short prompt verbatim).
+7. **Bench Sonnet for the resume role.** ADR 0012 moved all arithmetic into
+   `score.ts`; the model only marks facts — precisely the setup where a
+   faster model loses least. Run the existing gold bench both ways
+   (`CLAUDE_MODEL_RESUME=claude-sonnet-5 npm run bench:resume` vs Opus),
+   compare keyword/status/alignment agreement. If it holds: flip the
+   default (or document the per-engine "Resume model" select on /settings
+   as the speed dial — the UI already exists). Likely the cheapest big win:
+   ~2-3× on every scan/match with zero code.
+
+### 3.3 P2 — structural (only if P0+P1 measurements still miss the target)
+
+8. **First-class per-job keyword frame.** Split the mega-call: call A
+   (per job, cached until "Rebuild keywords") extracts the frame —
+   keywords + requirement/primary + hard gates; call B (per resume ×
+   version) judges statuses/aliases/where + alignment against a posting
+   *summary* instead of the full text. Smaller input AND output on every
+   re-compare; the frame becomes the artifact §4/§5 hang priorities and
+   overrides on. Needs an ADR (new AI call site; frame stored either as the
+   latest-match JSON formalized, or a `JobKeywordFrame` column/table).
+9. **Streaming partial render** (API engine only) — show keywords as they
+   arrive. Real work in the run-page plumbing, CLI engines can't join.
+   Defer.
+
+Explicit non-goals: no queues/Redis (ADR 0003), no worker involvement, no
+second HTTP server.
+
+### 3.4 Does it reach 30-40 s?
+
+| Scenario after the plan | Chain | est. wall time |
+| --- | --- | --- |
+| Re-upload vs analyzed job, instant check (5) | parse only | **~2-5 s** |
+| Quick AI check (6) on Sonnet (7) | match-lite | **~10-25 s** ✅ |
+| Quick AI check (6) on Opus | match-lite | ~20-40 s ✅ (borderline) |
+| Full analysis, Sonnet, P0 ordering | match | ~30-70 s (close; suggestions arrive with it) |
+| Full analysis, Opus, P0 ordering | match | ~60-160 s — becomes the explicit "thorough" tier |
+
+The 30-40 s promise is kept by making **quick check the default reaction**
+to "new resume/version" and full analysis an explicit, honestly-labeled
+upgrade — not by making Opus emit 4 000 tokens faster.
+
+---
+
+## 4. Keyword highlighting audit — why important words are missed
+
+How it works today: the AI emits ≤~25 verbatim keywords with aliases;
+[target.mjs](../src/web/public/target.mjs) `findTerm` does literal
+whole-token search (lowercase, whitespace-flexible inside a term,
+lookarounds so "C" ≠ "C++", "Java" ≠ "JavaScript"); `jobSpans` /
+`resumeSpans` paint every occurrence. **Anything not in the keyword list, or
+spelled differently than the list says, is invisible.** Failure modes, most
+frequent first:
+
+- **F1 — the list is capped, so terms drop out entirely.** `MATCH_SYSTEM`
+  says "at most ~25 keywords" (schema allows 80) and NOISE rules skip whole
+  sections. A posting with 30+ real terms loses the tail — usually
+  `nice`/`context` items like a secondary tool — and the JD pane shows an
+  obviously-technical word with no mark, which reads as a bug.
+  *Fix:* tiered budget in the prompt — **every** `must` and `preferred`
+  term always listed, the ~25 soft cap applies only to `nice`/`context`;
+  plus F8 as the safety net.
+- **F2 — non-verbatim terms render nowhere.** The VERBATIM rule lives only
+  in the prompt; when the model paraphrases ("REST APIs" for a posting that
+  says "RESTful services"), `findTerm` finds 0 spans in the posting — row in
+  the table, nothing highlighted. *Fix (deterministic, persist-time):* run
+  `findTerm(term+aliases, posting)` in `match.ts` after parsing; on 0 hits
+  try to anchor (locate the closest verbatim span, à la `locateQuote`) and
+  repair the term, else mark the row `unanchored` and log it — that log is
+  the regression metric for every future `PROMPT_VERSION` bump.
+- **F3 — aliases depend on the model remembering them.** The prompt begs
+  for resume-side spellings; when it forgets one, a present skill shows as
+  missing (the in-code comment admits this). *Fix:* a deterministic synonym
+  table in a pure module (`src/resume/keyword-aliases.ts`), unioned into
+  every keyword at persist time next to `applyFacts`: node/node.js/nodejs,
+  go/golang, postgres/postgresql, js/javascript, ts/typescript,
+  k8s/kubernetes, react/react.js/reactjs, next.js/nextjs, vue/vue.js/vuejs,
+  express/express.js, .net/dotnet, aws/amazon web services, gcp/google
+  cloud, ci/cd ↔ continuous integration/delivery, docker-compose/docker
+  compose, oop, tdd… (~100-200 curated pairs, tested). Bonus: the prompt can
+  then ask for *fewer* model-emitted aliases → fewer output tokens (§3
+  win from the same change).
+- **F4 — zero morphology.** "microservice" ≠ "microservices", "API" ≠
+  "APIs". *Fix:* plural tolerance only — optional `(?:e?s)?` suffix in
+  `termPattern` for letter-ending terms ≥4 chars. No stemming beyond that
+  (false-positive risk); irregular pairs go into the F3 table.
+- **F5 — separator variants.** "CI/CD" ≠ "CI / CD" ≠ "CI-CD";
+  "front-end" ≠ "front end" ≠ "frontend"; "Node.js" ≠ "NodeJS". *Fix:* in
+  `termPattern`, make separators between alphanumeric tokens of a
+  multi-token term interchangeable (`[\s/.\-]*`), with table-driven tests
+  enumerating each pair (target.mjs is the single implementation — browser
+  and node:test share it, nothing to mirror).
+- **F6 — granularity mismatch.** Model says "Node", posting says "Node.js":
+  the `(?!\.\w)` lookahead (correctly) refuses the partial hit, and with no
+  alias the term highlights nowhere. Covered by the F3 table in both
+  directions.
+- **F7 — a bad frame is sticky.** CONSISTENCY ACROSS RUNS + `previousKeywords`
+  deliberately freeze the term list per posting, so a term missed on run 1
+  stays missed on every later run. *Fix:* a "Rebuild keywords" action that
+  skips `previousKeywords` once, and an automatic skip when the stored
+  frame's `PROMPT_VERSION` is older than current.
+- **F8 (optional safety net) — deterministic lexicon sweep.** A pure module
+  with a few hundred known tech terms scans the posting for anything absent
+  from the AI list and shows them as neutral **unrated** marks (never
+  scored) with one-click "count this keyword" (feeds §5 overrides). This
+  makes "an important word was skipped" structurally impossible for known
+  tech vocabulary; the cost is curating the lexicon.
+
+Minor/by-design, to document rather than fix: overlapping spans keep the
+earlier-starting mark (cosmetic); benefits/EEO/marketing text is *deliberately*
+never keyworded (NOISE rule) — worth one line in the pane legend so it stops
+looking like a miss.
+
+## 5. Keyword priorities — present vs missing
+
+Already there: `priority` 1-4, `requirement` must/preferred/nice/context
+with deterministic weights 3/2/1/0, `primary` flag + score cap, chips sorted
+by priority, KeywordTable problems-first sorted hardest-requirement-first.
+
+Worth adding (all deterministic, no AI):
+
+- **User overrides per keyword** — the actual "виставляти пріоритет вручну":
+  re-level requirement (must ↔ preferred ↔ nice ↔ context), exclude a term
+  as noise, add an own term. Stored in the match's `keywords` JSON, score
+  recomputed via the existing `updateMatchScoring` path (same machinery as
+  ask_user fact flips — instant, free). Overrides carried into the next
+  run's `previousKeywords` so they stick per posting.
+- **Visual weight in the panes.** Today a missing `must`/`primary` term and
+  a missing `nice` term get the same yellow. Encode weight: stronger
+  border/intensity for must+primary, muted for nice/context; legend update.
+- **Frequency as a tiebreaker.** Count each term's occurrences in the
+  posting (`findTerm` already returns spans) — sort equal-weight keywords by
+  it and show "×4 in the posting" in the tooltip. Matches the
+  "mentioned-multiple-times matters" practice at zero AI cost.
+
+## 6. Best-practice cross-check
+
+Current guidance (Jobscan, uppl.ai, PassTheScan, TailorCV, ResumeAdapter,
+2026 editions) vs this codebase:
+
+| Practice | Status here |
+| --- | --- |
+| Mirror the posting's exact wording (ATS exact-match reality) | ✅ VERBATIM rule + literal matcher — enforce it deterministically (F2) |
+| 15-25 targeted keywords, not exhaustive stuffing | ✅ cap exists — tier it so `must`/`preferred` never fall off (F1) |
+| Must-have vs nice-to-have weighting | ✅ requirement weights 3/2/1/0 (ADR 0012) |
+| Placement/evidence weighting (summary, title, recent role > skills list) | ✅ alignment grades carry 40 pts; `where` per keyword |
+| Synonym/semantic tolerance (Workday/Greenhouse-class ATS now match variants) | ⚠️ model-dependent aliases → make deterministic (F3-F5); embedding-based semantic matching noted as a possible future tier, **out of scope** now |
+| No invented experience / no stuffing advice | ✅ NO TREADMILL + cannot_claim + fact gate |
+| Frequency of a term signals importance | ❌ cheap add (§5) |
+
+Verdict: the architecture already matches best practice; the deltas are
+**determinism** (aliases, morphology, verbatim enforcement) and **user
+control** (priority overrides) — not a redesign.
+
+Sources: [jobscan.co](https://www.jobscan.co/blog/top-resume-keywords-boost-resume/),
+[uppl.ai](https://www.uppl.ai/ats-resume-keywords),
+[passthescan.com](https://www.passthescan.com/blog/ats-resume-keywords-2026-complete-guide),
+[thetailorcv.com](https://thetailorcv.com/blog/resume-matching-with-job-description-complete-guide),
+[resumeadapter.com](https://www.resumeadapter.com/blog/ats-keywords-list).
+
+## 7. Implementation order (one branch = one PR each, per commit-discipline)
+
+1. `target-speed-p0` — §3.1 items 1-4 + §2.3 timing logs. No schema, no
+   prompt bump. Verification: measured before/after ms per scenario, run
+   page screenshots.
+2. `keyword-matcher-v2` — F2 verbatim guard + F3 alias module + F4/F5
+   pattern tolerance + tests (table-driven pairs in `target.test.ts`,
+   alias-module unit tests). Pure-module work; `PROMPT_VERSION` untouched
+   (post-processing).
+3. `target-instant-check` — §3.2 item 5 (parse-only reupload → dirty draft
+   in the editor). UX copy honest about "estimate vs frame".
+4. `match-fast-mode` — §3.2 items 6-7: keywords-only prompt variant +
+   `bench:resume` Sonnet-vs-Opus numbers + default/model-select decision.
+   `PROMPT_VERSION` bump; gotcha-11 guard tests extended to the short
+   prompt. Possibly an ADR (second match mode).
+5. `keyword-priority-ui` — §5 overrides + visual weight + frequency. Reuses
+   `updateMatchScoring`; ADR only if overrides outgrow the keywords JSON.
+6. (only if measurements demand) `match-split-frame` — §3.3 item 8 + ADR.
+
+## 8. Open questions for the owner
+
+- After the bench: flip the resume-role default to Sonnet, or keep Opus and
+  surface a "fast/thorough" choice per compare?
+- Should reupload land on the instant check by default (AI never auto-runs),
+  or instant check + full analysis auto-started in the background?
+- Is the F8 curated lexicon worth its maintenance, or are F1-F7 enough?


### PR DESCRIPTION
Docs-only: commits the three parallel-session analysis plans and their TASKS.md sections so the working tree is clean for the §10 implementation session.

- **§11** onboarding wizard + profile simplification + multi-resume search → [docs/onboarding-plan.md](docs/onboarding-plan.md)
- **§12** /resumes overhaul + on-demand resume strength review → [docs/resumes-plan.md](docs/resumes-plan.md)
- **§13** /target compare speed (30-40s target) + keyword-matcher accuracy → [docs/target-plan.md](docs/target-plan.md)

All three are explicitly analysis-only (nothing implemented) and coordinate against §10's status. No code, no schema.

## Release notes draft
No tag — docs-only per release-discipline; rides with the next minor.