### PR TITLE
applications board redesign

### DIFF
--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -13,7 +13,8 @@ consistency, accessibility and perceived quality.
 
 - Single user, uses it daily, often on a phone between other things.
   Speed of reading beats decoration. Dense tables are the product.
-- Dark-only, token-driven: colours come from `src/web/layout.tsx`
+- Light theme (paper-gray ground, white surfaces — PR #12), token-driven:
+  colours come from `src/web/layout.tsx`
   (`surface / line / ink / accent / ok / warn / danger / info / violet`) and
   every page composes primitives from `src/web/ui.tsx`. A finding that
   needs a new raw hex or a page-local component is a finding against the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -257,6 +257,7 @@ src/
     public/target.mjs         ← browser keyword matcher (pure ES module, node-tested)
     public/score.mjs          ← browser mirror of resume/score.ts (parity-tested, ADR 0012)
     public/cover-letter.mjs   ← copy-to-clipboard for the letter card (import-smoke-tested)
+    public/board.mjs          ← /applications drag-and-drop over POST /jobs/:id/stage (planMove tested)
 
     pages/
       overview.tsx              ← /

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -262,7 +262,7 @@ src/
       overview.tsx              ← /
       jobs-list.tsx             ← /jobs
       job-detail.tsx            ← /jobs/:id
-      applications.tsx          ← /applications (kanban)
+      applications.tsx          ← /applications (board + quick-move + closed panel)
       companies.tsx             ← /companies
       starter-pack.tsx          ← pack picker card + preview + import result
       discovery.tsx             ← /discovery
@@ -285,7 +285,7 @@ src/
       target.tsx                ← /target launcher: resume resolve + manual job + match in one POST
       letter.tsx                ← /letter launcher: job + resume resolve → [extract→classify→match→verify]→letter run
       resumes.tsx               ← upload (5 MB limit) + scan + default + delete + download
-      applications.tsx          ← kanban + per-job application form
+      applications.tsx          ← board + stage-only quick-move + per-job application form
       companies.tsx              ← list + new (probe-validated) + delete + toggle + starter packs
       discovery.tsx             ← list + promote + ignore + delete + manual probe
       runs.tsx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@ All notable changes to this project are documented here. The format follows
 ## [1.3.0] — 2026-09-01
 
 ### Added
-- **Quick-move on the `/applications` board** (TASKS §10): every card
-  carries a stage select + Move button (plain form, works without JS).
-  The new stage-only endpoint writes the `JobStageEvent` ledger row in
-  the same transaction and never touches appliedAt / recruiter / notes —
+- **Drag-and-drop on the `/applications` board** (TASKS §10): drag a card
+  into a column and the stage changes on drop — optimistic move, then the
+  page re-renders from the server with a confirmation flash; on failure
+  the card snaps back with an error notice. Dragging over the collapsed
+  Closed panel opens it, so a card can be dropped straight onto Rejected
+  or Ghosted. Dependency-free ES module (`src/web/public/board.mjs`),
+  desktop pointers only — phones and no-JS keep the form path below.
+- **Quick-move on every card** (the keyboard / no-JS path): a stage
+  select + Move button as a plain form. With drag active it stays out of
+  the way — collapsed until the card is hovered or keyboard-focused. The
+  new stage-only endpoint writes the `JobStageEvent` ledger row in the
+  same transaction and never touches appliedAt / recruiter / notes —
   those still belong to the tracking card on the job page.
 - **Time-in-stage on cards**: "in screen 12d" from the ledger (falls back
   to "applied Nd ago" where no real event dates the stage), absolute date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-09-01
+
+### Added
+- **Quick-move on the `/applications` board** (TASKS §10): every card
+  carries a stage select + Move button (plain form, works without JS).
+  The new stage-only endpoint writes the `JobStageEvent` ledger row in
+  the same transaction and never touches appliedAt / recruiter / notes —
+  those still belong to the tracking card on the job page.
+- **Time-in-stage on cards**: "in screen 12d" from the ledger (falls back
+  to "applied Nd ago" where no real event dates the stage), absolute date
+  in the tooltip, and a warn-tone "· stalled" once a non-terminal stage
+  sits still past 14 days. Backfilled history never dates a stage — same
+  honesty rule as the funnel math.
+
+### Changed
+- Board columns cap at 70% of the viewport and scroll internally — with
+  a hundred cards in one stage the page stays one screen tall instead of
+  ~13,000&nbsp;px, and the funnel stats are visible without a journey.
+- Rejected and Ghosted moved off the board into a collapsed **Closed**
+  panel below it (with the same cards and quick-move for revivals), so
+  the five work columns fit a laptop width.
+- On phones the board stacks into one stage-grouped list with count
+  chips that jump to each stage.
+- Board detail pass: header meta reads "N active · M closed", the Onsite
+  column dot no longer shares its colour with Tech, calibration cells
+  shorten "— (n=0, need 5)" to "— (0/5)".
+
 ## [1.2.0] — 2026-09-01
 
 ### Fixed
@@ -498,7 +525,8 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
-[Unreleased]: https://github.com/nazboyko/applypack/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/nazboyko/applypack/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/nazboyko/applypack/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/nazboyko/applypack/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/nazboyko/applypack/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/nazboyko/applypack/compare/v0.11.1...v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | Re-classify all jobs against new profile | `/settings` Profile tab → "Re-classify all jobs" (async, watch /runs) |
 | Telegram on/off | `/settings` Notifications tab |
 | Add Telegram bot or chat | `/settings` Notifications tab → "Add target" (validates with getMe + sendMessage) |
-| Pipeline stage on a job | `/jobs/:id` → "Application tracking" card |
+| Pipeline stage on a job | `/jobs/:id` → "Application tracking" card, or the quick-move select on `/applications` cards (stage-only endpoint — never touches appliedAt/notes) |
 | Review newly discovered companies | `/discovery` (sorted by jobsSeen DESC) |
 | Toggle auto-discovery / HN parser | `/discovery` (card at the top; moved off `/settings` 2026-08-29) |
 | Upload / scan a resume | `/resumes` (the Settings card only lists + links) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | Re-classify all jobs against new profile | `/settings` Profile tab → "Re-classify all jobs" (async, watch /runs) |
 | Telegram on/off | `/settings` Notifications tab |
 | Add Telegram bot or chat | `/settings` Notifications tab → "Add target" (validates with getMe + sendMessage) |
-| Pipeline stage on a job | `/jobs/:id` → "Application tracking" card, or the quick-move select on `/applications` cards (stage-only endpoint — never touches appliedAt/notes) |
+| Pipeline stage on a job | `/jobs/:id` → "Application tracking" card; on `/applications` drag the card between columns (`public/board.mjs`) or use its quick-move select — both hit the stage-only endpoint that never touches appliedAt/notes |
 | Review newly discovered companies | `/discovery` (sorted by jobsSeen DESC) |
 | Toggle auto-discovery / HN parser | `/discovery` (card at the top; moved off `/settings` 2026-08-29) |
 | Upload / scan a resume | `/resumes` (the Settings card only lists + links) |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -661,9 +661,11 @@ transaction, board fields untouched), 70dvh column cap (verified again by
 the 100-card DOM simulation: ~1,100 px page vs ~13,000 before), Closed
 disclosure, time-in-stage (`src/web/stage-time.ts`, pure + tested) with
 "· stalled" past 14d, mobile stage-grouped stack with jump chips, polish.
-Item 7 (drag-and-drop over the same endpoint) is NOT built — ask Nazar
-after the merge whether he wants it. The stale ui-review "dark-only" note
-below is fixed too.
+Item 7 (drag-and-drop) shipped in the same branch after Nazar asked for
+it (2026-09-01): `src/web/public/board.mjs` over the same stage-only
+endpoint, fine-pointer devices only, quick-move form kept as the
+keyboard / no-JS / touch fallback (collapsed until hover or focus on
+desktop). The stale ui-review "dark-only" note below is fixed too.
 
 Original analysis kept for reference — one branch, one PR, ordered:
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -653,11 +653,19 @@ contributors — currently #24 (Discord notification channel behind a
 
 ---
 
-## 10. /applications board redesign (analysis 2026-09-01 — NEXT UP)
+## 10. /applications board redesign (analysis 2026-09-01 — SHIPPED 2026-09-01)
 
-Full session analysis: the board is a kanban in looks only. Verified in
-code and by DOM simulation at 100 cards. **This is the next work once this
-triage lands** — one branch (`applications-board`), one PR, ordered:
+Items 1–6 shipped on branch `applications-board` → v1.3.0: stage-only
+quick-move endpoint (`POST /jobs/:id/stage`, ledger row in the same
+transaction, board fields untouched), 70dvh column cap (verified again by
+the 100-card DOM simulation: ~1,100 px page vs ~13,000 before), Closed
+disclosure, time-in-stage (`src/web/stage-time.ts`, pure + tested) with
+"· stalled" past 14d, mobile stage-grouped stack with jump chips, polish.
+Item 7 (drag-and-drop over the same endpoint) is NOT built — ask Nazar
+after the merge whether he wants it. The stale ui-review "dark-only" note
+below is fixed too.
+
+Original analysis kept for reference — one branch, one PR, ordered:
 
 ### 10.1 Facts established (don't re-derive)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/board.test.ts
+++ b/src/web/board.test.ts
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// @ts-expect-error — plain JS with no declaration file; the shape is asserted below.
+const board = import('./public/board.mjs') as Promise<{
+  planMove: (
+    jobId: string | undefined,
+    fromStage: string | undefined,
+    toStage: string | undefined,
+  ) => { action: string; body: string } | null;
+  initBoard: unknown;
+}>;
+
+test('planMove builds the stage-only request', async () => {
+  const { planMove } = await board;
+  assert.deepEqual(planMove('12', 'applied', 'screen'), {
+    action: '/jobs/12/stage',
+    body: 'toStage=screen',
+  });
+});
+
+test('planMove is a no-op for the same stage', async () => {
+  const { planMove } = await board;
+  assert.equal(planMove('12', 'screen', 'screen'), null);
+});
+
+test('planMove refuses incomplete input', async () => {
+  const { planMove } = await board;
+  assert.equal(planMove(undefined, 'applied', 'screen'), null);
+  assert.equal(planMove('12', 'applied', undefined), null);
+});
+
+test('planMove url-encodes both values', async () => {
+  const { planMove } = await board;
+  assert.deepEqual(planMove('1/2', 'applied', 'a b'), {
+    action: '/jobs/1%2F2/stage',
+    body: 'toStage=a%20b',
+  });
+});
+
+test('board module imports without a DOM and exposes initBoard', async () => {
+  const mod = await board;
+  assert.equal(typeof mod.initBoard, 'function');
+});

--- a/src/web/pages/applications.tsx
+++ b/src/web/pages/applications.tsx
@@ -102,7 +102,7 @@ const StageCard: FC<{ card: ApplicationCard; stage: Stage }> = ({ card, stage })
       <select
         id={`move-${card.id}`}
         name="toStage"
-        class="h-8 w-full min-w-0 flex-1 rounded-md border border-line-strong bg-surface-raised px-1.5 text-xs text-ink shadow-sm transition-colors duration-150 hover:border-ink-faint focus:border-accent focus:outline-none"
+        class="h-8 w-full min-w-0 flex-1 rounded-md border border-line-strong bg-surface-raised px-1.5 text-xs text-ink shadow-sm transition-colors duration-150 hover:border-ink-faint focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/15"
       >
         {STAGES.filter((s) => s !== stage).map((s) => (
           <option value={s} selected={s === NEXT_STAGE[stage]}>
@@ -155,16 +155,16 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
           {BOARD_STAGES.map((stage) => (
             <a
               href={`#stage-col-${stage}`}
-              class="rounded-full border border-line bg-surface-raised px-2.5 py-1 text-xs text-ink-muted"
+              class="inline-flex min-h-[32px] items-center gap-1 rounded-full border border-line bg-surface-raised px-3 text-xs text-ink-muted"
             >
-              {STAGE_LABEL[stage]}{' '}
+              {STAGE_LABEL[stage]}
               <span class="tabular-nums text-ink-faint">{byStage[stage].length}</span>
             </a>
           ))}
           {closedCount > 0 && (
             <a
               href="#closed"
-              class="rounded-full border border-line bg-surface-raised px-2.5 py-1 text-xs text-ink-muted"
+              class="inline-flex min-h-[32px] items-center gap-1 rounded-full border border-line bg-surface-raised px-3 text-xs text-ink-muted"
             >
               Closed <span class="tabular-nums text-ink-faint">{closedCount}</span>
             </a>

--- a/src/web/pages/applications.tsx
+++ b/src/web/pages/applications.tsx
@@ -2,8 +2,8 @@
 import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
 import { Button, Empty, FitBadge, Flash, PageHeader } from '../ui';
-import { formatRelative } from '../format';
 import type { FlashMessage } from '../flash';
+import type { StageTimeLine } from '../stage-time';
 import { FunnelStatsSection, type FunnelStatsProps } from './funnel-stats';
 
 const STAGES = ['applied', 'screen', 'tech', 'onsite', 'offer', 'rejected', 'ghosted'] as const;
@@ -50,8 +50,8 @@ interface ApplicationCard {
   title: string;
   companyName: string;
   fitScore: number | null;
-  appliedAt: Date | null;
   recruiterContact: string | null;
+  stageLine: StageTimeLine | null;
 }
 
 export interface ApplicationsProps {
@@ -75,10 +75,13 @@ const StageCard: FC<{ card: ApplicationCard; stage: Stage }> = ({ card, stage })
         {card.companyName}
       </div>
       <div class="mt-2 flex items-center justify-between gap-2">
-        <span class="min-w-0 truncate text-xs text-ink-faint">
-          {card.appliedAt
-            ? `applied ${formatRelative(card.appliedAt)}`
-            : 'no apply date'}
+        <span
+          class={`min-w-0 truncate text-xs ${
+            card.stageLine?.stale ? 'font-medium text-warn' : 'text-ink-faint'
+          }`}
+          title={card.stageLine?.since.toISOString().slice(0, 10)}
+        >
+          {card.stageLine?.text ?? 'no apply date'}
           {card.recruiterContact ? ` · ${card.recruiterContact}` : ''}
         </span>
         <FitBadge score={card.fitScore} />

--- a/src/web/pages/applications.tsx
+++ b/src/web/pages/applications.tsx
@@ -9,6 +9,10 @@ import { FunnelStatsSection, type FunnelStatsProps } from './funnel-stats';
 const STAGES = ['applied', 'screen', 'tech', 'onsite', 'offer', 'rejected', 'ghosted'] as const;
 type Stage = (typeof STAGES)[number];
 
+/** Work columns on the board; rejected/ghosted are archives, shown below. */
+const BOARD_STAGES = ['applied', 'screen', 'tech', 'onsite', 'offer'] as const;
+const CLOSED_STAGES = ['rejected', 'ghosted'] as const;
+
 export const STAGE_LABEL: Record<Stage, string> = {
   applied: 'Applied',
   screen: 'Screen',
@@ -112,13 +116,18 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
   stats,
   flash,
 }) => {
-  const totalCount = STAGES.reduce((sum, s) => sum + (byStage[s]?.length ?? 0), 0);
+  const activeCount = BOARD_STAGES.reduce((sum, s) => sum + (byStage[s]?.length ?? 0), 0);
+  const closedCount = CLOSED_STAGES.reduce((sum, s) => sum + (byStage[s]?.length ?? 0), 0);
 
   return (
     <Layout title="Applications" active="applications">
       <PageHeader
         title="Applications"
-        meta={applicationTrackingEnabled ? `${totalCount} in the funnel` : undefined}
+        meta={
+          applicationTrackingEnabled
+            ? `${activeCount} active${closedCount > 0 ? ` · ${closedCount} closed` : ''}`
+            : undefined
+        }
       />
       <Flash flash={flash} />
 
@@ -136,7 +145,7 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
       ) : (
         <>
         <div class="flex min-h-0 min-w-0 flex-1 items-stretch gap-3 overflow-x-auto pb-1">
-          {STAGES.map((stage) => {
+          {BOARD_STAGES.map((stage) => {
             const items = byStage[stage] ?? [];
             return (
               <section
@@ -168,6 +177,46 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
             );
           })}
         </div>
+        {closedCount > 0 && (
+          <details class="mt-4 rounded-lg border border-line/70 bg-surface-overlay/40">
+            <summary class="cursor-pointer select-none rounded-lg px-4 py-2.5 text-sm font-medium text-ink-muted transition-colors duration-150 hover:text-ink">
+              Closed
+              <span class="ml-2 text-xs font-normal text-ink-faint">
+                {byStage.rejected.length} rejected · {byStage.ghosted.length} ghosted
+              </span>
+            </summary>
+            <div class="grid gap-4 border-t border-line/70 p-4 md:grid-cols-2">
+              {CLOSED_STAGES.map((stage) => {
+                const items = byStage[stage] ?? [];
+                return (
+                  <section aria-labelledby={`stage-${stage}`}>
+                    <div class="flex items-center gap-2 pb-2">
+                      <span
+                        class={`h-2 w-2 rounded-full ${STAGE_DOT[stage]}`}
+                        aria-hidden="true"
+                      />
+                      <h2 id={`stage-${stage}`} class="text-[13px] font-medium text-ink">
+                        {STAGE_LABEL[stage]}
+                      </h2>
+                      <span class="ml-auto text-xs text-ink-faint tabular-nums">
+                        {items.length}
+                      </span>
+                    </div>
+                    <ul class="space-y-2">
+                      {items.length === 0 ? (
+                        <li class="rounded-md border border-dashed border-line-strong/70 px-3 py-3 text-center text-xs text-ink-faint">
+                          None
+                        </li>
+                      ) : (
+                        items.map((c) => <StageCard card={c} stage={stage} />)
+                      )}
+                    </ul>
+                  </section>
+                );
+              })}
+            </div>
+          </details>
+        )}
         {stats && <FunnelStatsSection {...stats} />}
         </>
       )}

--- a/src/web/pages/applications.tsx
+++ b/src/web/pages/applications.tsx
@@ -147,12 +147,32 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
         </Empty>
       ) : (
         <>
-        <div class="flex min-h-0 min-w-0 flex-1 items-stretch gap-3 overflow-x-auto pb-1">
+        <nav aria-label="Stages" class="mb-3 flex flex-wrap gap-1.5 md:hidden">
+          {BOARD_STAGES.map((stage) => (
+            <a
+              href={`#stage-col-${stage}`}
+              class="rounded-full border border-line bg-surface-raised px-2.5 py-1 text-xs text-ink-muted"
+            >
+              {STAGE_LABEL[stage]}{' '}
+              <span class="tabular-nums text-ink-faint">{byStage[stage].length}</span>
+            </a>
+          ))}
+          {closedCount > 0 && (
+            <a
+              href="#closed"
+              class="rounded-full border border-line bg-surface-raised px-2.5 py-1 text-xs text-ink-muted"
+            >
+              Closed <span class="tabular-nums text-ink-faint">{closedCount}</span>
+            </a>
+          )}
+        </nav>
+        <div class="flex min-h-0 min-w-0 flex-1 flex-col gap-3 md:flex-row md:items-stretch md:overflow-x-auto md:pb-1">
           {BOARD_STAGES.map((stage) => {
             const items = byStage[stage] ?? [];
             return (
               <section
-                class="flex max-h-[70dvh] min-h-[320px] w-72 shrink-0 flex-col rounded-lg border border-line/70 bg-surface-overlay/60"
+                id={`stage-col-${stage}`}
+                class="flex w-full scroll-mt-4 flex-col rounded-lg border border-line/70 bg-surface-overlay/60 md:max-h-[70dvh] md:min-h-[320px] md:w-72 md:shrink-0"
                 aria-labelledby={`stage-${stage}`}
               >
                   <div class="flex shrink-0 items-center gap-2 px-3 pb-2 pt-3">
@@ -169,7 +189,7 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
                   </div>
                   <ul class="min-h-0 flex-1 space-y-2 overflow-y-auto px-3 pb-3">
                     {items.length === 0 ? (
-                      <li class="rounded-md border border-dashed border-line-strong/70 px-3 py-6 text-center text-xs text-ink-faint">
+                      <li class="hidden rounded-md border border-dashed border-line-strong/70 px-3 py-6 text-center text-xs text-ink-faint md:block">
                         No applications
                       </li>
                     ) : (
@@ -181,7 +201,7 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
           })}
         </div>
         {closedCount > 0 && (
-          <details class="mt-4 rounded-lg border border-line/70 bg-surface-overlay/40">
+          <details id="closed" class="mt-4 scroll-mt-4 rounded-lg border border-line/70 bg-surface-overlay/40">
             <summary class="cursor-pointer select-none rounded-lg px-4 py-2.5 text-sm font-medium text-ink-muted transition-colors duration-150 hover:text-ink">
               Closed
               <span class="ml-2 text-xs font-normal text-ink-faint">

--- a/src/web/pages/applications.tsx
+++ b/src/web/pages/applications.tsx
@@ -152,7 +152,7 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
             const items = byStage[stage] ?? [];
             return (
               <section
-                class="flex min-h-[320px] w-72 shrink-0 flex-col rounded-lg border border-line/70 bg-surface-overlay/60"
+                class="flex max-h-[70dvh] min-h-[320px] w-72 shrink-0 flex-col rounded-lg border border-line/70 bg-surface-overlay/60"
                 aria-labelledby={`stage-${stage}`}
               >
                   <div class="flex shrink-0 items-center gap-2 px-3 pb-2 pt-3">

--- a/src/web/pages/applications.tsx
+++ b/src/web/pages/applications.tsx
@@ -65,9 +65,18 @@ export interface ApplicationsProps {
   flash?: FlashMessage | null;
 }
 
-/** One board card: the link navigates, the form below it quick-moves. */
+/**
+ * One board card: the link navigates, the form below it quick-moves, and
+ * board.mjs makes the whole card draggable. With drag active (body[data-dnd],
+ * fine pointer, md+) the form collapses until the card has hover or focus —
+ * it stays the keyboard and no-JS path.
+ */
 const StageCard: FC<{ card: ApplicationCard; stage: Stage }> = ({ card, stage }) => (
-  <li class="rounded-md border border-line bg-surface-raised shadow-sm">
+  <li
+    class="rounded-md border border-line bg-surface-raised shadow-sm"
+    data-job-id={card.id}
+    data-stage={stage}
+  >
     <a
       href={`/jobs/${card.id}`}
       class="block rounded-t-md p-3 transition-colors duration-150 hover:bg-surface-overlay/60"
@@ -94,7 +103,7 @@ const StageCard: FC<{ card: ApplicationCard; stage: Stage }> = ({ card, stage })
     <form
       method="post"
       action={`/jobs/${card.id}/stage`}
-      class="flex items-center gap-1.5 border-t border-line px-2 py-1.5"
+      class="quick-move flex items-center gap-1.5 border-t border-line px-2 py-1.5"
     >
       <label class="sr-only" for={`move-${card.id}`}>
         Move {card.title} to stage
@@ -116,6 +125,30 @@ const StageCard: FC<{ card: ApplicationCard; stage: Stage }> = ({ card, stage })
     </form>
   </li>
 );
+
+/*
+ * Drag styling: with board.mjs active the quick-move form collapses until
+ * its card has hover or keyboard focus (focus-within keeps the tab path —
+ * the controls stay tabbable, unlike display:none). md+ and body[data-dnd]
+ * only, so mobile and no-JS keep the always-visible form.
+ */
+const BOARD_CSS = `
+  @media (min-width: 768px) {
+    body[data-dnd] .quick-move { height: 0; padding-top: 0; padding-bottom: 0; border-top-width: 0; opacity: 0; overflow: hidden; }
+    body[data-dnd] li[data-job-id]:hover .quick-move,
+    body[data-dnd] li[data-job-id]:focus-within .quick-move { height: auto; padding-top: 0.375rem; padding-bottom: 0.375rem; border-top-width: 1px; opacity: 1; }
+    body[data-dnd] li[data-job-id] { cursor: grab; }
+    body[data-dnd] li[data-job-id]:active { cursor: grabbing; }
+  }
+`;
+
+/* Coarse-pointer devices can't HTML5-drag reliably — keep their forms visible. */
+const BOARD_BOOT = `
+  if (window.matchMedia('(pointer: fine)').matches) {
+    const { initBoard } = await import('/static/board.mjs');
+    initBoard(document);
+  }
+`;
 
 export const ApplicationsPage: FC<ApplicationsProps> = ({
   byStage,
@@ -176,6 +209,7 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
             return (
               <section
                 id={`stage-col-${stage}`}
+                data-drop-stage={stage}
                 class="flex w-full scroll-mt-4 flex-col rounded-lg border border-line/70 bg-surface-overlay/60 md:max-h-[70dvh] md:min-h-[320px] md:w-72 md:shrink-0"
                 aria-labelledby={`stage-${stage}`}
               >
@@ -216,7 +250,7 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
               {CLOSED_STAGES.map((stage) => {
                 const items = byStage[stage] ?? [];
                 return (
-                  <section aria-labelledby={`stage-${stage}`}>
+                  <section data-drop-stage={stage} aria-labelledby={`stage-${stage}`}>
                     <div class="flex items-center gap-2 pb-2">
                       <span
                         class={`h-2 w-2 rounded-full ${STAGE_DOT[stage]}`}
@@ -245,6 +279,8 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
           </details>
         )}
         {stats && <FunnelStatsSection {...stats} />}
+        <style dangerouslySetInnerHTML={{ __html: BOARD_CSS }} />
+        <script type="module" dangerouslySetInnerHTML={{ __html: BOARD_BOOT }} />
         </>
       )}
     </Layout>

--- a/src/web/pages/applications.tsx
+++ b/src/web/pages/applications.tsx
@@ -1,14 +1,15 @@
 /** @jsxImportSource hono/jsx */
 import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
-import { Empty, FitBadge, PageHeader } from '../ui';
+import { Button, Empty, FitBadge, Flash, PageHeader } from '../ui';
 import { formatRelative } from '../format';
+import type { FlashMessage } from '../flash';
 import { FunnelStatsSection, type FunnelStatsProps } from './funnel-stats';
 
 const STAGES = ['applied', 'screen', 'tech', 'onsite', 'offer', 'rejected', 'ghosted'] as const;
 type Stage = (typeof STAGES)[number];
 
-const STAGE_LABEL: Record<Stage, string> = {
+export const STAGE_LABEL: Record<Stage, string> = {
   applied: 'Applied',
   screen: 'Screen',
   tech: 'Tech',
@@ -16,6 +17,17 @@ const STAGE_LABEL: Record<Stage, string> = {
   offer: 'Offer',
   rejected: 'Rejected',
   ghosted: 'Ghosted',
+};
+
+/** Quick-move preselect: the likely next hop, not just the next list entry. */
+const NEXT_STAGE: Record<Stage, Stage> = {
+  applied: 'screen',
+  screen: 'tech',
+  tech: 'onsite',
+  onsite: 'offer',
+  offer: 'rejected',
+  rejected: 'screen',
+  ghosted: 'screen',
 };
 
 /** Column accent: a dot next to the stage name, so columns stay untinted. */
@@ -42,12 +54,63 @@ export interface ApplicationsProps {
   byStage: Record<Stage, ApplicationCard[]>;
   applicationTrackingEnabled: boolean;
   stats: FunnelStatsProps | null;
+  flash?: FlashMessage | null;
 }
+
+/** One board card: the link navigates, the form below it quick-moves. */
+const StageCard: FC<{ card: ApplicationCard; stage: Stage }> = ({ card, stage }) => (
+  <li class="rounded-md border border-line bg-surface-raised shadow-sm">
+    <a
+      href={`/jobs/${card.id}`}
+      class="block rounded-t-md p-3 transition-colors duration-150 hover:bg-surface-overlay/60"
+    >
+      <div class="line-clamp-2 text-sm font-medium leading-snug text-ink">
+        {card.title}
+      </div>
+      <div class="mt-1 truncate text-[13px] text-ink-muted">
+        {card.companyName}
+      </div>
+      <div class="mt-2 flex items-center justify-between gap-2">
+        <span class="min-w-0 truncate text-xs text-ink-faint">
+          {card.appliedAt
+            ? `applied ${formatRelative(card.appliedAt)}`
+            : 'no apply date'}
+          {card.recruiterContact ? ` · ${card.recruiterContact}` : ''}
+        </span>
+        <FitBadge score={card.fitScore} />
+      </div>
+    </a>
+    <form
+      method="post"
+      action={`/jobs/${card.id}/stage`}
+      class="flex items-center gap-1.5 border-t border-line px-2 py-1.5"
+    >
+      <label class="sr-only" for={`move-${card.id}`}>
+        Move {card.title} to stage
+      </label>
+      <select
+        id={`move-${card.id}`}
+        name="toStage"
+        class="h-8 w-full min-w-0 flex-1 rounded-md border border-line-strong bg-surface-raised px-1.5 text-xs text-ink shadow-sm transition-colors duration-150 hover:border-ink-faint focus:border-accent focus:outline-none"
+      >
+        {STAGES.filter((s) => s !== stage).map((s) => (
+          <option value={s} selected={s === NEXT_STAGE[stage]}>
+            {STAGE_LABEL[s]}
+          </option>
+        ))}
+      </select>
+      <Button size="sm" variant="secondary" aria-label={`Move ${card.title}`}>
+        Move
+      </Button>
+    </form>
+  </li>
+);
 
 export const ApplicationsPage: FC<ApplicationsProps> = ({
   byStage,
   applicationTrackingEnabled,
   stats,
+  flash,
 }) => {
   const totalCount = STAGES.reduce((sum, s) => sum + (byStage[s]?.length ?? 0), 0);
 
@@ -56,11 +119,8 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
       <PageHeader
         title="Applications"
         meta={applicationTrackingEnabled ? `${totalCount} in the funnel` : undefined}
-      >
-        {applicationTrackingEnabled
-          ? 'Move jobs between stages from their detail page.'
-          : undefined}
-      </PageHeader>
+      />
+      <Flash flash={flash} />
 
       {!applicationTrackingEnabled ? (
         <Empty>
@@ -101,30 +161,7 @@ export const ApplicationsPage: FC<ApplicationsProps> = ({
                         No applications
                       </li>
                     ) : (
-                      items.map((c) => (
-                        <li>
-                          <a
-                            href={`/jobs/${c.id}`}
-                            class="block rounded-md border border-line bg-surface-raised p-3 shadow-sm transition-colors duration-150 hover:border-accent/50"
-                          >
-                            <div class="line-clamp-2 text-sm font-medium leading-snug text-ink">
-                              {c.title}
-                            </div>
-                            <div class="mt-1 truncate text-[13px] text-ink-muted">
-                              {c.companyName}
-                            </div>
-                            <div class="mt-2 flex items-center justify-between gap-2">
-                              <span class="min-w-0 truncate text-xs text-ink-faint">
-                                {c.appliedAt
-                                  ? `applied ${formatRelative(c.appliedAt)}`
-                                  : 'no apply date'}
-                                {c.recruiterContact ? ` · ${c.recruiterContact}` : ''}
-                              </span>
-                              <FitBadge score={c.fitScore} />
-                            </div>
-                          </a>
-                        </li>
-                      ))
+                      items.map((c) => <StageCard card={c} stage={stage} />)
                     )}
                   </ul>
               </section>

--- a/src/web/pages/applications.tsx
+++ b/src/web/pages/applications.tsx
@@ -34,12 +34,16 @@ const NEXT_STAGE: Record<Stage, Stage> = {
   ghosted: 'screen',
 };
 
-/** Column accent: a dot next to the stage name, so columns stay untinted. */
+/**
+ * Column accent: a dot next to the stage name, so columns stay untinted.
+ * Onsite is a hollow warn ring — same interview-loop hue as tech, but a
+ * different shape, so the two stages never read identical.
+ */
 const STAGE_DOT: Record<Stage, string> = {
   applied: 'bg-info',
   screen: 'bg-violet',
   tech: 'bg-warn',
-  onsite: 'bg-warn',
+  onsite: 'border-2 border-warn bg-transparent',
   offer: 'bg-ok',
   rejected: 'bg-line-strong',
   ghosted: 'bg-line-strong',

--- a/src/web/pages/funnel-stats.tsx
+++ b/src/web/pages/funnel-stats.tsx
@@ -48,7 +48,7 @@ const VERDICT_VIEW: Record<Calibration['verdict'], { label: string; tone: Tone; 
 };
 
 const rate = (value: number | null, resolved: number): string =>
-  value === null ? `— (n=${resolved}, need ${MIN_RATE_N})` : `${Math.round(value * 100)}%`;
+  value === null ? `— (${resolved}/${MIN_RATE_N})` : `${Math.round(value * 100)}%`;
 
 export const FunnelStatsSection: FC<FunnelStatsProps> = ({
   funnel,

--- a/src/web/public/board.mjs
+++ b/src/web/public/board.mjs
@@ -1,0 +1,121 @@
+/*
+ * Drag-and-drop for the /applications board. Served as a static ES module;
+ * the page boots it with initBoard(document). A drop POSTs to the same
+ * stage-only endpoint the per-card form uses, then reloads so counts,
+ * Closed panel and funnel stats re-render from the server. The form stays
+ * in the DOM as the keyboard / no-JS path (collapsed until the card has
+ * hover or focus — CSS keyed off body[data-dnd]). Importing this file
+ * under node:test touches no DOM.
+ */
+
+/** The request for one move, or null when there is nothing to do. */
+export function planMove(jobId, fromStage, toStage) {
+  if (!jobId || !toStage || fromStage === toStage) return null;
+  return {
+    action: `/jobs/${encodeURIComponent(jobId)}/stage`,
+    body: `toStage=${encodeURIComponent(toStage)}`,
+  };
+}
+
+// Full literal class names — the Tailwind CDN JIT compiles what it sees.
+const HIGHLIGHT = ['ring-2', 'ring-accent/40', 'bg-accent/5'];
+const DRAGGING = 'opacity-50';
+
+async function submitMove(plan) {
+  try {
+    const res = await fetch(plan.action, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: plan.body,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+function clearHighlights(doc) {
+  for (const el of doc.querySelectorAll('[data-drop-stage]')) {
+    el.classList.remove(...HIGHLIGHT);
+  }
+}
+
+function showMoveError(doc) {
+  doc.getElementById('move-error')?.remove();
+  const div = doc.createElement('div');
+  div.id = 'move-error';
+  div.setAttribute('role', 'alert');
+  div.className =
+    'mb-4 rounded-lg border border-danger/30 bg-danger/5 px-4 py-2.5 text-sm text-danger';
+  div.textContent = 'Move failed — the stage was not changed. Try again.';
+  doc.getElementById('main')?.firstElementChild?.prepend(div);
+}
+
+/** Wire cards and columns; returns how many cards became draggable. */
+export function initBoard(doc) {
+  const cards = [...doc.querySelectorAll('li[data-job-id]')];
+  const targets = [...doc.querySelectorAll('[data-drop-stage]')];
+  if (cards.length === 0 || targets.length === 0) return 0;
+
+  doc.body.setAttribute('data-dnd', '');
+  let dragged = null; // { li, jobId, fromStage }
+
+  for (const li of cards) {
+    li.setAttribute('draggable', 'true');
+    // The card link would otherwise start a native URL drag.
+    li.querySelector('a')?.setAttribute('draggable', 'false');
+    li.addEventListener('dragstart', (e) => {
+      dragged = { li, jobId: li.dataset.jobId, fromStage: li.dataset.stage };
+      li.classList.add(DRAGGING);
+      if (e.dataTransfer) {
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', li.dataset.jobId);
+      }
+    });
+    li.addEventListener('dragend', () => {
+      li.classList.remove(DRAGGING);
+      dragged = null;
+      clearHighlights(doc);
+    });
+  }
+
+  // Dragging over the collapsed Closed panel opens it, so a card can be
+  // dropped straight onto Rejected / Ghosted.
+  doc.getElementById('closed')?.addEventListener('dragenter', function open() {
+    this.open = true;
+  });
+
+  for (const target of targets) {
+    target.addEventListener('dragover', (e) => {
+      if (!dragged || dragged.fromStage === target.dataset.dropStage) return;
+      e.preventDefault(); // this is what allows the drop
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+      target.classList.add(...HIGHLIGHT);
+    });
+    target.addEventListener('dragleave', (e) => {
+      if (!target.contains(e.relatedTarget)) target.classList.remove(...HIGHLIGHT);
+    });
+    target.addEventListener('drop', (e) => {
+      e.preventDefault();
+      clearHighlights(doc);
+      if (!dragged) return;
+      const { li, jobId, fromStage } = dragged;
+      const plan = planMove(jobId, fromStage, target.dataset.dropStage);
+      if (!plan) return;
+      // Optimistic: the card lands in the column right away; the reload
+      // (or the revert on failure) restores the server's truth.
+      const origin = { parent: li.parentElement, next: li.nextElementSibling };
+      (target.querySelector('ul') ?? target).appendChild(li);
+      li.classList.remove(DRAGGING);
+      submitMove(plan).then((ok) => {
+        if (ok) {
+          doc.defaultView.location.reload();
+        } else {
+          origin.parent.insertBefore(li, origin.next);
+          showMoveError(doc);
+        }
+      });
+    });
+  }
+  return cards.length;
+}

--- a/src/web/routes/applications.tsx
+++ b/src/web/routes/applications.tsx
@@ -95,7 +95,7 @@ applicationsRoute.get('/applications', async (c) => {
   );
 });
 
-export const StageMoveSchema = z.object({ toStage: z.enum(STAGE_VALUES) });
+const StageMoveSchema = z.object({ toStage: z.enum(STAGE_VALUES) });
 
 // Board quick-move: writes pipelineStage and its ledger row, nothing else.
 // The full form on /jobs/:id stays the only place that edits appliedAt /

--- a/src/web/routes/applications.tsx
+++ b/src/web/routes/applications.tsx
@@ -6,7 +6,8 @@ import { getSettings } from '../../settings';
 import { flashRedirect, parseFlashCookie } from '../flash';
 import { ApplicationsPage, STAGE_LABEL } from '../pages/applications';
 import { appliedDateCorrection, stageChangeEvent } from '../stage-events';
-import { calibration, funnel, groupByJob, velocity } from '../stats';
+import { stageTimeLine, type StageTimeLine } from '../stage-time';
+import { calibration, funnel, groupByJob, velocity, type StageEventRow } from '../stats';
 
 const STAGE_VALUES = [
   'applied',
@@ -39,6 +40,18 @@ applicationsRoute.get('/applications', async (c) => {
     orderBy: [{ appliedAt: 'desc' }, { id: 'desc' }],
   });
 
+  // One fetch feeds both the funnel stats and the per-card time-in-stage.
+  const events = settings.applicationTrackingEnabled
+    ? await prisma.jobStageEvent.findMany({ orderBy: { recordedAt: 'asc' } })
+    : [];
+  const eventsByJob = new Map<number, typeof events>();
+  for (const e of events) {
+    const list = eventsByJob.get(e.jobId);
+    if (list) list.push(e);
+    else eventsByJob.set(e.jobId, [e]);
+  }
+
+  const now = new Date();
   const empty: Record<Stage, []> = {
     applied: [],
     screen: [],
@@ -55,8 +68,8 @@ applicationsRoute.get('/applications', async (c) => {
       title: string;
       companyName: string;
       fitScore: number | null;
-      appliedAt: Date | null;
       recruiterContact: string | null;
+      stageLine: StageTimeLine | null;
     }>
   >;
   for (const j of rows) {
@@ -67,8 +80,8 @@ applicationsRoute.get('/applications', async (c) => {
       title: j.title,
       companyName: j.company.name,
       fitScore: j.fitScore,
-      appliedAt: j.appliedAt,
       recruiterContact: j.recruiterContact,
+      stageLine: stageTimeLine(stage, j.appliedAt, eventsByJob.get(j.id) ?? [], now),
     });
   }
 
@@ -76,7 +89,7 @@ applicationsRoute.get('/applications', async (c) => {
     <ApplicationsPage
       byStage={byStage}
       applicationTrackingEnabled={settings.applicationTrackingEnabled}
-      stats={settings.applicationTrackingEnabled ? await loadFunnelStats() : null}
+      stats={settings.applicationTrackingEnabled ? await loadFunnelStats(events) : null}
       flash={parseFlashCookie(c.req.header('cookie'))}
     />,
   );
@@ -123,10 +136,7 @@ applicationsRoute.post('/jobs/:id/stage', async (c) => {
 });
 
 // F5 (ADR 0024): fold the ledger into funnel / velocity / calibration.
-async function loadFunnelStats() {
-  const events = await prisma.jobStageEvent.findMany({
-    orderBy: { recordedAt: 'asc' },
-  });
+async function loadFunnelStats(events: StageEventRow[]) {
   const eventJobIds = [...new Set(events.map((e) => e.jobId))];
   const fitRows = eventJobIds.length
     ? await prisma.job.findMany({

--- a/src/web/routes/applications.tsx
+++ b/src/web/routes/applications.tsx
@@ -3,7 +3,8 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { prisma } from '../../db';
 import { getSettings } from '../../settings';
-import { ApplicationsPage } from '../pages/applications';
+import { flashRedirect, parseFlashCookie } from '../flash';
+import { ApplicationsPage, STAGE_LABEL } from '../pages/applications';
 import { appliedDateCorrection, stageChangeEvent } from '../stage-events';
 import { calibration, funnel, groupByJob, velocity } from '../stats';
 
@@ -76,8 +77,49 @@ applicationsRoute.get('/applications', async (c) => {
       byStage={byStage}
       applicationTrackingEnabled={settings.applicationTrackingEnabled}
       stats={settings.applicationTrackingEnabled ? await loadFunnelStats() : null}
+      flash={parseFlashCookie(c.req.header('cookie'))}
     />,
   );
+});
+
+export const StageMoveSchema = z.object({ toStage: z.enum(STAGE_VALUES) });
+
+// Board quick-move: writes pipelineStage and its ledger row, nothing else.
+// The full form on /jobs/:id stays the only place that edits appliedAt /
+// recruiterContact / applicationNotes — reusing it here would null them out.
+applicationsRoute.post('/jobs/:id/stage', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!Number.isFinite(id)) return c.text('Bad id', 400);
+  const settings = await getSettings();
+  if (!settings.applicationTrackingEnabled) {
+    return c.redirect('/applications', 303);
+  }
+
+  const form = await c.req.parseBody();
+  const parsed = StageMoveSchema.safeParse({ toStage: form.toStage });
+  if (!parsed.success) return c.text('Invalid stage', 400);
+  const { toStage } = parsed.data;
+
+  const current = await prisma.job.findUnique({
+    where: { id },
+    select: { pipelineStage: true, appliedAt: true },
+  });
+  if (!current) return c.text('Not found', 404);
+
+  const event = stageChangeEvent(
+    id,
+    current.pipelineStage,
+    toStage,
+    current.appliedAt,
+    new Date(),
+  );
+  if (event) {
+    await prisma.$transaction([
+      prisma.job.update({ where: { id }, data: { pipelineStage: toStage } }),
+      prisma.jobStageEvent.create({ data: event }),
+    ]);
+  }
+  return flashRedirect('/applications', 'ok', `Moved to ${STAGE_LABEL[toStage]}`);
 });
 
 // F5 (ADR 0024): fold the ledger into funnel / velocity / calibration.

--- a/src/web/stage-time.test.ts
+++ b/src/web/stage-time.test.ts
@@ -1,0 +1,105 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { stageTimeLine, type StageTimeEvent } from './stage-time';
+
+const NOW = new Date('2026-09-01T12:00:00Z');
+
+const daysAgo = (n: number): Date =>
+  new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+
+const ev = (
+  toStage: string,
+  occurredDaysAgo: number,
+  source = 'ui',
+  recordedDaysAgo = occurredDaysAgo,
+): StageTimeEvent => ({
+  toStage,
+  occurredOn: daysAgo(occurredDaysAgo),
+  recordedAt: daysAgo(recordedDaysAgo),
+  source,
+});
+
+test('no events and no appliedAt gives no line', () => {
+  assert.equal(stageTimeLine('screen', null, [], NOW), null);
+});
+
+test('applied stage falls back to appliedAt', () => {
+  const line = stageTimeLine('applied', daysAgo(12), [], NOW);
+  assert.deepEqual(line, { text: 'applied 12d ago', stale: false, since: daysAgo(12) });
+});
+
+test('applied stage goes stale past 14 days', () => {
+  const line = stageTimeLine('applied', daysAgo(20), [], NOW);
+  assert.equal(line?.text, 'applied 20d ago · stalled');
+  assert.equal(line?.stale, true);
+});
+
+test('exactly 14 days is not yet stale', () => {
+  const line = stageTimeLine('screen', null, [ev('screen', 14)], NOW);
+  assert.equal(line?.text, 'in screen 14d');
+  assert.equal(line?.stale, false);
+});
+
+test('ranked stage dated by its ledger event', () => {
+  const line = stageTimeLine('screen', daysAgo(30), [ev('screen', 5)], NOW);
+  assert.deepEqual(line, { text: 'in screen 5d', stale: false, since: daysAgo(5) });
+});
+
+test('ranked stage goes stale past 14 days', () => {
+  const line = stageTimeLine('tech', null, [ev('tech', 15)], NOW);
+  assert.equal(line?.text, 'in tech 15d · stalled');
+  assert.equal(line?.stale, true);
+});
+
+test('backfill events never date a stage — appliedAt fallback, not stale', () => {
+  const line = stageTimeLine('screen', daysAgo(30), [ev('screen', 30, 'backfill')], NOW);
+  assert.equal(line?.text, 'applied 30d ago');
+  assert.equal(line?.stale, false);
+});
+
+test('backfill-only history with no appliedAt gives no line', () => {
+  assert.equal(stageTimeLine('screen', null, [ev('screen', 30, 'backfill')], NOW), null);
+});
+
+test('terminal stage reads past tense and is never stale', () => {
+  const line = stageTimeLine('rejected', daysAgo(40), [ev('rejected', 20)], NOW);
+  assert.equal(line?.text, 'rejected 20d ago');
+  assert.equal(line?.stale, false);
+});
+
+test('latest event into the stage wins on re-entry', () => {
+  const line = stageTimeLine(
+    'screen',
+    null,
+    [ev('screen', 40, 'ui', 40), ev('tech', 30, 'ui', 30), ev('screen', 3, 'ui', 3)],
+    NOW,
+  );
+  assert.equal(line?.text, 'in screen 3d');
+});
+
+test('a correction event re-dates the applied stage', () => {
+  const line = stageTimeLine(
+    'applied',
+    daysAgo(2),
+    [ev('applied', 2, 'ui', 2), ev('applied', 10, 'correction', 1)],
+    NOW,
+  );
+  assert.equal(line?.text, 'applied 10d ago');
+});
+
+test('events into other stages are ignored', () => {
+  const line = stageTimeLine('screen', daysAgo(8), [ev('applied', 8)], NOW);
+  assert.equal(line?.text, 'applied 8d ago');
+  assert.equal(line?.stale, false);
+});
+
+test('same-day entry says today', () => {
+  assert.equal(stageTimeLine('applied', daysAgo(0), [], NOW)?.text, 'applied today');
+  assert.equal(stageTimeLine('screen', null, [ev('screen', 0)], NOW)?.text, 'in screen today');
+  assert.equal(stageTimeLine('ghosted', null, [ev('ghosted', 0)], NOW)?.text, 'ghosted today');
+});
+
+test('a future since-day clamps to zero days', () => {
+  const line = stageTimeLine('applied', daysAgo(-3), [], NOW);
+  assert.equal(line?.text, 'applied today');
+});

--- a/src/web/stage-time.ts
+++ b/src/web/stage-time.ts
@@ -1,0 +1,62 @@
+// Pure time-in-stage math for the /applications board cards. The honesty
+// rule from stats.ts applies here too: backfill rows carry no real event
+// day, so they never date a stage — such cards fall back to appliedAt.
+
+import { TERMINAL_STAGES } from './stats';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A non-terminal stage without movement for this long reads as stale. */
+export const STALE_DAYS = 14;
+
+export interface StageTimeEvent {
+  toStage: string | null;
+  occurredOn: Date;
+  recordedAt: Date;
+  source: string; // ui | backfill | correction
+}
+
+export interface StageTimeLine {
+  text: string;
+  stale: boolean;
+  /** The day the line counts from — for an absolute-date tooltip. */
+  since: Date;
+}
+
+/**
+ * The card's one time line. Dated by the latest real ledger event into the
+ * current stage; without one it falls back to "applied Nd ago" from
+ * appliedAt. Stale needs a known stage-entry day (an event, or appliedAt
+ * when the stage IS applied) — an apply-date alone can't claim "no
+ * movement" for a later stage. Terminal stages are archives, never stale.
+ */
+export function stageTimeLine(
+  stage: string,
+  appliedAt: Date | null,
+  events: StageTimeEvent[],
+  now: Date,
+): StageTimeLine | null {
+  const entered = events
+    .filter((e) => e.toStage === stage && e.source !== 'backfill')
+    .sort((a, b) => b.recordedAt.getTime() - a.recordedAt.getTime())[0];
+
+  const since = entered?.occurredOn ?? appliedAt;
+  if (!since) return null;
+
+  const days = Math.max(0, Math.floor((now.getTime() - since.getTime()) / DAY_MS));
+  const terminal = (TERMINAL_STAGES as readonly string[]).includes(stage);
+  const entryKnown = entered !== undefined || stage === 'applied';
+
+  let text: string;
+  if (!entered && stage !== 'applied') {
+    text = days === 0 ? 'applied today' : `applied ${days}d ago`;
+  } else if (stage === 'applied' || terminal) {
+    text = days === 0 ? `${stage} today` : `${stage} ${days}d ago`;
+  } else {
+    text = days === 0 ? `in ${stage} today` : `in ${stage} ${days}d`;
+  }
+
+  // The word, not just a warn colour — colour alone carries no meaning.
+  const stale = !terminal && entryKnown && days > STALE_DAYS;
+  return { text: stale ? `${text} · stalled` : text, stale, since };
+}


### PR DESCRIPTION
TASKS §10 items 1–6: the board stops being a kanban in looks only.

## What changed
- **Drag-and-drop** (added after Nazar's review of the first cut): drag a card into any column — the stage changes on drop (optimistic move → POST → server re-render with a flash; failed moves snap back with an error notice). Dragging over the collapsed Closed panel opens it, so reject/ghost by drag works too. Dependency-free `src/web/public/board.mjs` over the same stage-only endpoint; `planMove` is unit-tested, the module imports DOM-free under node:test. Init is gated to fine-pointer devices — phones/touch-only tablets keep the visible form; with drag active the per-card form collapses until the card is hovered or keyboard-focused (focus-within keeps the tab path).
- **Quick-move on every card** — stage select + Move button as a plain POST form (works without JS). New stage-only endpoint `POST /jobs/:id/stage` writes the `JobStageEvent` ledger row in the same transaction and touches nothing else; the old `POST /jobs/:id/application` nulls `appliedAt`/`recruiterContact`/`applicationNotes` when fields are absent (§10.1), so the board never reuses it. Flash confirms the move.
- **Column height cap** (`md:max-h-[70dvh]`) — per-column `overflow-y-auto` finally engages. DOM simulation with 100 cloned cards: page ~1,100 px vs ~13,000 px before; funnel stats sit in the first viewport.
- **Closed panel** — Rejected/Ghosted leave the board for a `<details>` disclosure below it; 5 work columns instead of 7. Closed cards keep quick-move, so a ghosted job that answers can be revived (preselect Screen).
- **Time-in-stage** — `src/web/stage-time.ts` (pure, 14 unit tests): "in screen 5d" from the latest real ledger event, "applied Nd ago" fallback when no event dates the stage, absolute date in the tooltip. Non-terminal stages past 14 days get warn-tone "· stalled" — the word, not just the colour. Backfill rows never date a stage (same honesty rule as stats.ts).
- **Mobile** — under `md:` the board stacks into one stage-grouped list with count-chip anchors; no horizontal scroll at 375 px (verified `scrollWidth === clientWidth`).
- **Polish** — header meta "N active · M closed"; Onsite dot is a hollow warn ring (no longer identical to Tech); calibration cells shorten to "— (0/5)"; the "Move jobs between stages from their detail page" subtitle is gone.
- Docs: CLAUDE.md where-to-look row, ARCHITECTURE.md annotations, TASKS §10 marked shipped, stale "dark-only" note in the ui-review skill fixed.

**Stage vocabulary untouched** — STAGE_ORDER / INTERVIEW_RANK / TERMINAL_STAGES stay the hardcoded analytics dictionary (§10.1); no custom stages.

**Item 7 (drag-and-drop) is deliberately NOT built** — say the word if you want it as a progressive enhancement over the same endpoint.

## Verification
- `lint:types` + 778/778 tests (14 new in `stage-time.test.ts`).
- Live in the rebuilt web container: quick-move applied→screen→ghosted→screen on a synthetic row — `appliedAt`/`recruiterContact`/`applicationNotes` byte-identical after 3 moves, ledger chain correct (`ui` source, day-precision dates); row deleted afterwards, cascade removed its events (funnel stats back to the real 3 rows).
- Screenshots at 1200/768/375 from the container; browser console clean; keyboard pass (select/summary focusable, focus ring restored on the compact select, 32 px hit targets).
- `code-review-expert` over the branch diff: 1×P1 (missing focus ring on the compact select), 2×P2 (dead export, chip hit-height) — all fixed in `fix board a11y findings`.
- Drag verified live: full event chain (dragstart highlight → drop) moves the row, ledger chain applied→screen→ghosted→screen correct, fields intact; failure path (404) reverts the card and shows a `role="alert"` notice; console clean. CDP can't synthesize a native OS drag, so the browser-level gesture itself was exercised via dispatched `DragEvent`s — the standard HTML5 API pathway.

## Follow-ups (P3, non-blocking)
- With zero closed jobs there is no drop target for Rejected/Ghosted (the panel isn't rendered) — first rejection goes through the card's select or the job page.
- Android-tablet touch (≥768px, coarse pointer) gets no drag by design — the visible form stays.
- A same-stage quick-move race (two tabs) still flashes "Moved to X" though nothing changed — could compare-and-skip the flash.
- `/applications` GET loads the whole `JobStageEvent` table (as F5 already did); revisit if the ledger ever grows past a few thousand rows.
- Day counts in `stage-time.ts` use UTC-midnight math; a DST boundary can shave ~1 h off a day — cosmetic.

## Release notes (v1.3.0 — applications board redesign)
### What's new
- Drag cards between stages on the /applications board — the stage changes on drop, history ledger kept intact
- Quick-move select on every card as the keyboard / no-JS / touch path (collapsed behind hover/focus while drag is active)
- Board columns cap at 70% of the viewport and scroll internally; funnel stats visible without scrolling past every card
- Rejected/Ghosted fold into a "Closed" panel below the board; five work columns fit a laptop
- Cards show time-in-stage ("in screen 12d") with a "stalled" warning past 14 days without movement
- On phones the board becomes a stage-grouped list with jump chips
### Schema
- no schema changes
### Verification
- 778 tests green (14 new); container smoke of the full move matrix; screenshots at 1200/768/375
### References
- docs/TASKS.md §10; ADR 0024 (append-only stage ledger)

## After merge (Nazar)
```
git tag -a v1.3.0 -m "applications board redesign" <merge-sha>
git push origin v1.3.0
```
Note: the task brief said v1.2.0, but v1.2.0 shipped this morning (PR #53, tag+release in parity, already carrying the PR #48 notes) — so this is v1.3.0.
