### PR TITLE
Blank-profile guardrails (#50) — v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+## [1.4.1] — 2026-09-01
+
+### Fixed
+- **Blank-profile guardrails** ([#50](https://github.com/nazboyko/applypack/issues/50)).
+  A freshly created "New profile" used to activate immediately; with no
+  required stack and no role types the base filter's title gate turns off
+  and the classifier scores generic job quality — one tick classified 118
+  off-stack jobs and alerted 17 of them at scores up to 93. Four
+  independent guards now close this, all deciding through the pure
+  `src/profile-guards.ts` module:
+  - "+ New profile" creates the profile **inactive** and opens it in the
+    editor (`/settings?tab=profile&profile=<id>`); the first save that
+    gives it a required stack or role types activates it. "Fill from a
+    resume" flows into the same rule.
+  - The worker skips classification and alerts for the whole tick when
+    the active profile is blank (fetching and source health stay alive);
+    `/runs` shows `skippedBlankProfile`, and "Re-classify all jobs"
+    refuses to run. Banners on `/jobs` and Settings → Profile say
+    "classification idle" until the profile is fixed.
+  - Code-side floor: a classification made while `stackRequired` is empty
+    is clamped to fit ≤ 50, tagged with a `no-profile-stack` red flag,
+    and never alerts — whatever the threshold or priority boosts say.
+  - Activating a blank profile is refused server-side, and its Activate
+    controls are disabled with a hint.
+
 ## [1.4.0] — 2026-09-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | How many jobs are classified at once | `AI_CONCURRENCY` in `.env` (default 3); limiter in `src/concurrency.ts`, used by `jobs/process-jobs.ts` and `jobs/reclassify-job.ts` |
 | The two-stage prefilter prompt | `src/classifier-prefilter.ts:buildPrefilterPrompt` |
 | Per-job filter rules (pre-Claude) | `src/filter.ts:passesBaseFilter` |
+| Blank-profile guards (skip tick, fit ≤ 50 cap, activation gate) | `src/profile-guards.ts` (pure, issue #50) — wired in `process-jobs.ts`, `classifier.ts`, `routes/settings.tsx` |
 | Telegram MarkdownV2 escape | `src/notifier.ts:escapeMarkdownV2` |
 | Profile-to-prompt translation | `src/classifier.ts:buildSystemPrompt` (stack/role/location/notes lines) |
 | Discovery candidate extraction | `src/discovery.ts:recordCandidatesFromText` (calls `extractAtsToken`) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -4,6 +4,7 @@ import { logger } from './logger';
 import { extractJson } from './text-utils';
 import { getAiRuntime } from './ai-runtime';
 import { preClassify } from './classifier-prefilter';
+import { capFitForMissingStack } from './profile-guards';
 import { INJECTION_FLAG, fence, untrustedDirective } from './prompt-fence';
 import type { ClassifyInput, ClaudeClassification } from './types';
 
@@ -130,7 +131,9 @@ export async function classifyWithClaude(
 
     const json = extractJson(out.text);
     const parsed = json === null ? null : ClassificationSchema.safeParse(json);
-    if (parsed?.success) return parsed.data;
+    // The prompt's stack-mismatch cap is vacuous without a required stack
+    // (issue #50), so the cap is enforced in code — gotcha 11.
+    if (parsed?.success) return capFitForMissingStack(parsed.data, profile);
     logger.warn(
       {
         raw: out.text.slice(0, 500),

--- a/src/jobs/fetch-job.ts
+++ b/src/jobs/fetch-job.ts
@@ -95,6 +95,7 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     crossListed: 0,
     abortedMidRun: 0,
     skippedByPause: 0,
+    skippedBlankProfile: 0,
   };
   await processNormalizedJobs(fetched, profile, classifierMode, inner, paused);
 

--- a/src/jobs/hn-hiring-job.ts
+++ b/src/jobs/hn-hiring-job.ts
@@ -99,6 +99,7 @@ export async function runHnHiringJob(): Promise<{ stats: CronStats }> {
     crossListed: 0,
     abortedMidRun: 0,
     skippedByPause: 0,
+    skippedBlankProfile: 0,
   };
   await processNormalizedJobs(items, profile, settings.classifierMode, inner, paused);
 

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -6,6 +6,7 @@ import { createLimiter } from '../concurrency';
 import { passesBaseFilter } from '../filter';
 import { withApplyLinkFlags } from '../apply-link';
 import { classifyJob, type ClassifyOutcome } from '../classifier';
+import { isBlankProfile } from '../profile-guards';
 import { sendTelegramAlert } from '../notifier';
 import { applyPriorityFloor, parsePriorityRules } from '../priority-rules';
 import {
@@ -44,6 +45,8 @@ export interface ProcessStats {
   abortedMidRun: number;
   /** Classifications scheduled but discarded by the mid-run abort. */
   skippedByPause: number;
+  /** 1 when the tick skipped classify+alerts because the profile is blank. */
+  skippedBlankProfile: number;
 }
 
 /** How far back the cross-listing scan looks. */
@@ -61,6 +64,18 @@ export async function processNormalizedJobs(
   stats: ProcessStats,
   isCancelled?: () => Promise<boolean>,
 ): Promise<void> {
+  // Issue #50: a profile with no required stack and no role types has nothing
+  // to gate on — the filter admits everything and the classifier scores on
+  // vibes. Fetching already happened (source health stays alive); stop here.
+  if (isBlankProfile(profile)) {
+    stats.skippedBlankProfile = 1;
+    logger.warn(
+      { profile: profile.name },
+      'process-jobs: active profile has no required stack and no role types; skipping classification and alerts',
+    );
+    return;
+  }
+
   const priorityRules = parsePriorityRules(profile.priorityRules);
 
   // Once true, queued classify thunks below become no-ops, so an abort

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -6,7 +6,7 @@ import { createLimiter } from '../concurrency';
 import { passesBaseFilter } from '../filter';
 import { withApplyLinkFlags } from '../apply-link';
 import { classifyJob, type ClassifyOutcome } from '../classifier';
-import { isBlankProfile } from '../profile-guards';
+import { isBlankProfile, NO_PROFILE_STACK_FLAG } from '../profile-guards';
 import { sendTelegramAlert } from '../notifier';
 import { applyPriorityFloor, parsePriorityRules } from '../priority-rules';
 import {
@@ -248,6 +248,12 @@ export async function processNormalizedJobs(
       descriptionSimhash: fingerprint,
     });
     stats.persisted++;
+
+    // A score produced without a required stack never alerts, whatever the
+    // threshold or priority boosts say (issue #50). The row stays NEW.
+    if (finalClassification.red_flags.includes(NO_PROFILE_STACK_FLAG)) {
+      continue;
+    }
 
     try {
       await sendTelegramAlert(

--- a/src/jobs/reclassify-job.ts
+++ b/src/jobs/reclassify-job.ts
@@ -7,6 +7,7 @@ import { classifyJob } from '../classifier';
 import { passesBaseFilter } from '../filter';
 import { getActiveProfile } from '../profiles';
 import { getSettings } from '../settings';
+import { isBlankProfile } from '../profile-guards';
 import { parsePriorityRules } from '../priority-rules';
 import { applyPriorityFloor } from './process-jobs';
 import { withApplyLinkFlags } from '../apply-link';
@@ -25,6 +26,15 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
   if (!profile) {
     logger.warn('reclassify-all: no active profile');
     return { stats: { aborted: 1, reason: 'no-active-profile' } };
+  }
+  // Issue #50: re-scoring every job against a blank profile would overwrite
+  // real scores with vibes-based ones and demote most of the inbox.
+  if (isBlankProfile(profile)) {
+    logger.warn(
+      { profile: profile.name },
+      'reclassify-all: active profile has no required stack and no role types; aborting',
+    );
+    return { stats: { aborted: 1, reason: 'blank-profile' } };
   }
 
   const { classifierMode } = await getSettings();

--- a/src/profile-guards.test.ts
+++ b/src/profile-guards.test.ts
@@ -1,0 +1,71 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  capFitForMissingStack,
+  isBlankProfile,
+  NO_PROFILE_STACK_FLAG,
+  NO_STACK_FIT_CAP,
+} from './profile-guards';
+import type { ClaudeClassification } from './types';
+
+const classification = (
+  over: Partial<ClaudeClassification> = {},
+): ClaudeClassification => ({
+  fit_score: 93,
+  location_match: true,
+  salary_min_usd: null,
+  salary_max_usd: null,
+  tech_match: [],
+  red_flags: [],
+  summary: 'x',
+  ...over,
+});
+
+test('isBlankProfile: true only when stack AND roles are both empty', () => {
+  assert.equal(isBlankProfile({ stackRequired: [], roleTypes: [] }), true);
+  assert.equal(isBlankProfile({ stackRequired: ['php'], roleTypes: [] }), false);
+  assert.equal(isBlankProfile({ stackRequired: [], roleTypes: ['backend'] }), false);
+  assert.equal(
+    isBlankProfile({ stackRequired: ['php'], roleTypes: ['backend'] }),
+    false,
+  );
+});
+
+test('isBlankProfile: whitespace-only entries count as empty', () => {
+  assert.equal(isBlankProfile({ stackRequired: ['', '  '], roleTypes: [' '] }), true);
+});
+
+test('capFitForMissingStack: empty stack caps fit at 50 and adds the flag', () => {
+  const capped = capFitForMissingStack(classification(), { stackRequired: [] });
+  assert.equal(capped.fit_score, NO_STACK_FIT_CAP);
+  assert.deepEqual(capped.red_flags, [NO_PROFILE_STACK_FLAG]);
+});
+
+test('capFitForMissingStack: scores at or under the cap keep their value', () => {
+  const capped = capFitForMissingStack(classification({ fit_score: 32 }), {
+    stackRequired: [],
+  });
+  assert.equal(capped.fit_score, 32);
+  assert.deepEqual(capped.red_flags, [NO_PROFILE_STACK_FLAG]);
+});
+
+test('capFitForMissingStack: non-empty stack returns the input untouched', () => {
+  const input = classification();
+  const out = capFitForMissingStack(input, { stackRequired: ['php'] });
+  assert.equal(out, input);
+});
+
+test('capFitForMissingStack: existing flags are kept, ours not duplicated', () => {
+  const capped = capFitForMissingStack(
+    classification({ red_flags: ['low-pay', NO_PROFILE_STACK_FLAG] }),
+    { stackRequired: [] },
+  );
+  assert.deepEqual(capped.red_flags, ['low-pay', NO_PROFILE_STACK_FLAG]);
+});
+
+test('capFitForMissingStack: does not mutate the input', () => {
+  const input = classification();
+  capFitForMissingStack(input, { stackRequired: [] });
+  assert.equal(input.fit_score, 93);
+  assert.deepEqual(input.red_flags, []);
+});

--- a/src/profile-guards.ts
+++ b/src/profile-guards.ts
@@ -1,0 +1,55 @@
+import type { ClaudeClassification } from './types';
+
+/**
+ * Guards against classifying with a blank profile (issue #50): when the
+ * active profile constrains nothing, the base filter's title gate turns off
+ * and the classifier prompt loses every stack rule, so it scores generic
+ * job quality — 90+ for roles the candidate can't do. Pure module; the
+ * worker, the classifier and the settings routes all decide through it.
+ */
+
+/** Red flag stamped on classifications made without a required stack. */
+export const NO_PROFILE_STACK_FLAG = 'no-profile-stack';
+
+/** A score produced with no stack to match against cannot exceed this. */
+export const NO_STACK_FIT_CAP = 50;
+
+/** The two fields every guard decision is based on. */
+export interface GuardableProfile {
+  stackRequired: string[];
+  roleTypes: string[];
+}
+
+function hasEntries(list: string[]): boolean {
+  return list.some((s) => s.trim().length > 0);
+}
+
+/**
+ * True when the profile has no required stack AND no role types — nothing
+ * for `passesBaseFilter` or the classifier to gate on. Blank profiles are
+ * never auto-activated, refuse manual activation, and make the worker skip
+ * classification + alerts for the tick.
+ */
+export function isBlankProfile(profile: GuardableProfile): boolean {
+  return !hasEntries(profile.stackRequired) && !hasEntries(profile.roleTypes);
+}
+
+/**
+ * Post-parse clamp: with no required stack the prompt's stack-mismatch cap
+ * (gotcha 8/11) is vacuous, so the cap moves into code — fit ≤ 50 plus the
+ * `no-profile-stack` flag. The flag survives priority-rule boosts, and the
+ * alert path skips any job carrying it.
+ */
+export function capFitForMissingStack(
+  c: ClaudeClassification,
+  profile: Pick<GuardableProfile, 'stackRequired'>,
+): ClaudeClassification {
+  if (hasEntries(profile.stackRequired)) return c;
+  return {
+    ...c,
+    fit_score: Math.min(c.fit_score, NO_STACK_FIT_CAP),
+    red_flags: c.red_flags.includes(NO_PROFILE_STACK_FLAG)
+      ? c.red_flags
+      : [...c.red_flags, NO_PROFILE_STACK_FLAG],
+  };
+}

--- a/src/web/pages/jobs-list.tsx
+++ b/src/web/pages/jobs-list.tsx
@@ -46,6 +46,8 @@ export interface JobsListProps {
     sort: string;
     verified: string;
   };
+  /** True when the active profile is blank — classification is idling (issue #50). */
+  blankProfileBanner?: boolean;
 }
 
 const STATUS_OPTIONS: { value: string; label: string }[] = [
@@ -70,6 +72,7 @@ export const JobsListPage: FC<JobsListProps> = ({
   page,
   pageSize,
   filters,
+  blankProfileBanner,
 }) => {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
   const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
@@ -92,6 +95,17 @@ export const JobsListPage: FC<JobsListProps> = ({
           </Button>
         }
       />
+
+      {blankProfileBanner && (
+        <div class="mb-4 shrink-0 rounded-md border border-warn/25 bg-warn/5 px-3.5 py-2.5 text-[13px] leading-5 text-warn">
+          Active profile is empty — classification idle. New jobs are fetched but not scored
+          or alerted until the profile lists a required stack or role types.{' '}
+          <a href="/settings?tab=profile" class="font-medium underline">
+            Fix the profile
+          </a>
+          .
+        </div>
+      )}
 
       <div class="mb-4 flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2">
         <nav aria-label="Job filters" class="flex flex-wrap items-center gap-1">

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -261,10 +261,10 @@ export const SettingsPage: FC<SettingsProps> = ({
             <Button variant="violet">Re-classify all jobs</Button>
           </ActionForm>
         </div>
-        {activeProfile && activeProfile.stackRequired.length === 0 && activeProfile.roleTypes.length === 0 && (
+        {profiles.some((p) => p.active && p.blank) && (
           <div class="rounded-md border border-warn/25 bg-warn/5 px-3.5 py-2.5 text-[13px] leading-5 text-warn">
-            This profile lists no required stack and no role types yet, so every fetched job
-            goes to the AI classifier.{' '}
+            Active profile is empty — classification idle. New jobs are fetched but not
+            scored or alerted until it lists a required stack or role types.{' '}
             {resumes.length > 0 ? (
               'Fastest fix: fill the fields from a resume below.'
             ) : (

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -47,6 +47,8 @@ interface ProfileListItem {
   name: string;
   stackPreview: string; // first 3 required tags
   active: boolean;
+  /** No required stack and no role types — activation is gated (issue #50). */
+  blank: boolean;
 }
 
 interface AvailableTarget {
@@ -241,9 +243,9 @@ export const SettingsPage: FC<SettingsProps> = ({
           >
             <Select name="id" class="!w-auto min-w-0 max-w-full" aria-label="Profile to activate">
               {profiles.map((p) => (
-                <option value={p.id} selected={p.active}>
+                <option value={p.id} selected={p.active} disabled={p.blank && !p.active}>
                   {p.name}
-                  {p.active ? ' (active)' : ''}
+                  {p.active ? ' (active)' : p.blank ? ' (empty — fill in first)' : ''}
                 </option>
               ))}
             </Select>
@@ -336,12 +338,22 @@ export const SettingsPage: FC<SettingsProps> = ({
                 .filter((p) => !p.active)
                 .map((p) => (
                   <Tr>
-                    <Td class="font-medium text-ink">{p.name}</Td>
-                    <Td class="text-[13px] text-ink-muted">{p.stackPreview}</Td>
+                    <Td class="font-medium text-ink">
+                      <a href={`/settings?tab=profile&profile=${p.id}`} class="hover:underline">
+                        {p.name}
+                      </a>
+                    </Td>
+                    <Td class="text-[13px] text-ink-muted">
+                      {p.blank ? (
+                        <span class="text-warn">empty — add a stack or role types to activate</span>
+                      ) : (
+                        p.stackPreview
+                      )}
+                    </Td>
                     <Td>
                       <div class="flex justify-end gap-2">
                         <ActionForm action="/settings/profiles/activate" hidden={{ id: p.id }}>
-                          <Button size="sm" variant="secondary">
+                          <Button size="sm" variant="secondary" disabled={p.blank}>
                             Activate
                           </Button>
                         </ActionForm>

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -29,6 +29,7 @@ import type { FlashMessage } from '../flash';
 import { sourceLabel } from '../source-names';
 import { dotClassFor, MAX_WORK_STAGES } from '../stage-config';
 import { formatPriorityRulesText, parsePriorityRules } from '../../priority-rules';
+import { isBlankProfile } from '../../profile-guards';
 import { SENIORITY_LEVELS } from '../../resume/profile-draft';
 
 interface MaskedTarget {
@@ -229,8 +230,8 @@ export const SettingsPage: FC<SettingsProps> = ({
 
       {activeTab === 'profile' && (
       <Section
-        title="Active profile"
-        desc="What a matching job looks like: stack, role types, regions, salary floor. The classifier scores every job against this."
+        title="Profile"
+        desc="What a matching job looks like: stack, role types, regions, salary floor. The classifier scores every job against the active profile."
       >
         <div class="flex flex-wrap items-center gap-2">
           <form
@@ -305,6 +306,14 @@ export const SettingsPage: FC<SettingsProps> = ({
               <Button variant="violet">Fill from resume</Button>
             </form>
           </Card>
+        )}
+        {activeProfile && !profiles.some((p) => p.id === activeProfile.id && p.active) && (
+          <div class="rounded-md border border-line bg-surface-overlay px-3.5 py-2.5 text-[13px] leading-5 text-ink-muted">
+            Editing an inactive profile — the worker keeps scoring with the active one.
+            {isBlankProfile(activeProfile)
+              ? ' It activates automatically on the first save with a required stack or role types.'
+              : ' Use Activate above to make it the scoring profile.'}
+          </div>
         )}
         {activeProfile ? (
           <Card>

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -7,6 +7,8 @@ import { logger } from '../../logger';
 import { getSettings } from '../../settings';
 import { allStages, parseStageConfig } from '../stage-config';
 import { classifyExistingJob } from '../../jobs/classify-existing';
+import { getActiveProfile } from '../../profiles';
+import { isBlankProfile } from '../../profile-guards';
 import { createManualJob, ManualJobSchema, MIN_DESCRIPTION_CHARS } from '../../jobs/manual-job';
 import { checkLiveness, listVerificationsForJob, verifyJob } from '../../verification/verify';
 import { LIVENESS_CODE_LABEL } from '../../verification/liveness';
@@ -116,7 +118,7 @@ jobsRoute.get('/jobs', async (c) => {
 
   const orderBy = sortToOrderBy(sort);
 
-  const [jobs, total] = await Promise.all([
+  const [jobs, total, activeProfile] = await Promise.all([
     prisma.job.findMany({
       where,
       orderBy,
@@ -132,6 +134,7 @@ jobsRoute.get('/jobs', async (c) => {
       },
     }),
     prisma.job.count({ where }),
+    getActiveProfile(),
   ]);
 
   return c.html(
@@ -147,6 +150,7 @@ jobsRoute.get('/jobs', async (c) => {
         sort,
         verified,
       }}
+      blankProfileBanner={activeProfile !== null && isBlankProfile(activeProfile)}
     />,
   );
 });

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -65,6 +65,7 @@ import {
   parsePriorityRulesText,
 } from '../../priority-rules';
 import { prisma } from '../../db';
+import { isBlankProfile } from '../../profile-guards';
 import { isSettingsTab, SettingsPage } from '../pages/settings';
 import { sourceLabel } from '../source-names';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
@@ -229,6 +230,14 @@ settingsRoute.get('/settings', async (c) => {
   const props = await loadSettingsProps();
   const tabParam = c.req.query('tab');
   const activeTab = isSettingsTab(tabParam) ? tabParam : 'general';
+  // ?profile= points the editor at a specific (possibly inactive) profile.
+  // "+ New profile" lands here: new profiles are born inactive (issue #50)
+  // and must be editable before activation.
+  const profileParam = Number(c.req.query('profile'));
+  if (Number.isFinite(profileParam)) {
+    const editorProfile = await getProfile(profileParam);
+    if (editorProfile) props.activeProfile = editorProfile;
+  }
   const flash = parseFlashCookie(c.req.header('cookie'));
   return c.html(<SettingsPage {...props} activeTab={activeTab} flash={flash} />, 200, {
     'Set-Cookie': clearFlashCookie(),
@@ -624,11 +633,12 @@ settingsRoute.post('/settings/profiles/new', async (c) => {
     telegramTargetId: null,
     priorityRules: [],
   });
-  await setActiveProfile(profile.id);
+  // Born inactive (issue #50): a blank profile must never become the
+  // scoring profile. The first save with real content activates it.
   return flashRedirect(
-    '/settings?tab=profile',
+    `/settings?tab=profile&profile=${profile.id}`,
     'ok',
-    'New profile created and activated. Edit the fields below and save.',
+    'New profile created. Add a required stack or role types and save — it activates on the first save with content.',
   );
 });
 
@@ -670,7 +680,8 @@ settingsRoute.post('/settings/profiles/:id/delete', async (c) => {
 settingsRoute.post('/settings/profiles/:id/save', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
-  if (!(await getProfile(id))) {
+  const before = await getProfile(id);
+  if (!before) {
     return flashRedirect('/settings?tab=profile', 'err', 'Profile not found.');
   }
 
@@ -703,7 +714,7 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
     );
   }
 
-  await updateProfile(id, {
+  const input = {
     name: f.name,
     stackRequired: parseTagList(f.stackRequired),
     roleTypes: parseTagList(f.roleTypes),
@@ -722,17 +733,50 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
         ? telegramTargetId
         : null,
     priorityRules,
-  });
+  };
+  await updateProfile(id, input);
+
+  // The second half of "born inactive" (issue #50): the first save that
+  // gives a blank profile real content makes it the active profile. Edits
+  // to profiles that already had content never steal activation.
+  const active = await getActiveProfile();
+  let isActive = active?.id === id;
+  let activated = false;
+  if (!isActive && isBlankProfile(before) && !isBlankProfile(input)) {
+    await setActiveProfile(id);
+    isActive = true;
+    activated = true;
+  }
+  const editorUrl = isActive
+    ? '/settings?tab=profile'
+    : `/settings?tab=profile&profile=${id}`;
 
   if (f.action === 'save-and-reclassify') {
+    if (!isActive) {
+      return flashRedirect(
+        editorUrl,
+        'warn',
+        'Profile saved, but re-classify skipped — it runs against the active profile only.',
+      );
+    }
     triggerReclassifyAsync();
     return flashRedirect(
-      '/settings?tab=profile',
+      editorUrl,
       'ok',
-      'Profile saved. Re-classify started in the background — track progress at /runs.',
+      `Profile saved${activated ? ' and activated' : ''}. Re-classify started in the background — track progress at /runs.`,
     );
   }
-  return flashRedirect('/settings?tab=profile', 'ok', 'Profile saved.');
+  if (activated) {
+    return flashRedirect(editorUrl, 'ok', 'Profile saved and activated.');
+  }
+  if (!isActive && isBlankProfile(input)) {
+    return flashRedirect(
+      editorUrl,
+      'ok',
+      'Profile saved. It stays inactive until it lists a required stack or role types.',
+    );
+  }
+  return flashRedirect(editorUrl, 'ok', 'Profile saved.');
 });
 
 // Prefill the editor from a resume's AI scan. Renders the draft directly —

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -210,6 +210,7 @@ async function loadSettingsProps() {
         p.stackRequired.slice(0, 4).join(', ') +
         (p.stackRequired.length > 4 ? '...' : ''),
       active: active?.id === p.id,
+      blank: isBlankProfile(p),
     })),
     activeProfile: active,
     availableTargets: targets.map((t) => ({
@@ -646,6 +647,16 @@ settingsRoute.post('/settings/profiles/activate', async (c) => {
   const form = await c.req.parseBody();
   const id = Number(form.id);
   if (!Number.isFinite(id)) return flashRedirect('/settings?tab=profile', 'err', 'Invalid id.');
+  // Server-side half of the activation gate (issue #50) — the disabled
+  // Activate button is advisory only.
+  const target = await getProfile(id);
+  if (target && isBlankProfile(target)) {
+    return flashRedirect(
+      `/settings?tab=profile&profile=${id}`,
+      'err',
+      'This profile has no required stack and no role types — fill it in and save before activating.',
+    );
+  }
   try {
     await setActiveProfile(id);
   } catch (err) {


### PR DESCRIPTION
Closes #50.

A blank active profile used to degrade the whole pipeline to "accept everything, score on vibes": the `+ New profile` button activated the empty profile it created, `passesBaseFilter` lost its title gate, the classifier prompt lost every stack rule, and one tick classified 118 off-stack jobs and alerted 17 of them (fit up to 93 for a role the candidate can't do). Four independent guards now close this — defense in depth, all deciding through one pure module.

## What changed

**New pure module `src/profile-guards.ts`** (+ unit tests): `isBlankProfile` (no required stack AND no role types) and `capFitForMissingStack` (no required stack → fit ≤ 50 + `no-profile-stack` red flag). Every guard below calls these two functions.

1. **Create inactive** — `+ New profile` no longer activates. It redirects to `/settings?tab=profile&profile=<id>` (the editor now takes a `?profile=` override, so an inactive profile is editable), and the first save that gives a blank profile real content activates it. "Fill from a resume" flows into the same rule. Edits to profiles that already had content never steal activation.
2. **Worker guard** — `processNormalizedJobs` (both fetch and HN ticks) skips classification + alerts entirely when the active profile is blank; fetching and source health stay alive. `/runs` shows `skippedBlankProfile: 1`. "Re-classify all jobs" aborts with `reason: blank-profile` instead of overwriting 800+ real scores. Banners on `/jobs` and Settings → Profile say "Active profile is empty — classification idle".
3. **Code-side floor** (gotcha 11: caps live in code, not prompts) — post-parse in `classifyWithClaude`, so every path (tick, Re-classify button, pasted jobs, reclassify-all) is covered: with no required stack, fit is clamped to ≤ 50 and the `no-profile-stack` flag is stamped. A job carrying the flag is never alerted, whatever the threshold or priority boosts say (the flag survives `applyPriorityFloor` — verified).
4. **Activation gate** — the server refuses `POST /settings/profiles/activate` for a blank profile; the dropdown option and the table's Activate button are disabled with visible hints.

## Verification

- `npm run lint:types` + `npm test` green (796 tests, 7 new for the guards module).
- Live, in Docker (both images rebuilt):
  - `+ New profile` → created, **not** activated (`activeProfileId` unchanged), lands in the editor via `?profile=`.
  - `POST /activate` on the blank profile → refused with the error flash; DB unchanged.
  - First save with `stackRequired=php` → "Profile saved and activated", `activeProfileId` switched. Re-saving the now non-blank inactive profile does **not** steal activation.
  - Forced the incident state via psql (blank profile activated behind the guards): fetch tick → `fetched: 5506, classified: 0, skippedBlankProfile: 1`, zero alerts, zero AI spend. Reclassify-all → `{"aborted": 1, "reason": "blank-profile"}`.
  - Guard 3 on a throwaway pasted job against the blank profile: stored with `fitScore=50`, `redFlags={no-profile-stack}` (row deleted after).
  - Banners visible on `/jobs` and Settings → Profile at 1200/768/375, no horizontal overflow, browser console clean. Test profiles deleted, profile 1 restored active, control tick on the normal profile runs the full pipeline (no guard misfire).

## Follow-ups (P2/P3 from the pre-merge review)

- A **roles-only** profile (role types set, stack empty) now caps at 50, so with the default threshold 70 everything lands DISMISSED. This is what issue #50 guard 3 specifies, and the `no-profile-stack` flag makes it visible — but if a legitimate stack-agnostic profile ever appears (e.g. EM roles), the cap needs a relaxation switch.
- A priority-rule floor can lift the **displayed** fit above the 50 cap (explicit user rule; the flag and the never-alert rule still hold).
- Fill-from-resume's "already matches" branch redirects without `&profile=`, so the editor jumps back to the active profile.
- "Save & re-classify" on an active profile that was just emptied flashes "Re-classify started", which then aborts as `blank-profile` on `/runs` — honest but two-step.

These guards don't conflict with the upcoming §11 onboarding rework: it replaces the create-flow UI, the guards stay underneath.

## Release notes (v1.4.1)

Bug-fix release per release-discipline (patch): `package.json` → 1.4.1, CHANGELOG section included in this branch. After merge:

```
git tag -a v1.4.1 -m "Blank-profile guardrails (#50)" && git push origin v1.4.1
```

**Cleanup of the incident window (separate, operator-approved step):** jobs classified by the blank profile during CronRun 939 (2026-09-01 04:05+) still carry garbage scores and 17 bogus ALERTED rows; some are already in the pipeline with stages. Surgical re-classify of just those rows (signature: high fitScore with `techMatch = {}`), via classify-existing — not "Re-classify all" — waits for explicit approval, and pipelineStage / JobStageEvent rows are untouched in any case.
