### PR TITLE
point every repo URL at applypack/applypack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+- **Moved to the `applypack` organization** — the repository now lives at
+  `applypack/applypack`. Old URLs redirect, so existing clones and forks
+  keep working, but the outbound `User-Agent` job boards see, the README
+  badges, the `CHANGELOG` compare links and the launch drafts all point at
+  the new address. `scripts/archive-traffic.sh` follows via its `REPO`
+  default.
+
 ## [1.4.1] — 2026-09-01
 
 ### Fixed
-- **Blank-profile guardrails** ([#50](https://github.com/nazboyko/applypack/issues/50)).
+- **Blank-profile guardrails** ([#50](https://github.com/applypack/applypack/issues/50)).
   A freshly created "New profile" used to activate immediately; with no
   required stack and no role types the base filter's title gate turns off
   and the classifier scores generic job quality — one tick classified 118
@@ -582,23 +590,24 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
-[Unreleased]: https://github.com/nazboyko/applypack/compare/v1.4.0...HEAD
-[1.4.0]: https://github.com/nazboyko/applypack/compare/v1.3.0...v1.4.0
-[1.3.0]: https://github.com/nazboyko/applypack/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/nazboyko/applypack/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/nazboyko/applypack/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/nazboyko/applypack/compare/v0.11.1...v1.0.0
-[0.11.1]: https://github.com/nazboyko/applypack/compare/v0.11.0...v0.11.1
-[0.11.0]: https://github.com/nazboyko/applypack/compare/v0.10.0...v0.11.0
-[0.10.0]: https://github.com/nazboyko/applypack/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/nazboyko/applypack/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/nazboyko/applypack/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/nazboyko/applypack/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/nazboyko/applypack/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/nazboyko/applypack/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/nazboyko/applypack/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/nazboyko/applypack/compare/v0.2.1...v0.3.0
-[0.2.1]: https://github.com/nazboyko/applypack/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/nazboyko/applypack/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/nazboyko/applypack/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/nazboyko/applypack/releases/tag/v0.1.0
+[Unreleased]: https://github.com/applypack/applypack/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/applypack/applypack/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/applypack/applypack/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/applypack/applypack/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/applypack/applypack/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/applypack/applypack/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/applypack/applypack/compare/v0.11.1...v1.0.0
+[0.11.1]: https://github.com/applypack/applypack/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/applypack/applypack/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/applypack/applypack/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/applypack/applypack/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/applypack/applypack/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/applypack/applypack/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/applypack/applypack/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/applypack/applypack/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/applypack/applypack/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/applypack/applypack/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/applypack/applypack/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/applypack/applypack/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/applypack/applypack/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/applypack/applypack/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,9 @@ npm run lint:types && npm test   # must be green before every PR; CI runs the sa
   [CLAUDE.md](./CLAUDE.md) → "ATS templates", wire it into
   `src/fetchers/index.ts:fetchOne`, add the `AtsType` enum value with a
   hand-written migration, and unit-test the pure mapper. Unsure the
-  source qualifies? Open a [source proposal](https://github.com/nazboyko/applypack/issues/new?template=new_source.yml)
+  source qualifies? Open a [source proposal](https://github.com/applypack/applypack/issues/new?template=new_source.yml)
   first.
-- **Grab a [good first issue](https://github.com/nazboyko/applypack/labels/good%20first%20issue).**
+- **Grab a [good first issue](https://github.com/applypack/applypack/labels/good%20first%20issue).**
   Scoped tasks with file pointers.
 - **Report bugs.** Use the issue template; logs beat prose.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 **A self-hosted AI console for the whole job search: it reads the boards so you don't have to, then helps you apply well.**
 
-[![CI](https://github.com/nazboyko/applypack/actions/workflows/test.yml/badge.svg)](https://github.com/nazboyko/applypack/actions/workflows/test.yml)
+[![CI](https://github.com/applypack/applypack/actions/workflows/test.yml/badge.svg)](https://github.com/applypack/applypack/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Node 24](https://img.shields.io/badge/node-%3E%3D22-339933?logo=node.js&logoColor=white)](./package.json)
 [![TypeScript strict](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](./tsconfig.json)
-[![Release](https://img.shields.io/github/v/release/nazboyko/applypack?display_name=tag)](./CHANGELOG.md)
+[![Release](https://img.shields.io/github/v/release/applypack/applypack?display_name=tag)](./CHANGELOG.md)
 
 [Quick start](#quick-start) · [What you get](#what-you-get) ·
 [How it works](#how-it-works) · [Bring your own AI](#bring-your-own-ai) ·
@@ -54,7 +54,7 @@ $5 VPS is the whole deployment story.
 ## Quick start
 
 ```bash
-git clone https://github.com/nazboyko/applypack.git
+git clone https://github.com/applypack/applypack.git
 cd applypack
 cp .env.example .env    # add one AI engine, see below
 docker compose up -d    # postgres + worker + dashboard → http://localhost:4747
@@ -311,7 +311,7 @@ Three good entry points:
   one-file change: CLAUDE.md ships three copy-paste fetcher templates
   (single RSS, per-company JSON, list + detail). Propose the source in an
   issue first if you're unsure it fits the sourcing policy.
-- **Grab a [good first issue](https://github.com/nazboyko/applypack/labels/good%20first%20issue).**
+- **Grab a [good first issue](https://github.com/applypack/applypack/labels/good%20first%20issue).**
   Scoped tasks with file pointers.
 - **Break it and report.** A fresh-machine setup that stumbled, an ATS
   edge case, a resume that parses badly: issues with logs are gold.
@@ -321,8 +321,8 @@ setup, tests and conventions. The sourcing policy is non-negotiable:
 official public APIs and RSS only, never scraping
 ([ADR 0005](./docs/adr/0005-no-linkedin-indeed-workday.md)).
 
-<a href="https://github.com/nazboyko/applypack/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=nazboyko/applypack" alt="Contributors" />
+<a href="https://github.com/applypack/applypack/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=applypack/applypack" alt="Contributors" />
 </a>
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Use GitHub's private vulnerability reporting: **Security → Report a
 vulnerability** on this repository
-([direct link](https://github.com/nazboyko/applypack/security/advisories/new)).
+([direct link](https://github.com/applypack/applypack/security/advisories/new)).
 Please don't open a public issue for anything you believe is exploitable.
 
 Expect an acknowledgement within a few days. There is no bug bounty — this

--- a/docs/adr/0005-no-linkedin-indeed-workday.md
+++ b/docs/adr/0005-no-linkedin-indeed-workday.md
@@ -39,7 +39,7 @@ golangprojects, HN's Algolia).
 "this person scrapes our jobs" flags in HR systems.
 ✅ Sources don't break weekly when their anti-bot rules update.
 ✅ The project's `User-Agent` is honest — `applypack/0.11
-(+https://github.com/nazboyko/applypack)` — and we explicitly probe
+(+https://github.com/applypack/applypack)` — and we explicitly probe
 endpoints that ATSes intend us to call.
 
 ❌ We miss roles posted only on LinkedIn / Indeed / Glassdoor. The

--- a/docs/launch/awesome-selfhosted-pr.md
+++ b/docs/launch/awesome-selfhosted-pr.md
@@ -41,7 +41,7 @@ disagree.
 ```yaml
 name: ApplyPack
 website_url: https://applypack.dev
-source_code_url: https://github.com/nazboyko/applypack
+source_code_url: https://github.com/applypack/applypack
 demo_url: https://applypack.dev/demo/
 description: Job-search console that watches company ATS boards and job feeds, scores postings against your profile using your own AI accounts, verifies ghost jobs and tracks applications, with Telegram alerts.
 licenses:

--- a/docs/launch/reddit-selfhosted.md
+++ b/docs/launch/reddit-selfhosted.md
@@ -57,5 +57,5 @@ Self-hosting details, since that's why we're here:
   company boards into a review queue
 
 Single-user by design, MIT. Repo:
-https://github.com/nazboyko/applypack. Setup for every AI engine, local
+https://github.com/applypack/applypack. Setup for every AI engine, local
 and Docker, is in docs/ai-engines.md.

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -64,6 +64,6 @@ making a subscription the primary engine. Sources are official public
 APIs and RSS only; no LinkedIn, Indeed or Workday scraping, and
 docs/adr/0005 says why. MIT.
 
-Repo: https://github.com/nazboyko/applypack. If you want to argue with
+Repo: https://github.com/applypack/applypack. If you want to argue with
 the scoring weights, the decision record is docs/adr/0012 and it is a
 two-minute read.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Nazar Boyko (https://github.com/nazboyko)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nazboyko/applypack.git"
+    "url": "https://github.com/applypack/applypack.git"
   },
   "engines": {
     "node": ">=22"

--- a/scripts/archive-traffic.sh
+++ b/scripts/archive-traffic.sh
@@ -7,7 +7,7 @@
 # Requires: gh (authenticated), jq.
 set -eu
 
-REPO="${REPO:-nazboyko/applypack}"
+REPO="${REPO:-applypack/applypack}"
 OUT="${1:-$HOME/applypack-evidence/traffic}"
 DATE="$(date +%Y-%m-%d)"
 

--- a/site/public/demo/index.html
+++ b/site/public/demo/index.html
@@ -70,7 +70,7 @@
       <div class="mark">AP</div><div class="word">ApplyPack</div>
     </a>
     <div class="spacer"></div>
-    <a class="btn" href="https://github.com/nazboyko/applypack">GitHub&nbsp;→</a>
+    <a class="btn" href="https://github.com/applypack/applypack">GitHub&nbsp;→</a>
   </div>
 </header>
 
@@ -115,7 +115,7 @@
   <p class="fineprint">What's AI and what isn't: one AI call marked each keyword as
   present / missing / ask-the-user against the original resume, and graded the
   alignment. Everything since — coverage, the primary-stack cap, the number — is
-  <a href="https://github.com/nazboyko/applypack/blob/main/src/web/public/score.mjs">score.mjs</a>,
+  <a href="https://github.com/applypack/applypack/blob/main/src/web/public/score.mjs">score.mjs</a>,
   the same file the dashboard ships. A parity test keeps this page's copy
   byte-identical.</p>
 </main>

--- a/site/public/index.html
+++ b/site/public/index.html
@@ -28,7 +28,7 @@
     <a class="plain" href="#features">What you get</a>
     <a class="plain" href="#score">Honest scoring</a>
     <a class="plain" href="#start">Quick start</a>
-    <a class="btn" href="https://github.com/nazboyko/applypack">GitHub&nbsp;→</a>
+    <a class="btn" href="https://github.com/applypack/applypack">GitHub&nbsp;→</a>
   </div>
 </header>
 
@@ -42,7 +42,7 @@
     <div class="cta">
       <a class="btn primary" href="#start">Get started</a>
       <a class="btn" href="demo/">Try the live score</a>
-      <a class="btn" href="https://github.com/nazboyko/applypack">Star on GitHub</a>
+      <a class="btn" href="https://github.com/applypack/applypack">Star on GitHub</a>
     </div>
     <div class="shot"><img src="img/target.png" alt="Resume match: a deterministic 82/100 score with the primary-stack verdict, experience confirmations and the side-by-side editor with keyword highlights" loading="eager"></div>
     <p class="under">The targeted editor: an honest, deterministic resume-vs-posting score,
@@ -128,7 +128,7 @@
       A laptop or a $5 VPS is the whole deployment story.</p>
       <div class="term">
         <div class="bar"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>
-        <pre><span class="g">git</span> clone https://github.com/nazboyko/applypack.git
+        <pre><span class="g">git</span> clone https://github.com/applypack/applypack.git
 <span class="g">cd</span> applypack
 <span class="g">cp</span> .env.example .env    <span class="c"># add one AI engine key</span>
 <span class="g">docker</span> compose up -d    <span class="c"># → http://localhost:4747</span></pre>
@@ -152,10 +152,10 @@
     <div class="word" style="font-size:15px">ApplyPack</div>
     <div class="spacer" style="flex:1"></div>
     <div class="links">
-      <a href="https://github.com/nazboyko/applypack">GitHub</a>
-      <a href="https://github.com/nazboyko/applypack/releases">Releases</a>
-      <a href="https://github.com/nazboyko/applypack/blob/main/CONTRIBUTING.md">Contributing</a>
-      <a href="https://github.com/nazboyko/applypack/blob/main/SECURITY.md">Security</a>
+      <a href="https://github.com/applypack/applypack">GitHub</a>
+      <a href="https://github.com/applypack/applypack/releases">Releases</a>
+      <a href="https://github.com/applypack/applypack/blob/main/CONTRIBUTING.md">Contributing</a>
+      <a href="https://github.com/applypack/applypack/blob/main/SECURITY.md">Security</a>
     </div>
     <div class="tail">MIT licensed. Runs locally — your data stays in your Postgres.</div>
   </div>

--- a/src/http.test.ts
+++ b/src/http.test.ts
@@ -12,7 +12,7 @@ describe('DEFAULT_USER_AGENT', () => {
     const majorMinor = pkg.version.split('.').slice(0, 2).join('.');
     assert.equal(
       DEFAULT_USER_AGENT,
-      `applypack/${majorMinor} (+https://github.com/nazboyko/applypack)`,
+      `applypack/${majorMinor} (+https://github.com/applypack/applypack)`,
     );
   });
 });

--- a/src/http.ts
+++ b/src/http.ts
@@ -17,7 +17,7 @@ function packageMajorMinor(): string {
   }
 }
 
-export const DEFAULT_USER_AGENT = `applypack/${packageMajorMinor()} (+https://github.com/nazboyko/applypack)`;
+export const DEFAULT_USER_AGENT = `applypack/${packageMajorMinor()} (+https://github.com/applypack/applypack)`;
 
 export interface FetchOptions {
   timeoutMs?: number;

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -178,7 +178,7 @@ export const CompaniesPage: FC<CompaniesProps> = ({
           list of boards we can see. There is no "all Greenhouse postings" endpoint, and we
           never scrape LinkedIn / Indeed / Workday (
           <a
-            href="https://github.com/nazboyko/applypack/blob/main/docs/adr/0005-no-linkedin-indeed-workday.md"
+            href="https://github.com/applypack/applypack/blob/main/docs/adr/0005-no-linkedin-indeed-workday.md"
             class="font-medium text-accent-strong hover:text-accent-deep"
           >
             ADR 0005


### PR DESCRIPTION
The repository moved to the `applypack` organization today. Old URLs
redirect, so nothing is broken — but a redirect is not an address, and
three of these links are about to be printed somewhere permanent.

Every `nazboyko/applypack` occurrence now reads `applypack/applypack`:

- **`src/http.ts` — `DEFAULT_USER_AGENT`.** The one that leaves the
  process. ADR 0005 promises job boards an honest, resolvable contact URL;
  that promise should not lean on a redirect. Test in `http.test.ts`
  follows.
- **`docs/launch/*` (3 files).** The whole reason to do this now: the
  awesome-selfhosted `source_code_url` sits in that list for years, and the
  Show HN / r/selfhosted posts are immutable once sent.
- **`site/public/*`.** Landing and demo pages served on applypack.dev.
- README badges, clone line, contrib.rocks, CONTRIBUTING, SECURITY,
  ADR 0005, `package.json` `repository.url`, `scripts/archive-traffic.sh`
  `REPO` default, `companies.tsx` ADR link, all CHANGELOG compare links.

Deliberately unchanged, because there `nazboyko` is a person or another
repository: `package.json` `author`, `.github/CODEOWNERS`,
`CODE_OF_CONDUCT.md`, the README maintainer line, and
`docs/TASKS.md` (`nazboyko/claude-skills`). Also `CHANGELOG.md:163` — it
records that the repo moved to `nazboyko/applypack` in v0.11.1, which is
what actually happened.

**Pre-merge review (P2, fixed here):** `## [1.4.1]` had no reference-link
definition and `[Unreleased]` still compared from `v1.4.0`, so the 1.4.1
heading rendered as a broken link and the unreleased diff silently
included the whole 1.4.1 release. Pre-existing, but this PR is already
rewriting exactly those lines.

### Verification

- `npm run lint:types` clean, `npm test` 796/796
- post-transfer parity confirmed against the pre-transfer snapshot: 7
  stars, 4 forks, 8 issues with numbers intact, 20 tags / 20 releases,
  `protect-main` ruleset active with all four rules, Actions enabled with
  `default: read`
- `grep -rn "nazboyko"` returns only the five intentional person /
  other-repo references listed above

### Follow-ups (not in this PR)

- Cloudflare Pages git integration still points at the personal account —
  a GitHub App does not follow a repo into an org. Until it is reinstalled
  on the org and the project relinked, applypack.dev keeps serving the last
  build but stops deploying on push.
- Org hygiene: verify `applypack.dev` on the org, `applypack/.github`
  profile README, base permissions, 2FA, and a second owner.
- `protect-main` has `required_approving_review_count: 0` and
  `require_code_owner_review: false`, which contradicts the comment in
  `.github/CODEOWNERS`. Harmless while there is one collaborator; fix
  before granting write to anyone.
