### PR TITLE
Profile tab quick wins + journey reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,35 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.5.0] — 2026-09-01
 
 ### Changed
+- **Settings → Profile now follows the user's journey**
+  ([docs/onboarding-plan.md §3](docs/onboarding-plan.md)): contextual
+  warnings first, then "Fill from a resume", then the editor; the profile
+  management row (switch / Activate / Delete / + New) moved to the bottom
+  and the "Other profiles" table is gone — the select is the one
+  mechanism. The standalone "Re-classify all jobs" button was removed:
+  "Save & re-classify" in the editor footer covers it, and a paid AI
+  action no longer greets a fresh install at the top of the page.
+- **"Fill from a resume" accepts a direct file upload** when no resumes
+  exist yet — no more round trip to `/resumes` and back. The upload
+  becomes a normal Resume row (first one becomes the default), is
+  scanned, and the profile draft renders as before; nothing is saved
+  until "Save profile".
+- The three chip fields sit under one "What are we hunting for?" heading
+  with a two-line legend (languages/frameworks → required; job-title
+  words → role types), each with real example placeholders
+  ("php, laravel, mysql…") instead of three identical "Add and press
+  Enter…" prompts.
+- Priority rules live in their own collapsed sub-section; the
+  region-phrase warning shows only when rules exist. The Advanced block
+  no longer auto-opens because of a seeded salary or a Telegram target —
+  only notes, on-site cities or rules open it.
+- The Settings header no longer claims everything saves on click — the
+  profile editor saves on submit, and the copy now says so.
+- Overview explains a paused pipeline: fresh installs start paused so a
+  blank profile doesn't spend AI credit, with a link to fill the profile.
 - **Moved to the `applypack` organization** — the repository now lives at
   `applypack/applypack`. Old URLs redirect, so existing clones and forks
   keep working, but the outbound `User-Agent` job boards see, the README
@@ -590,7 +616,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
-[Unreleased]: https://github.com/applypack/applypack/compare/v1.4.1...HEAD
+[1.5.0]: https://github.com/applypack/applypack/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/applypack/applypack/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/applypack/applypack/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/applypack/applypack/compare/v1.2.0...v1.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | Edit profile (stack, role types, regions, fit threshold) | `/settings` Profile tab (excludes, notes, priority rules, thresholds live in its "Advanced" block) |
 | Fill the profile from a resume (AI draft, review before save) | `/settings` Profile tab → "Fill from a resume" |
 | Switch between profiles | `/settings` Profile tab → dropdown + Activate |
-| Re-classify all jobs against new profile | `/settings` Profile tab → "Re-classify all jobs" (async, watch /runs) |
+| Re-classify all jobs against new profile | `/settings` Profile tab → "Save & re-classify" in the editor (async, watch /runs) |
 | Telegram on/off | `/settings` Notifications tab |
 | Add Telegram bot or chat | `/settings` Notifications tab → "Add target" (validates with getMe + sendMessage) |
 | Pipeline stage on a job | `/jobs/:id` → "Application tracking" card; on `/applications` drag the card between columns (`public/board.mjs`) or use its quick-move select — both hit the stage-only endpoint that never touches appliedAt/notes |
@@ -431,6 +431,6 @@ Always:
 | Flag apply links on already-stored jobs | `docker compose exec app node dist/scripts/backfill-apply-link-flags.js --dry-run`, then without the flag |
 | Re-pull descriptions from the boards (structure lost) | `docker compose exec app node dist/scripts/refetch-descriptions.js --dry-run`, then without the flag |
 | Migrate after a schema change | `DATABASE_URL=… npx prisma migrate dev --name <name>` |
-| Re-classify everything against the active profile | UI: `/settings` → "Re-classify all jobs" |
+| Re-classify everything against the active profile | UI: `/settings` → Profile → "Save & re-classify" |
 | Pause all alerts temporarily | UI: `/settings` → "Telegram alerts" → Disable |
 | Pause new-job fetching entirely (no docker) | UI: `/settings` → "Job fetching" → Pause |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -744,9 +744,10 @@ first-run is a non-technical user. Critical path decided by owner:
 connect AI → prove search works → build profile from a resume;
 Telegram explicitly optional.
 
-- [ ] `profile-tab-quickwins` — reorder Profile tab around the journey,
+- [x] `profile-tab-quickwins` — reorder Profile tab around the journey,
       kill top "Re-classify all", placeholders, conditional rules hint,
-      `advancedOpen` fix, inline upload in the Fill card
+      `advancedOpen` fix, inline upload in the Fill card — done 2026-09-01,
+      branch `profile-tab-quickwins`
 - [ ] `fetch-now` — "Fetch now" button + `{classify: false}` seam +
       background run (reclassify pattern) + progress page
 - [ ] `welcome-wizard` — `/welcome` 4-step first-run flow

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/pages/overview.tsx
+++ b/src/web/pages/overview.tsx
@@ -93,6 +93,20 @@ export const OverviewPage: FC<OverviewProps> = ({
       />
       <Flash flash={flash} />
 
+      {!fetchingEnabled && (
+        <p class="-mt-2 mb-4 text-[13px] leading-5 text-ink-faint">
+          Paused means no new jobs or alerts. Fresh installs start paused so a blank profile
+          doesn't spend AI credit —{' '}
+          <a
+            href="/settings?tab=profile"
+            class="font-medium text-accent-strong transition-colors duration-150 hover:text-accent-deep"
+          >
+            fill the profile
+          </a>
+          , then press Resume.
+        </p>
+      )}
+
       <div class="mb-3 grid grid-cols-2 gap-3 xl:grid-cols-4">
         {PRIMARY_STATUSES.map((s) => {
           const delta = byStatus24h[s] ?? 0;

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -31,6 +31,11 @@ import { dotClassFor, MAX_WORK_STAGES } from '../stage-config';
 import { formatPriorityRulesText, parsePriorityRules } from '../../priority-rules';
 import { isBlankProfile } from '../../profile-guards';
 import { SENIORITY_LEVELS } from '../../resume/profile-draft';
+import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
+import { MAX_UPLOAD_MB } from '../upload';
+
+const FILE_INPUT_CLASS =
+  'file:mr-3 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink';
 
 interface MaskedTarget {
   id: number;
@@ -183,8 +188,9 @@ export const SettingsPage: FC<SettingsProps> = ({
   <Layout title="Settings" active="settings">
     <div class="w-full">
       <PageHeader title="Settings">
-        Changes save the moment you click — no restarts needed. Dashboard actions use them
-        immediately; the background worker picks them up within the hour.
+        Toggles apply the moment you click; forms like the profile editor save on submit. No
+        restarts needed — dashboard actions use changes immediately; the background worker
+        picks them up within the hour.
       </PageHeader>
       <Flash flash={flash} />
 
@@ -235,87 +241,85 @@ export const SettingsPage: FC<SettingsProps> = ({
         title="Profile"
         desc="What a matching job looks like: stack, role types, regions, salary floor. The classifier scores every job against the active profile."
       >
-        <div class="flex flex-wrap items-center gap-2">
-          <form
-            method="post"
-            action="/settings/profiles/activate"
-            class="flex min-w-0 max-w-full flex-wrap items-center gap-2"
-          >
-            <Select name="id" class="!w-auto min-w-0 max-w-full" aria-label="Profile to activate">
-              {profiles.map((p) => (
-                <option value={p.id} selected={p.active} disabled={p.blank && !p.active}>
-                  {p.name}
-                  {p.active ? ' (active)' : p.blank ? ' (empty — fill in first)' : ''}
-                </option>
-              ))}
-            </Select>
-            <Button variant="secondary">Activate</Button>
-          </form>
-          <ActionForm action="/settings/profiles/new">
-            <Button variant="secondary">+ New profile</Button>
-          </ActionForm>
-          <ActionForm
-            action="/settings/reclassify"
-            confirm="Re-classify all jobs (except APPLIED) against the active profile? Takes 2-5 minutes and spends AI credit."
-          >
-            <Button variant="violet">Re-classify all jobs</Button>
-          </ActionForm>
-        </div>
+        {/* Order follows the user's journey: contextual warnings → fill from a
+            resume → the editor → profile management last (docs/onboarding-plan.md §3). */}
         {profiles.some((p) => p.active && p.blank) && (
           <div class="rounded-md border border-warn/25 bg-warn/5 px-3.5 py-2.5 text-[13px] leading-5 text-warn">
             Active profile is empty — classification idle. New jobs are fetched but not
-            scored or alerted until it lists a required stack or role types.{' '}
-            {resumes.length > 0 ? (
-              'Fastest fix: fill the fields from a resume below.'
-            ) : (
-              <>
-                Fastest fix:{' '}
-                <a href="/resumes" class="font-medium underline">
-                  upload a resume
-                </a>{' '}
-                and fill the fields from it here.
-              </>
-            )}
+            scored or alerted until it lists a required stack or role types.
+            {resumes.length > 0
+              ? ' Fastest fix: fill the fields from a resume below.'
+              : ' Fastest fix: upload a resume below and fill the fields from it.'}
           </div>
-        )}
-        {activeProfile && resumes.length > 0 && (
-          <Card>
-            <div class="mb-1 text-[13px] font-medium text-ink">Fill from a resume</div>
-            <Hint class="mb-3">
-              AI maps the resume's scanned stack onto the profile — primary stack → required,
-              other skills → nice-to-have, plus role types and seniority. Re-scans the resume
-              when needed. The result appears below as a draft; nothing is saved until you
-              press "Save profile".
-            </Hint>
-            <form
-              method="post"
-              action={`/settings/profiles/${activeProfile.id}/fill-from-resume`}
-              class="flex flex-wrap items-center gap-2"
-            >
-              <Select
-                name="resumeId"
-                class="!w-auto min-w-0 max-w-full"
-                aria-label="Resume to fill the profile from"
-              >
-                {resumes.map((r) => (
-                  <option value={r.id} selected={r.isDefault}>
-                    {r.name}
-                    {r.isDefault ? ' (default)' : ''}
-                    {r.scannedAt ? '' : ' (not scanned yet)'}
-                  </option>
-                ))}
-              </Select>
-              <Button variant="violet">Fill from resume</Button>
-            </form>
-          </Card>
         )}
         {activeProfile && !profiles.some((p) => p.id === activeProfile.id && p.active) && (
           <div class="rounded-md border border-line bg-surface-overlay px-3.5 py-2.5 text-[13px] leading-5 text-ink-muted">
             Editing an inactive profile — the worker keeps scoring with the active one.
             {isBlankProfile(activeProfile)
               ? ' It activates automatically on the first save with a required stack or role types.'
-              : ' Use Activate above to make it the scoring profile.'}
+              : ' Use Activate below to make it the scoring profile.'}
           </div>
+        )}
+        {activeProfile && (
+          <Card>
+            <div class="mb-1 text-[13px] font-medium text-ink">Fill from a resume</div>
+            {resumes.length > 0 ? (
+              <>
+                <Hint class="mb-3">
+                  AI maps the resume's scanned stack onto the profile — primary stack →
+                  required, other skills → nice-to-have, plus role types and seniority.
+                  Re-scans the resume when needed. The result appears below as a draft;
+                  nothing is saved until you press "Save profile".
+                </Hint>
+                <form
+                  method="post"
+                  action={`/settings/profiles/${activeProfile.id}/fill-from-resume`}
+                  class="flex flex-wrap items-center gap-2"
+                >
+                  <Select
+                    name="resumeId"
+                    class="!w-auto min-w-0 max-w-full"
+                    aria-label="Resume to fill the profile from"
+                  >
+                    {resumes.map((r) => (
+                      <option value={r.id} selected={r.isDefault}>
+                        {r.name}
+                        {r.isDefault ? ' (default)' : ''}
+                        {r.scannedAt ? '' : ' (not scanned yet)'}
+                      </option>
+                    ))}
+                  </Select>
+                  <Button variant="violet">Fill from resume</Button>
+                </form>
+              </>
+            ) : (
+              <>
+                <Hint class="mb-3">
+                  No resumes yet — pick a file ({ACCEPTED_EXTENSIONS.join(', ')} · up to{' '}
+                  {MAX_UPLOAD_MB} MB) and AI maps its stack onto the profile: primary stack →
+                  required, other skills → nice-to-have, plus role types and seniority. Takes
+                  about a minute; the file also lands in Resumes. The result appears below as
+                  a draft; nothing is saved until you press "Save profile".
+                </Hint>
+                <form
+                  method="post"
+                  action={`/settings/profiles/${activeProfile.id}/fill-from-resume`}
+                  enctype="multipart/form-data"
+                  class="flex flex-wrap items-center gap-2"
+                >
+                  <Input
+                    type="file"
+                    name="file"
+                    required
+                    accept={ACCEPTED_EXTENSIONS.join(',')}
+                    aria-label="Resume file"
+                    class={`!w-auto min-w-0 max-w-full ${FILE_INPUT_CLASS}`}
+                  />
+                  <Button variant="violet">Upload &amp; fill</Button>
+                </form>
+              </>
+            )}
+          </Card>
         )}
         {activeProfile ? (
           <Card>
@@ -326,52 +330,39 @@ export const SettingsPage: FC<SettingsProps> = ({
             />
           </Card>
         ) : (
-          <Empty>No active profile. Pick one above or create a new one.</Empty>
+          <Empty>No active profile. Pick one below or create a new one.</Empty>
         )}
-        {profiles.length > 1 && (
-          <Card flush>
-            <div class="border-b border-line px-5 py-3 text-[13px] font-medium text-ink">
-              Other profiles
-            </div>
-            <Table columns={['Name', 'Stack', <span class="block text-right">Actions</span>]}>
-              {profiles
-                .filter((p) => !p.active)
-                .map((p) => (
-                  <Tr>
-                    <Td class="font-medium text-ink">
-                      <a href={`/settings?tab=profile&profile=${p.id}`} class="hover:underline">
-                        {p.name}
-                      </a>
-                    </Td>
-                    <Td class="text-[13px] text-ink-muted">
-                      {p.blank ? (
-                        <span class="text-warn">empty — add a stack or role types to activate</span>
-                      ) : (
-                        p.stackPreview
-                      )}
-                    </Td>
-                    <Td>
-                      <div class="flex justify-end gap-2">
-                        <ActionForm action="/settings/profiles/activate" hidden={{ id: p.id }}>
-                          <Button size="sm" variant="secondary" disabled={p.blank}>
-                            Activate
-                          </Button>
-                        </ActionForm>
-                        <ActionForm
-                          action={`/settings/profiles/${p.id}/delete`}
-                          confirm="Delete this profile?"
-                        >
-                          <Button size="sm" variant="danger">
-                            Delete
-                          </Button>
-                        </ActionForm>
-                      </div>
-                    </Td>
-                  </Tr>
-                ))}
-            </Table>
-          </Card>
-        )}
+        <div class="flex flex-wrap items-center gap-2">
+          <form
+            method="post"
+            action="/settings/profiles/activate"
+            class="flex min-w-0 max-w-full flex-wrap items-center gap-2"
+          >
+            <Select
+              name="id"
+              class="!w-auto min-w-0 max-w-full"
+              aria-label="Profile to activate or delete"
+            >
+              {profiles.map((p) => (
+                <option value={p.id} selected={p.active}>
+                  {p.name}
+                  {p.active ? ' (active)' : p.blank ? ' (empty — fill in first)' : ''}
+                </option>
+              ))}
+            </Select>
+            <Button variant="secondary">Activate</Button>
+            <Button
+              variant="danger"
+              formaction="/settings/profiles/delete"
+              onclick="return confirm('Delete the selected profile? This cannot be undone.')"
+            >
+              Delete
+            </Button>
+          </form>
+          <ActionForm action="/settings/profiles/new">
+            <Button variant="secondary">+ New profile</Button>
+          </ActionForm>
+        </div>
       </Section>
       )}
 
@@ -874,13 +865,13 @@ const ProfileEditor: FC<{
   draft?: ProfileDraftNotice | null;
 }> = ({ profile, availableTargets, draft }) => {
   const rulesCount = parsePriorityRules(profile.priorityRules).length;
-  // Open the advanced block only when something in it is already customised.
+  // Open the advanced block only when free-form content lives in it. Salary
+  // and the Telegram target deliberately don't count — init.ts seeds a salary
+  // from .env, which used to keep the block permanently open for everyone.
   const advancedOpen =
     Boolean(profile.notes && profile.notes.trim().length > 0) ||
     profile.onsiteCities.length > 0 ||
-    rulesCount > 0 ||
-    profile.minSalaryUsd > 0 ||
-    profile.telegramTargetId !== null;
+    rulesCount > 0;
   return (
   <form
     method="post"
@@ -906,24 +897,36 @@ const ProfileEditor: FC<{
       <Input type="text" name="name" required value={profile.name} />
     </Field>
 
-    <TagListInput
-      label="Tech stack — required (real technologies)"
-      hint="Languages / frameworks the role must actually use: typescript, react, python, go, php. Not role types."
-      name="stackRequired"
-      values={profile.stackRequired}
-    />
-    <TagListInput
-      label="Role types (job category hints)"
-      hint='Title shapes you accept: "full-stack", "backend", "platform". Admits jobs to the classifier, but a role type alone is never a tech match.'
-      name="roleTypes"
-      values={profile.roleTypes}
-    />
-    <TagListInput
-      label="Stack — nice to have (boosts fit score)"
-      hint="Tags the classifier rewards when they show up in the description."
-      name="stackNiceToHave"
-      values={profile.stackNiceToHave}
-    />
+    <fieldset class="space-y-4">
+      <legend class="text-[13px] font-medium text-ink">What are we hunting for?</legend>
+      <Hint class="!mt-0.5">
+        Languages and frameworks the job must use go into the required stack.
+        <br />
+        Words from job titles ("backend", "full-stack") go into role types — a title match
+        alone is never a tech match.
+      </Hint>
+      <TagListInput
+        label="Tech stack — required"
+        hint="Real technologies the role must use."
+        name="stackRequired"
+        values={profile.stackRequired}
+        placeholder="php, laravel, mysql…"
+      />
+      <TagListInput
+        label="Role types"
+        hint="Title shapes you accept — they admit jobs to the classifier."
+        name="roleTypes"
+        values={profile.roleTypes}
+        placeholder="backend, full-stack…"
+      />
+      <TagListInput
+        label="Stack — nice to have"
+        hint="Boosts the fit score when they show up in the description."
+        name="stackNiceToHave"
+        values={profile.stackNiceToHave}
+        placeholder="docker, aws…"
+      />
+    </fieldset>
 
     <fieldset>
       <legend class="text-[13px] font-medium text-ink">Seniority</legend>
@@ -1052,10 +1055,12 @@ const TagListInput: FC<{
   name: string;
   values: string[];
   rows?: number;
-}> = ({ label, hint, name, values, rows = 3 }) => (
+  /** Real example values — shown in the textarea and the chip input alike. */
+  placeholder?: string;
+}> = ({ label, hint, name, values, rows = 3, placeholder }) => (
   <Field label={label} hint={hint}>
-    <div data-chips data-label={label}>
-      <Textarea name={name} rows={rows} mono>
+    <div data-chips data-label={label} data-placeholder={placeholder}>
+      <Textarea name={name} rows={rows} mono placeholder={placeholder}>
         {values.join('\n')}
       </Textarea>
     </div>
@@ -1066,41 +1071,51 @@ const PriorityRulesEditor: FC<{ profile: Profile }> = ({ profile }) => {
   const rules = parsePriorityRules(profile.priorityRules);
   const text = formatPriorityRulesText(rules);
   return (
-    <div>
-      <label class="block text-[13px] font-medium text-ink" for="priorityRules">
+    <details class="rounded-md border border-line" open={rules.length > 0}>
+      <summary class="cursor-pointer select-none rounded-md px-4 py-3 text-[13px] font-medium text-ink transition-colors duration-150 hover:text-accent-strong">
         Priority rules (post-classifier overrides)
-      </label>
-      <Hint class="mt-0.5">
-        One rule per line: <Code>LABEL | techs,csv | regions,csv | MIN_FIT</Code>. If the title
-        or description contains any tech and the location matches any region phrase, fit is
-        clamped up to MIN_FIT and the location check passes. Empty regions match anywhere.{' '}
-        <Code>#</Code> starts a comment. A bad line stops the save.
-      </Hint>
-      <Hint class="mt-1 text-warn">
-        Region entries are phrases — every word must appear in the location.{' '}
-        <Code>Remote US</Code> matches "Dallas (Remote US)" but not "Remote · Germany". Avoid a
-        bare <Code>Remote</Code>; prefer <Code>Remote US,United States,USA,Worldwide</Code>.
-      </Hint>
-      <Textarea
-        id="priorityRules"
-        name="priorityRules"
-        rows={Math.max(3, rules.length + 1)}
-        placeholder="Python remote-US | python | Remote US,United States,USA,Worldwide | 90"
-        class="mt-1.5"
-        mono
-      >
-        {text}
-      </Textarea>
-      {rules.length > 0 && (
-        <div class="mt-2 flex flex-wrap gap-1.5">
-          {rules.map((r) => (
-            <Tag tone="violet">
-              {r.label} → ≥{r.minFitFloor}
-            </Tag>
-          ))}
-        </div>
-      )}
-    </div>
+        <span class="ml-2 font-normal text-ink-faint">
+          {rules.length > 0
+            ? `${rules.length} rule${rules.length === 1 ? '' : 's'} set`
+            : 'None set — most people never need these.'}
+        </span>
+      </summary>
+      <div class="border-t border-line px-4 py-4">
+        <Hint>
+          One rule per line: <Code>LABEL | techs,csv | regions,csv | MIN_FIT</Code>. If the
+          title or description contains any tech and the location matches any region phrase,
+          fit is clamped up to MIN_FIT and the location check passes. Empty regions match
+          anywhere. <Code>#</Code> starts a comment. A bad line stops the save.
+        </Hint>
+        {rules.length > 0 && (
+          <Hint class="mt-1 text-warn">
+            Region entries are phrases — every word must appear in the location.{' '}
+            <Code>Remote US</Code> matches "Dallas (Remote US)" but not "Remote · Germany".
+            Avoid a bare <Code>Remote</Code>; prefer{' '}
+            <Code>Remote US,United States,USA,Worldwide</Code>.
+          </Hint>
+        )}
+        <Textarea
+          name="priorityRules"
+          aria-label="Priority rules"
+          rows={Math.max(3, rules.length + 1)}
+          placeholder="Python remote-US | python | Remote US,United States,USA,Worldwide | 90"
+          class="mt-1.5"
+          mono
+        >
+          {text}
+        </Textarea>
+        {rules.length > 0 && (
+          <div class="mt-2 flex flex-wrap gap-1.5">
+            {rules.map((r) => (
+              <Tag tone="violet">
+                {r.label} → ≥{r.minFitFloor}
+              </Tag>
+            ))}
+          </div>
+        )}
+      </div>
+    </details>
   );
 };
 
@@ -1123,7 +1138,7 @@ const SETTINGS_JS = `
       var input = document.createElement('input');
       input.type = 'text';
       input.className = 'min-w-[8rem] flex-1 border-0 bg-transparent p-0.5 text-sm text-ink placeholder:text-ink-faint focus:outline-none focus:ring-0';
-      input.placeholder = 'Add and press Enter…';
+      input.placeholder = host.dataset.placeholder || 'Add and press Enter…';
       input.setAttribute('aria-label', (host.dataset.label || 'Tags') + ' — add item');
 
       function items() {

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -50,7 +50,6 @@ interface MaskedTarget {
 interface ProfileListItem {
   id: number;
   name: string;
-  stackPreview: string; // first 3 required tags
   active: boolean;
   /** No required stack and no role types — activation is gated (issue #50). */
   blank: boolean;

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -69,9 +69,10 @@ import { isBlankProfile } from '../../profile-guards';
 import { isSettingsTab, SettingsPage } from '../pages/settings';
 import { sourceLabel } from '../source-names';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
-import { getResume, listResumes } from '../../resume/store';
+import { createResume, getResume, listResumes } from '../../resume/store';
 import { scanResume } from '../../resume/scan';
 import { buildProfileDraft } from '../../resume/profile-draft';
+import { nameFromFilename, readResumeUpload, resumeUploadLimit } from '../upload';
 
 const NewTargetSchema = z.object({
   name: z.string().min(1).max(100),
@@ -669,13 +670,15 @@ settingsRoute.post('/settings/profiles/activate', async (c) => {
   return flashRedirect(
     '/settings?tab=profile',
     'ok',
-    'Profile activated. Click "Re-classify all jobs" to score them with this profile.',
+    'Profile activated. "Save & re-classify" in the editor re-scores existing jobs against it.',
   );
 });
 
-settingsRoute.post('/settings/profiles/:id/delete', async (c) => {
-  const id = Number(c.req.param('id'));
-  if (!Number.isFinite(id)) return c.text('Bad id', 400);
+// The management row's Delete posts the select's value — id in the body.
+settingsRoute.post('/settings/profiles/delete', async (c) => {
+  const form = await c.req.parseBody();
+  const id = Number(form.id);
+  if (!Number.isFinite(id)) return flashRedirect('/settings?tab=profile', 'err', 'Invalid id.');
   try {
     await deleteProfile(id);
   } catch (err) {
@@ -791,18 +794,30 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
 });
 
 // Prefill the editor from a resume's AI scan. Renders the draft directly —
-// nothing is saved until the user submits the profile form.
-settingsRoute.post('/settings/profiles/:id/fill-from-resume', async (c) => {
+// nothing is saved until the user submits the profile form. With no resumes
+// yet the card sends a file instead of a resumeId: the upload becomes a real
+// Resume row (first one turns default in createResume), then the same flow.
+settingsRoute.post(
+  '/settings/profiles/:id/fill-from-resume',
+  resumeUploadLimit('/settings?tab=profile'),
+  async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const profile = await getProfile(id);
   if (!profile) return flashRedirect('/settings?tab=profile', 'err', 'Profile not found.');
   const form = await c.req.parseBody();
-  const resumeId = Number(form.resumeId);
-  if (!Number.isFinite(resumeId)) {
-    return flashRedirect('/settings?tab=profile', 'err', 'Pick a resume first.');
+  let resume;
+  if (form.file instanceof File && form.file.size > 0) {
+    const upload = await readResumeUpload(form);
+    if ('error' in upload) return flashRedirect('/settings?tab=profile', 'err', upload.error);
+    resume = await createResume({ name: nameFromFilename(upload.sourceFilename), ...upload });
+  } else {
+    const resumeId = Number(form.resumeId);
+    if (!Number.isFinite(resumeId)) {
+      return flashRedirect('/settings?tab=profile', 'err', 'Pick a resume first.');
+    }
+    resume = await getResume(resumeId);
   }
-  let resume = await getResume(resumeId);
   if (!resume || resume.hidden) {
     return flashRedirect('/settings?tab=profile', 'err', 'Resume not found.');
   }
@@ -817,7 +832,7 @@ settingsRoute.post('/settings/profiles/:id/fill-from-resume', async (c) => {
         `The AI scan of "${resume.name}" failed — check the web logs and try again.`,
       );
     }
-    resume = (await getResume(resumeId)) ?? resume;
+    resume = (await getResume(resume.id)) ?? resume;
   }
 
   const draft = buildProfileDraft(profile, {
@@ -853,22 +868,8 @@ settingsRoute.post('/settings/profiles/:id/fill-from-resume', async (c) => {
 });
 
 // --- Re-classify ------------------------------------------------------------
-
-settingsRoute.post('/settings/reclassify', (c) => {
-  if (reclassifyInFlight) {
-    return flashRedirect(
-      '/settings?tab=profile',
-      'err',
-      'A re-classify is already running. Watch /runs for progress.',
-    );
-  }
-  triggerReclassifyAsync();
-  return flashRedirect(
-    '/settings?tab=profile',
-    'ok',
-    'Re-classify started in the background. Track progress at /runs.',
-  );
-});
+// Reached only through "Save & re-classify" in the profile editor — the
+// standalone top-row button was removed (docs/onboarding-plan.md §3).
 
 function triggerReclassifyAsync(): void {
   if (reclassifyInFlight) return;

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -207,9 +207,6 @@ async function loadSettingsProps() {
     profiles: profiles.map((p) => ({
       id: p.id,
       name: p.name,
-      stackPreview:
-        p.stackRequired.slice(0, 4).join(', ') +
-        (p.stackRequired.length > 4 ? '...' : ''),
       active: active?.id === p.id,
       blank: isBlankProfile(p),
     })),


### PR DESCRIPTION
Rebuilds Settings → Profile around the user's actual journey — the follow-through on the blank-profile guards (#50): the guards stop a bad profile, this leads the user to a good one. TASKS §11 block 1; full plan in docs/onboarding-plan.md §3.

## What changed

- **Section order**: contextual warnings → "Fill from a resume" → editor → compact management row (select + Activate + Delete + "+ New profile") at the bottom. The "Other profiles" table is gone — the select is the one mechanism (activating a blank profile redirects into its editor with the explanation, which replaces the table's edit links).
- **Standalone "Re-classify all jobs" button removed** — a paid AI action, harmful at 0 jobs, was the most colourful thing a fresh install saw. "Save & re-classify" in the editor footer covers it. The dead `/settings/reclassify` route is deleted; profile delete moved to `/settings/profiles/delete` (id in the body, from the select).
- **"Fill from a resume" accepts a direct file upload** when no resumes exist — kills the `/resumes` round trip. Multipart on the same fill route: upload → Resume row (first becomes default) → scan → draft. Nothing saved until "Save profile" (ADR 0015 intact). If the scan fails, the row exists, so the card switches to the select for the retry.
- **Chip fields grouped** under "What are we hunting for?" with a two-line legend (languages/frameworks → required; job-title words → role types), explained once instead of three times in fine print. Real example placeholders — `php, laravel, mysql…` / `backend, full-stack…` / `docker, aws…` — server-rendered, so the no-JS textarea shows them too.
- **Priority rules** in their own nested `<details>` (open only when rules exist); the region-phrase warn hint renders only when rules are non-empty.
- **`advancedOpen` fix**: `minSalaryUsd > 0` and `telegramTargetId` no longer count — `init.ts` seeds a salary from `.env`, which kept Advanced permanently open for everyone. Notes / cities / rules only.
- **Header copy** no longer claims everything saves on click — toggles do, the profile editor saves on submit, and the copy says so.
- **Overview**: one explanatory line under the header when the pipeline is paused ("fresh installs start paused so a blank profile doesn't spend AI credit"), linking to the profile tab.

Also: the v1.5.0 changelog section absorbs the org-move entry that was sitting in Unreleased (docs-only, rides with the next minor per release-discipline).

## Verification

- `lint:types` + 796 unit tests green.
- Web container rebuilt; before/after screenshots at desktop and 375px; 0 console errors; all tabs 200.
- **Round-trip**: all three chip fields + notes + cities + rules + multi-value checkboxes (seniority, remoteRegions) save and reload intact — `parseBody({all: true})` path untouched (gotcha 1).
- **No-JS path**: textareas render visible with placeholders in raw HTML; the chip editor is added by JS only. JS chip Enter-commit verified live.
- **advancedOpen**: with `minSalaryUsd=120000` + a Telegram target set and empty notes/cities/rules, Advanced renders CLOSED; adding notes/cities/rules opens it (and the nested rules details + warn hint appear).
- **Inline upload e2e**: multipart `.txt` → Resume row → scan → draft rendered in 12s (rust/c++ → required, backend/systems → role types); test row deleted after.
- **Delete route**: refuses the active profile (server guard), deletes an inactive one; born-inactive → auto-activate-on-first-content-save flow re-verified live (issue #50 gate intact).

## Follow-ups (P2/P3 from the pre-merge review)

- P3: `FILE_INPUT_CLASS` is now duplicated in 4 pages (letter-start, resumes, target-start, settings) — worth hoisting into `ui.tsx`.
- P3: the delete-failure flash surfaces the raw Prisma error message (pre-existing pattern shared by other routes).
- P3: upload+scan in the Fill card is a synchronous ~1 min request — §12 `resumes-page-p0` moves resume scans onto the async run registry; this card should ride along when that lands.

## Release notes (draft for v1.5.0)

```
## What's new
- Settings → Profile reordered around the journey: warnings → Fill from a resume → editor → management row; "Other profiles" table removed
- "Fill from a resume" takes a direct file upload when you have no resumes yet
- Chip fields grouped under "What are we hunting for?" with real example placeholders
- Priority rules collapsed into their own sub-section; Advanced stops auto-opening from the seeded salary
- Standalone "Re-classify all jobs" button removed — "Save & re-classify" covers it
- Overview explains why a fresh install starts paused

## Schema
- no schema changes

## Verification
- 796 unit tests; dashboard rebuild + desktop/375px screenshots; profile save round-trip; no-JS chip path; inline-upload e2e

## References
- docs/onboarding-plan.md §3 · TASKS §11 block 1 · follows the #50 guards (v1.4.1)
```

Tag after merge (release-discipline):

```
git tag -a v1.5.0 -m "profile tab quick wins" <merge-sha> && git push origin v1.5.0
```
