### PR TITLE
fix table rename gaps after #59

### DIFF
--- a/docs/adr/0026-snake-case-table-names.md
+++ b/docs/adr/0026-snake-case-table-names.md
@@ -1,0 +1,40 @@
+# 0026 — Database tables are snake_case, mapped with `@@map()`
+
+**Status:** Accepted (2026-09-01)
+
+## Context
+
+Prisma's default names tables after models (PascalCase), so every psql
+session quotes them (`SELECT … FROM "Job"`), and the DB reads unlike
+conventional Postgres. PR #59 shipped the rename via `@@map()` on all 13
+models plus one rename migration. The rename reaches every deployment on
+next boot — `init.ts` runs `prisma migrate deploy`, and a failed statement
+means the container does not start — so every named object must be covered
+exactly. Two raw-SQL sites (`ai-runtime.ts:recordUsage`,
+`cleanup-job.ts`) still referenced `"AppSettings"` by name: the first
+fails silently (try/catch, debug log), the second crashes the nightly
+cleanup. #59 also left the 12 autoincrement sequences PascalCase.
+
+## Decision
+
+- Every model carries `@@map("snake_case")`; new models must add one.
+- Columns stay camelCase (no `@map`) — only table-level identifiers move.
+- Table/constraint/index renames are **strict** (fail loud → transaction
+  rolls back). Sequence renames ride a separate follow-up migration with
+  `IF EXISTS` — a merged migration file is never edited (checksum), and
+  sequence names are cosmetic: Prisma neither tracks nor drifts on them.
+- Enum types (`"AtsType"`, `"JobStatus"`, …) stay PascalCase: no raw SQL
+  names them, and renaming them would double the surface for zero gain.
+- Raw SQL writes table names unquoted (`app_settings`), columns quoted
+  (`"aiUsage"`).
+
+## Consequences
+
+✅ quote-free psql; conventional naming for every future table
+❌ one all-tables rename migration on every existing deployment (backup
+   first); enum types stay as-is
+
+## When to revisit
+
+If a raw-SQL site ever needs an enum type name, rename the enums then, in
+their own migration with the same strict/tolerant split.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0023 — Trust is apply-link flags, not a score](./0023-apply-link-flags-not-a-trust-score.md)
 - [0024 — Funnel history is an append-only stage ledger](./0024-append-only-stage-ledger.md)
 - [0025 — Work columns are user-defined; fixed entry and exits](./0025-custom-work-stages.md)
+- [0026 — Database tables are snake_case, mapped with `@@map()`](./0026-snake-case-table-names.md)
 
 ## When to write a new one
 

--- a/prisma/migrations/20260901190000_rename_sequences/migration.sql
+++ b/prisma/migrations/20260901190000_rename_sequences/migration.sql
@@ -1,0 +1,20 @@
+-- Finish 20260901175000_normalize_table_names: rename the autoincrement
+-- sequences it left behind. A separate migration because the rename one is
+-- already merged and possibly applied — editing an applied migration file
+-- breaks its checksum in _prisma_migrations.
+-- Column defaults reference sequences by OID, not by name, so nextval()
+-- keeps working. IF EXISTS because sequence names are cosmetic — Prisma
+-- neither tracks nor drifts on them, and a missing one must not abort the
+-- (transactional) migration.
+ALTER SEQUENCE IF EXISTS "CandidateFact_id_seq" RENAME TO "candidate_fact_id_seq";
+ALTER SEQUENCE IF EXISTS "Company_id_seq" RENAME TO "company_id_seq";
+ALTER SEQUENCE IF EXISTS "CompanyCandidate_id_seq" RENAME TO "company_candidate_id_seq";
+ALTER SEQUENCE IF EXISTS "CoverLetter_id_seq" RENAME TO "cover_letter_id_seq";
+ALTER SEQUENCE IF EXISTS "CronRun_id_seq" RENAME TO "cron_run_id_seq";
+ALTER SEQUENCE IF EXISTS "Job_id_seq" RENAME TO "job_id_seq";
+ALTER SEQUENCE IF EXISTS "JobStageEvent_id_seq" RENAME TO "job_stage_event_id_seq";
+ALTER SEQUENCE IF EXISTS "JobVerification_id_seq" RENAME TO "job_verification_id_seq";
+ALTER SEQUENCE IF EXISTS "Profile_id_seq" RENAME TO "profile_id_seq";
+ALTER SEQUENCE IF EXISTS "Resume_id_seq" RENAME TO "resume_id_seq";
+ALTER SEQUENCE IF EXISTS "ResumeMatch_id_seq" RENAME TO "resume_match_id_seq";
+ALTER SEQUENCE IF EXISTS "TelegramTarget_id_seq" RENAME TO "telegram_target_id_seq";

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -181,7 +181,7 @@ async function recordUsage(id: AiProviderId, role: AiRole): Promise<void> {
   const day = new Date().toISOString().slice(0, 10);
   try {
     await prisma.$executeRaw`
-      UPDATE "AppSettings" SET "aiUsage" =
+      UPDATE app_settings SET "aiUsage" =
         jsonb_set(
           jsonb_set(
             jsonb_set(

--- a/src/jobs/cleanup-job.ts
+++ b/src/jobs/cleanup-job.ts
@@ -28,7 +28,7 @@ export async function runCleanupJob(): Promise<{ stats: CronStats }> {
     .toISOString()
     .slice(0, 10);
   await prisma.$executeRaw`
-    UPDATE "AppSettings" SET "aiUsage" = (
+    UPDATE app_settings SET "aiUsage" = (
       SELECT COALESCE(jsonb_object_agg(key, value), '{}'::jsonb)
       FROM jsonb_each(COALESCE("aiUsage", '{}'::jsonb))
       WHERE key >= ${usageCutoff}


### PR DESCRIPTION
#59 merged the snake_case rename but left three gaps; this PR closes them (no reverts — everything builds on top).

- **Two raw-SQL sites still wrote `UPDATE "AppSettings"`** — dead table name after the rename. `recordUsage` (`src/ai-runtime.ts`) would fail silently on every AI call (try/catch + debug log: usage counters just stop), and the aiUsage trim in `src/jobs/cleanup-job.ts` would crash the nightly cleanup. Both now reference `app_settings`.
- **The 12 autoincrement sequences stayed PascalCase** (`"Job_id_seq"`, …). New migration `20260901190000_rename_sequences` renames them with `IF EXISTS` — a separate file because #59's migration is merged and must not be edited (checksum in `_prisma_migrations`).
- **ADR 0026** records the decision: tables snake_case via `@@map()`, columns camelCase, enum types stay PascalCase.

### Verification (branch = main after #59 + #60, plus these fixes)
- `lint:types` + 796/796 tests
- `prisma migrate deploy` against a full clone of the live DB — both pending migrations applied in order (exactly what the next container boot will do): 13 tables + 12 sequences snake_case, row counts intact (981 jobs / 95 companies / 3 resumes / 17 letters / 25 stage events), both fixed statements executed, autoincrement INSERT works
- `prisma migrate diff --from-migrations --to-schema-datamodel` → "No difference detected"
- NOT run pre-merge: live `docker compose build && up -d` — that happens at the normal post-merge rebuild.

### Deploy note
⚠️ Do not rebuild the containers from main until this PR is merged: main currently carries the rename migration together with the broken `"AppSettings"` statements. First boot after this merge runs both migrations; back up the DB first.

### Release notes draft
- All database tables and sequences renamed to snake_case (`app_settings`, `job`, `job_id_seq`, …) via `@@map()` + two transactional migrations; data preserved, back up before upgrading. Fixes the raw-SQL usage-counter and cleanup statements missed in the rename. (ADR 0026)