### PR TITLE
Fetch now: manual fetch tick with live progress + unscored seam

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,9 @@ cron job. The two processes share state only through Postgres
 
 ## Per-tick fetch pipeline
 
-This is what runs every hour at `:05`:
+This is what runs every hour at `:05` — and, since v1.6.0, whenever
+"Fetch now" is pressed on the dashboard (same `runFetchJob`, in the web
+process; while the pipeline is paused it stores the new jobs unscored):
 
 ```mermaid
 sequenceDiagram
@@ -228,7 +230,7 @@ src/
     hn-parser.ts                         pure heuristic parser
 
   jobs/
-    fetch-job.ts                ← runFetchJob (cron entry)
+    fetch-job.ts                ← runFetchJob (cron entry; {manual:true} from "Fetch now")
     digest-job.ts               ← runDigestJob (daily 09:00)
     cleanup-job.ts              ← runCleanupJob (Sunday 03:00)
     stale-applications-job.ts   ← runStaleApplicationsJob (daily 08:00)
@@ -254,10 +256,13 @@ src/
     flash.ts                  ← POST → redirect → GET flash cookie
     upload.ts                 ← multipart resume upload helper + 5 MB limit
     target-runs.ts            ← in-memory compare-run registry (async classify/scan/match)
+    fetch-runs.ts             ← in-memory "Fetch now" registry (live source progress; the 'fetch-now' CronRun is the record)
+    fetch-summary.ts          ← pure one-line verdict of a finished fetch-now run
     public/target.mjs         ← browser keyword matcher (pure ES module, node-tested)
     public/score.mjs          ← browser mirror of resume/score.ts (parity-tested, ADR 0012)
     public/cover-letter.mjs   ← copy-to-clipboard for the letter card (import-smoke-tested)
     public/board.mjs          ← /applications drag-and-drop over POST /jobs/:id/stage (planMove tested)
+    public/fetch-run.mjs      ← activity lines for the fetch-now progress page (pure; target-run.mjs polls)
 
     pages/
       overview.tsx              ← /
@@ -267,7 +272,9 @@ src/
       companies.tsx             ← /companies
       starter-pack.tsx          ← pack picker card + preview + import result
       discovery.tsx             ← /discovery
-      runs.tsx                  ← /runs
+      runs.tsx                  ← /runs (+ Fetch now button)
+      fetch-run.tsx             ← /runs/fetch-now/:id progress page + FetchNowButton
+      run-steps.tsx             ← step list shared by the two progress pages
       settings.tsx              ← /settings (9 cards)
       resumes.tsx               ← /resumes (list + upload form component)
       resume-detail.tsx         ← /resumes/:id
@@ -277,7 +284,7 @@ src/
       job-new.tsx               ← /jobs/new (paste a posting)
       target-start.tsx          ← /target (paste posting + pick/upload/paste resume → one run)
       letter-start.tsx          ← /letter (job by pick/URL/paste + resume + optional match/verify → letter)
-      target-run.tsx            ← /target/runs/:id (progress steps, meta-refresh 2s)
+      target-run.tsx            ← /target/runs/:id (progress steps, polled by target-run.mjs)
       target.tsx                ← /jobs/:id/target (side-by-side editor, live score)
 
     routes/
@@ -289,7 +296,7 @@ src/
       applications.tsx          ← board + stage-only quick-move + per-job application form
       companies.tsx              ← list + new (probe-validated) + delete + toggle + starter packs
       discovery.tsx             ← list + promote + ignore + delete + manual probe
-      runs.tsx
+      runs.tsx                  ← /runs + POST /runs/fetch-now (the tick in the web process) + progress/state
       settings.tsx              ← profile editor + 8 toggles + telegram targets
       health.ts                 ← JSON liveness for external monitoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ All notable changes to this project are documented here. The format follows
   badges, the `CHANGELOG` compare links and the launch drafts all point at
   the new address. `scripts/archive-traffic.sh` follows via its `REPO`
   default.
+- **Database tables are snake_case now** ([ADR 0026](docs/adr/0026-snake-case-table-names.md),
+  [#59](https://github.com/applypack/applypack/pull/59),
+  [#61](https://github.com/applypack/applypack/pull/61)): all 13 models map
+  to snake_case tables (`"Job"` → `job`, `"AppSettings"` → `app_settings`)
+  and the autoincrement sequences follow in a second migration; columns and
+  enum types keep their names. Both migrations run on the next boot — back
+  up an existing deployment first. #61 also fixed the two raw-SQL sites (AI
+  usage counters, nightly cleanup) that still named `"AppSettings"`.
 
 ## [1.4.1] — 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.6.0] — 2026-09-01
+
+### Added
+- **"Fetch now"** ([docs/onboarding-plan.md §2 step 2](docs/onboarding-plan.md),
+  TASKS §11 block 2): a button in the Overview header and on `/runs` runs
+  the hourly fetch tick immediately, in the web process, with a live
+  progress page (`/runs/fetch-now/:id`) that narrates the sources as they
+  answer and lands back on `/runs` with a one-line verdict ("312 jobs from
+  71 sources in 40s — 118 new stored…"). One run at a time; recorded as a
+  `fetch-now` row on `/runs`.
+- **Unscored ingestion seam**: `processNormalizedJobs` accepts
+  `{ classify: false }` and stores what passes the base filter with no fit
+  score, no AI call and no alert. "Fetch now" uses it while the pipeline is
+  paused — paused still means no AI spend — so a fresh install can prove the
+  search works before any profile exists (the wizard's step 2 builds on it).
+  Score those rows later with Re-classify; the hourly tick dedupes them and
+  never revisits them.
+
+### Changed
+- Fetch stats on `/runs` carry `sources` / `sourcesFailed` per tick, and a
+  run started while paused shows `classify: false`.
+- A posting stored by another run meanwhile (the hourly tick and a manual
+  fetch can overlap) now counts as a duplicate instead of failing the whole
+  tick.
+
 ## [1.5.0] — 2026-09-01
 
 ### Changed
@@ -624,6 +649,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.6.0]: https://github.com/applypack/applypack/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/applypack/applypack/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/applypack/applypack/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/applypack/applypack/compare/v1.3.0...v1.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,8 @@
   (DB row → `.env` fallback, pure merge in `ai-engine.ts` — ADR 0013).
 - `jobs/process-jobs.ts` is the single source of truth for the inner
   filter → dedupe → classify → persist → alert sequence. Reused by
-  `runFetchJob` and `runHnHiringJob`.
+  `runFetchJob` and `runHnHiringJob`. `{ classify: false }` stores what
+  passes the filter unscored (no AI, no alert) — "Fetch now" while paused.
 - `AiProvider` calls are tool-free unless the request sets `webTools`; only
   `src/verification/verify.ts` does (ADR 0009). Never turn it on for the classifier.
 - Every AI call site takes its prompt from an exported `build*Prompt`, and
@@ -141,6 +142,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Apply-link flags (missing / unusable / shortened / not-an-application) | `src/apply-link.ts` (pure, ADR 0023); merged into `Job.redFlags` at all three persist paths |
 | Stable id for a feed row with no id of its own | `src/text-utils.ts:feedItemKey` (URL key → text key → null, never `''`) |
 | The cron list (6 schedules) | `src/index.ts:registerCron` |
+| "Fetch now" (the tick from the dashboard: live progress, unscored while paused) | `POST /runs/fetch-now` in `src/web/routes/runs.tsx` → `runFetchJob({ manual: true })` in `src/jobs/fetch-job.ts`; registry `src/web/fetch-runs.ts`; verdict line `src/web/fetch-summary.ts` (pure) |
 | What runs on container boot | `src/init.ts` |
 | Adding a new ATS source — single-feed template | `src/fetchers/larajobs.ts` (LARAJOBS_RSS) or `src/fetchers/golangprojects.ts` (single RSS) |
 | Adding a new ATS source — per-company JSON | `src/fetchers/ashby.ts` (cleanest), `src/fetchers/greenhouse.ts` |
@@ -197,6 +199,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | What | Page |
 | --- | --- |
 | Pause / resume all new-job fetching | `/settings` General tab → "Job fetching" |
+| Pull jobs right now instead of waiting for the hourly tick | Overview header or `/runs` → "Fetch now" (progress page; while paused the jobs land unscored — score them later with Save & re-classify) |
 | See which boards stopped answering | `/companies` → "Quiet sources" card (Re-probe to repair) |
 | Telegram line when a source goes quiet | `/settings` Notifications tab → "Source health alerts" |
 | Pick / order AI engines + models, test them | `/settings` AI engine tab (per-engine cards: Enable, ↑ priority, model selects, Test) |
@@ -418,7 +421,7 @@ Always:
 
 | Task | Command |
 | --- | --- |
-| Run one fetch tick now | `docker compose exec app node dist/scripts/fetch-once.js` |
+| Run one fetch tick now | UI: Overview → "Fetch now" (live progress, row on `/runs`); or `docker compose exec app node dist/scripts/fetch-once.js` |
 | Run discovery probe now | `docker compose exec app node dist/scripts/discovery-once.js` |
 | Pull HN Who-is-hiring now | `docker compose exec app node dist/scripts/hn-once.js` |
 | Send the stale-applications digest now | `docker compose exec app node dist/scripts/stale-once.js` |

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ profile would classify everything as a miss and waste your AI quota.
 3. **Notifications tab** (optional): add a Telegram bot. The form
    validates the token by sending you a real message before it saves.
 4. **General tab**: press **Resume** on the "Job fetching" switch. Too
-   impatient for the hourly tick:
-   `docker compose exec app node dist/scripts/fetch-once.js`
+   impatient for the hourly tick: press **Fetch now** on the Overview and
+   watch the sources answer (it works while paused too — the jobs are then
+   stored unscored).
 
 From then on it runs itself. Every settings change saves to Postgres on
 click: no restarts, no `.env` edits. The worker picks changes up within

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -748,8 +748,9 @@ Telegram explicitly optional.
       kill top "Re-classify all", placeholders, conditional rules hint,
       `advancedOpen` fix, inline upload in the Fill card — done 2026-09-01,
       branch `profile-tab-quickwins`
-- [ ] `fetch-now` — "Fetch now" button + `{classify: false}` seam +
-      background run (reclassify pattern) + progress page
+- [x] `fetch-now` — "Fetch now" button + `{classify: false}` seam +
+      background run (reclassify pattern) + progress page — done 2026-09-01,
+      branch `fetch-now`; lives on Overview AND `/runs` (one shared button)
 - [ ] `welcome-wizard` — `/welcome` 4-step first-run flow
       (AI → test search → resume → first matches), redirect while
       `AppSettings.setupCompletedAt` null, skip link, Overview chip;

--- a/docs/onboarding-plan.md
+++ b/docs/onboarding-plan.md
@@ -8,7 +8,8 @@
 > [CLAUDE.md](../CLAUDE.md), the testing-gate / commit-discipline skills and
 > the ADR register in [docs/adr](./adr/).
 >
-> **Status: analysis only.** Nothing here is implemented. Constants
+> **Status:** stages 1–2 of §5 shipped (`profile-tab-quickwins` v1.5.0,
+> `fetch-now` v1.6.0); stages 3–7 are analysis only. Constants
 > (batch caps, source subsets, timings) are starting hypotheses to
 > re-measure at implementation time.
 
@@ -317,7 +318,13 @@ resumes in one sitting.
   Hypothesis: all enabled, with the progress page making the wait fun.
 - Step-4 classification cap (hypothesis 100 — measure cost/latency on
   Haiku 4.5 two-stage vs single).
-- Whether "Fetch now" lives on `/runs`, Overview, or both.
+- ~~Whether "Fetch now" lives on `/runs`, Overview, or both.~~ Decided in
+  stage 2: **both**, one shared `FetchNowButton` — Overview because it is
+  the page a fresh install lands on ("does the search work?" is answered
+  next to the pipeline switch), `/runs` because that is where the verdict
+  lands and where a re-run is wanted. The CronRun row is named `fetch-now`
+  (not `fetch-test`), and classification follows the pause flag: paused →
+  stored unscored, running → the hourly tick, just now.
 - Wizard copy voice pass (stop-slop skill) once screens exist.
 - Whether step 3 should offer multi-upload immediately or defer extra
   resumes to `/resumes` until stage 5 lands.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -41,8 +41,18 @@ export interface FetcherResult {
   companyName: string;
 }
 
+/** One source answered — live progress for the dashboard's "Fetch now" page. */
+export interface SourceProgress {
+  company: string;
+  status: FetchStatus;
+  count: number;
+  done: number;
+  total: number;
+}
+
 export async function runAllFetchers(
   isCancelled?: () => Promise<boolean>,
+  onSource?: (progress: SourceProgress) => void,
 ): Promise<FetcherResult[]> {
   const settings = await getSettings();
   const disabled = toAtsTypes(settings.disabledSources);
@@ -71,13 +81,15 @@ export async function runAllFetchers(
     }
     done++;
     let status: FetchStatus;
+    let count = 0;
     try {
       const jobs = await fetchOne(company);
+      count = jobs.length;
       // Status comes from the RAW count, before passesBaseFilter — a profile
       // that matches nothing is not a broken board (ADR 0019).
-      status = classifyFetchCount(jobs.length);
+      status = classifyFetchCount(count);
       logger.info(
-        { company: company.name, count: jobs.length, ats: company.atsType, status },
+        { company: company.name, count, ats: company.atsType, status },
         'fetcher: ok',
       );
       for (const job of jobs) {
@@ -91,6 +103,7 @@ export async function runAllFetchers(
       );
     }
     await recordFetchHealth(company, status);
+    onSource?.({ company: company.name, status, count, done, total: companies.length });
     await sleep(POLITE_DELAY_MS);
   }
 

--- a/src/fetchers/source-health.test.ts
+++ b/src/fetchers/source-health.test.ts
@@ -9,6 +9,7 @@ import {
   classifyFetchError,
   describeStatus,
   isFailing,
+  isFailureStatus,
   isSilent,
   nextStreak,
   quietReason,
@@ -212,5 +213,16 @@ describe('describeStatus', () => {
 
   it('never calls a rate limit a dead slug', () => {
     assert.notEqual(describeStatus('rate_limit').tone, describeStatus('slug_gone').tone);
+  });
+});
+
+describe('isFailureStatus', () => {
+  it('treats only ok and empty as answers', () => {
+    assert.equal(isFailureStatus('ok'), false);
+    assert.equal(isFailureStatus('empty'), false);
+    for (const s of FETCH_STATUSES) {
+      if (s === 'ok' || s === 'empty') continue;
+      assert.equal(isFailureStatus(s), true, s);
+    }
   });
 });

--- a/src/fetchers/source-health.ts
+++ b/src/fetchers/source-health.ts
@@ -105,13 +105,18 @@ export function classifyFetchCount(count: number): FetchStatus {
   return count > 0 ? 'ok' : 'empty';
 }
 
+/** Anything but a successful fetch — `empty` is an answer, not a failure. */
+export function isFailureStatus(status: FetchStatus): boolean {
+  return !HEALTHY.has(status);
+}
+
 /**
  * The streak, inverted on purpose: `ok` and `empty` reset, EVERYTHING else
  * increments — including `unknown`. A status added later cannot fall out of
  * the streak by omission; the worst it can do is be counted.
  */
 export function nextStreak(status: FetchStatus, current: number): number {
-  if (HEALTHY.has(status)) return 0;
+  if (!isFailureStatus(status)) return 0;
   return Math.max(0, current) + 1;
 }
 

--- a/src/jobs/fetch-job.ts
+++ b/src/jobs/fetch-job.ts
@@ -1,5 +1,6 @@
 import { logger } from '../logger';
-import { runAllFetchers } from '../fetchers';
+import { runAllFetchers, type SourceProgress } from '../fetchers';
+import { isFailureStatus } from '../fetchers/source-health';
 import { getActiveProfile } from '../profiles';
 import { getSettings } from '../settings';
 import { recordCandidatesFromText } from '../discovery';
@@ -7,15 +8,28 @@ import { makeFetchPauseProbe } from './fetch-pause';
 import { processNormalizedJobs, type ProcessStats } from './process-jobs';
 import type { CronStats } from './cron-run';
 
-export async function runFetchJob(): Promise<{ stats: CronStats }> {
+export interface FetchJobOptions {
+  /**
+   * "Fetch now" from the dashboard. The cron tick skips while fetching is
+   * paused; a manual run fetches anyway but then stores jobs unscored —
+   * paused means no AI spend (issue #50), so classification follows the flag.
+   */
+  manual?: boolean;
+  /** Live progress for the dashboard's run page. */
+  onSource?: (progress: SourceProgress) => void;
+  onProcessing?: () => void;
+}
+
+export async function runFetchJob(opts: FetchJobOptions = {}): Promise<{ stats: CronStats }> {
   const started = Date.now();
-  logger.info('fetch-job: start');
+  logger.info({ manual: opts.manual === true }, 'fetch-job: start');
 
   const settings = await getSettings();
-  if (!settings.fetchingEnabled) {
+  if (!settings.fetchingEnabled && !opts.manual) {
     logger.info('fetch-job: skipped (fetching paused in settings)');
     return { stats: { skipped: 1, reason: 'fetching-paused' } };
   }
+  const classify = settings.fetchingEnabled;
 
   const profile = await getActiveProfile();
   if (!profile) {
@@ -26,16 +40,23 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
   }
   const { classifierMode } = settings;
   logger.info(
-    { profile: profile.name, minFitScore: profile.minFitScore, classifierMode },
+    { profile: profile.name, minFitScore: profile.minFitScore, classifierMode, classify },
     'fetch-job: using active profile',
   );
 
   // Pausing on /settings must also stop a tick that is already running —
-  // every long phase below polls this probe and aborts within seconds.
-  const paused = makeFetchPauseProbe();
+  // every long phase below polls this probe and aborts within seconds. A
+  // manual run that started paused has nothing to abort on.
+  const paused = classify ? makeFetchPauseProbe() : undefined;
 
-  const fetched = await runAllFetchers(paused);
-  logger.info({ count: fetched.length }, 'fetch-job: total fetched');
+  let sources = 0;
+  let sourcesFailed = 0;
+  const fetched = await runAllFetchers(paused, (progress) => {
+    sources = progress.done;
+    if (isFailureStatus(progress.status)) sourcesFailed++;
+    opts.onSource?.(progress);
+  });
+  logger.info({ count: fetched.length, sources, sourcesFailed }, 'fetch-job: total fetched');
 
   // Phase 7.5 — universal ATS-URL discovery from any fetched job's URL
   // and description. The HN /jobs feed is the primary source: each
@@ -49,7 +70,7 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
   if (settings.discoveryEnabled) {
     const sourceTag = `fetch-${new Date().toISOString().slice(0, 7)}`;
     for (const { job, companyName } of fetched) {
-      if (await paused()) break;
+      if (paused && (await paused())) break;
       const text = `${job.url}\n${job.description}`;
       const recorded = await recordCandidatesFromText(text, sourceTag, {
         name: null,
@@ -63,7 +84,7 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     }
   }
 
-  if (await paused()) {
+  if (paused && (await paused())) {
     const durationMs = Date.now() - started;
     logger.warn(
       { fetched: fetched.length, durationMs },
@@ -75,12 +96,15 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
         aborted: 1,
         reason: 'paused-mid-run',
         fetched: fetched.length,
+        sources,
+        sourcesFailed,
         candidatesRecorded: candidates,
         durationMs,
       },
     };
   }
 
+  opts.onProcessing?.();
   const inner: ProcessStats = {
     filterRejected: 0,
     duplicate: 0,
@@ -97,13 +121,20 @@ export async function runFetchJob(): Promise<{ stats: CronStats }> {
     skippedByPause: 0,
     skippedBlankProfile: 0,
   };
-  await processNormalizedJobs(fetched, profile, classifierMode, inner, paused);
+  await processNormalizedJobs(fetched, profile, inner, {
+    classifierMode,
+    classify,
+    isCancelled: paused,
+  });
 
   const durationMs = Date.now() - started;
   const stats: CronStats = {
     profile: profile.name,
     classifierMode,
+    ...(!classify && { classify: false }),
     fetched: fetched.length,
+    sources,
+    sourcesFailed,
     candidatesRecorded: candidates,
     ...inner,
     durationMs,

--- a/src/jobs/hn-hiring-job.ts
+++ b/src/jobs/hn-hiring-job.ts
@@ -101,7 +101,10 @@ export async function runHnHiringJob(): Promise<{ stats: CronStats }> {
     skippedByPause: 0,
     skippedBlankProfile: 0,
   };
-  await processNormalizedJobs(items, profile, settings.classifierMode, inner, paused);
+  await processNormalizedJobs(items, profile, inner, {
+    classifierMode: settings.classifierMode,
+    isCancelled: paused,
+  });
 
   const durationMs = Date.now() - started;
   const stats: CronStats = {

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -353,18 +353,6 @@ async function persistJob(
 ): Promise<{ created: Job; crossListing: CrossListing } | null> {
   const fingerprint = simhash64(job.description);
   const crossListing = findCrossListing(fingerprint, job.companyId, recentFingerprints);
-  if (crossListing) {
-    stats.crossListed++;
-    logger.info(
-      {
-        title: job.title,
-        companyName,
-        originalJobId: crossListing.job.id,
-        distance: crossListing.distance,
-      },
-      'process-jobs: cross-listed posting',
-    );
-  }
 
   let created: Job;
   try {
@@ -391,6 +379,18 @@ async function persistJob(
     descriptionSimhash: fingerprint,
   });
   stats.persisted++;
+  if (crossListing) {
+    stats.crossListed++;
+    logger.info(
+      {
+        title: job.title,
+        companyName,
+        originalJobId: crossListing.job.id,
+        distance: crossListing.distance,
+      },
+      'process-jobs: cross-listed posting',
+    );
+  }
   return { created, crossListing };
 }
 

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -1,4 +1,4 @@
-import { JobStatus, type Prisma, type Profile } from '@prisma/client';
+import { JobStatus, Prisma, type Job, type Profile } from '@prisma/client';
 import { prisma } from '../db';
 import { config } from '../config';
 import { logger } from '../logger';
@@ -9,6 +9,7 @@ import { classifyJob, type ClassifyOutcome } from '../classifier';
 import { isBlankProfile, NO_PROFILE_STACK_FLAG } from '../profile-guards';
 import { sendTelegramAlert } from '../notifier';
 import { applyPriorityFloor, parsePriorityRules } from '../priority-rules';
+import type { ClassifierMode } from '../settings';
 import {
   findCrossListing,
   fromDbBigInt,
@@ -49,6 +50,18 @@ export interface ProcessStats {
   skippedBlankProfile: number;
 }
 
+export interface ProcessOptions {
+  classifierMode: ClassifierMode;
+  /**
+   * false = store what passes the filter unscored (fitScore null, no AI, no
+   * alerts): the dashboard's "Fetch now" while the pipeline is paused. The
+   * cron dedupes on (companyId, externalId), so it never revisits those rows;
+   * scoring is left to Re-classify. Default true.
+   */
+  classify?: boolean;
+  isCancelled?: () => Promise<boolean>;
+}
+
 /** How far back the cross-listing scan looks. */
 const DEDUP_WINDOW_DAYS = 90;
 
@@ -60,14 +73,15 @@ const DEDUP_WINDOW_DAYS = 90;
 export async function processNormalizedJobs(
   items: FetchResult[],
   profile: Profile,
-  classifierMode: 'single' | 'two_stage',
   stats: ProcessStats,
-  isCancelled?: () => Promise<boolean>,
+  opts: ProcessOptions,
 ): Promise<void> {
+  const { classifierMode, classify = true, isCancelled } = opts;
+
   // Issue #50: a profile with no required stack and no role types has nothing
   // to gate on — the filter admits everything and the classifier scores on
   // vibes. Fetching already happened (source health stays alive); stop here.
-  if (isBlankProfile(profile)) {
+  if (classify && isBlankProfile(profile)) {
     stats.skippedBlankProfile = 1;
     logger.warn(
       { profile: profile.name },
@@ -112,8 +126,17 @@ export async function processNormalizedJobs(
   // Fingerprints of everything ingested in the dedup window, read once for
   // the whole batch. Cross-listing is an annotation, so this never changes
   // which jobs get classified (ADR 0018).
-  const recentFingerprints =
-    candidates.length > 0 ? await loadRecentFingerprints() : [];
+  const batch: Batch = {
+    stats,
+    recentFingerprints: candidates.length > 0 ? await loadRecentFingerprints() : [],
+  };
+
+  if (!classify) {
+    for (const item of candidates) {
+      await persistJob(item, null, JobStatus.NEW, [], batch);
+    }
+    return;
+  }
 
   // Classify up to AI_CONCURRENCY jobs at once; results are consumed in the
   // original order, so persisting and alerting stay sequential and ordered.
@@ -137,7 +160,8 @@ export async function processNormalizedJobs(
   }
 
   let consumed = 0;
-  for (const { job, companyName, outcome } of pending) {
+  for (const item of pending) {
+    const { job, companyName, outcome } = item;
     if (isCancelled && (await isCancelled())) {
       cancelled = true;
       stats.abortedMidRun = 1;
@@ -180,74 +204,27 @@ export async function processNormalizedJobs(
     const finalClassification = priority.classification;
     const appliedLabels = priority.applied.map((r) => r.label);
 
-    const fingerprint = simhash64(job.description);
-    const crossListing = findCrossListing(
-      fingerprint,
-      job.companyId,
-      recentFingerprints,
-    );
-    if (crossListing) {
-      stats.crossListed++;
-      logger.info(
-        {
-          title: job.title,
-          companyName,
-          originalJobId: crossListing.job.id,
-          distance: crossListing.distance,
-        },
-        'process-jobs: cross-listed posting',
-      );
-    }
-    const dedup = {
-      descriptionSimhash: fingerprint,
-      crossListedOfJobId: crossListing?.job.id ?? null,
-    };
-
     const dismissReason = decideDismissReason(finalClassification, profile);
     if (dismissReason) {
-      const dismissed = await prisma.job.create({
-        data: buildJobData(
-          job,
-          finalClassification,
-          JobStatus.DISMISSED,
-          appliedLabels,
-          dedup,
-        ),
-      });
-      recentFingerprints.push({
-        id: dismissed.id,
-        companyId: job.companyId,
-        descriptionSimhash: fingerprint,
-      });
-      stats.persisted++;
-      stats.dismissed++;
-      logger.debug(
-        {
-          title: job.title,
-          companyName,
-          fitScore: finalClassification.fit_score,
-          reason: dismissReason,
-        },
-        'process-jobs: dismissed',
-      );
+      const stored = await persistJob(item, finalClassification, JobStatus.DISMISSED, appliedLabels, batch);
+      if (stored) {
+        stats.dismissed++;
+        logger.debug(
+          {
+            title: job.title,
+            companyName,
+            fitScore: finalClassification.fit_score,
+            reason: dismissReason,
+          },
+          'process-jobs: dismissed',
+        );
+      }
       continue;
     }
 
-    const created = await prisma.job.create({
-      data: buildJobData(
-        job,
-        finalClassification,
-        JobStatus.NEW,
-        appliedLabels,
-        dedup,
-      ),
-    });
-    recentFingerprints.push({
-      id: created.id,
-      companyId: job.companyId,
-      descriptionSimhash: fingerprint,
-    });
-    stats.persisted++;
+    const stored = await persistJob(item, finalClassification, JobStatus.NEW, appliedLabels, batch);
+    if (!stored) continue;
+    const { created, crossListing } = stored;
 
     // A score produced without a required stack never alerts, whatever the
     // threshold or priority boosts say (issue #50). The row stays NEW.
@@ -353,14 +330,79 @@ async function companyNameOfJob(jobId: number): Promise<string | null> {
   return row?.company.name ?? null;
 }
 
+/** State shared by every persist of one call: the batch stats and the
+ *  fingerprint window, which grows as rows are stored. */
+interface Batch {
+  stats: ProcessStats;
+  recentFingerprints: FingerprintedJob[];
+}
+
+type CrossListing = ReturnType<typeof findCrossListing<FingerprintedJob>>;
+
+/**
+ * Fingerprint, annotate a cross-listing (ADR 0018) and store the row. Returns
+ * null when the unique key clashed: the hourly tick and a dashboard "Fetch
+ * now" can overlap, and the loser of that race holds a duplicate, not an error.
+ */
+async function persistJob(
+  { job, companyName }: FetchResult,
+  c: ClaudeClassification | null,
+  status: JobStatus,
+  priorityRulesApplied: string[],
+  { stats, recentFingerprints }: Batch,
+): Promise<{ created: Job; crossListing: CrossListing } | null> {
+  const fingerprint = simhash64(job.description);
+  const crossListing = findCrossListing(fingerprint, job.companyId, recentFingerprints);
+  if (crossListing) {
+    stats.crossListed++;
+    logger.info(
+      {
+        title: job.title,
+        companyName,
+        originalJobId: crossListing.job.id,
+        distance: crossListing.distance,
+      },
+      'process-jobs: cross-listed posting',
+    );
+  }
+
+  let created: Job;
+  try {
+    created = await prisma.job.create({
+      data: buildJobData(job, c, status, priorityRulesApplied, {
+        descriptionSimhash: fingerprint,
+        crossListedOfJobId: crossListing?.job.id ?? null,
+      }),
+    });
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+      stats.duplicate++;
+      logger.warn(
+        { title: job.title, companyName },
+        'process-jobs: stored by another run meanwhile; counted as duplicate',
+      );
+      return null;
+    }
+    throw err;
+  }
+  recentFingerprints.push({
+    id: created.id,
+    companyId: job.companyId,
+    descriptionSimhash: fingerprint,
+  });
+  stats.persisted++;
+  return { created, crossListing };
+}
+
 interface DedupData {
   descriptionSimhash: bigint | null;
   crossListedOfJobId: number | null;
 }
 
+/** `c === null` stores the posting unscored — every classifier field stays empty. */
 function buildJobData(
   job: NormalizedJob,
-  c: ClaudeClassification,
+  c: ClaudeClassification | null,
   status: JobStatus,
   priorityRulesApplied: string[],
   dedup: DedupData,
@@ -377,17 +419,16 @@ function buildJobData(
     location: job.location,
     description: job.description,
     postedAt: job.postedAt,
-    fitScore: c.fit_score,
-    salaryMin: c.salary_min_usd,
-    salaryMax: c.salary_max_usd,
-    techMatch: c.tech_match,
+    fitScore: c?.fit_score ?? null,
+    salaryMin: c?.salary_min_usd ?? null,
+    salaryMax: c?.salary_max_usd ?? null,
+    techMatch: c?.tech_match ?? [],
     // `pasted: false` is an invariant, not an assumption: a MANUAL company's
     // fetchOne returns [], so a pasted row never reaches this loop. Pasted
     // jobs get their flags from classify-existing.ts instead.
-    redFlags: withApplyLinkFlags(c.red_flags, { url: job.url, pasted: false }),
-    summary: c.summary,
+    redFlags: withApplyLinkFlags(c?.red_flags ?? [], { url: job.url, pasted: false }),
+    summary: c?.summary ?? null,
     status,
     priorityRulesApplied,
   };
 }
-

--- a/src/web/fetch-run.test.ts
+++ b/src/web/fetch-run.test.ts
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// The activity module ships to the browser as a static ES module; node loads it the same way.
+// @ts-expect-error — plain JS with no declaration file; the shape is asserted below.
+const page = import('./public/fetch-run.mjs') as Promise<{
+  sourceLine: (state: Record<string, unknown>) => string;
+  fetchActivity: (step: string, state: Record<string, unknown>) => string;
+}>;
+
+test('sourceLine narrates the sources as they answer', async () => {
+  const { sourceLine } = await page;
+  assert.equal(sourceLine({ sourcesTotal: null, sourcesDone: 0, jobsFetched: 0 }), 'Contacting the first source…');
+  assert.equal(
+    sourceLine({
+      sourcesTotal: 71,
+      sourcesDone: 14,
+      jobsFetched: 312,
+      lastSource: { name: 'RemoteOK', count: 120, failed: false },
+    }),
+    '14 of 71 sources · 312 jobs so far · RemoteOK: 120 jobs',
+  );
+  assert.match(
+    sourceLine({ sourcesTotal: 71, sourcesDone: 2, jobsFetched: 1, lastSource: { name: 'Acme', count: 0, failed: true } }),
+    /1 job so far · Acme: failed$/,
+  );
+  assert.match(
+    sourceLine({ sourcesTotal: 71, sourcesDone: 3, jobsFetched: 1, lastSource: { name: 'Acme', count: 0, failed: false } }),
+    /Acme: no jobs$/,
+  );
+});
+
+test('fetchActivity paces the store step by mode and ignores unknown steps', async () => {
+  const { fetchActivity } = await page;
+  const unscored = fetchActivity('store', { classify: false, stageElapsedMs: 0 });
+  assert.match(unscored, /^Filtering/);
+  assert.match(fetchActivity('store', { classify: false, stageElapsedMs: 10 * 60_000 }), /unscored/);
+  assert.match(fetchActivity('store', { classify: true, stageElapsedMs: 10 * 60_000 }), /alerts/);
+  assert.equal(fetchActivity('fetch', { sourcesTotal: null }), 'Contacting the first source…');
+  assert.equal(fetchActivity('nope', {}), '');
+});

--- a/src/web/fetch-runs.ts
+++ b/src/web/fetch-runs.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from 'node:crypto';
+import { logger } from '../logger';
+import type { CronStats } from '../jobs/cron-run';
+import type { SourceProgress } from '../fetchers';
+import { isFailureStatus } from '../fetchers/source-health';
+
+/*
+ * In-memory registry for "Fetch now" — the fetch tick started from the
+ * dashboard instead of the cron. Same shape as target-runs.ts: the POST
+ * returns at once with a redirect to /runs/fetch-now/:id, whose page polls
+ * the state route until the run flips to done or error. The CronRun row
+ * ('fetch-now') is the durable record on /runs; a web restart only forgets
+ * the live progress (ADR 0003: no queue).
+ */
+
+export type FetchRunStage = 'fetch' | 'store' | 'done' | 'error';
+
+export const FETCH_RUN_STEPS: FetchRunStage[] = ['fetch', 'store'];
+
+export interface FetchRun {
+  id: string;
+  stage: FetchRunStage;
+  startedAt: number;
+  /** When the current stage began — paces the progress page's activity line. */
+  stageAt: number;
+  /** False while the pipeline is paused: jobs are stored unscored. */
+  classify: boolean;
+  sourcesDone: number;
+  /** Unknown until the first source answers. */
+  sourcesTotal: number | null;
+  jobsFetched: number;
+  /** The last source that answered, for the activity line. */
+  lastSource: { name: string; count: number; failed: boolean } | null;
+  stats?: CronStats;
+  error?: string;
+}
+
+const RUN_TTL_MS = 30 * 60_000;
+const runs = new Map<string, FetchRun>();
+
+export function createFetchRun(fields: Pick<FetchRun, 'classify'>): FetchRun {
+  prune();
+  const run: FetchRun = {
+    id: randomUUID(),
+    stage: 'fetch',
+    startedAt: Date.now(),
+    stageAt: Date.now(),
+    sourcesDone: 0,
+    sourcesTotal: null,
+    jobsFetched: 0,
+    lastSource: null,
+    ...fields,
+  };
+  runs.set(run.id, run);
+  return run;
+}
+
+export function updateFetchRun(id: string, patch: Partial<Omit<FetchRun, 'id'>>): void {
+  const run = runs.get(id);
+  if (!run) return;
+  if (patch.stage && patch.stage !== run.stage) run.stageAt = Date.now();
+  Object.assign(run, patch);
+}
+
+export function recordSource(id: string, p: SourceProgress): void {
+  const run = runs.get(id);
+  if (!run) return;
+  run.sourcesDone = p.done;
+  run.sourcesTotal = p.total;
+  run.jobsFetched += p.count;
+  run.lastSource = { name: p.company, count: p.count, failed: isFailureStatus(p.status) };
+}
+
+export function getFetchRun(id: string): FetchRun | null {
+  return runs.get(id) ?? null;
+}
+
+/** The in-flight guard: at most one manual fetch at a time per web process. */
+export function activeFetchRun(): FetchRun | null {
+  for (const run of runs.values()) {
+    if (run.stage === 'fetch' || run.stage === 'store') return run;
+  }
+  return null;
+}
+
+/** Runs the tick; any uncaught failure flips the run to error. */
+export function startFetchRun(id: string, fn: () => Promise<void>): void {
+  void fn().catch((err) => {
+    logger.error({ err, runId: id }, 'web: fetch-now run failed');
+    updateFetchRun(id, { stage: 'error', error: 'The run failed — see the web logs and the row on /runs.' });
+  });
+}
+
+function prune(): void {
+  const cutoff = Date.now() - RUN_TTL_MS;
+  for (const [id, run] of runs) {
+    if (run.startedAt < cutoff) runs.delete(id);
+  }
+}

--- a/src/web/fetch-summary.test.ts
+++ b/src/web/fetch-summary.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { summarizeFetchRun } from './fetch-summary';
+
+const base = { fetched: 312, sources: 71, sourcesFailed: 0, durationMs: 40_000, persisted: 118 };
+
+test('a paused-pipeline run reports unscored storage and no AI spend', () => {
+  const { kind, text } = summarizeFetchRun({ ...base, classify: false });
+  assert.equal(kind, 'ok');
+  assert.match(text, /312 jobs from 71 sources in 40\.0s — 118 new stored unscored/);
+  assert.match(text, /no AI spent/);
+});
+
+test('a running-pipeline run reports scored and alerted counts', () => {
+  const { kind, text } = summarizeFetchRun({ ...base, classified: 100, alerted: 5, sourcesFailed: 3 });
+  assert.equal(kind, 'ok');
+  assert.match(text, /71 sources \(3 failed\)/);
+  assert.match(text, /118 new stored, 100 scored, 5 alerted\./);
+});
+
+test('zero jobs from every source points at the network', () => {
+  const { kind, text } = summarizeFetchRun({ ...base, fetched: 0, persisted: 0, sourcesFailed: 71 });
+  assert.equal(kind, 'warn');
+  assert.match(text, /no jobs from 71 sources \(71 failed\)/);
+  assert.match(text, /Quiet sources/);
+});
+
+test('aborted runs and a blank profile are named honestly', () => {
+  assert.equal(summarizeFetchRun({ aborted: 1, reason: 'no-active-profile' }).kind, 'err');
+  const paused = summarizeFetchRun({ aborted: 1, reason: 'paused-mid-run', fetched: 40, sources: 9, durationMs: 9_000 });
+  assert.equal(paused.kind, 'warn');
+  assert.match(paused.text, /paused mid-run after 9 sources/);
+  const blank = summarizeFetchRun({ ...base, persisted: 0, skippedBlankProfile: 1 });
+  assert.equal(blank.kind, 'warn');
+  assert.match(blank.text, /profile is blank/);
+  const midRun = summarizeFetchRun({ ...base, abortedMidRun: 1, skippedByPause: 20 });
+  assert.equal(midRun.kind, 'warn');
+  assert.match(midRun.text, /paused mid-run/);
+});

--- a/src/web/fetch-summary.ts
+++ b/src/web/fetch-summary.ts
@@ -1,0 +1,53 @@
+import type { CronStats } from '../jobs/cron-run';
+import type { FlashKind } from './flash';
+import { formatDuration } from './format';
+
+/*
+ * The one-line verdict of a finished "Fetch now" run, built from the
+ * CronRun stats runFetchJob returns. Pure — tested in fetch-summary.test.ts.
+ */
+
+function num(stats: CronStats, key: string): number {
+  const v = stats[key];
+  return typeof v === 'number' ? v : 0;
+}
+
+export function summarizeFetchRun(stats: CronStats): { kind: FlashKind; text: string } {
+  if (stats.reason === 'no-active-profile') {
+    return { kind: 'err', text: 'Fetch now: no active profile — create one on Settings → Profile.' };
+  }
+  const fetched = num(stats, 'fetched');
+  const sources = num(stats, 'sources');
+  const failed = num(stats, 'sourcesFailed');
+  const took = formatDuration(num(stats, 'durationMs'));
+  if (stats.reason === 'paused-mid-run') {
+    return {
+      kind: 'warn',
+      text: `Fetch now stopped: fetching was paused mid-run after ${sources} sources (${fetched} jobs, nothing stored).`,
+    };
+  }
+  if (fetched === 0) {
+    return {
+      kind: 'warn',
+      text: `Fetch now: no jobs from ${sources} sources${failed > 0 ? ` (${failed} failed)` : ''} in ${took} — check the network, then the Quiet sources card on /companies.`,
+    };
+  }
+  const persisted = num(stats, 'persisted');
+  const head = `Fetch now: ${fetched} jobs from ${sources} sources${failed > 0 ? ` (${failed} failed)` : ''} in ${took} — ${persisted} new stored`;
+  if (stats.classify === false) {
+    return {
+      kind: 'ok',
+      text: `${head} unscored, no AI spent while the pipeline is paused. Score them with Re-classify when you resume.`,
+    };
+  }
+  if (stats.skippedBlankProfile === 1) {
+    return {
+      kind: 'warn',
+      text: `Fetch now: ${fetched} jobs from ${sources} sources in ${took}, nothing stored — the active profile is blank, so classification is idle.`,
+    };
+  }
+  if (stats.abortedMidRun === 1) {
+    return { kind: 'warn', text: `${head}; the rest was skipped when fetching was paused mid-run.` };
+  }
+  return { kind: 'ok', text: `${head}, ${num(stats, 'classified')} scored, ${num(stats, 'alerted')} alerted.` };
+}

--- a/src/web/fetch-summary.ts
+++ b/src/web/fetch-summary.ts
@@ -37,7 +37,7 @@ export function summarizeFetchRun(stats: CronStats): { kind: FlashKind; text: st
   if (stats.classify === false) {
     return {
       kind: 'ok',
-      text: `${head} unscored, no AI spent while the pipeline is paused. Score them with Re-classify when you resume.`,
+      text: `${head} unscored, no AI spent while the pipeline is paused. Score them later with Save & re-classify on Settings → Profile.`,
     };
   }
   if (stats.skippedBlankProfile === 1) {

--- a/src/web/pages/fetch-run.tsx
+++ b/src/web/pages/fetch-run.tsx
@@ -1,0 +1,106 @@
+/** @jsxImportSource hono/jsx */
+import type { FC } from 'hono/jsx';
+import { Layout } from '../layout';
+import { ActionForm, Button, Card, Hint } from '../ui';
+import { RunSteps, type StepView } from './run-steps';
+import { FETCH_RUN_STEPS, type FetchRun } from '../fetch-runs';
+
+function stepView(classify: boolean): Record<string, StepView> {
+  return {
+    fetch: {
+      label: 'Ask every enabled source',
+      detail: 'one request per board, a polite second apart — a few minutes',
+    },
+    store: classify
+      ? {
+          label: 'Score what is new',
+          detail:
+            'filter, de-duplicate, then the AI scores each new job and alerts on matches — minutes for a big batch',
+        }
+      : {
+          label: 'Store what is new',
+          detail: 'filter and de-duplicate; stored unscored — no AI spent while the pipeline is paused',
+        },
+  };
+}
+
+/** "Fetch now" — one form shared by Overview and /runs; a link to the live run while one is in flight. */
+export const FetchNowButton: FC<{ run: FetchRun | null }> = ({ run }) =>
+  run ? (
+    <Button href={`/runs/fetch-now/${run.id}`} size="sm" variant="secondary">
+      Fetching… watch
+    </Button>
+  ) : (
+    <ActionForm action="/runs/fetch-now">
+      <Button
+        size="sm"
+        variant="secondary"
+        title="Run the hourly fetch now. While the pipeline is paused, new jobs are stored unscored."
+      >
+        Fetch now
+      </Button>
+    </ActionForm>
+  );
+
+/**
+ * Live progress for a "Fetch now" run: target-run.mjs polls the state route
+ * with fetch-run.mjs narrating the sources as they answer. Terminal states
+ * reload into the server-side redirect (flash on /runs).
+ */
+export const FetchRunPage: FC<{ run: FetchRun }> = ({ run }) => {
+  const failed = run.stage === 'error';
+  const currentIdx = FETCH_RUN_STEPS.indexOf(run.stage);
+  const elapsed = Math.max(0, Math.round((Date.now() - run.startedAt) / 1000));
+  const heading = failed ? 'Fetch failed' : 'Fetching now';
+  return (
+    <Layout title={failed ? heading : `${heading}…`} active="runs">
+      <div class="w-full pt-6 lg:pt-16">
+        <Card>
+          <div class="mb-1 text-sm font-semibold text-ink">{heading}</div>
+          <div class="text-sm text-ink-muted">
+            {run.classify
+              ? 'Every enabled source, then the new jobs are scored and alerted — the hourly tick, just now.'
+              : 'Every enabled source; new jobs are stored unscored because the pipeline is paused.'}
+          </div>
+
+          {failed ? (
+            <div class="mt-4 space-y-4">
+              <div class="rounded-md border border-danger/25 bg-danger/5 px-3.5 py-2.5 text-sm text-danger">
+                {run.error ?? 'The run failed — see the web logs.'}
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <Button href="/runs" variant="secondary">
+                  ← Back to runs
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <RunSteps steps={FETCH_RUN_STEPS} currentIdx={currentIdx} view={stepView(run.classify)} />
+              <div class="mt-5 flex items-center justify-between gap-3 border-t border-line pt-3">
+                <Hint>You can close this page — the run keeps going, and its row lands on Runs.</Hint>
+                <span id="run-elapsed" class="shrink-0 text-xs tabular-nums text-ink-faint">
+                  {elapsed}s
+                </span>
+              </div>
+              <script
+                id="run-data"
+                type="application/json"
+                dangerouslySetInnerHTML={{
+                  __html: JSON.stringify({ id: run.id, stateUrl: `/runs/fetch-now/${run.id}/state` }),
+                }}
+              />
+              <script type="module" dangerouslySetInnerHTML={{ __html: RUN_BOOT }} />
+            </>
+          )}
+        </Card>
+      </div>
+    </Layout>
+  );
+};
+
+const RUN_BOOT = `
+import { init } from '/static/target-run.mjs';
+import { fetchActivity } from '/static/fetch-run.mjs';
+init(JSON.parse(document.getElementById('run-data').textContent), fetchActivity);
+`;

--- a/src/web/pages/overview.tsx
+++ b/src/web/pages/overview.tsx
@@ -4,6 +4,8 @@ import type { CronRunStatus } from '@prisma/client';
 import { Layout } from '../layout';
 import { Badge, Button, Card, Empty, FitBadge, Flash, PageHeader, SectionTitle, Stat, StatusBadge } from '../ui';
 import type { FlashMessage } from '../flash';
+import type { FetchRun } from '../fetch-runs';
+import { FetchNowButton } from './fetch-run';
 import {
   formatDateShort,
   formatDuration,
@@ -41,6 +43,8 @@ export interface OverviewProps {
   recentAlerts: JobRow[];
   latestRuns: { name: string; run: RunRow | null }[];
   fetchingEnabled: boolean;
+  /** The manual fetch in flight, if any — the button turns into a link to it. */
+  fetchRun: FetchRun | null;
   flash?: FlashMessage | null;
 }
 
@@ -62,6 +66,7 @@ export const OverviewPage: FC<OverviewProps> = ({
   recentAlerts,
   latestRuns,
   fetchingEnabled,
+  fetchRun,
   flash,
 }) => {
   const byStatus = mapCounts(counts);
@@ -75,20 +80,23 @@ export const OverviewPage: FC<OverviewProps> = ({
         title="Overview"
         meta="Refreshes every 30s"
         actions={
-          /* Quick master switch — same toggle as Settings → General. */
-          <form
-            method="post"
-            action="/settings/fetching-toggle"
-            class="flex items-center gap-2"
-          >
-            <input type="hidden" name="back" value="/" />
-            <Badge tone={fetchingEnabled ? 'ok' : 'neutral'}>
-              {fetchingEnabled ? 'Pipeline running' : 'Pipeline paused'}
-            </Badge>
-            <Button size="sm" variant="secondary">
-              {fetchingEnabled ? 'Pause' : 'Resume'}
-            </Button>
-          </form>
+          <>
+            <FetchNowButton run={fetchRun} />
+            {/* Quick master switch — same toggle as Settings → General. */}
+            <form
+              method="post"
+              action="/settings/fetching-toggle"
+              class="flex items-center gap-2"
+            >
+              <input type="hidden" name="back" value="/" />
+              <Badge tone={fetchingEnabled ? 'ok' : 'neutral'}>
+                {fetchingEnabled ? 'Pipeline running' : 'Pipeline paused'}
+              </Badge>
+              <Button size="sm" variant="secondary">
+                {fetchingEnabled ? 'Pause' : 'Resume'}
+              </Button>
+            </form>
+          </>
         }
       />
       <Flash flash={flash} />
@@ -103,7 +111,7 @@ export const OverviewPage: FC<OverviewProps> = ({
           >
             fill the profile
           </a>
-          , then press Resume.
+          , then press Resume. Fetch now still works while paused — it stores new jobs unscored.
         </p>
       )}
 

--- a/src/web/pages/run-steps.tsx
+++ b/src/web/pages/run-steps.tsx
@@ -1,0 +1,64 @@
+/** @jsxImportSource hono/jsx */
+import type { FC } from 'hono/jsx';
+import { MarkIcon } from '../ui';
+
+export interface StepView {
+  label: string;
+  detail: string;
+}
+
+/*
+ * Step list shared by the progress pages (/target/runs/:id, /runs/fetch-now/:id).
+ * data-state drives the visuals through RUN_CSS, so the poller
+ * (target-run.mjs) only flips attributes; the activity line under the active
+ * step is filled by the page's activity function.
+ */
+export const RunSteps: FC<{
+  steps: string[];
+  currentIdx: number;
+  view: Record<string, StepView>;
+}> = ({ steps, currentIdx, view }) => (
+  <>
+    <ol class="mt-5 space-y-5" aria-label="Progress">
+      {steps.map((s, i) => (
+        <li
+          class="step flex items-start gap-3"
+          data-step={s}
+          data-state={i < currentIdx ? 'done' : i === currentIdx ? 'active' : 'pending'}
+        >
+          <span class="mt-0.5 grid h-5 w-5 shrink-0 place-items-center" aria-hidden="true">
+            <span class="i i-done">
+              <MarkIcon kind="check" class="text-ok" />
+            </span>
+            <span class="i i-active h-4 w-4 animate-spin rounded-full border-2 border-line-strong border-t-accent"></span>
+            <span class="i i-pending h-2 w-2 rounded-full bg-line-strong"></span>
+          </span>
+          <span class="min-w-0 flex-1">
+            <span class="t-label block text-sm">{view[s]?.label ?? s}</span>
+            <span class="t-detail block text-xs">{view[s]?.detail}</span>
+            <span
+              class="t-activity mt-1.5 block text-[13px] leading-5 text-violet transition-opacity duration-300"
+              data-activity
+              aria-live="polite"
+            ></span>
+          </span>
+        </li>
+      ))}
+    </ol>
+    <style dangerouslySetInnerHTML={{ __html: RUN_CSS }} />
+  </>
+);
+
+/* Step visuals are CSS-driven off data-state so the poller only flips attributes. */
+const RUN_CSS = `
+  .step .i { display: none; }
+  .step[data-state="done"] .i-done,
+  .step[data-state="active"] .i-active,
+  .step[data-state="pending"] .i-pending { display: block; }
+  .step .t-label { color: rgb(var(--ink)); font-weight: 500; }
+  .step[data-state="pending"] .t-label { color: rgb(var(--ink-faint)); font-weight: 400; }
+  .step .t-detail { color: rgb(var(--ink-faint)); }
+  .step[data-state="active"] .t-detail { color: rgb(var(--ink-muted)); }
+  .step .t-activity { display: none; }
+  .step[data-state="active"] .t-activity { display: block; }
+`;

--- a/src/web/pages/runs.tsx
+++ b/src/web/pages/runs.tsx
@@ -2,8 +2,11 @@
 import type { FC } from 'hono/jsx';
 import type { CronRunStatus } from '@prisma/client';
 import { Layout } from '../layout';
-import { Badge, Card, Empty, PageHeader, Table, Td, Tr } from '../ui';
+import { Badge, Card, Empty, Flash, PageHeader, Table, Td, Tr } from '../ui';
+import type { FlashMessage } from '../flash';
 import { formatDate, formatDuration } from '../format';
+import type { FetchRun } from '../fetch-runs';
+import { FetchNowButton } from './fetch-run';
 import { runLabel, runTone } from './overview';
 
 interface RunRow {
@@ -18,14 +21,22 @@ interface RunRow {
 
 export interface RunsProps {
   runs: RunRow[];
+  /** The manual fetch in flight, if any — the button turns into a link to it. */
+  fetchRun: FetchRun | null;
+  flash?: FlashMessage | null;
 }
 
-export const RunsPage: FC<RunsProps> = ({ runs }) => (
+export const RunsPage: FC<RunsProps> = ({ runs, fetchRun, flash }) => (
   <Layout title="Cron runs" active="runs">
-    <PageHeader title="Cron runs" meta={`last ${runs.length}`} />
+    <PageHeader
+      title="Cron runs"
+      meta={`last ${runs.length}`}
+      actions={<FetchNowButton run={fetchRun} />}
+    />
+    <Flash flash={flash} />
 
     {runs.length === 0 ? (
-      <Empty>No runs recorded yet. Worker has not ticked.</Empty>
+      <Empty>No runs recorded yet. The worker has not ticked — press Fetch now to run the first one.</Empty>
     ) : (
       <Card flush>
         <div class="overflow-x-auto">

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -1,10 +1,11 @@
 /** @jsxImportSource hono/jsx */
 import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
-import { Button, Card, Hint, MarkIcon } from '../ui';
+import { Button, Card, Hint } from '../ui';
+import { RunSteps, type StepView } from './run-steps';
 import type { RunStep, TargetRun } from '../target-runs';
 
-const STEP_VIEW: Record<RunStep, { label: string; detail: string }> = {
+const STEP_VIEW: Record<RunStep, StepView> = {
   fetch: {
     label: 'Read the posting page',
     detail: 'one request to the URL you gave — seconds',
@@ -80,32 +81,7 @@ export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
             </div>
           ) : (
             <>
-              <ol class="mt-5 space-y-5" aria-label="Progress">
-                {run.steps.map((s, i) => (
-                  <li
-                    class="step flex items-start gap-3"
-                    data-step={s}
-                    data-state={i < currentIdx ? 'done' : i === currentIdx ? 'active' : 'pending'}
-                  >
-                    <span class="mt-0.5 grid h-5 w-5 shrink-0 place-items-center" aria-hidden="true">
-                      <span class="i i-done">
-                        <MarkIcon kind="check" class="text-ok" />
-                      </span>
-                      <span class="i i-active h-4 w-4 animate-spin rounded-full border-2 border-line-strong border-t-accent"></span>
-                      <span class="i i-pending h-2 w-2 rounded-full bg-line-strong"></span>
-                    </span>
-                    <span class="min-w-0 flex-1">
-                      <span class="t-label block text-sm">{STEP_VIEW[s].label}</span>
-                      <span class="t-detail block text-xs">{STEP_VIEW[s].detail}</span>
-                      <span
-                        class="t-activity mt-1.5 block text-[13px] leading-5 text-violet transition-opacity duration-300"
-                        data-activity
-                        aria-live="polite"
-                      ></span>
-                    </span>
-                  </li>
-                ))}
-              </ol>
+              <RunSteps steps={run.steps} currentIdx={currentIdx} view={STEP_VIEW} />
               <div class="mt-5 flex items-center justify-between gap-3 border-t border-line pt-3">
                 <Hint>
                   You can close this page — the run keeps going and the result lands on the job
@@ -115,7 +91,6 @@ export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
                   {elapsed}s
                 </span>
               </div>
-              <style dangerouslySetInnerHTML={{ __html: RUN_CSS }} />
               <script
                 id="run-data"
                 type="application/json"
@@ -129,20 +104,6 @@ export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
     </Layout>
   );
 };
-
-/* Step visuals are CSS-driven off data-state so the poller only flips attributes. */
-const RUN_CSS = `
-  .step .i { display: none; }
-  .step[data-state="done"] .i-done,
-  .step[data-state="active"] .i-active,
-  .step[data-state="pending"] .i-pending { display: block; }
-  .step .t-label { color: rgb(var(--ink)); font-weight: 500; }
-  .step[data-state="pending"] .t-label { color: rgb(var(--ink-faint)); font-weight: 400; }
-  .step .t-detail { color: rgb(var(--ink-faint)); }
-  .step[data-state="active"] .t-detail { color: rgb(var(--ink-muted)); }
-  .step .t-activity { display: none; }
-  .step[data-state="active"] .t-activity { display: block; }
-`;
 
 const RUN_BOOT = `
 import { init } from '/static/target-run.mjs';

--- a/src/web/public/fetch-run.mjs
+++ b/src/web/public/fetch-run.mjs
@@ -1,0 +1,43 @@
+/*
+ * Activity lines for the "Fetch now" progress page (/runs/fetch-now/:id).
+ * The fetch step reports live counts, so its line is data-driven; the store
+ * step has no per-job signal and rotates on time like the compare page.
+ * Pure — tested from src/web/fetch-run.test.ts; target-run.mjs polls.
+ */
+import { paced } from './target-run.mjs';
+
+const STORE_LINES = {
+  unscored: [
+    'Filtering against the active profile…',
+    'Checking for duplicates and cross-listings…',
+    'Storing the new postings unscored…',
+  ],
+  scored: [
+    'Filtering against the active profile…',
+    'Checking for duplicates and cross-listings…',
+    'Scoring each new job with the AI — minutes for a big batch…',
+    'Sending alerts for the matches…',
+  ],
+};
+
+function jobs(n) {
+  return `${n} job${n === 1 ? '' : 's'}`;
+}
+
+/** "14 of 71 sources · 312 jobs so far · RemoteOK: 120 jobs" */
+export function sourceLine(state) {
+  if (state.sourcesTotal == null) return 'Contacting the first source…';
+  const last = state.lastSource;
+  const tail = last
+    ? ` · ${last.name}: ${last.failed ? 'failed' : last.count === 0 ? 'no jobs' : jobs(last.count)}`
+    : '';
+  return `${state.sourcesDone} of ${state.sourcesTotal} sources · ${jobs(state.jobsFetched)} so far${tail}`;
+}
+
+export function fetchActivity(step, state) {
+  if (step === 'fetch') return sourceLine(state);
+  if (step === 'store') {
+    return paced(state.classify ? STORE_LINES.scored : STORE_LINES.unscored, state.stageElapsedMs);
+  }
+  return '';
+}

--- a/src/web/public/target-run.mjs
+++ b/src/web/public/target-run.mjs
@@ -1,10 +1,12 @@
 /*
- * Progress-page driver: polls /target/runs/:id/state every 2 s, advances the
+ * Progress-page driver: polls the run's state route every 2 s, advances the
  * step list and rotates a "what the analysis is doing right now" line with a
  * fade. On a terminal state it reloads — the server route then redirects with
  * the flash. The activity lines mirror the checklist the prompts actually walk
  * through (profile scoring; the MATCH_SYSTEM steps), paced by stage-elapsed
- * time. activityFor is pure — tested from src/web/target-run.test.ts.
+ * time. The "Fetch now" page reuses init with its own state URL and activity
+ * function (fetch-run.mjs). activityFor / paced are pure — tested from
+ * src/web/target-run.test.ts.
  */
 
 const ACTIVITIES = {
@@ -50,11 +52,15 @@ const ROTATE_MS = 9000;
 const POLL_MS = 2000;
 const FADE_MS = 250;
 
-/** Which activity line a step shows after `stageElapsedMs`; holds on the last one. */
-export function activityFor(step, stageElapsedMs) {
-  const list = ACTIVITIES[step] ?? [];
+/** Which line of `list` shows after `elapsedMs`; holds on the last one. */
+export function paced(list, elapsedMs) {
   if (list.length === 0) return '';
-  return list[Math.min(Math.floor(stageElapsedMs / ROTATE_MS), list.length - 1)];
+  return list[Math.min(Math.floor(elapsedMs / ROTATE_MS), list.length - 1)];
+}
+
+/** Which activity line a step shows after `stageElapsedMs`. */
+export function activityFor(step, stageElapsedMs) {
+  return paced(ACTIVITIES[step] ?? [], stageElapsedMs);
 }
 
 export function formatElapsed(ms) {
@@ -62,7 +68,7 @@ export function formatElapsed(ms) {
   return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
 }
 
-export function init(data) {
+export function init(data, activity = (step, state) => activityFor(step, state.stageElapsedMs)) {
   const steps = [...document.querySelectorAll('[data-step]')];
   const elapsedEl = document.getElementById('run-elapsed');
   let state = null;
@@ -79,7 +85,7 @@ export function init(data) {
     const active = steps.find((li) => li.dataset.state === 'active');
     if (!active) return;
     const el = active.querySelector('[data-activity]');
-    const text = activityFor(active.dataset.step, state.stageElapsedMs);
+    const text = activity(active.dataset.step, state);
     if (el && text !== shownText) {
       shownText = text;
       el.style.opacity = '0';
@@ -92,7 +98,7 @@ export function init(data) {
 
   async function poll() {
     try {
-      const res = await fetch(`/target/runs/${data.id}/state`);
+      const res = await fetch(data.stateUrl ?? `/target/runs/${data.id}/state`);
       if (res.status === 404) return location.reload();
       if (!res.ok) return;
       state = await res.json();

--- a/src/web/routes/overview.tsx
+++ b/src/web/routes/overview.tsx
@@ -4,6 +4,7 @@ import { JobStatus } from '@prisma/client';
 import { prisma } from '../../db';
 import { getSettings } from '../../settings';
 import { clearFlashCookie, parseFlashCookie } from '../flash';
+import { activeFetchRun } from '../fetch-runs';
 import { OverviewPage } from '../pages/overview';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -62,6 +63,7 @@ overviewRoute.get('/', async (c) => {
       recentAlerts={recentAlerts}
       latestRuns={latestRuns}
       fetchingEnabled={settings.fetchingEnabled}
+      fetchRun={activeFetchRun()}
       flash={parseFlashCookie(c.req.header('cookie'))}
     />,
     200,

--- a/src/web/routes/runs.tsx
+++ b/src/web/routes/runs.tsx
@@ -1,7 +1,22 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
 import { prisma } from '../../db';
+import { getSettings } from '../../settings';
+import { recordCronRun, type CronStats } from '../../jobs/cron-run';
+import { runFetchJob } from '../../jobs/fetch-job';
 import { RunsPage } from '../pages/runs';
+import { FetchRunPage } from '../pages/fetch-run';
+import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
+import {
+  FETCH_RUN_STEPS,
+  activeFetchRun,
+  createFetchRun,
+  getFetchRun,
+  recordSource,
+  startFetchRun,
+  updateFetchRun,
+} from '../fetch-runs';
+import { summarizeFetchRun } from '../fetch-summary';
 
 const RUNS_LIMIT = 100;
 
@@ -12,5 +27,71 @@ runsRoute.get('/runs', async (c) => {
     orderBy: { startedAt: 'desc' },
     take: RUNS_LIMIT,
   });
-  return c.html(<RunsPage runs={runs} />);
+  return c.html(
+    <RunsPage runs={runs} fetchRun={activeFetchRun()} flash={parseFlashCookie(c.req.header('cookie'))} />,
+    200,
+    { 'Set-Cookie': clearFlashCookie() },
+  );
+});
+
+/**
+ * "Fetch now": the hourly tick started from the dashboard — one at a time,
+ * in the web process, recorded as a 'fetch-now' CronRun (the re-classify
+ * pattern). While the pipeline is paused the run still fetches, but stores
+ * new jobs unscored: paused means no AI spend.
+ */
+runsRoute.post('/runs/fetch-now', async (c) => {
+  const { fetchingEnabled } = await getSettings();
+  // No await between the guard and the create — a double submit lands on the same run.
+  const active = activeFetchRun();
+  if (active) return c.redirect(`/runs/fetch-now/${active.id}`, 303);
+  const run = createFetchRun({ classify: fetchingEnabled });
+  startFetchRun(run.id, async () => {
+    let stats: CronStats | undefined;
+    await recordCronRun('fetch-now', async () => {
+      const out = await runFetchJob({
+        manual: true,
+        onSource: (p) => recordSource(run.id, p),
+        onProcessing: () => updateFetchRun(run.id, { stage: 'store' }),
+      });
+      stats = out.stats;
+      return out;
+    });
+    updateFetchRun(run.id, { stage: 'done', stats });
+  });
+  return c.redirect(`/runs/fetch-now/${run.id}`, 303);
+});
+
+/** Polled by the progress page; terminal states reload into the redirect below. */
+runsRoute.get('/runs/fetch-now/:id/state', (c) => {
+  const run = getFetchRun(c.req.param('id'));
+  if (!run) return c.json({ gone: true }, 404);
+  const { stage, classify, sourcesDone, sourcesTotal, jobsFetched, lastSource } = run;
+  return c.json({
+    stage,
+    steps: FETCH_RUN_STEPS,
+    classify,
+    sourcesDone,
+    sourcesTotal,
+    jobsFetched,
+    lastSource,
+    stageElapsedMs: Date.now() - run.stageAt,
+    elapsedMs: Date.now() - run.startedAt,
+  });
+});
+
+runsRoute.get('/runs/fetch-now/:id', (c) => {
+  const run = getFetchRun(c.req.param('id'));
+  if (!run) {
+    return flashRedirect(
+      '/runs',
+      'err',
+      'That fetch run is gone (live progress lasts ~30 min) — its row below still has the result.',
+    );
+  }
+  if (run.stage === 'done') {
+    const { kind, text } = summarizeFetchRun(run.stats ?? {});
+    return flashRedirect('/runs', kind, text);
+  }
+  return c.html(<FetchRunPage run={run} />);
 });


### PR DESCRIPTION
Stage 2 of the onboarding plan (docs/onboarding-plan.md §2 step 2 / §5 row 2; TASKS §11 block 2): the pipeline can now be exercised from the UI instead of `docker compose exec … fetch-once.js`, and a fresh install can prove the search works before any profile or AI exists.

## What changed

- **`{ classify: false }` seam in `jobs/process-jobs.ts`** — `processNormalizedJobs(items, profile, stats, { classifierMode, classify, isCancelled })`. With `classify: false` the loop still filters and dedupes, then stores what passed with `fitScore null`, empty `techMatch`/`summary`, status `NEW` — no AI call, no alert, and the blank-profile guard is skipped because there is nothing to guard. Default `true`; the cron and HN paths are unchanged in behaviour (call sites updated to the options object).
- **`persistJob`** — the fingerprint → cross-listing → `job.create` block that was duplicated across the DISMISSED / NEW branches is one function now, shared by the unscored path. It also turns a `P2002` unique clash into a counted duplicate: the hourly tick and a manual fetch can overlap on the same posting, and before this the loser threw and the *whole* tick was recorded FAILED with its remaining classifications discarded.
- **`runFetchJob({ manual, onSource, onProcessing })`** — a manual run ignores the "skip while paused" gate but sets `classify = settings.fetchingEnabled`: paused still means no AI spend (issue #50 / plan principle 5), running means the hourly tick, just now. The pause probe is only created when the pipeline is running (a run that started paused has nothing to abort on). Every fetch tick's stats now carry `sources` / `sourcesFailed`; a paused run adds `classify: false`.
- **`runAllFetchers(isCancelled, onSource)`** — per-source progress callback (company, status, count, done/total) behind the live page.
- **Web: `POST /runs/fetch-now`** — in-memory registry `src/web/fetch-runs.ts` (target-runs pattern: uuid, TTL 30 min, one active run per web process as the in-flight guard; a double submit redirects to the same run), the tick runs under `recordCronRun('fetch-now', …)` so the row lands on `/runs` like re-classify and discovery do. `GET /runs/fetch-now/:id` is the progress page, `/state` the JSON it polls; a finished run redirects to `/runs` with a one-line verdict from the pure `fetch-summary.ts` ("5394 jobs from 73 sources (2 failed) in 2.7m — 2 new stored unscored, no AI spent while the pipeline is paused…"; zero jobs → "check the network, then the Quiet sources card"; paused mid-run, blank profile and no-profile cases named honestly).
- **Progress page** — the compare page's poller (`target-run.mjs`) gained two default parameters (`data.stateUrl`, an `activity(step, state)` function) instead of a second poller; `fetch-run.mjs` is the pure activity module ("35 of 73 sources · 2403 jobs so far · Digital Science: 7 jobs", then time-paced store/score lines). The step list + CSS moved into `pages/run-steps.tsx`, shared by both progress pages; step labels tell the truth per mode ("Store what is new — stored unscored, no AI spent while paused" vs "Score what is new — the AI scores each new job and alerts on matches").
- **`FetchNowButton`** on the Overview header (next to the pipeline switch) and on `/runs`; while a run is in flight it becomes a "Fetching… watch" link to the live page. `/runs` gained a Flash slot; its empty state and the Overview's paused explainer mention the button.

## Decision: where "Fetch now" lives (plan §6)

**Both, one shared component.** Overview is the page a fresh install lands on — "does the search work?" is answered right next to "Pipeline paused / Resume", which is the P0 gap in §0.1. `/runs` is where the verdict lands and where the next run is wanted after reading the stats. Two forms posting to one endpoint cost ~10 lines; a single location would have meant a round trip from either page. Recorded in `docs/onboarding-plan.md` §6.

Two smaller calls made along the way: the CronRun is named `fetch-now` (not the plan's `fetch-test` — it is the same tick, not a test), and classification follows the pause flag rather than being always-off: an always-unscored button would have left a running pipeline's user with rows the cron never revisits (it dedupes on `(companyId, externalId)`), and the AI spend of a manual run on a running pipeline is exactly the spend the next tick would have made anyway.

## Verification

- `npm run lint:types` + **803** unit tests green (new: `fetch-summary.test.ts`, `fetch-run.test.ts`, `isFailureStatus`).
- Web + app containers rebuilt (twice: feature, then review nits).
- **Smoke A — paused pipeline (unscored path)**: Fetch now from a curl POST → 303 to the run page; second POST while running → same run (in-flight guard). Live line advanced ("35 of 73 sources · 2403 jobs so far…"); `/runs` row `fetch-now` OK with `{fetched: 5394, sources: 73, sourcesFailed: 2, classify: false, filterRejected: 5102, duplicate: 290, persisted: 2, classified: 0, alerted: 0, durationMs: 161418}`; the two new rows in Postgres had `status NEW, fitScore NULL, techMatch {}, redFlags {}, summary NULL`, simhash set. Flash on `/runs` rendered with the verdict. The 16:05 cron tick was skipped as `fetching-paused` (no overlap). The two smoke rows were deleted afterwards so smoke B / the cron ingest them scored.
- **Smoke B — running pipeline (scored path)**: Fetching resumed after the 16:05 cron slot, then Fetch now → `/runs` row `fetch-now` OK with `{fetched: 5395, sources: 73, sourcesFailed: 2, classified: 2, dismissed: 2, persisted: 2, alerted: 0, durationMs: 217311}` and no `classify` key (scored path); the two postings from smoke A came back scored (fit 15 and 12 → DISMISSED, with summaries) — the same result the next cron tick would have produced. Flash: "Fetch now: 5395 jobs from 73 sources (2 failed) in 3.6m — 2 new stored, 2 scored, 0 alerted." Progress page showed the "Score what is new" variant. Worker container rebuilt too and re-registered its cron (`applypack: cron registered, idle`); the unscored count in the DB is back to the 3 pre-existing rows.
- Routes curl'd for status: `/` 200, `/runs` 200, `/runs/fetch-now/:id` 200 (running), `/state` 200, bogus id → 303 to `/runs` with the "gone" flash, bogus `/state` → 404, `/static/fetch-run.mjs` + `/static/target-run.mjs` 200, `/target` `/jobs` `/discovery` `/settings` 200.
- Screenshots at 1200 / 768 / 375 of the progress page (running), Overview ("Fetching… watch" state) and `/runs` (row + flash); **0 console errors** at every width; no horizontal scroll at 375. Keyboard: the button is a real `<button>` in a form, the in-flight state a real `<a>`.
- Not verified live: a `P2002` clash (would need the cron and a manual run to store the same posting within the same seconds) — covered by reasoning and the duplicate counter path; the compare progress page after the poller generalisation (defaults keep the old behaviour, exercised end to end by the fetch page; `target-run.test.ts` still passes).

## Follow-ups (P2/P3 from the pre-merge review)

- P2: the score step of a running-pipeline run has no per-job progress (time-paced lines only) — the wizard's step 4 will want "n of m scored"; `processNormalizedJobs` could take an `onJob` callback then.
- P3: a web restart mid-run leaves the `fetch-now` CronRun row RUNNING forever (same as re-classify / discovery today) — a boot-time sweep of stale RUNNING rows would fix all three.
- P3: a manual run is a tick for source health too — pressing Fetch now repeatedly can push a flaky source to the quiet threshold (3 failures) faster than three hours.
- P3: `FetchRunPage` and `TargetRunPage` still duplicate the hint/elapsed footer and the boot script; only `RunSteps` is shared.

## Release notes (draft for v1.6.0)

```
## What's new
- "Fetch now" on the Overview header and on /runs runs the hourly fetch immediately, with a live progress page that narrates the sources as they answer and a one-line verdict on /runs
- While the pipeline is paused, Fetch now stores new jobs unscored — no AI spent — so a fresh install can prove the search works before any profile exists
- New `{ classify: false }` seam in the shared ingest loop (the wizard's step 2 builds on it)
- Fetch stats show sources / sourcesFailed per tick; a posting stored by another run meanwhile counts as a duplicate instead of failing the tick

## Schema
- no schema changes

## Verification
- 803 unit tests; web + app rebuilt; two live smoke runs (paused → unscored rows in Postgres, running → scored); 1200/768/375 screenshots, 0 console errors

## References
- docs/onboarding-plan.md §2 step 2, §5 row 2, §6 (placement decided) · TASKS §11 block 2 · CHANGELOG 1.6.0
```

Tag after merge (release-discipline):

```
git tag -a v1.6.0 -m "fetch now" <merge-sha> && git push origin v1.6.0
```
