### PR TITLE
Welcome wizard: four-step first-run setup at /welcome

### DIFF
--- a/.claude/skills/testing-gate/SKILL.md
+++ b/.claude/skills/testing-gate/SKILL.md
@@ -16,7 +16,7 @@ kinds of code and they are verified differently — see CLAUDE.md "Testing".
 | New fetcher / ATS source | Pure `mapXFeed` mapper + unit test; then `npm run fetch:once` smoke against the real endpoint (or `docker compose exec app node dist/scripts/fetch-once.js`) |
 | Classifier prompt or parser | Parser test (`parsePrefilterResponse`, `parseClaudeCodeOutput` pattern); smoke one real classification via the once-script |
 | AI provider | `ai-provider-parse.test.ts` for output parsing; one live `complete()` smoke per provider before commit |
-| Prisma schema | Hand-written migration under `prisma/migrations/` (CLAUDE.md gotcha 7 — host `migrate dev` P1010s); verify with `docker compose build app && up -d app` and read init logs |
+| Prisma schema | Hand-written migration under `prisma/migrations/` (CLAUDE.md gotcha 7 — host `migrate dev` P1010s); `npx prisma format` after the edit — CI runs `prisma format --check` and a new field that widens a column realigns the whole block; verify with `docker compose build app && up -d app` and read init logs |
 | Settings toggle | Column → `settings.ts` getter/setter → page → route, all in one commit; click it in the dashboard |
 | Dashboard page / primitive | `npm run lint:types`; `docker compose build web && up -d web`; curl every route for 200; screenshot at 1200px, 768px and 375px with the playwright plugin; browser console has 0 errors |
 | Telegram formatting | `notifier.test.ts` for escaping; `npm run test:telegram` for a real send |
@@ -26,6 +26,7 @@ kinds of code and they are verified differently — see CLAUDE.md "Testing".
 ```
 npm run lint:types                 # every commit
 npm test                           # every commit (pure modules only)
+npx prisma format --check          # after any schema edit (CI gates on it)
 npm run build                      # before a web/app container rebuild
 docker compose build web && docker compose up -d web   # dashboard changes
 docker compose build app && docker compose up -d app   # worker changes

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -238,7 +238,8 @@ src/
     hn-hiring-job.ts            ← runHnHiringJob (monthly 1st 06:00)
     discovery-job.ts            ← runDiscoveryJob (Sunday 04:00, validation probe)
     process-jobs.ts             ← shared inner loop used by fetch + HN
-    reclassify-job.ts           ← runReclassifyAll (web-triggered, async)
+    reclassify-job.ts           ← runReclassifyAll + runScoreUnscored (web-triggered, async)
+    score-pick.ts               ← pure ranking of unscored jobs by profile mentions (wizard step 4)
     classify-existing.ts        ← classify one stored job (Re-classify button, manual entry)
     posting-url.ts              ← one user-requested posting-page GET → plain text (ADR 0005 blocklist, honest bot-check failure)
     manual-job.ts               ← pasted posting → MANUAL company + Job + classify (used by /jobs/new and /target)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -258,6 +258,9 @@ src/
     target-runs.ts            ← in-memory compare-run registry (async classify/scan/match)
     fetch-runs.ts             ← in-memory "Fetch now" registry (live source progress; the 'fetch-now' CronRun is the record)
     fetch-summary.ts          ← pure one-line verdict of a finished fetch-now run
+    welcome-steps.ts          ← pure first-run wizard rules (steps from data, score-run summary)
+    welcome-facts.ts          ← loads what the wizard and the Overview chip derive from
+    ai-test.ts                ← one live engine call — Settings Test button + wizard step 1
     public/target.mjs         ← browser keyword matcher (pure ES module, node-tested)
     public/score.mjs          ← browser mirror of resume/score.ts (parity-tested, ADR 0012)
     public/cover-letter.mjs   ← copy-to-clipboard for the letter card (import-smoke-tested)
@@ -273,6 +276,7 @@ src/
       starter-pack.tsx          ← pack picker card + preview + import result
       discovery.tsx             ← /discovery
       runs.tsx                  ← /runs (+ Fetch now button)
+      welcome.tsx               ← /welcome first-run wizard (4 steps, one card at a time)
       fetch-run.tsx             ← /runs/fetch-now/:id progress page + FetchNowButton
       run-steps.tsx             ← step list shared by the two progress pages
       settings.tsx              ← /settings (9 cards)
@@ -297,6 +301,7 @@ src/
       companies.tsx              ← list + new (probe-validated) + delete + toggle + starter packs
       discovery.tsx             ← list + promote + ignore + delete + manual probe
       runs.tsx                  ← /runs + POST /runs/fetch-now (the tick in the web process) + progress/state
+      welcome.tsx               ← /welcome + skip / finish / ai test / resume → scan run / profile apply / score run
       settings.tsx              ← profile editor + 8 toggles + telegram targets
       health.ts                 ← JSON liveness for external monitoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,16 @@ All notable changes to this project are documented here. The format follows
      "Yes, that's me" applies the draft to the active profile, "Let me
      adjust" opens it in the profile editor. No file handy: three
      questions (technologies, role words, seniority) write the same fields.
-  4. **See your first matches** — "Score the jobs we found" scores up to
-     100 of the most recent stored jobs that mention the profile's words
-     (`runScoreUnscored`); the rest that don't fit are set aside without
-     AI. Result: "18 of 100 look like a match" with the top five, "Score
-     100 more" while jobs are waiting, then "Start the hourly watch"
-     (turns fetching on, marks setup done). Telegram is a quiet link.
+  4. **See your first matches** — "Score the best matches" scores the ten
+     stored jobs that mention the most of your profile (`runScoreUnscored`
+     over the pure ranking in `jobs/score-pick.ts`: a title hit counts
+     double a description hit, required stack outranks role words);
+     everything that mentions none of your words is set aside without
+     spending anything. Result: "8 of 10 look like a match" with the top
+     five, "Score 10 more" while jobs are waiting, then "Start the hourly
+     watch" (turns fetching on, marks setup done). Ten because a CLI
+     engine needs 15-30 s per job — 100 would have meant a 24-minute wait
+     on the first screen. Telegram is a quiet link.
 - "Skip setup" marks setup done; the Overview shows a "Finish setup →"
   chip while any step is still open, flag or no flag.
 - Progress pages carry their own heading and subtitle and can show

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.7.0] — 2026-09-01
+
+### Added
+- **First-run wizard at `/welcome`** ([docs/onboarding-plan.md §2](docs/onboarding-plan.md),
+  TASKS §11 block 3). A fresh install lands there from `/` until setup is
+  finished or skipped; every other page keeps working. Four steps, each
+  derived from data and auto-completing when its result already exists:
+  1. **Connect an AI** — detected engines are listed (zero clicks for a
+     `.env` key); with nothing detected, plain-language cards say which
+     line to add per engine. "Send a test message" runs the same tiny live
+     call as the Settings Test button.
+  2. **Test the search** — "Run a test search" is Fetch now with the
+     verdict routed back into setup: no AI, no profile needed, jobs stored
+     unscored.
+  3. **Tell us about you** — upload a resume (or pick one), the scan runs
+     on a progress page and comes back as a one-paragraph summary ("Looks
+     like you're a Senior Backend Engineer — main tools PHP, Laravel…");
+     "Yes, that's me" applies the draft to the active profile, "Let me
+     adjust" opens it in the profile editor. No file handy: three
+     questions (technologies, role words, seniority) write the same fields.
+  4. **See your first matches** — "Score the jobs we found" scores up to
+     100 of the most recent stored jobs that mention the profile's words
+     (`runScoreUnscored`); the rest that don't fit are set aside without
+     AI. Result: "18 of 100 look like a match" with the top five, "Score
+     100 more" while jobs are waiting, then "Start the hourly watch"
+     (turns fetching on, marks setup done). Telegram is a quiet link.
+- "Skip setup" marks setup done; the Overview shows a "Finish setup →"
+  chip while any step is still open, flag or no flag.
+- Progress pages carry their own heading and subtitle and can show
+  data-driven progress ("12 of 100 jobs scored").
+
+### Changed
+- The engine connectivity test moved into `src/web/ai-test.ts`, shared by
+  Settings and the wizard; the file-input style is one constant in `ui.tsx`.
+
+### Schema
+- `AppSettings.setupCompletedAt` (nullable) — migration
+  `20260901220000_add_setup_completed_at` backfills existing deployments
+  with `now()`, so nobody who already set up by hand is walked through the
+  wizard.
+
 ## [1.6.0] — 2026-09-01
 
 ### Added
@@ -649,6 +690,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.7.0]: https://github.com/applypack/applypack/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/applypack/applypack/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/applypack/applypack/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/applypack/applypack/compare/v1.4.0...v1.4.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Apply-link flags (missing / unusable / shortened / not-an-application) | `src/apply-link.ts` (pure, ADR 0023); merged into `Job.redFlags` at all three persist paths |
 | Stable id for a feed row with no id of its own | `src/text-utils.ts:feedItemKey` (URL key → text key → null, never `''`) |
 | The cron list (6 schedules) | `src/index.ts:registerCron` |
-| First-run wizard (`/welcome`: steps derived from data, `/` redirect, skip/finish) | `src/web/welcome-steps.ts` (pure: step rules + score summary) · `src/web/welcome-facts.ts` (loads the facts) · `src/web/routes/welcome.tsx` + `pages/welcome.tsx`; step 4 = `runScoreUnscored` in `src/jobs/reclassify-job.ts` |
+| First-run wizard (`/welcome`: steps derived from data, `/` redirect, skip/finish) | `src/web/welcome-steps.ts` (pure: step rules + score summary) · `src/web/welcome-facts.ts` (loads the facts) · `src/web/routes/welcome.tsx` + `pages/welcome.tsx`; step 4 = `runScoreUnscored` in `src/jobs/reclassify-job.ts`, which picks its batch with `src/jobs/score-pick.ts` (pure ranking, `SCORE_BATCH`) |
 | "Fetch now" (the tick from the dashboard: live progress, unscored while paused) | `POST /runs/fetch-now` in `src/web/routes/runs.tsx` → `runFetchJob({ manual: true })` in `src/jobs/fetch-job.ts`; registry `src/web/fetch-runs.ts`; verdict line `src/web/fetch-summary.ts` (pure) |
 | What runs on container boot | `src/init.ts` |
 | Adding a new ATS source — single-feed template | `src/fetchers/larajobs.ts` (LARAJOBS_RSS) or `src/fetchers/golangprojects.ts` (single RSS) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Apply-link flags (missing / unusable / shortened / not-an-application) | `src/apply-link.ts` (pure, ADR 0023); merged into `Job.redFlags` at all three persist paths |
 | Stable id for a feed row with no id of its own | `src/text-utils.ts:feedItemKey` (URL key → text key → null, never `''`) |
 | The cron list (6 schedules) | `src/index.ts:registerCron` |
+| First-run wizard (`/welcome`: steps derived from data, `/` redirect, skip/finish) | `src/web/welcome-steps.ts` (pure: step rules + score summary) · `src/web/welcome-facts.ts` (loads the facts) · `src/web/routes/welcome.tsx` + `pages/welcome.tsx`; step 4 = `runScoreUnscored` in `src/jobs/reclassify-job.ts` |
 | "Fetch now" (the tick from the dashboard: live progress, unscored while paused) | `POST /runs/fetch-now` in `src/web/routes/runs.tsx` → `runFetchJob({ manual: true })` in `src/jobs/fetch-job.ts`; registry `src/web/fetch-runs.ts`; verdict line `src/web/fetch-summary.ts` (pure) |
 | What runs on container boot | `src/init.ts` |
 | Adding a new ATS source — single-feed template | `src/fetchers/larajobs.ts` (LARAJOBS_RSS) or `src/fetchers/golangprojects.ts` (single RSS) |
@@ -199,6 +200,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | What | Page |
 | --- | --- |
 | Pause / resume all new-job fetching | `/settings` General tab → "Job fetching" |
+| Walk through first-run setup again (AI → test search → profile → first matches) | `/welcome` — `/` redirects there while `AppSettings.setupCompletedAt` is NULL; "Skip setup" or "Start the hourly watch" ends it; Overview shows "Finish setup →" while a step is open |
 | Pull jobs right now instead of waiting for the hourly tick | Overview header or `/runs` → "Fetch now" (progress page; while paused the jobs land unscored — score them later with Save & re-classify) |
 | See which boards stopped answering | `/companies` → "Quiet sources" card (Re-probe to repair) |
 | Telegram line when a source goes quiet | `/settings` Notifications tab → "Source health alerts" |

--- a/README.md
+++ b/README.md
@@ -72,24 +72,29 @@ ANTHROPIC_API_KEY=sk-ant-...                              # Anthropic API
 
 ### Your first fifteen minutes
 
-Fetching starts **paused** on a fresh install, on purpose: a blank
-profile would classify everything as a miss and waste your AI quota.
+The dashboard opens on a four-step setup (`/welcome`) and walks you
+through it — about four clicks and one file pick:
 
-1. **Settings → AI engine**: engines from `.env` are already detected.
-   Press **Test** on each and watch it reply.
-2. **Profile tab**: fill in your stack and preferences by hand, or upload
-   your resume on `/resumes` and press **"Fill from a resume"** to review
-   an AI-drafted profile before anything is saved.
-3. **Notifications tab** (optional): add a Telegram bot. The form
-   validates the token by sending you a real message before it saves.
-4. **General tab**: press **Resume** on the "Job fetching" switch. Too
-   impatient for the hourly tick: press **Fetch now** on the Overview and
-   watch the sources answer (it works while paused too — the jobs are then
-   stored unscored).
+1. **Connect an AI** — the engine from `.env` is detected automatically;
+   with none, the page shows which line to add.
+2. **Test the search** — one button asks every job board and stores what
+   it finds, no AI spent. You watch the sources answer.
+3. **Tell us about you** — upload your resume; the summary it comes back
+   with ("looks like you're a senior backend engineer — PHP, Laravel…")
+   becomes your search profile with one click. No resume handy: three
+   questions instead.
+4. **See your first matches** — score the jobs found, read the top five,
+   then **Start the hourly watch**.
+
+Fetching starts **paused** until that last click, on purpose: a blank
+profile would classify everything as a miss and waste your AI quota.
+Telegram alerts are optional — **Settings → Notifications** whenever you
+like. Skipped the wizard? The Overview keeps a "Finish setup" link.
 
 From then on it runs itself. Every settings change saves to Postgres on
 click: no restarts, no `.env` edits. The worker picks changes up within
-the hour; dashboard actions use them immediately.
+the hour; dashboard actions use them immediately. Too impatient for the
+hourly tick: **Fetch now** on the Overview.
 
 <details>
 <summary><b>Running without Docker</b></summary>

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -751,10 +751,11 @@ Telegram explicitly optional.
 - [x] `fetch-now` — "Fetch now" button + `{classify: false}` seam +
       background run (reclassify pattern) + progress page — done 2026-09-01,
       branch `fetch-now`; lives on Overview AND `/runs` (one shared button)
-- [ ] `welcome-wizard` — `/welcome` 4-step first-run flow
+- [x] `welcome-wizard` — `/welcome` 4-step first-run flow
       (AI → test search → resume → first matches), redirect while
       `AppSettings.setupCompletedAt` null, skip link, Overview chip;
-      ~4 clicks + one file pick end-to-end
+      ~4 clicks + one file pick end-to-end — done 2026-09-01, branch
+      `welcome-wizard`; step 4 caps at 100 with "Score 100 more"
 - [ ] `ai-key-in-db` — paste API key in UI, DB-stored, masked
       (**ADR**: extends 0013 + secrets policy; TelegramTarget precedent)
 - [ ] `profile-resume-link` — `Profile.resumeId` + one-click "Create

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -755,7 +755,7 @@ Telegram explicitly optional.
       (AI → test search → resume → first matches), redirect while
       `AppSettings.setupCompletedAt` null, skip link, Overview chip;
       ~4 clicks + one file pick end-to-end — done 2026-09-01, branch
-      `welcome-wizard`; step 4 caps at 100 with "Score 100 more"
+      `welcome-wizard`; step 4 scores the best 10 per press ("Score 10 more")
 - [ ] `ai-key-in-db` — paste API key in UI, DB-stored, masked
       (**ADR**: extends 0013 + secrets policy; TelegramTarget precedent)
 - [ ] `profile-resume-link` — `Profile.resumeId` + one-click "Create

--- a/docs/onboarding-plan.md
+++ b/docs/onboarding-plan.md
@@ -321,7 +321,10 @@ resumes in one sitting.
   jobs per press** (`SCORE_UNSCORED_CAP`): the base filter runs first, so
   jobs that don't mention the profile's words are dismissed without AI and
   only the rest count against the cap; "Score 100 more" takes the next
-  batch. Still to measure: minutes per 100 on a CLI engine vs the API.
+  batch. Measured 2026-09-01 in Docker on the `claude_code` CLI engine at
+  `AI_CONCURRENCY=3`: ~2.7 jobs/min, i.e. 35–40 min per 100 — slow enough
+  that the wizard copy says "a few minutes" only for API engines; the cap
+  is the right size for the API and generous for a CLI.
 - ~~Whether "Fetch now" lives on `/runs`, Overview, or both.~~ Decided in
   stage 2: **both**, one shared `FetchNowButton` — Overview because it is
   the page a fresh install lands on ("does the search work?" is answered

--- a/docs/onboarding-plan.md
+++ b/docs/onboarding-plan.md
@@ -8,8 +8,9 @@
 > [CLAUDE.md](../CLAUDE.md), the testing-gate / commit-discipline skills and
 > the ADR register in [docs/adr](./adr/).
 >
-> **Status:** stages 1–2 of §5 shipped (`profile-tab-quickwins` v1.5.0,
-> `fetch-now` v1.6.0); stages 3–7 are analysis only. Constants
+> **Status:** stages 1–3 of §5 shipped (`profile-tab-quickwins` v1.5.0,
+> `fetch-now` v1.6.0, `welcome-wizard` v1.7.0); stages 4–7 are analysis
+> only. Constants
 > (batch caps, source subsets, timings) are starting hypotheses to
 > re-measure at implementation time.
 
@@ -313,11 +314,14 @@ resumes in one sitting.
 
 ## 6. Open decisions
 
-- Step-2 source subset: all enabled sources vs a fast-aggregator subset
-  (RemoteOK/Remotive answer in seconds; per-company boards add minutes).
-  Hypothesis: all enabled, with the progress page making the wait fun.
-- Step-4 classification cap (hypothesis 100 — measure cost/latency on
-  Haiku 4.5 two-stage vs single).
+- ~~Step-2 source subset~~ — stage 3 kept **all enabled sources** (the
+  same Fetch now run, verdict routed back into setup); the live progress
+  line carries the wait.
+- ~~Step-4 classification cap~~ — stage 3 shipped **100 filter-passing
+  jobs per press** (`SCORE_UNSCORED_CAP`): the base filter runs first, so
+  jobs that don't mention the profile's words are dismissed without AI and
+  only the rest count against the cap; "Score 100 more" takes the next
+  batch. Still to measure: minutes per 100 on a CLI engine vs the API.
 - ~~Whether "Fetch now" lives on `/runs`, Overview, or both.~~ Decided in
   stage 2: **both**, one shared `FetchNowButton` — Overview because it is
   the page a fresh install lands on ("does the search work?" is answered

--- a/docs/onboarding-plan.md
+++ b/docs/onboarding-plan.md
@@ -317,15 +317,18 @@ resumes in one sitting.
 - ~~Step-2 source subset~~ — stage 3 kept **all enabled sources** (the
   same Fetch now run, verdict routed back into setup); the live progress
   line carries the wait.
-- ~~Step-4 classification cap~~ — stage 3 shipped **100 filter-passing
-  jobs per press** (`SCORE_UNSCORED_CAP`): the base filter runs first, so
-  jobs that don't mention the profile's words are dismissed without AI and
-  only the rest count against the cap; "Score 100 more" takes the next
-  batch. Measured 2026-09-01 in Docker on the `claude_code` CLI engine at
-  `AI_CONCURRENCY=3`: 100 jobs in 24 min (~4 jobs/min; 2,124 off-topic rows
-  dismissed without AI first) — slow enough that "a few minutes" only holds
-  for the API engines; the cap is the right size for the API and generous
-  for a CLI.
+- ~~Step-4 classification cap~~ — the hypothesis of 100 was **measured and
+  rejected**. On the `claude_code` CLI engine (a `claude -p` process per
+  job, `AI_CONCURRENCY=3`) 100 jobs took 24 min — the wow moment turns
+  into an afternoon. Stage 3 ships **`SCORE_BATCH = 10` per press**, and
+  the ten are the *best* matches, not the newest: `jobs/score-pick.ts`
+  (pure) ranks the filter-passing rows by how much of the profile the
+  posting actually mentions (title hit worth double a description hit;
+  required stack > role words > nice-to-have). Measured on the same
+  engine: 10 jobs in 5.4 min, scores 89 / 88 / 85 / 80 / 79 / 75 at the
+  top — the first screen is a real shortlist. "Score 10 more" walks the
+  rest, and the hourly watch scores new arrivals anyway. On an API engine
+  the same ten take well under a minute.
 - ~~Whether "Fetch now" lives on `/runs`, Overview, or both.~~ Decided in
   stage 2: **both**, one shared `FetchNowButton` — Overview because it is
   the page a fresh install lands on ("does the search work?" is answered

--- a/docs/onboarding-plan.md
+++ b/docs/onboarding-plan.md
@@ -322,9 +322,10 @@ resumes in one sitting.
   jobs that don't mention the profile's words are dismissed without AI and
   only the rest count against the cap; "Score 100 more" takes the next
   batch. Measured 2026-09-01 in Docker on the `claude_code` CLI engine at
-  `AI_CONCURRENCY=3`: ~2.7 jobs/min, i.e. 35–40 min per 100 — slow enough
-  that the wizard copy says "a few minutes" only for API engines; the cap
-  is the right size for the API and generous for a CLI.
+  `AI_CONCURRENCY=3`: 100 jobs in 24 min (~4 jobs/min; 2,124 off-topic rows
+  dismissed without AI first) — slow enough that "a few minutes" only holds
+  for the API engines; the cap is the right size for the API and generous
+  for a CLI.
 - ~~Whether "Fetch now" lives on `/runs`, Overview, or both.~~ Decided in
   stage 2: **both**, one shared `FetchNowButton` — Overview because it is
   the page a fresh install lands on ("does the search work?" is answered

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/prisma/migrations/20260901220000_add_setup_completed_at/migration.sql
+++ b/prisma/migrations/20260901220000_add_setup_completed_at/migration.sql
@@ -1,0 +1,6 @@
+-- First-run wizard flag (docs/onboarding-plan.md §2). NULL = show /welcome.
+-- A settings row that exists at migration time belongs to a deployment
+-- that was set up by hand already: backfill it so the wizard never
+-- interrupts an existing install. A fresh install has no row yet.
+ALTER TABLE app_settings ADD COLUMN "setupCompletedAt" TIMESTAMP(3);
+UPDATE app_settings SET "setupCompletedAt" = NOW();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -160,26 +160,26 @@ model CronRun {
 
 // Singleton table — always one row with id=1.
 model AppSettings {
-  id                             Int      @id @default(1)
-  telegramEnabled                Boolean  @default(false)
+  id                             Int       @id @default(1)
+  telegramEnabled                Boolean   @default(false)
   activeProfileId                Int?
-  activeProfile                  Profile? @relation(fields: [activeProfileId], references: [id], onDelete: SetNull)
+  activeProfile                  Profile?  @relation(fields: [activeProfileId], references: [id], onDelete: SetNull)
   // Classifier mode: 'single' = full classifier only;
   // 'two_stage' = short prefilter prompt, full classifier only on yes.
-  classifierMode                 String   @default("single")
+  classifierMode                 String    @default("single")
   // Phase 3.4 toggles
-  applicationTrackingEnabled     Boolean  @default(true)
-  staleApplicationsDigestEnabled Boolean  @default(true)
+  applicationTrackingEnabled     Boolean   @default(true)
+  staleApplicationsDigestEnabled Boolean   @default(true)
   // Phase 3.2 toggle
-  hnParserEnabled                Boolean  @default(false)
+  hnParserEnabled                Boolean   @default(false)
   // Phase 4.1: list of AtsType values to skip in runAllFetchers, e.g.
   // ["LEVER","ARBEITNOW"]. Empty array = all enabled. Coexists with
   // per-Company.active so users can disable a whole source family with
   // one click without flipping each company toggle.
-  disabledSources                String[] @default([])
+  disabledSources                String[]  @default([])
   // Phase 4.2: discovery toggle (gates auto-creation of CompanyCandidate
   // rows from HN comments and the weekly probe job).
-  discoveryEnabled               Boolean  @default(false)
+  discoveryEnabled               Boolean   @default(false)
   // Phase 7.7: master pause for new-job ingestion. When false, the hourly
   // fetch tick and the monthly HN pull exit early ("fetching-paused" in
   // /runs). Digest, stale nudge, cleanup, discovery probe, and the
@@ -187,7 +187,7 @@ model AppSettings {
   // touching docker" switch. Default FALSE by user choice: deployments
   // (and the existing row, backfilled by the migration) start paused;
   // enable from /settings → "Job fetching" when ready.
-  fetchingEnabled                Boolean  @default(false)
+  fetchingEnabled                Boolean   @default(false)
   // AI engine chain (ADR 0013/0014): { order: [provider ids by priority],
   // models: { <id>: { classifier, resume } } }. The first usable engine
   // serves each call; the rest are automatic fallbacks. NULL = follow .env
@@ -200,7 +200,7 @@ model AppSettings {
   aiUsage                        Json?
   // F4 (ADR 0019): one digest line when a source crosses the failure
   // streak. Default TRUE — the alert adds a signal, never suppresses a job.
-  sourceHealthAlerts             Boolean  @default(true)
+  sourceHealthAlerts             Boolean   @default(true)
   // F8.1: standing angle inputs for the cover-letter card ({ whyCompany,
   // problem, approach, notes }), saved on every generation so the user
   // never retypes them. Parse with readCoverAngles (resume/prompts.ts).
@@ -212,7 +212,7 @@ model AppSettings {
   // /welcome. Set by the wizard's last step or "Skip setup"; the migration
   // backfills existing deployments so nobody is walked through setup twice.
   setupCompletedAt               DateTime?
-  updatedAt                      DateTime @updatedAt
+  updatedAt                      DateTime  @updatedAt
 
   @@map("app_settings")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -208,6 +208,10 @@ model AppSettings {
   // ADR 0025: ordered work columns [{key,label}] between the fixed
   // 'applied' entry and the fixed rejected/ghosted exits. null = defaults.
   pipelineStages                 Json?
+  // First-run wizard (docs/onboarding-plan.md §2): NULL sends `/` to
+  // /welcome. Set by the wizard's last step or "Skip setup"; the migration
+  // backfills existing deployments so nobody is walked through setup twice.
+  setupCompletedAt               DateTime?
   updatedAt                      DateTime @updatedAt
 
   @@map("app_settings")

--- a/src/jobs/reclassify-job.ts
+++ b/src/jobs/reclassify-job.ts
@@ -11,16 +11,12 @@ import { isBlankProfile } from '../profile-guards';
 import { parsePriorityRules } from '../priority-rules';
 import { applyPriorityFloor } from './process-jobs';
 import { withApplyLinkFlags } from '../apply-link';
+import { rankByProfileFit, SCORE_BATCH, type ScorableJob } from './score-pick';
+
+export { SCORE_BATCH };
 import type { CronStats } from './cron-run';
 
 const RECLASSIFY_BATCH_SIZE = 50;
-
-/**
- * How many stored-unscored jobs one wizard "Score" pass sends to the AI
- * (docs/onboarding-plan.md §2 step 4 — a starting hypothesis; pressing the
- * button again scores the next batch).
- */
-export const SCORE_UNSCORED_CAP = 100;
 
 export interface ReclassifyOptions {
   /** Restrict the pass to these ids; default: every job except APPLIED. */
@@ -40,12 +36,13 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
 /**
  * The wizard's step 4: jobs a paused "Fetch now" stored unscored get their
  * score against the profile that now exists. Rows failing the base filter
- * are dismissed in one update — no AI spent on them; of the rest, the most
- * recent SCORE_UNSCORED_CAP are classified, and `remaining` says how many
- * a second press would take.
+ * are dismissed in one update — no AI spent on them; of the rest, the
+ * `limit` best matches by rankByProfileFit are classified (the wizard reads
+ * the most promising ten, not the ten most recent), and `remaining` says
+ * how many a second press would take.
  */
 export async function runScoreUnscored(
-  opts: Pick<ReclassifyOptions, 'onProgress'> = {},
+  opts: Pick<ReclassifyOptions, 'onProgress'> & { limit?: number } = {},
 ): Promise<{ stats: CronStats }> {
   const profile = await getActiveProfile();
   if (!profile) return { stats: { aborted: 1, reason: 'no-active-profile' } };
@@ -53,13 +50,13 @@ export async function runScoreUnscored(
 
   const unscored = await prisma.job.findMany({
     where: { fitScore: null, status: JobStatus.NEW },
-    orderBy: { fetchedAt: 'desc' },
-    select: { id: true, title: true, location: true },
+    select: { id: true, title: true, location: true, description: true, fetchedAt: true },
   });
   const rejectedIds: number[] = [];
-  const passingIds: number[] = [];
+  const passing: ScorableJob[] = [];
   for (const j of unscored) {
-    (passesBaseFilter(j, profile) ? passingIds : rejectedIds).push(j.id);
+    if (passesBaseFilter(j, profile)) passing.push(j);
+    else rejectedIds.push(j.id);
   }
   if (rejectedIds.length > 0) {
     await prisma.job.updateMany({
@@ -67,14 +64,15 @@ export async function runScoreUnscored(
       data: { status: JobStatus.DISMISSED },
     });
   }
-  const ids = passingIds.slice(0, SCORE_UNSCORED_CAP);
+  const ranked = rankByProfileFit(passing, profile);
+  const ids = ranked.slice(0, opts.limit ?? SCORE_BATCH).map((r) => r.id);
   const { stats } = await reclassify({ ids, onProgress: opts.onProgress });
   return {
     stats: {
       ...stats,
       unscored: unscored.length,
       filterDismissed: rejectedIds.length,
-      remaining: passingIds.length - ids.length,
+      remaining: ranked.length - ids.length,
     },
   };
 }

--- a/src/jobs/reclassify-job.ts
+++ b/src/jobs/reclassify-job.ts
@@ -16,11 +16,70 @@ import type { CronStats } from './cron-run';
 const RECLASSIFY_BATCH_SIZE = 50;
 
 /**
+ * How many stored-unscored jobs one wizard "Score" pass sends to the AI
+ * (docs/onboarding-plan.md §2 step 4 — a starting hypothesis; pressing the
+ * button again scores the next batch).
+ */
+export const SCORE_UNSCORED_CAP = 100;
+
+export interface ReclassifyOptions {
+  /** Restrict the pass to these ids; default: every job except APPLIED. */
+  ids?: number[];
+  onProgress?: (done: number, total: number) => void;
+}
+
+/**
  * Re-classifies all jobs (except APPLIED) against the currently active
  * profile. Updates fitScore / techMatch / redFlags / summary / salary, and
  * may move jobs between NEW and DISMISSED based on the new score.
  */
 export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
+  return reclassify({});
+}
+
+/**
+ * The wizard's step 4: jobs a paused "Fetch now" stored unscored get their
+ * score against the profile that now exists. Rows failing the base filter
+ * are dismissed in one update — no AI spent on them; of the rest, the most
+ * recent SCORE_UNSCORED_CAP are classified, and `remaining` says how many
+ * a second press would take.
+ */
+export async function runScoreUnscored(
+  opts: Pick<ReclassifyOptions, 'onProgress'> = {},
+): Promise<{ stats: CronStats }> {
+  const profile = await getActiveProfile();
+  if (!profile) return { stats: { aborted: 1, reason: 'no-active-profile' } };
+  if (isBlankProfile(profile)) return { stats: { aborted: 1, reason: 'blank-profile' } };
+
+  const unscored = await prisma.job.findMany({
+    where: { fitScore: null, status: JobStatus.NEW },
+    orderBy: { fetchedAt: 'desc' },
+    select: { id: true, title: true, location: true },
+  });
+  const rejectedIds: number[] = [];
+  const passingIds: number[] = [];
+  for (const j of unscored) {
+    (passesBaseFilter(j, profile) ? passingIds : rejectedIds).push(j.id);
+  }
+  if (rejectedIds.length > 0) {
+    await prisma.job.updateMany({
+      where: { id: { in: rejectedIds } },
+      data: { status: JobStatus.DISMISSED },
+    });
+  }
+  const ids = passingIds.slice(0, SCORE_UNSCORED_CAP);
+  const { stats } = await reclassify({ ids, onProgress: opts.onProgress });
+  return {
+    stats: {
+      ...stats,
+      unscored: unscored.length,
+      filterDismissed: rejectedIds.length,
+      remaining: passingIds.length - ids.length,
+    },
+  };
+}
+
+async function reclassify(opts: ReclassifyOptions): Promise<{ stats: CronStats }> {
   const started = Date.now();
   const profile = await getActiveProfile();
   if (!profile) {
@@ -38,6 +97,8 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
   }
 
   const { classifierMode } = await getSettings();
+  const scope = { status: { not: JobStatus.APPLIED }, ...(opts.ids && { id: { in: opts.ids } }) };
+  const total = opts.ids ? opts.ids.length : await prisma.job.count({ where: scope });
   const priorityRules = parsePriorityRules(profile.priorityRules);
   logger.info(
     {
@@ -64,8 +125,8 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
   while (true) {
     const batch = await prisma.job.findMany({
       where: {
-        status: { not: JobStatus.APPLIED },
-        id: { gt: lastId },
+        ...scope,
+        id: { ...scope.id, gt: lastId },
       },
       include: { company: { select: { name: true, atsType: true } } },
       orderBy: { id: 'asc' },
@@ -98,6 +159,7 @@ export async function runReclassifyAll(): Promise<{ stats: CronStats }> {
 
     for (const { job: j, outcome } of pending) {
       scanned++;
+      opts.onProgress?.(scanned, total);
 
       if (outcome === null) {
         if (j.status !== JobStatus.DISMISSED) {

--- a/src/jobs/score-pick.test.ts
+++ b/src/jobs/score-pick.test.ts
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { rankByProfileFit, SCORE_BATCH, type ScorableJob } from './score-pick';
+
+const profile = {
+  stackRequired: ['php', 'laravel'],
+  roleTypes: ['backend'],
+  stackNiceToHave: ['docker'],
+};
+
+const job = (id: number, title: string, description: string, day: number): ScorableJob => ({
+  id,
+  title,
+  description,
+  fetchedAt: new Date(2026, 0, day),
+});
+
+test('a title hit outranks a description hit, required outranks role words', () => {
+  const ranked = rankByProfileFit(
+    [
+      job(1, 'Backend Engineer', 'we use go and kubernetes', 1),
+      job(2, 'Senior PHP Engineer', 'laravel, mysql, docker', 1),
+      job(3, 'Software Engineer', 'php somewhere in the text', 1),
+    ],
+    profile,
+  );
+  assert.deepEqual(
+    ranked.map((r) => r.id),
+    [2, 1, 3],
+  );
+  assert.ok(ranked[0]!.hits > ranked[1]!.hits);
+});
+
+test('ties keep the newer posting, and a term must stand as a word', () => {
+  const ranked = rankByProfileFit(
+    [job(1, 'PHP Developer', '', 1), job(2, 'PHP Developer', '', 5)],
+    profile,
+  );
+  assert.deepEqual(ranked.map((r) => r.id), [2, 1]);
+
+  const [only] = rankByProfileFit([job(9, 'Graphphp Wrangler', 'phpstorm user', 1)], profile);
+  assert.equal(only!.hits, 0, 'substrings inside other words are not hits');
+});
+
+test('a job mentioning nothing still ranks, last, and the batch is small', () => {
+  const ranked = rankByProfileFit([job(1, 'Chef', 'cooking', 1)], profile);
+  assert.deepEqual(ranked, [{ id: 1, hits: 0 }]);
+  assert.ok(SCORE_BATCH <= 25, 'a CLI engine needs 15-30s per job');
+});

--- a/src/jobs/score-pick.ts
+++ b/src/jobs/score-pick.ts
@@ -1,0 +1,69 @@
+import type { FilterProfile } from '../filter';
+
+/*
+ * Which stored-unscored jobs the wizard's "Score" pass spends AI on first.
+ * The base filter only answers yes/no; this ranks the yeses so a batch of
+ * ten is the ten most likely matches rather than the ten most recent. Pure
+ * — tested in score-pick.test.ts.
+ */
+
+/** One press of "Score the jobs we found" — small on purpose: a CLI engine
+ *  needs ~15-30 s per job, so ten is a coffee, a hundred is an afternoon. */
+export const SCORE_BATCH = 10;
+
+export interface ScorableJob {
+  id: number;
+  title: string;
+  description: string;
+  fetchedAt: Date;
+}
+
+export interface RankedJob {
+  id: number;
+  /** Distinct profile terms found; higher is scored first. */
+  hits: number;
+}
+
+/** Word-boundary match that survives "Node.js", "C++" and "full-stack". */
+function mentions(haystack: string, term: string): boolean {
+  const t = term.trim().toLowerCase();
+  if (t.length === 0) return false;
+  const i = haystack.indexOf(t);
+  if (i === -1) return false;
+  const before = haystack[i - 1];
+  const after = haystack[i + t.length];
+  const isWord = (ch: string | undefined): boolean => ch !== undefined && /[a-z0-9]/.test(ch);
+  return !isWord(before) && !isWord(after);
+}
+
+/**
+ * Ranks by how much of the profile the posting actually mentions: a title
+ * hit counts double (that is what the base filter gates on), description
+ * hits count once, and required stack outweighs role words. Ties keep the
+ * newer posting.
+ */
+export function rankByProfileFit(
+  jobs: readonly ScorableJob[],
+  profile: Pick<FilterProfile, 'stackRequired' | 'roleTypes'> & { stackNiceToHave?: string[] },
+): RankedJob[] {
+  const weighted: { terms: string[]; weight: number }[] = [
+    { terms: profile.stackRequired, weight: 3 },
+    { terms: profile.roleTypes, weight: 2 },
+    { terms: profile.stackNiceToHave ?? [], weight: 1 },
+  ];
+  return jobs
+    .map((job) => {
+      const title = job.title.toLowerCase();
+      const body = job.description.toLowerCase();
+      let hits = 0;
+      for (const { terms, weight } of weighted) {
+        for (const term of terms) {
+          if (mentions(title, term)) hits += weight * 2;
+          else if (mentions(body, term)) hits += weight;
+        }
+      }
+      return { id: job.id, hits, fetchedAt: job.fetchedAt.getTime() };
+    })
+    .sort((a, b) => b.hits - a.hits || b.fetchedAt - a.fetchedAt || b.id - a.id)
+    .map(({ id, hits }) => ({ id, hits }));
+}

--- a/src/prompt-fence-registry.test.ts
+++ b/src/prompt-fence-registry.test.ts
@@ -48,7 +48,7 @@ const KNOWN_CALL_SITES: Record<string, string> = {
   'resume/cover-letter.ts': 'buildCoverPrompt',
   'verification/verify.ts': 'buildVerifyPrompt',
   'scripts/resume-bench-once.ts': 'bench harness, reuses buildMatchPrompt',
-  'web/routes/settings.tsx': 'engine connectivity test — a fixed literal, no outside text',
+  'web/ai-test.ts': 'engine connectivity test — a fixed literal, no outside text',
 };
 
 const PROFILE = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -29,6 +29,8 @@ export interface AppSettingsView {
   coverAngles: unknown;
   /** Raw AppSettings.pipelineStages JSON — parse with parseStageConfig (ADR 0025). */
   pipelineStages: unknown;
+  /** NULL until the first-run wizard finishes or is skipped — `/` redirects to /welcome meanwhile. */
+  setupCompletedAt: Date | null;
   updatedAt: Date;
 }
 
@@ -55,8 +57,19 @@ export async function getSettings(): Promise<AppSettingsView> {
     aiUsage: row.aiUsage,
     coverAngles: row.coverAngles,
     pipelineStages: row.pipelineStages,
+    setupCompletedAt: row.setupCompletedAt,
     updatedAt: row.updatedAt,
   };
+}
+
+/** Marks the first-run wizard as finished (or skipped); `/` stops redirecting. */
+export async function setSetupCompleted(): Promise<void> {
+  await prisma.appSettings.upsert({
+    where: { id: SETTINGS_ID },
+    update: { setupCompletedAt: new Date() },
+    create: { id: SETTINGS_ID, setupCompletedAt: new Date() },
+  });
+  logger.info('settings: setup marked complete');
 }
 
 /**

--- a/src/web/ai-test.ts
+++ b/src/web/ai-test.ts
@@ -1,0 +1,45 @@
+import { getAiProviderById } from '../ai-provider';
+import { AI_PROVIDER_LABELS, resolveAiEngine, type AiProviderId } from '../ai-engine';
+import { getAiEngineEnv } from '../ai-runtime';
+import { getSettings } from '../settings';
+
+const ENGINE_TEST_TIMEOUT_MS = 90_000;
+
+export interface EngineTestResult {
+  ok: boolean;
+  text: string;
+}
+
+/** One tiny live call through `provider` — the Test button on /settings and the wizard's step 1. */
+export async function testAiEngine(provider: AiProviderId): Promise<EngineTestResult> {
+  const label = AI_PROVIDER_LABELS[provider];
+  let backend;
+  try {
+    backend = getAiProviderById(provider);
+  } catch (err) {
+    return {
+      ok: false,
+      text: `${label} test failed: ${err instanceof Error ? err.message : 'not configured'}.`,
+    };
+  }
+  const settings = await getSettings();
+  const engine = resolveAiEngine(settings.aiEngine, getAiEngineEnv());
+  const model = engine.modelFor(provider, 'classifier');
+  const started = Date.now();
+  const text = await backend.complete({
+    system: 'You are a connectivity test. Reply with exactly: OK',
+    user: 'Reply with exactly: OK',
+    maxTokens: 20,
+    label: 'engine-test',
+    model,
+    timeoutMs: ENGINE_TEST_TIMEOUT_MS,
+  });
+  const seconds = ((Date.now() - started) / 1000).toFixed(1);
+  if (text !== null) {
+    return { ok: true, text: `${label} works — replied in ${seconds}s (model ${model || 'CLI default'}).` };
+  }
+  return {
+    ok: false,
+    text: `${label} test failed after ${seconds}s — see the web container logs for the reason.`,
+  };
+}

--- a/src/web/fetch-runs.ts
+++ b/src/web/fetch-runs.ts
@@ -25,6 +25,8 @@ export interface FetchRun {
   stageAt: number;
   /** False while the pipeline is paused: jobs are stored unscored. */
   classify: boolean;
+  /** Where the verdict lands: /runs, or /welcome for the wizard's test search. */
+  backUrl: string;
   sourcesDone: number;
   /** Unknown until the first source answers. */
   sourcesTotal: number | null;
@@ -38,7 +40,7 @@ export interface FetchRun {
 const RUN_TTL_MS = 30 * 60_000;
 const runs = new Map<string, FetchRun>();
 
-export function createFetchRun(fields: Pick<FetchRun, 'classify'>): FetchRun {
+export function createFetchRun(fields: Pick<FetchRun, 'classify' | 'backUrl'>): FetchRun {
   prune();
   const run: FetchRun = {
     id: randomUUID(),

--- a/src/web/pages/fetch-run.tsx
+++ b/src/web/pages/fetch-run.tsx
@@ -69,8 +69,8 @@ export const FetchRunPage: FC<{ run: FetchRun }> = ({ run }) => {
                 {run.error ?? 'The run failed — see the web logs.'}
               </div>
               <div class="flex flex-wrap gap-2">
-                <Button href="/runs" variant="secondary">
-                  ← Back to runs
+                <Button href={run.backUrl} variant="secondary">
+                  ← {run.backUrl === '/welcome' ? 'Back to setup' : 'Back to runs'}
                 </Button>
               </div>
             </div>

--- a/src/web/pages/letter-start.tsx
+++ b/src/web/pages/letter-start.tsx
@@ -1,18 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
-import {
-  Button,
-  Card,
-  Checkbox,
-  Flash,
-  Hint,
-  Input,
-  PageHeader,
-  SectionTitle,
-  Select,
-  Textarea,
-} from '../ui';
+import { Button, Card, Checkbox, FILE_INPUT_CLASS, Flash, Hint, Input, PageHeader, SectionTitle, Select, Textarea } from '../ui';
 import type { FlashMessage } from '../flash';
 import { ModeCard } from './target-start';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
@@ -42,9 +31,6 @@ export interface LetterStartProps {
   presetUrl?: string;
   flash?: FlashMessage | null;
 }
-
-const FILE_INPUT_CLASS =
-  'file:mr-3 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink';
 
 export const LetterStartPage: FC<LetterStartProps> = ({
   jobs,

--- a/src/web/pages/overview.tsx
+++ b/src/web/pages/overview.tsx
@@ -45,6 +45,8 @@ export interface OverviewProps {
   fetchingEnabled: boolean;
   /** The manual fetch in flight, if any — the button turns into a link to it. */
   fetchRun: FetchRun | null;
+  /** A wizard step is still undone (skipped or not) — show the way back to /welcome. */
+  finishSetup: boolean;
   flash?: FlashMessage | null;
 }
 
@@ -67,6 +69,7 @@ export const OverviewPage: FC<OverviewProps> = ({
   latestRuns,
   fetchingEnabled,
   fetchRun,
+  finishSetup,
   flash,
 }) => {
   const byStatus = mapCounts(counts);
@@ -81,6 +84,11 @@ export const OverviewPage: FC<OverviewProps> = ({
         meta="Refreshes every 30s"
         actions={
           <>
+            {finishSetup && (
+              <a href="/welcome" class="inline-flex" title="Some setup steps are still open">
+                <Badge tone="warn">Finish setup →</Badge>
+              </a>
+            )}
             <FetchNowButton run={fetchRun} />
             {/* Quick master switch — same toggle as Settings → General. */}
             <form

--- a/src/web/pages/resumes.tsx
+++ b/src/web/pages/resumes.tsx
@@ -1,22 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
-import {
-  ActionForm,
-  Badge,
-  Button,
-  Card,
-  Empty,
-  Field,
-  Flash,
-  Hint,
-  Input,
-  PageHeader,
-  SectionTitle,
-  Table,
-  Td,
-  Tr,
-} from '../ui';
+import { ActionForm, Badge, Button, Card, Empty, Field, FILE_INPUT_CLASS, Flash, Hint, Input, PageHeader, SectionTitle, Table, Td, Tr } from '../ui';
 import type { FlashMessage } from '../flash';
 import { formatRelative } from '../format';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
@@ -40,9 +25,6 @@ export interface FactRow {
 }
 
 const SKILLS_PREVIEW = 6;
-
-const FILE_INPUT_CLASS =
-  'file:mr-3 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink';
 
 export const ResumesPage: FC<{
   resumes: ResumeRow[];

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -2,28 +2,7 @@
 import type { Child, FC, PropsWithChildren } from 'hono/jsx';
 import type { Profile } from '@prisma/client';
 import { Layout } from '../layout';
-import {
-  ActionForm,
-  Badge,
-  Button,
-  Card,
-  Code,
-  Empty,
-  Field,
-  Flash,
-  Hint,
-  Input,
-  PageHeader,
-  PillCheckbox,
-  Radio,
-  Select,
-  Table,
-  Tag,
-  Td,
-  Textarea,
-  ToggleRow,
-  Tr,
-} from '../ui';
+import { ActionForm, Badge, Button, Card, Code, Empty, Field, FILE_INPUT_CLASS, Flash, Hint, Input, PageHeader, PillCheckbox, Radio, Select, Table, Tag, Td, Textarea, ToggleRow, Tr } from '../ui';
 import { formatRelative } from '../format';
 import type { FlashMessage } from '../flash';
 import { sourceLabel } from '../source-names';
@@ -33,9 +12,6 @@ import { isBlankProfile } from '../../profile-guards';
 import { SENIORITY_LEVELS } from '../../resume/profile-draft';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
 import { MAX_UPLOAD_MB } from '../upload';
-
-const FILE_INPUT_CLASS =
-  'file:mr-3 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink';
 
 interface MaskedTarget {
   id: number;

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -34,6 +34,10 @@ const STEP_VIEW: Record<RunStep, StepView> = {
     label: 'Write the cover letter',
     detail: 'grounded in the resume, fact-checked before it is shown — about a minute',
   },
+  score: {
+    label: 'Score the jobs we found',
+    detail: 'the AI reads each one against your profile — a few seconds per job',
+  },
 };
 
 /**
@@ -45,22 +49,25 @@ export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
   const failed = run.stage === 'error';
   const currentIdx = run.steps.indexOf(run.stage as RunStep);
   const elapsed = Math.max(0, Math.round((Date.now() - run.startedAt) / 1000));
-  // A letter run reads oddly as "Comparing" — the verb follows the steps.
+  // A letter run reads oddly as "Comparing" — the verb follows the steps;
+  // wizard runs (scan / score) bring their own copy.
   const letter = run.steps.includes('letter');
-  const heading = failed
-    ? letter
-      ? 'Generation failed'
-      : 'Comparison failed'
-    : letter
-      ? 'Writing a cover letter'
-      : 'Comparing';
+  const copy = run.heading ?? {
+    running: letter ? 'Writing a cover letter' : 'Comparing',
+    failed: letter ? 'Generation failed' : 'Comparison failed',
+  };
+  const heading = failed ? copy.failed : copy.running;
   return (
-    <Layout title={failed ? heading : `${heading}…`} active="target">
+    <Layout title={failed ? heading : `${heading}…`} active={run.heading ? undefined : 'target'}>
       <div class="mx-auto w-full max-w-2xl pt-6 lg:pt-16">
         <Card>
           <div class="mb-1 text-sm font-semibold text-ink">{heading}</div>
           <div class="text-sm text-ink-muted">
-            "{run.resumeName}" ↔ "<span id="run-job-title">{run.jobTitle}</span>"
+            {run.subtitle ?? (
+              <>
+                "{run.resumeName}" ↔ "<span id="run-job-title">{run.jobTitle}</span>"
+              </>
+            )}
           </div>
 
           {failed ? (
@@ -84,8 +91,8 @@ export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
               <RunSteps steps={run.steps} currentIdx={currentIdx} view={STEP_VIEW} />
               <div class="mt-5 flex items-center justify-between gap-3 border-t border-line pt-3">
                 <Hint>
-                  You can close this page — the run keeps going and the result lands on the job
-                  page.
+                  You can close this page — the run keeps going and the result lands{' '}
+                  {run.heading ? 'back in setup' : 'on the job page'}.
                 </Hint>
                 <span id="run-elapsed" class="shrink-0 text-xs tabular-nums text-ink-faint">
                   {elapsed}s

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -35,8 +35,8 @@ const STEP_VIEW: Record<RunStep, StepView> = {
     detail: 'grounded in the resume, fact-checked before it is shown — about a minute',
   },
   score: {
-    label: 'Score the jobs we found',
-    detail: 'the AI reads each one against your profile — a few seconds per job',
+    label: 'Score the best matches',
+    detail: 'the AI reads each one against your profile — seconds on an API engine, up to half a minute on a CLI one',
   },
 };
 

--- a/src/web/pages/target-start.tsx
+++ b/src/web/pages/target-start.tsx
@@ -1,18 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import type { FC, PropsWithChildren } from 'hono/jsx';
 import { Layout } from '../layout';
-import {
-  Button,
-  Card,
-  Field,
-  Flash,
-  Hint,
-  Input,
-  PageHeader,
-  SectionTitle,
-  Select,
-  Textarea,
-} from '../ui';
+import { Button, Card, Field, FILE_INPUT_CLASS, Flash, Hint, Input, PageHeader, SectionTitle, Select, Textarea } from '../ui';
 import type { FlashMessage } from '../flash';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
 import { MAX_UPLOAD_MB } from '../upload';
@@ -30,9 +19,6 @@ export interface TargetStartProps {
   resumes: { id: number; name: string; isDefault: boolean; version: number }[];
   flash?: FlashMessage | null;
 }
-
-const FILE_INPUT_CLASS =
-  'file:mr-3 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink';
 
 export const TargetStartPage: FC<TargetStartProps> = ({ resumes, flash }) => {
   const hasResumes = resumes.length > 0;

--- a/src/web/pages/welcome.tsx
+++ b/src/web/pages/welcome.tsx
@@ -1,0 +1,619 @@
+/** @jsxImportSource hono/jsx */
+import type { FC, PropsWithChildren } from 'hono/jsx';
+import { Layout } from '../layout';
+import {
+  ActionForm,
+  Badge,
+  Button,
+  Card,
+  Code,
+  FILE_INPUT_CLASS,
+  Field,
+  FitBadge,
+  Flash,
+  Hint,
+  Input,
+  MarkIcon,
+  PillCheckbox,
+  Select,
+} from '../ui';
+import type { FlashMessage } from '../flash';
+import { formatDuration } from '../format';
+import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
+import { SENIORITY_LEVELS } from '../../resume/profile-draft';
+import type { AiProviderId } from '../../ai-engine';
+import { WELCOME_STEPS, type WelcomeStep } from '../welcome-steps';
+
+/*
+ * First-run wizard (docs/onboarding-plan.md §2). One screen, one action:
+ * the checklist on top, the first undone step below it. Copy stays in plain
+ * words — "match score", never "classifier" — the jargon lives in Settings.
+ */
+
+export interface EngineStatusRow {
+  id: AiProviderId;
+  label: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface LastSearch {
+  fetched: number;
+  sources: number;
+  failed: number;
+  stored: number;
+  durationMs: number;
+}
+
+export interface ProfileDraftCard {
+  resumeId: number;
+  resumeName: string;
+  title: string | null;
+  primarySkills: string[];
+  skillCount: number;
+  seniority: string | null;
+  roleTypes: string[];
+  /** Editor-facing labels of the fields the draft fills. */
+  changed: string[];
+  warnings: string[];
+}
+
+export interface TopJob {
+  id: number;
+  title: string;
+  companyName: string;
+  fitScore: number | null;
+}
+
+export interface WelcomeProps {
+  steps: { key: WelcomeStep; done: boolean }[];
+  /** The expanded step; null when every step is done. */
+  current: WelcomeStep | null;
+  setupCompleted: boolean;
+  fetchingEnabled: boolean;
+  telegramEnabled: boolean;
+  ai: { engines: EngineStatusRow[] };
+  search: { jobCount: number; last: LastSearch | null; runningRunId: string | null };
+  profile: {
+    id: number;
+    name: string;
+    stackRequired: string[];
+    roleTypes: string[];
+    seniority: string[];
+    resumes: { id: number; name: string }[];
+    draft: ProfileDraftCard | null;
+  };
+  matches: {
+    scoredCount: number;
+    matchCount: number;
+    minFitScore: number;
+    top: TopJob[];
+    /** Stored-unscored jobs that fit the profile's words — what one more "Score" press would take. */
+    waiting: number;
+    runningRunId: string | null;
+  };
+  flash?: FlashMessage | null;
+}
+
+const STEP_TITLES: Record<WelcomeStep, string> = {
+  ai: 'Connect an AI',
+  search: 'Test the search',
+  profile: 'Tell us about you',
+  matches: 'See your first matches',
+};
+
+/** Plain-language setup cards for the "nothing detected" state, in the order a newcomer reads them. */
+const ENGINE_CARDS: { id: AiProviderId; title: string; how: string; env: string | null }[] = [
+  {
+    id: 'claude_code',
+    title: 'I have a Claude subscription',
+    how: 'Run `claude setup-token` on your computer, paste the token into .env, then `docker compose up -d`.',
+    env: 'CLAUDE_CODE_OAUTH_TOKEN=…',
+  },
+  {
+    id: 'anthropic_api',
+    title: 'I have an Anthropic API key',
+    how: 'Keys live at console.anthropic.com → API keys. Pays per token — the classifier is cheap.',
+    env: 'ANTHROPIC_API_KEY=sk-ant-…',
+  },
+  {
+    id: 'gemini_cli',
+    title: 'I have a Gemini key — the free tier works',
+    how: 'Get one at aistudio.google.com/apikey.',
+    env: 'GEMINI_API_KEY=…',
+  },
+  {
+    id: 'openai_api',
+    title: 'OpenAI, OpenRouter, Groq or a local model',
+    how: 'Any server that speaks /chat/completions; add OPENAI_BASE_URL for the non-OpenAI ones.',
+    env: 'OPENAI_API_KEY=…',
+  },
+  {
+    id: 'codex_cli',
+    title: 'I have a ChatGPT subscription',
+    how: 'Run `codex login` on your computer and mount ~/.codex into the containers — see docs/ai-engines.md.',
+    env: null,
+  },
+];
+
+export const WelcomePage: FC<WelcomeProps> = (p) => (
+  <Layout title="Welcome">
+    <header class="mb-6">
+      <div class="flex flex-wrap items-start justify-between gap-x-4 gap-y-3">
+        <div>
+          <h1 class="text-xl font-semibold tracking-tight">Welcome to ApplyPack</h1>
+          <p class="mt-1 text-[13px] leading-5 text-ink-faint">
+            Four short steps: connect an AI, prove the search works, tell us about you, see your
+            first matches. Everything here can be changed later in Settings.
+          </p>
+        </div>
+        {!p.setupCompleted && (
+          <ActionForm action="/welcome/skip">
+            <Button size="sm" variant="ghost" title="Mark setup as done; every step stays reachable in Settings">
+              Skip setup
+            </Button>
+          </ActionForm>
+        )}
+      </div>
+    </header>
+    <Flash flash={p.flash} />
+
+    <ol class="mb-6 grid gap-2 sm:grid-cols-2 xl:grid-cols-4" aria-label="Setup steps">
+      {p.steps.map((s, i) => {
+        const state = s.done ? 'done' : s.key === p.current ? 'active' : 'pending';
+        return (
+          <li>
+            <a
+              href={`/welcome?step=${s.key}`}
+              aria-current={state === 'active' ? 'step' : undefined}
+              class={`flex items-center gap-2.5 rounded-lg border px-3.5 py-2.5 text-sm transition-colors duration-150 ${
+                state === 'active'
+                  ? 'border-accent/40 bg-accent/5 text-ink'
+                  : state === 'done'
+                    ? 'border-line bg-surface-raised text-ink'
+                    : 'border-line bg-surface-raised text-ink-faint hover:text-ink'
+              }`}
+            >
+              <span
+                class={`grid h-5 w-5 shrink-0 place-items-center rounded-full text-xs font-medium ${
+                  state === 'done'
+                    ? 'bg-ok/10 text-ok'
+                    : state === 'active'
+                      ? 'bg-accent text-white'
+                      : 'bg-surface-overlay text-ink-faint'
+                }`}
+                aria-hidden="true"
+              >
+                {state === 'done' ? <MarkIcon kind="check" /> : i + 1}
+              </span>
+              <span class="truncate">{STEP_TITLES[s.key]}</span>
+              {state === 'done' && <span class="sr-only">(done)</span>}
+            </a>
+          </li>
+        );
+      })}
+    </ol>
+
+    {p.current === 'ai' && <AiStep {...p} />}
+    {p.current === 'search' && <SearchStep {...p} />}
+    {p.current === 'profile' && <ProfileStep {...p} />}
+    {p.current === 'matches' && <MatchesStep {...p} />}
+    {p.current === null && <AllDone {...p} />}
+  </Layout>
+);
+
+const StepCard: FC<PropsWithChildren<{ n: number; step: WelcomeStep; done: boolean }>> = ({
+  n,
+  step,
+  done,
+  children,
+}) => (
+  <Card>
+    <div class="mb-1 flex flex-wrap items-center gap-2">
+      <h2 class="text-sm font-semibold text-ink">
+        Step {n} — {STEP_TITLES[step]}
+      </h2>
+      {done && <Badge tone="ok">done</Badge>}
+    </div>
+    {children}
+  </Card>
+);
+
+/* ---------- step 1 ---------- */
+
+const AiStep: FC<WelcomeProps> = ({ ai, steps }) => {
+  const connected = ai.engines.filter((e) => e.ok);
+  const done = steps.find((s) => s.key === 'ai')?.done ?? false;
+  return (
+    <StepCard n={1} step="ai" done={done}>
+      {connected.length > 0 ? (
+        <>
+          <p class="text-sm text-ink-muted">
+            An AI reads every job and scores how well it matches you. Detected on this machine:
+          </p>
+          <ul class="mt-3 space-y-1.5">
+            {connected.map((e) => (
+              <li class="flex items-center gap-2 text-sm text-ink">
+                <MarkIcon kind="check" class="text-ok" />
+                <span class="font-medium">{e.label}</span>
+                <span class="text-ink-faint">— {e.detail}</span>
+              </li>
+            ))}
+          </ul>
+          <div class="mt-4 flex flex-wrap items-center gap-2">
+            <Button href="/welcome?step=search">Continue →</Button>
+            <ActionForm action="/welcome/ai/test">
+              <Button variant="violet" title="One tiny live call — proves the connection end to end">
+                Send a test message
+              </Button>
+            </ActionForm>
+            <Hint>Optional: the test takes a few seconds and spends one tiny AI call.</Hint>
+          </div>
+        </>
+      ) : (
+        <>
+          <p class="text-sm text-ink-muted">
+            An AI reads every job and scores how well it matches you. Nothing usable was detected
+            yet — pick the one you have, add the line to <Code>.env</Code>, restart with{' '}
+            <Code>docker compose up -d</Code> and press Check again.
+          </p>
+          <ul class="mt-4 grid gap-3 lg:grid-cols-2">
+            {ENGINE_CARDS.map((card) => {
+              const status = ai.engines.find((e) => e.id === card.id);
+              return (
+                <li class="rounded-md border border-line px-4 py-3">
+                  <div class="text-sm font-medium text-ink">{card.title}</div>
+                  <p class="mt-1 text-[13px] leading-5 text-ink-faint">{card.how}</p>
+                  {card.env && (
+                    <pre class="mt-2 overflow-x-auto rounded bg-surface-overlay px-2.5 py-1.5 font-mono text-xs text-ink">
+                      {card.env}
+                    </pre>
+                  )}
+                  {status && (
+                    <p class="mt-2 text-xs text-ink-faint">Right now: {status.detail}</p>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+          <div class="mt-4 flex flex-wrap items-center gap-2">
+            <Button href="/welcome">Check again</Button>
+            <Hint>
+              Full instructions per engine:{' '}
+              <a
+                href="https://github.com/applypack/applypack/blob/main/docs/ai-engines.md"
+                class="font-medium text-accent-strong hover:text-accent-deep"
+              >
+                docs/ai-engines.md
+              </a>
+              .
+            </Hint>
+          </div>
+        </>
+      )}
+    </StepCard>
+  );
+};
+
+/* ---------- step 2 ---------- */
+
+const SearchStep: FC<WelcomeProps> = ({ search, steps }) => {
+  const done = steps.find((s) => s.key === 'search')?.done ?? false;
+  const last = search.last;
+  return (
+    <StepCard n={2} step="search" done={done}>
+      {done ? (
+        <>
+          <p class="text-sm text-ink">
+            <MarkIcon kind="check" class="mr-1 inline text-ok" />
+            <span class="font-medium">{search.jobCount.toLocaleString()} jobs</span> are in your
+            database.
+            {last && (
+              <>
+                {' '}
+                The last search saw {last.fetched.toLocaleString()} from {last.sources} sources
+                {last.failed > 0 ? ` (${last.failed} did not answer)` : ''} in{' '}
+                {formatDuration(last.durationMs)} and stored {last.stored.toLocaleString()} new.
+              </>
+            )}
+          </p>
+          <p class="mt-1 text-sm text-ink-muted">
+            The search works — now let's find the ones that match <em>you</em>.
+          </p>
+          <div class="mt-4 flex flex-wrap items-center gap-2">
+            <Button href="/welcome?step=profile">Continue →</Button>
+            <ActionForm action="/runs/fetch-now" hidden={{ back: '/welcome' }}>
+              <Button variant="secondary">Search again</Button>
+            </ActionForm>
+          </div>
+        </>
+      ) : (
+        <>
+          <p class="text-sm text-ink-muted">
+            Does the job search actually work? Find out before setting anything up: this asks
+            every enabled job board and stores what it finds — no AI, no profile needed. It takes a
+            few minutes; you'll watch the sources answer one by one.
+          </p>
+          {last && last.fetched === 0 && (
+            <p class="mt-2 text-[13px] leading-5 text-warn">
+              The last search got nothing from {last.sources} sources — that usually means no
+              network. Check the connection and try again; the Companies page shows which boards
+              stopped answering.
+            </p>
+          )}
+          <div class="mt-4 flex flex-wrap items-center gap-2">
+            {search.runningRunId ? (
+              <Button href={`/runs/fetch-now/${search.runningRunId}`}>Watch the search →</Button>
+            ) : (
+              <ActionForm action="/runs/fetch-now" hidden={{ back: '/welcome' }}>
+                <Button>Run a test search</Button>
+              </ActionForm>
+            )}
+          </div>
+        </>
+      )}
+    </StepCard>
+  );
+};
+
+/* ---------- step 3 ---------- */
+
+const ProfileStep: FC<WelcomeProps> = ({ profile, steps }) => {
+  const done = steps.find((s) => s.key === 'profile')?.done ?? false;
+  const d = profile.draft;
+  return (
+    <StepCard n={3} step="profile" done={done}>
+      {d ? (
+        <>
+          <p class="text-sm text-ink-muted">From your resume "{d.resumeName}":</p>
+          <p class="mt-2 text-sm leading-6 text-ink">
+            Looks like you're a <span class="font-medium">{d.title ?? 'software professional'}</span>
+            {d.primarySkills.length > 0 && (
+              <>
+                {' '}
+                — main tools <span class="font-medium">{d.primarySkills.join(', ')}</span>
+              </>
+            )}
+            {d.skillCount > 0 && <>, plus {d.skillCount} more skills</>}.{' '}
+            We'll hunt for{d.seniority ? ` ${d.seniority}` : ''}{' '}
+            {d.roleTypes.length > 0 ? d.roleTypes.join(' / ') : 'matching'} roles using these.
+          </p>
+          {d.warnings.length > 0 && (
+            <p class="mt-2 text-[13px] leading-5 text-warn">Note: {d.warnings.join('; ')}.</p>
+          )}
+          <div class="mt-4 flex flex-wrap items-center gap-2">
+            {d.changed.length > 0 ? (
+              <ActionForm action="/welcome/profile/apply" hidden={{ resumeId: d.resumeId }}>
+                <Button>Yes, that's me — start matching</Button>
+              </ActionForm>
+            ) : (
+              <Button href="/welcome?step=matches">Continue →</Button>
+            )}
+            <ActionForm
+              action={`/settings/profiles/${profile.id}/fill-from-resume`}
+              hidden={{ resumeId: d.resumeId }}
+            >
+              <Button variant="secondary">Let me adjust</Button>
+            </ActionForm>
+          </div>
+          <Hint class="mt-3">Nothing is saved until you press one of these.</Hint>
+        </>
+      ) : done ? (
+        <>
+          <p class="text-sm text-ink">
+            <MarkIcon kind="check" class="mr-1 inline text-ok" />
+            Profile <span class="font-medium">"{profile.name}"</span> hunts for{' '}
+            {profile.roleTypes.length > 0 ? profile.roleTypes.join(' / ') : 'matching'} roles
+            {profile.stackRequired.length > 0 && <> built with {profile.stackRequired.join(', ')}</>}.
+          </p>
+          <div class="mt-4 flex flex-wrap items-center gap-2">
+            <Button href="/welcome?step=matches">Continue →</Button>
+            <Button href="/settings?tab=profile" variant="secondary">
+              Adjust in Settings
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p class="text-sm text-ink-muted">
+            Upload your resume and we'll read the tools you use and the roles you do. Takes about a
+            minute; the file stays on your Resumes page for later comparisons and cover letters.
+          </p>
+          <form
+            method="post"
+            action="/welcome/resume"
+            enctype="multipart/form-data"
+            class="mt-4 flex flex-wrap items-end gap-3"
+          >
+            <Field label="Your resume" hint={`${ACCEPTED_EXTENSIONS.join(', ')} · up to 5 MB`} class="min-w-0 flex-1">
+              <input
+                type="file"
+                name="file"
+                accept={ACCEPTED_EXTENSIONS.join(',')}
+                required
+                class={`block w-full text-sm text-ink-muted ${FILE_INPUT_CLASS}`}
+              />
+            </Field>
+            <Button>Upload your resume</Button>
+          </form>
+          {profile.resumes.length > 0 && (
+            <form method="post" action="/welcome/resume" class="mt-3 flex flex-wrap items-end gap-3">
+              <Field label="…or use one you already uploaded" class="min-w-0 flex-1">
+                <Select name="resumeId">
+                  {profile.resumes.map((r) => (
+                    <option value={r.id}>{r.name}</option>
+                  ))}
+                </Select>
+              </Field>
+              <Button variant="secondary">Use this resume</Button>
+            </form>
+          )}
+          <details class="mt-5 rounded-md border border-line">
+            <summary class="cursor-pointer select-none px-4 py-2.5 text-[13px] font-medium text-ink hover:text-accent-strong">
+              No file handy? Answer three questions instead.
+            </summary>
+            <form method="post" action="/welcome/profile" class="space-y-4 border-t border-line px-4 py-4">
+              <Field
+                label="Main technologies"
+                hint="Languages and frameworks a job must use — comma-separated."
+              >
+                <Input
+                  type="text"
+                  name="stackRequired"
+                  placeholder="php, laravel, mysql"
+                  value={profile.stackRequired.join(', ')}
+                />
+              </Field>
+              <Field label="Role words" hint="Words from job titles you'd apply to.">
+                <Input
+                  type="text"
+                  name="roleTypes"
+                  placeholder="backend, full-stack"
+                  value={profile.roleTypes.join(', ')}
+                />
+              </Field>
+              <fieldset>
+                <legend class="text-[13px] font-medium text-ink">Seniority</legend>
+                <div class="mt-2 flex flex-wrap gap-1.5">
+                  {SENIORITY_LEVELS.map((s) => (
+                    <PillCheckbox name="seniority" value={s} checked={profile.seniority.includes(s)}>
+                      {s}
+                    </PillCheckbox>
+                  ))}
+                </div>
+              </fieldset>
+              <Button>Save and continue</Button>
+            </form>
+          </details>
+        </>
+      )}
+    </StepCard>
+  );
+};
+
+/* ---------- step 4 ---------- */
+
+const MatchesStep: FC<WelcomeProps> = (p) => {
+  const { matches, steps } = p;
+  const done = steps.find((s) => s.key === 'matches')?.done ?? false;
+  return (
+    <StepCard n={4} step="matches" done={done}>
+      {done ? (
+        <>
+          <p class="text-sm text-ink">
+            <MarkIcon kind="check" class="mr-1 inline text-ok" />
+            <span class="font-medium">
+              {matches.matchCount} of {matches.scoredCount}
+            </span>{' '}
+            scored jobs look like a match (score {matches.minFitScore} or more).
+            {matches.top.length > 0 && ' Top of the list:'}
+          </p>
+          {matches.top.length > 0 && (
+            <ul class="mt-3 divide-y divide-line rounded-md border border-line">
+              {matches.top.map((j) => (
+                <li>
+                  <a
+                    href={`/jobs/${j.id}`}
+                    class="flex items-center justify-between gap-4 px-4 py-2.5 text-sm transition-colors duration-150 hover:bg-surface-overlay/50"
+                  >
+                    <span class="min-w-0">
+                      <span class="block truncate font-medium text-ink">{j.title}</span>
+                      <span class="block truncate text-[13px] text-ink-faint">{j.companyName}</span>
+                    </span>
+                    <FitBadge score={j.fitScore} label="match" />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+          {matches.waiting > 0 && (
+            <p class="mt-3 text-[13px] leading-5 text-ink-faint">
+              {matches.waiting.toLocaleString()} more stored jobs fit your words and are still
+              unscored.
+            </p>
+          )}
+          <div class="mt-4 flex flex-wrap items-center gap-2">
+            <ScoreOrWatch {...p} />
+          </div>
+        </>
+      ) : (
+        <>
+          <p class="text-sm text-ink-muted">
+            The AI reads the jobs we found against your profile and gives each a match score. This
+            pass takes up to 100 of the most recent jobs that mention your tools or role words —
+            jobs that don't are set aside without spending anything. A few minutes.
+          </p>
+          {matches.waiting === 0 && (
+            <p class="mt-2 text-[13px] leading-5 text-warn">
+              None of the stored jobs mention your technologies or role words yet — the hourly watch
+              keeps looking once you start it below.
+            </p>
+          )}
+          <div class="mt-4 flex flex-wrap items-center gap-2">
+            <ScoreOrWatch {...p} />
+          </div>
+        </>
+      )}
+    </StepCard>
+  );
+};
+
+/** The score button (or the live-run link), plus the closing "Start the hourly watch". */
+const ScoreOrWatch: FC<WelcomeProps> = ({ matches, fetchingEnabled, telegramEnabled, steps }) => {
+  const done = steps.find((s) => s.key === 'matches')?.done ?? false;
+  return (
+    <>
+      {matches.runningRunId ? (
+        <Button href={`/target/runs/${matches.runningRunId}`} variant="violet">
+          Watch the scoring →
+        </Button>
+      ) : matches.waiting > 0 ? (
+        <ActionForm action="/welcome/score">
+          <Button variant="violet">{done ? 'Score 100 more' : 'Score the jobs we found'}</Button>
+        </ActionForm>
+      ) : null}
+      <ActionForm action="/welcome/finish">
+        <Button variant={done || matches.waiting === 0 ? 'primary' : 'secondary'}>
+          {fetchingEnabled ? 'Finish setup' : 'Start the hourly watch'}
+        </Button>
+      </ActionForm>
+      {!telegramEnabled && (
+        <Hint>
+          Want new matches on your phone? Set up Telegram later in{' '}
+          <a href="/settings?tab=notifications" class="font-medium text-accent-strong hover:text-accent-deep">
+            Settings → Notifications
+          </a>
+          .
+        </Hint>
+      )}
+    </>
+  );
+};
+
+/* ---------- all done ---------- */
+
+const AllDone: FC<WelcomeProps> = ({ setupCompleted, fetchingEnabled, matches }) => (
+  <Card>
+    <h2 class="text-sm font-semibold text-ink">Everything is set up</h2>
+    <p class="mt-1 text-sm text-ink-muted">
+      AI connected, {matches.scoredCount.toLocaleString()} jobs scored, profile filled.{' '}
+      {fetchingEnabled
+        ? 'The hourly watch is running — new matches land on the Overview.'
+        : 'The hourly watch is paused; start it to keep the matches coming.'}
+    </p>
+    <div class="mt-4 flex flex-wrap items-center gap-2">
+      {setupCompleted && fetchingEnabled ? (
+        <Button href="/">Go to the Overview →</Button>
+      ) : (
+        <ActionForm action="/welcome/finish">
+          <Button>{fetchingEnabled ? 'Finish setup' : 'Start the hourly watch'}</Button>
+        </ActionForm>
+      )}
+      {matches.waiting > 0 && (
+        <ActionForm action="/welcome/score">
+          <Button variant="violet">Score 100 more</Button>
+        </ActionForm>
+      )}
+    </div>
+  </Card>
+);

--- a/src/web/pages/welcome.tsx
+++ b/src/web/pages/welcome.tsx
@@ -22,6 +22,7 @@ import { formatDuration } from '../format';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
 import { SENIORITY_LEVELS } from '../../resume/profile-draft';
 import type { AiProviderId } from '../../ai-engine';
+import { SCORE_BATCH } from '../../jobs/score-pick';
 import { WELCOME_STEPS, type WelcomeStep } from '../welcome-steps';
 
 /*
@@ -529,8 +530,9 @@ const MatchesStep: FC<WelcomeProps> = (p) => {
           )}
           {matches.waiting > 0 && (
             <p class="mt-3 text-[13px] leading-5 text-ink-faint">
-              {matches.waiting.toLocaleString()} more stored jobs fit your words and are still
-              unscored.
+              {matches.waiting.toLocaleString()} more stored jobs mention your words and are still
+              unscored — score the next {SCORE_BATCH} whenever you like, or let the hourly watch
+              score new ones as they arrive.
             </p>
           )}
           <div class="mt-4 flex flex-wrap items-center gap-2">
@@ -541,8 +543,9 @@ const MatchesStep: FC<WelcomeProps> = (p) => {
         <>
           <p class="text-sm text-ink-muted">
             The AI reads the jobs we found against your profile and gives each a match score. This
-            pass takes up to 100 of the most recent jobs that mention your tools or role words —
-            jobs that don't are set aside without spending anything. A few minutes.
+            pass takes the {SCORE_BATCH} that match you best — jobs that mention none of your tools
+            or role words are set aside without spending anything. Seconds per job on an API engine,
+            up to half a minute each on a CLI one; press it again for the next {SCORE_BATCH}.
           </p>
           {matches.waiting === 0 && (
             <p class="mt-2 text-[13px] leading-5 text-warn">
@@ -570,7 +573,9 @@ const ScoreOrWatch: FC<WelcomeProps> = ({ matches, fetchingEnabled, telegramEnab
         </Button>
       ) : matches.waiting > 0 ? (
         <ActionForm action="/welcome/score">
-          <Button variant="violet">{done ? 'Score 100 more' : 'Score the jobs we found'}</Button>
+          <Button variant="violet">
+            {done ? `Score ${SCORE_BATCH} more` : 'Score the best matches'}
+          </Button>
         </ActionForm>
       ) : null}
       <ActionForm action="/welcome/finish">
@@ -612,7 +617,7 @@ const AllDone: FC<WelcomeProps> = ({ setupCompleted, fetchingEnabled, matches })
       )}
       {matches.waiting > 0 && (
         <ActionForm action="/welcome/score">
-          <Button variant="violet">Score 100 more</Button>
+          <Button variant="violet">Score {SCORE_BATCH} more</Button>
         </ActionForm>
       )}
     </div>

--- a/src/web/pages/welcome.tsx
+++ b/src/web/pages/welcome.tsx
@@ -495,7 +495,8 @@ const ProfileStep: FC<WelcomeProps> = ({ profile, steps }) => {
 
 const MatchesStep: FC<WelcomeProps> = (p) => {
   const { matches, steps } = p;
-  const done = steps.find((s) => s.key === 'matches')?.done ?? false;
+  // A pass in flight already scored a few rows — show the running copy, not "0 of 3".
+  const done = (steps.find((s) => s.key === 'matches')?.done ?? false) && !matches.runningRunId;
   return (
     <StepCard n={4} step="matches" done={done}>
       {done ? (

--- a/src/web/public/target-run.mjs
+++ b/src/web/public/target-run.mjs
@@ -47,7 +47,13 @@ const ACTIVITIES = {
     'Drafting the letter — role, evidence, why this company…',
     'Fact-checking every claim against the resume…',
   ],
+  score: [
+    'Filtering the stored jobs against your profile…',
+    'Scoring what passed — a few seconds per job…',
+  ],
 };
+/** What one unit of a step's progress is called. */
+const PROGRESS_UNIT = { score: 'jobs scored' };
 const ROTATE_MS = 9000;
 const POLL_MS = 2000;
 const FADE_MS = 250;
@@ -63,12 +69,21 @@ export function activityFor(step, stageElapsedMs) {
   return paced(ACTIVITIES[step] ?? [], stageElapsedMs);
 }
 
+/** "12 of 100 jobs scored" — the line once the run reports real counts. */
+export function progressLine(step, progress) {
+  return `${progress.done} of ${progress.total} ${PROGRESS_UNIT[step] ?? 'done'}`;
+}
+
+function defaultActivity(step, state) {
+  return state.progress ? progressLine(step, state.progress) : activityFor(step, state.stageElapsedMs);
+}
+
 export function formatElapsed(ms) {
   const s = Math.max(0, Math.round(ms / 1000));
   return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
 }
 
-export function init(data, activity = (step, state) => activityFor(step, state.stageElapsedMs)) {
+export function init(data, activity = defaultActivity) {
   const steps = [...document.querySelectorAll('[data-step]')];
   const elapsedEl = document.getElementById('run-elapsed');
   let state = null;

--- a/src/web/routes/overview.tsx
+++ b/src/web/routes/overview.tsx
@@ -2,9 +2,10 @@
 import { Hono } from 'hono';
 import { JobStatus } from '@prisma/client';
 import { prisma } from '../../db';
-import { getSettings } from '../../settings';
 import { clearFlashCookie, parseFlashCookie } from '../flash';
 import { activeFetchRun } from '../fetch-runs';
+import { loadWelcomeContext } from '../welcome-facts';
+import { currentStep, needsWelcome } from '../welcome-steps';
 import { OverviewPage } from '../pages/overview';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -14,10 +15,13 @@ const CRON_NAMES = ['fetch', 'digest', 'cleanup'] as const;
 export const overviewRoute = new Hono();
 
 overviewRoute.get('/', async (c) => {
-  const since24h = new Date(Date.now() - DAY_MS);
+  // A fresh install is walked through setup first (docs/onboarding-plan.md §2);
+  // every other page keeps working meanwhile.
+  const { facts, settings } = await loadWelcomeContext();
+  if (needsWelcome(settings)) return c.redirect('/welcome', 303);
 
-  const [settings, countsRows, last24hRows, recentAlerts, latestRunRows] = await Promise.all([
-    getSettings(),
+  const since24h = new Date(Date.now() - DAY_MS);
+  const [countsRows, last24hRows, recentAlerts, latestRunRows] = await Promise.all([
     prisma.job.groupBy({
       by: ['status'],
       _count: { _all: true },
@@ -64,6 +68,7 @@ overviewRoute.get('/', async (c) => {
       latestRuns={latestRuns}
       fetchingEnabled={settings.fetchingEnabled}
       fetchRun={activeFetchRun()}
+      finishSetup={currentStep(facts) !== null}
       flash={parseFlashCookie(c.req.header('cookie'))}
     />,
     200,

--- a/src/web/routes/runs.tsx
+++ b/src/web/routes/runs.tsx
@@ -41,11 +41,14 @@ runsRoute.get('/runs', async (c) => {
  * new jobs unscored: paused means no AI spend.
  */
 runsRoute.post('/runs/fetch-now', async (c) => {
+  const form = await c.req.parseBody();
+  // The wizard's "Run a test search" wants the verdict back in setup.
+  const backUrl = form.back === '/welcome' ? '/welcome' : '/runs';
   const { fetchingEnabled } = await getSettings();
   // No await between the guard and the create — a double submit lands on the same run.
   const active = activeFetchRun();
   if (active) return c.redirect(`/runs/fetch-now/${active.id}`, 303);
-  const run = createFetchRun({ classify: fetchingEnabled });
+  const run = createFetchRun({ classify: fetchingEnabled, backUrl });
   startFetchRun(run.id, async () => {
     let stats: CronStats | undefined;
     await recordCronRun('fetch-now', async () => {
@@ -91,7 +94,7 @@ runsRoute.get('/runs/fetch-now/:id', (c) => {
   }
   if (run.stage === 'done') {
     const { kind, text } = summarizeFetchRun(run.stats ?? {});
-    return flashRedirect('/runs', kind, text);
+    return flashRedirect(run.backUrl, kind, text);
   }
   return c.html(<FetchRunPage run={run} />);
 });

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -46,7 +46,7 @@ import {
   type AiProviderId,
 } from '../../ai-engine';
 import { getAiEngineEnv, probeAiProviders } from '../../ai-runtime';
-import { getAiProviderById } from '../../ai-provider';
+import { testAiEngine } from '../ai-test';
 import {
   createProfile,
   deleteProfile,
@@ -108,8 +108,6 @@ const AI_PROVIDER_DESCS: Record<AiProviderId, string> = {
     'Any server speaking /chat/completions: OpenAI, OpenRouter, Groq, local LM Studio / Ollama. Pays per token (or free locally).',
   codex_cli: 'Headless codex exec on your ChatGPT subscription.',
 };
-
-const ENGINE_TEST_TIMEOUT_MS = 90_000;
 
 let reclassifyInFlight = false;
 
@@ -377,42 +375,8 @@ settingsRoute.post('/settings/ai/test', async (c) => {
   const form = await c.req.parseBody();
   const provider = typeof form.provider === 'string' ? form.provider : '';
   if (!isAiProviderId(provider)) return flashRedirect('/settings?tab=ai', 'err', 'Unknown engine.');
-  const label = AI_PROVIDER_LABELS[provider];
-  let backend;
-  try {
-    backend = getAiProviderById(provider);
-  } catch (err) {
-    return flashRedirect(
-      '/settings?tab=ai',
-      'err',
-      `${label} test failed: ${err instanceof Error ? err.message : 'not configured'}.`,
-    );
-  }
-  const settings = await getSettings();
-  const engine = resolveAiEngine(settings.aiEngine, getAiEngineEnv());
-  const model = engine.modelFor(provider, 'classifier');
-  const started = Date.now();
-  const text = await backend.complete({
-    system: 'You are a connectivity test. Reply with exactly: OK',
-    user: 'Reply with exactly: OK',
-    maxTokens: 20,
-    label: 'engine-test',
-    model,
-    timeoutMs: ENGINE_TEST_TIMEOUT_MS,
-  });
-  const seconds = ((Date.now() - started) / 1000).toFixed(1);
-  if (text !== null) {
-    return flashRedirect(
-      '/settings?tab=ai',
-      'ok',
-      `${label} works — replied in ${seconds}s (model ${model || 'CLI default'}).`,
-    );
-  }
-  return flashRedirect(
-    '/settings?tab=ai',
-    'err',
-    `${label} test failed after ${seconds}s — see the web container logs for the reason.`,
-  );
+  const result = await testAiEngine(provider);
+  return flashRedirect('/settings?tab=ai', result.ok ? 'ok' : 'err', result.text);
 });
 
 function cleanModelId(value: unknown): string | null {

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -68,6 +68,7 @@ targetRoute.get('/target/runs/:id/state', (c) => {
     stage: run.stage,
     steps: run.steps,
     jobTitle: run.jobTitle,
+    progress: run.progress ?? null,
     stageElapsedMs: Date.now() - run.stageAt,
     elapsedMs: Date.now() - run.startedAt,
   });

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -1,0 +1,324 @@
+/** @jsxImportSource hono/jsx */
+import { Hono } from 'hono';
+import { CronRunStatus, JobStatus, type Profile } from '@prisma/client';
+import { prisma } from '../../db';
+import { setFetchingEnabled, setSetupCompleted } from '../../settings';
+import { updateProfile, type ProfileInput } from '../../profiles';
+import { passesBaseFilter } from '../../filter';
+import { parsePriorityRules } from '../../priority-rules';
+import { parseTagList, toStringArray } from '../../text-utils';
+import { getAiEngineEnv } from '../../ai-runtime';
+import { AI_PROVIDER_IDS, AI_PROVIDER_LABELS, resolveAiEngine } from '../../ai-engine';
+import { createResume, getResume, listResumes, type ResumeSummary } from '../../resume/store';
+import { scanResume } from '../../resume/scan';
+import { buildProfileDraft, SENIORITY_LEVELS } from '../../resume/profile-draft';
+import { recordCronRun, type CronStats } from '../../jobs/cron-run';
+import { runScoreUnscored } from '../../jobs/reclassify-job';
+import { activeFetchRun } from '../fetch-runs';
+import { createRun, getRun, startRun, updateRun } from '../target-runs';
+import { testAiEngine } from '../ai-test';
+import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
+import { nameFromFilename, readResumeUpload, resumeUploadLimit } from '../upload';
+import { WelcomePage, type LastSearch, type ProfileDraftCard } from '../pages/welcome';
+import { loadWelcomeContext } from '../welcome-facts';
+import {
+  WELCOME_STEPS,
+  currentStep,
+  isWelcomeStep,
+  stepDone,
+  summarizeScoreRun,
+} from '../welcome-steps';
+
+const TOP_MATCHES = 5;
+const PROFILE_STEP = '/welcome?step=profile';
+const MATCHES_STEP = '/welcome?step=matches';
+
+/** The scoring pass in flight, if any — one at a time, like re-classify. */
+let scoreRunId: string | null = null;
+
+function runningScoreRun(): string | null {
+  const run = scoreRunId ? getRun(scoreRunId) : null;
+  return run && run.stage !== 'done' && run.stage !== 'error' ? run.id : null;
+}
+
+export const welcomeRoute = new Hono();
+
+welcomeRoute.get('/welcome', async (c) => {
+  const { facts, settings, statuses, profile } = await loadWelcomeContext();
+  const requested = c.req.query('step');
+  const current = isWelcomeStep(requested) ? requested : currentStep(facts);
+
+  const [resumes, lastSearch, matchCount, top, waiting] = await Promise.all([
+    listResumes(),
+    findLastSearch(),
+    profile
+      ? prisma.job.count({
+          where: { fitScore: { gte: profile.minFitScore }, status: { not: JobStatus.DISMISSED } },
+        })
+      : 0,
+    prisma.job.findMany({
+      where: { fitScore: { not: null }, status: { not: JobStatus.DISMISSED } },
+      orderBy: [{ fitScore: 'desc' }, { fetchedAt: 'desc' }],
+      take: TOP_MATCHES,
+      select: { id: true, title: true, fitScore: true, company: { select: { name: true } } },
+    }),
+    profile && facts.profileReady ? countWaitingUnscored(profile) : 0,
+  ]);
+
+  const resumeId = Number(c.req.query('resume'));
+  const draftResume = Number.isFinite(resumeId) && profile ? await getResume(resumeId) : null;
+  const draft = draftResume && profile ? draftCard(profile, draftResume) : null;
+
+  return c.html(
+    <WelcomePage
+      steps={WELCOME_STEPS.map((key) => ({ key, done: stepDone(key, facts) }))}
+      current={current}
+      setupCompleted={settings.setupCompletedAt !== null}
+      fetchingEnabled={settings.fetchingEnabled}
+      telegramEnabled={settings.telegramEnabled}
+      ai={{
+        engines: AI_PROVIDER_IDS.map((id) => ({ id, label: AI_PROVIDER_LABELS[id], ...statuses[id] })),
+      }}
+      search={{ jobCount: facts.jobCount, last: lastSearch, runningRunId: activeFetchRun()?.id ?? null }}
+      profile={{
+        id: profile?.id ?? 0,
+        name: profile?.name ?? '',
+        stackRequired: profile?.stackRequired ?? [],
+        roleTypes: profile?.roleTypes ?? [],
+        seniority: profile?.seniority ?? [],
+        resumes: resumes.map((r) => ({ id: r.id, name: r.name })),
+        draft,
+      }}
+      matches={{
+        scoredCount: facts.scoredCount,
+        matchCount,
+        minFitScore: profile?.minFitScore ?? 0,
+        top: top.map((j) => ({ id: j.id, title: j.title, companyName: j.company.name, fitScore: j.fitScore })),
+        waiting,
+        runningRunId: runningScoreRun(),
+      }}
+      flash={parseFlashCookie(c.req.header('cookie'))}
+    />,
+    200,
+    { 'Set-Cookie': clearFlashCookie() },
+  );
+});
+
+welcomeRoute.post('/welcome/skip', async () => {
+  await setSetupCompleted();
+  return flashRedirect(
+    '/',
+    'ok',
+    'Setup skipped — everything lives in Settings. The Overview keeps a "Finish setup" link until every step is done.',
+  );
+});
+
+/** Step 4's closing action: the hourly watch starts and the wizard stops greeting. */
+welcomeRoute.post('/welcome/finish', async () => {
+  await setFetchingEnabled(true);
+  await setSetupCompleted();
+  return flashRedirect('/', 'ok', 'Setup complete — the hourly watch is on. New matches land here.');
+});
+
+/** Step 1's optional proof: one tiny live call through the engine that would serve the pipeline. */
+welcomeRoute.post('/welcome/ai/test', async () => {
+  const { statuses, settings } = await loadWelcomeContext();
+  const chain = resolveAiEngine(settings.aiEngine, getAiEngineEnv()).chain;
+  const provider = chain.find((id) => statuses[id].ok) ?? AI_PROVIDER_IDS.find((id) => statuses[id].ok);
+  if (!provider) return flashRedirect('/welcome?step=ai', 'err', 'No usable AI engine detected yet.');
+  const result = await testAiEngine(provider);
+  return flashRedirect('/welcome?step=ai', result.ok ? 'ok' : 'err', result.text);
+});
+
+/**
+ * Step 3, resume path: a new upload becomes a Resume row (first one turns
+ * default), then the scan runs on the progress page and lands back here
+ * with the draft. An already-scanned resume skips straight to the draft.
+ */
+welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) => {
+  const form = await c.req.parseBody();
+  let resume: ResumeSummary | null = null;
+  if (form.file instanceof File && form.file.size > 0) {
+    const upload = await readResumeUpload(form);
+    if ('error' in upload) return flashRedirect(PROFILE_STEP, 'err', upload.error);
+    resume = await createResume({ name: nameFromFilename(upload.sourceFilename), ...upload });
+  } else {
+    const id = Number(form.resumeId);
+    if (Number.isFinite(id)) resume = await getResume(id);
+  }
+  if (!resume || resume.hidden) return flashRedirect(PROFILE_STEP, 'err', 'Pick a resume file first.');
+  if (resume.scannedAt && resume.primarySkills.length > 0) {
+    return c.redirect(`${PROFILE_STEP}&resume=${resume.id}`, 303);
+  }
+
+  const { id, name, text } = resume;
+  const run = createRun({
+    steps: ['scan'],
+    jobTitle: '',
+    resumeName: name,
+    heading: { running: 'Reading your resume', failed: 'Could not read the resume' },
+    subtitle: `"${name}" — headline, tools, seniority. About a minute.`,
+    backUrl: PROFILE_STEP,
+    backLabel: 'Back to setup',
+  });
+  startRun(run.id, async () => {
+    const scan = await scanResume({ id, text });
+    if (!scan) {
+      updateRun(run.id, {
+        stage: 'error',
+        error: `The AI could not read "${name}" — check the web logs and try again, or answer the three questions instead.`,
+      });
+      return;
+    }
+    updateRun(run.id, {
+      stage: 'done',
+      resultUrl: `${PROFILE_STEP}&resume=${id}`,
+      flash: `Read "${name}" — check the summary below.`,
+    });
+  });
+  return c.redirect(`/target/runs/${run.id}`, 303);
+});
+
+/** "Yes, that's me": the draft the summary card showed becomes the profile. */
+welcomeRoute.post('/welcome/profile/apply', async (c) => {
+  const form = await c.req.parseBody();
+  const { profile } = await loadWelcomeContext();
+  const resume = await getResume(Number(form.resumeId));
+  if (!profile) return flashRedirect(PROFILE_STEP, 'err', 'No active profile — create one in Settings → Profile.');
+  if (!resume || !resume.scannedAt) return flashRedirect(PROFILE_STEP, 'err', 'That resume has not been read yet.');
+  const draft = buildProfileDraft(profile, scanOf(resume));
+  await updateProfile(profile.id, { ...profileInput(profile), ...draft.changes });
+  return flashRedirect(
+    MATCHES_STEP,
+    'ok',
+    draft.changed.length > 0
+      ? `Profile filled from "${resume.name}" — ${draft.changed.join(', ')}. Adjust it any time in Settings → Profile.`
+      : `Profile already matched "${resume.name}".`,
+  );
+});
+
+/** Step 3, no-resume path: three answers write the same fields. */
+welcomeRoute.post('/welcome/profile', async (c) => {
+  const form = await c.req.parseBody({ all: true });
+  const { profile } = await loadWelcomeContext();
+  if (!profile) return flashRedirect(PROFILE_STEP, 'err', 'No active profile — create one in Settings → Profile.');
+  const stackRequired = parseTagList(String(form.stackRequired ?? ''));
+  const roleTypes = parseTagList(String(form.roleTypes ?? ''));
+  const seniority = toStringArray(form.seniority).filter((s) =>
+    (SENIORITY_LEVELS as readonly string[]).includes(s),
+  );
+  if (stackRequired.length === 0 && roleTypes.length === 0) {
+    return flashRedirect(PROFILE_STEP, 'err', 'Add at least one technology or one role word.');
+  }
+  await updateProfile(profile.id, { ...profileInput(profile), stackRequired, roleTypes, seniority });
+  return flashRedirect(MATCHES_STEP, 'ok', 'Profile saved. Adjust it any time in Settings → Profile.');
+});
+
+/** Step 4: score the stored-unscored jobs on the progress page; one pass at a time. */
+welcomeRoute.post('/welcome/score', async (c) => {
+  const running = runningScoreRun();
+  if (running) return c.redirect(`/target/runs/${running}`, 303);
+  const { facts } = await loadWelcomeContext();
+  if (!facts.profileReady) {
+    return flashRedirect(PROFILE_STEP, 'err', 'Fill the profile first — scoring needs your technologies or role words.');
+  }
+  const run = createRun({
+    steps: ['score'],
+    jobTitle: '',
+    resumeName: '',
+    heading: { running: 'Scoring the jobs we found', failed: 'Scoring failed' },
+    subtitle: 'Up to 100 recent jobs that mention your tools or role words — a few seconds each.',
+    backUrl: MATCHES_STEP,
+    backLabel: 'Back to setup',
+  });
+  scoreRunId = run.id;
+  startRun(run.id, async () => {
+    let stats: CronStats = {};
+    await recordCronRun('score-unscored', async () => {
+      const out = await runScoreUnscored({
+        onProgress: (done, total) => updateRun(run.id, { progress: { done, total } }),
+      });
+      stats = out.stats;
+      return out;
+    });
+    updateRun(run.id, { stage: 'done', resultUrl: MATCHES_STEP, flash: summarizeScoreRun(stats).text });
+  });
+  return c.redirect(`/target/runs/${run.id}`, 303);
+});
+
+/* ---------- helpers ---------- */
+
+/** The last search that actually ran — a paused-skip row carries no counts. */
+async function findLastSearch(): Promise<LastSearch | null> {
+  const rows = await prisma.cronRun.findMany({
+    where: { name: { in: ['fetch-now', 'fetch'] }, status: CronRunStatus.OK },
+    orderBy: { startedAt: 'desc' },
+    take: 5,
+    select: { stats: true },
+  });
+  for (const row of rows) {
+    const s = row.stats as Record<string, unknown> | null;
+    if (s && typeof s.fetched === 'number') {
+      const n = (key: string): number => (typeof s[key] === 'number' ? (s[key] as number) : 0);
+      return { fetched: n('fetched'), sources: n('sources'), failed: n('sourcesFailed'), stored: n('persisted'), durationMs: n('durationMs') };
+    }
+  }
+  return null;
+}
+
+/** Stored-unscored jobs that pass the profile's words — what one "Score" press would read. */
+async function countWaitingUnscored(profile: Profile): Promise<number> {
+  const rows = await prisma.job.findMany({
+    where: { fitScore: null, status: JobStatus.NEW },
+    select: { title: true, location: true },
+  });
+  return rows.filter((j) => passesBaseFilter(j, profile)).length;
+}
+
+function scanOf(resume: ResumeSummary) {
+  return {
+    title: resume.title,
+    seniority: resume.seniority,
+    skills: resume.skills,
+    primarySkills: resume.primarySkills,
+    roleTypes: resume.roleTypes,
+  };
+}
+
+function draftCard(profile: Profile, resume: ResumeSummary): ProfileDraftCard | null {
+  if (!resume.scannedAt || resume.hidden) return null;
+  const draft = buildProfileDraft(profile, scanOf(resume));
+  const primary = draft.changes.stackRequired ?? resume.primarySkills;
+  return {
+    resumeId: resume.id,
+    resumeName: resume.name,
+    title: resume.title,
+    primarySkills: primary,
+    skillCount: Math.max(0, resume.skills.length - primary.length),
+    seniority: resume.seniority,
+    roleTypes: draft.changes.roleTypes ?? resume.roleTypes,
+    changed: draft.changed,
+    warnings: draft.warnings,
+  };
+}
+
+/** A stored Profile row as the input shape updateProfile takes. */
+function profileInput(p: Profile): ProfileInput {
+  return {
+    name: p.name,
+    stackRequired: p.stackRequired,
+    roleTypes: p.roleTypes,
+    stackNiceToHave: p.stackNiceToHave,
+    stackExclude: p.stackExclude,
+    notes: p.notes,
+    seniority: p.seniority,
+    remoteOk: p.remoteOk,
+    remoteRegions: p.remoteRegions,
+    onsiteCities: p.onsiteCities,
+    hybridOk: p.hybridOk,
+    minSalaryUsd: p.minSalaryUsd,
+    minFitScore: p.minFitScore,
+    telegramTargetId: p.telegramTargetId,
+    priorityRules: parsePriorityRules(p.priorityRules),
+  };
+}

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -13,7 +13,7 @@ import { createResume, getResume, listResumes, type ResumeSummary } from '../../
 import { scanResume } from '../../resume/scan';
 import { buildProfileDraft, SENIORITY_LEVELS } from '../../resume/profile-draft';
 import { recordCronRun, type CronStats } from '../../jobs/cron-run';
-import { runScoreUnscored } from '../../jobs/reclassify-job';
+import { runScoreUnscored, SCORE_BATCH } from '../../jobs/reclassify-job';
 import { activeFetchRun } from '../fetch-runs';
 import { createRun, getRun, startRun, updateRun } from '../target-runs';
 import { testAiEngine } from '../ai-test';
@@ -227,7 +227,7 @@ welcomeRoute.post('/welcome/score', async (c) => {
     jobTitle: '',
     resumeName: '',
     heading: { running: 'Scoring the jobs we found', failed: 'Scoring failed' },
-    subtitle: 'Up to 100 recent jobs that mention your tools or role words — a few seconds each.',
+    subtitle: `The ${SCORE_BATCH} stored jobs that match your profile best — seconds each on an API engine, up to half a minute on a CLI one.`,
     backUrl: MATCHES_STEP,
     backLabel: 'Back to setup',
   });
@@ -236,6 +236,7 @@ welcomeRoute.post('/welcome/score', async (c) => {
     let stats: CronStats = {};
     await recordCronRun('score-unscored', async () => {
       const out = await runScoreUnscored({
+        limit: SCORE_BATCH,
         onProgress: (done, total) => updateRun(run.id, { progress: { done, total } }),
       });
       stats = out.stats;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -18,6 +18,7 @@ import { targetRoute } from './routes/target';
 import { letterRoute } from './routes/letter';
 import { factsRoute } from './routes/facts';
 import { healthRoute } from './routes/health';
+import { welcomeRoute } from './routes/welcome';
 
 const app = new Hono();
 
@@ -75,6 +76,7 @@ app.use('*', async (c, next) => {
 app.use('/static/*', serveStatic({ root: './src/web/public', rewriteRequestPath: (p) => p.replace(/^\/static/, '') }));
 
 app.route('/', overviewRoute);
+app.route('/', welcomeRoute);
 app.route('/', jobsRoute);
 app.route('/', applicationsRoute);
 app.route('/', resumesRoute);

--- a/src/web/target-run.test.ts
+++ b/src/web/target-run.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 const page = import('./public/target-run.mjs') as Promise<{
   activityFor: (step: string, stageElapsedMs: number) => string;
   formatElapsed: (ms: number) => string;
+  progressLine: (step: string, progress: { done: number; total: number }) => string;
   init: unknown;
 }>;
 
@@ -30,4 +31,11 @@ test('formatElapsed switches to minutes past 60 s', async () => {
 
 test('target-run module imports without a DOM and exposes init', async () => {
   assert.equal(typeof (await page).init, 'function');
+});
+
+test('progressLine names the unit per step', async () => {
+  const { progressLine, activityFor } = await page;
+  assert.equal(progressLine('score', { done: 12, total: 100 }), '12 of 100 jobs scored');
+  assert.equal(progressLine('nope', { done: 1, total: 2 }), '1 of 2 done');
+  assert.notEqual(activityFor('score', 0), '', 'the score step narrates before counts arrive');
 });

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -9,7 +9,7 @@ import { logger } from '../logger';
  * runs (node-cron philosophy: no queue, ADR 0003).
  */
 
-export type RunStep = 'fetch' | 'extract' | 'classify' | 'scan' | 'match' | 'verify' | 'letter';
+export type RunStep = 'fetch' | 'extract' | 'classify' | 'scan' | 'match' | 'verify' | 'letter' | 'score';
 export type RunStage = RunStep | 'done' | 'error';
 
 export interface TargetRun {
@@ -26,6 +26,11 @@ export interface TargetRun {
   backLabel: string;
   /** Set once the job row exists — the error state can link to it. */
   jobId?: number;
+  /** Page copy for runs that are not a comparison (the wizard's scan / score). */
+  heading?: { running: string; failed: string };
+  subtitle?: string;
+  /** Data-driven progress of the active step, when the job reports it. */
+  progress?: { done: number; total: number };
   /** Set on done: where to send the user, with the flash to show there. */
   resultUrl?: string;
   flash?: string;
@@ -37,7 +42,7 @@ const runs = new Map<string, TargetRun>();
 
 export function createRun(
   fields: Pick<TargetRun, 'steps' | 'jobTitle' | 'resumeName'> &
-    Partial<Pick<TargetRun, 'jobId' | 'backUrl' | 'backLabel'>>,
+    Partial<Pick<TargetRun, 'jobId' | 'backUrl' | 'backLabel' | 'heading' | 'subtitle'>>,
 ): TargetRun {
   prune();
   const run: TargetRun = {

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -341,6 +341,10 @@ export const Td: FC<PropsWithChildren<{ class?: string; title?: string }>> = ({
 
 /* ---------- forms ---------- */
 
+/** Native file input styled to match the controls (shared by every upload form). */
+export const FILE_INPUT_CLASS =
+  'file:mr-3 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink';
+
 export const Field: FC<PropsWithChildren<{ label: string; hint?: string; class?: string }>> = ({
   label,
   hint,

--- a/src/web/welcome-facts.ts
+++ b/src/web/welcome-facts.ts
@@ -1,0 +1,44 @@
+import type { Profile } from '@prisma/client';
+import { prisma } from '../db';
+import { probeAiProviders, type AiProviderStatus } from '../ai-runtime';
+import type { AiProviderId } from '../ai-engine';
+import { getSettings, type AppSettingsView } from '../settings';
+import { getActiveProfile } from '../profiles';
+import { isBlankProfile } from '../profile-guards';
+import type { WelcomeFacts } from './welcome-steps';
+
+/*
+ * Gathers what the wizard derives its steps from (welcome-steps.ts) — shared
+ * by /welcome and the Overview's "Finish setup" chip. The engine probe is
+ * cached for a minute inside probeAiProviders, so the 30 s Overview refresh
+ * does not spawn CLI processes every time.
+ */
+
+export interface WelcomeContext {
+  facts: WelcomeFacts;
+  settings: AppSettingsView;
+  statuses: Record<AiProviderId, AiProviderStatus>;
+  profile: Profile | null;
+}
+
+export async function loadWelcomeContext(): Promise<WelcomeContext> {
+  const [settings, statuses, profile, jobCount, scoredCount] = await Promise.all([
+    getSettings(),
+    probeAiProviders(),
+    getActiveProfile(),
+    prisma.job.count(),
+    prisma.job.count({ where: { fitScore: { not: null } } }),
+  ]);
+  return {
+    settings,
+    statuses,
+    profile,
+    facts: {
+      aiReady: Object.values(statuses).some((s) => s.ok),
+      jobCount,
+      profileReady: profile !== null && !isBlankProfile(profile),
+      scoredCount,
+      setupCompletedAt: settings.setupCompletedAt,
+    },
+  };
+}

--- a/src/web/welcome-steps.test.ts
+++ b/src/web/welcome-steps.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { currentStep, isWelcomeStep, needsWelcome, stepDone, summarizeScoreRun, type WelcomeFacts } from './welcome-steps';
+
+const fresh: WelcomeFacts = {
+  aiReady: false,
+  jobCount: 0,
+  profileReady: false,
+  scoredCount: 0,
+  setupCompletedAt: null,
+};
+
+test('the wizard walks the steps in order, each derived from data', () => {
+  assert.equal(currentStep(fresh), 'ai');
+  assert.equal(currentStep({ ...fresh, aiReady: true }), 'search');
+  assert.equal(currentStep({ ...fresh, aiReady: true, jobCount: 312 }), 'profile');
+  assert.equal(currentStep({ ...fresh, aiReady: true, jobCount: 312, profileReady: true }), 'matches');
+  assert.equal(
+    currentStep({ ...fresh, aiReady: true, jobCount: 312, profileReady: true, scoredCount: 18 }),
+    null,
+    'a returning user has nothing left to do',
+  );
+});
+
+test('a later step can be done before an earlier one — completion is per step', () => {
+  const f = { ...fresh, profileReady: true, scoredCount: 3 };
+  assert.equal(stepDone('profile', f), true);
+  assert.equal(stepDone('matches', f), true);
+  assert.equal(currentStep(f), 'ai', 'the first undone step still leads');
+});
+
+test('needsWelcome follows the flag alone, not the steps', () => {
+  assert.equal(needsWelcome(fresh), true);
+  assert.equal(needsWelcome({ setupCompletedAt: new Date() }), false);
+  assert.equal(isWelcomeStep('profile'), true);
+  assert.equal(isWelcomeStep('nope'), false);
+});
+
+test('summarizeScoreRun reads the reclassify stats in plain words', () => {
+  const ok = summarizeScoreRun({ reclassified: 100, unchanged: 18, promoted: 0, filterDismissed: 212, remaining: 40 });
+  assert.equal(ok.kind, 'ok');
+  assert.equal(
+    ok.text,
+    'Scored 100 jobs — 18 look like a match; 212 set aside as off-topic without AI; 40 more waiting for the next pass.',
+  );
+  assert.equal(summarizeScoreRun({ aborted: 1, reason: 'blank-profile' }).kind, 'warn');
+  assert.equal(summarizeScoreRun({ reclassified: 0, failed: 3 }).kind, 'warn');
+});

--- a/src/web/welcome-steps.ts
+++ b/src/web/welcome-steps.ts
@@ -1,0 +1,65 @@
+/*
+ * The first-run wizard's state is derived from data, never stored
+ * (docs/onboarding-plan.md §1, principle 2): a step is done when the thing
+ * it produces exists. Pure — the route gathers the facts, the page renders
+ * the first undone step. Tested in welcome-steps.test.ts.
+ */
+
+export const WELCOME_STEPS = ['ai', 'search', 'profile', 'matches'] as const;
+export type WelcomeStep = (typeof WELCOME_STEPS)[number];
+
+export interface WelcomeFacts {
+  /** At least one AI engine probes usable on this host. */
+  aiReady: boolean;
+  jobCount: number;
+  /** The active profile lists a required stack or role types (issue #50). */
+  profileReady: boolean;
+  /** Jobs that carry a match score. */
+  scoredCount: number;
+  setupCompletedAt: Date | null;
+}
+
+export function stepDone(step: WelcomeStep, f: WelcomeFacts): boolean {
+  switch (step) {
+    case 'ai':
+      return f.aiReady;
+    case 'search':
+      return f.jobCount > 0;
+    case 'profile':
+      return f.profileReady;
+    case 'matches':
+      return f.scoredCount > 0;
+  }
+}
+
+/** The first step still to do — null once every step is done. */
+export function currentStep(f: WelcomeFacts): WelcomeStep | null {
+  return WELCOME_STEPS.find((s) => !stepDone(s, f)) ?? null;
+}
+
+/** `/` sends a fresh install to /welcome until the wizard finishes or is skipped. */
+export function needsWelcome(f: Pick<WelcomeFacts, 'setupCompletedAt'>): boolean {
+  return f.setupCompletedAt === null;
+}
+
+export function isWelcomeStep(value: unknown): value is WelcomeStep {
+  return typeof value === 'string' && (WELCOME_STEPS as readonly string[]).includes(value);
+}
+
+/** Flash line for a finished "Score the jobs we found" pass, from its CronRun stats. */
+export function summarizeScoreRun(stats: Record<string, unknown>): { kind: 'ok' | 'warn'; text: string } {
+  const n = (key: string): number => (typeof stats[key] === 'number' ? (stats[key] as number) : 0);
+  if (stats.reason === 'blank-profile') {
+    return { kind: 'warn', text: 'Scoring skipped — the profile lists no technologies or role words yet.' };
+  }
+  if (stats.reason === 'no-active-profile') {
+    return { kind: 'warn', text: 'Scoring skipped — no active profile. Create one in Settings → Profile.' };
+  }
+  const scored = n('reclassified');
+  const matches = n('unchanged') + n('promoted');
+  const parts = [`Scored ${scored} jobs — ${matches} look like a match`];
+  if (n('filterDismissed') > 0) parts.push(`${n('filterDismissed')} set aside as off-topic without AI`);
+  if (n('failed') > 0) parts.push(`${n('failed')} could not be scored`);
+  if (n('remaining') > 0) parts.push(`${n('remaining')} more waiting for the next pass`);
+  return { kind: scored === 0 && n('failed') > 0 ? 'warn' : 'ok', text: `${parts.join('; ')}.` };
+}


### PR DESCRIPTION
Stage 3 of the onboarding plan (docs/onboarding-plan.md §2, §5 row 3; TASKS §11 block 3): a fresh install is walked through setup instead of landing on four zeros and a "Pipeline paused" badge.

## What changed

- **`AppSettings.setupCompletedAt`** (nullable) + migration `20260901220000_add_setup_completed_at`. The migration backfills every existing row with `now()`: a settings row that exists at migration time belongs to a deployment set up by hand, so nobody is walked through the wizard twice; a fresh install has no row yet (init creates it after `migrate deploy`) and gets NULL.
- **`/` → `/welcome`** while the flag is NULL (`needsWelcome`). Every other page keeps working; "Skip setup" sets the flag; the wizard's last step sets it too. The Overview shows a **"Finish setup →"** chip while any step is still undone, flag or no flag.
- **Steps derived from data, never stored** (`src/web/welcome-steps.ts`, pure, tested): AI detected → jobs exist → active profile has stack/role words → a scored job exists. The page expands the first undone step; `?step=` lets the user revisit any of them. `welcome-facts.ts` gathers the facts (engine probe is the cached one from `ai-runtime.ts`, so the Overview's 30 s refresh does not spawn CLIs).
- **Step 1 — Connect an AI.** Detected engines listed (zero clicks for a `.env` key); with nothing detected, five plain-language cards ("I have a Claude subscription" …) each with the `.env` line and the probe's own reason ("claude not found on PATH"). "Send a test message" runs the same live call as the Settings Test button — that call moved into `src/web/ai-test.ts`, shared by both (the call-site roster in `prompt-fence-registry.test.ts` follows).
- **Step 2 — Test the search.** "Run a test search" = `POST /runs/fetch-now` with `back=/welcome`; the fetch run's verdict lands back in setup. Done state shows the numbers from the last search that actually ran ("2,650 seen from 32 sources in 1.5m, 2,237 stored"). Zero jobs from every source says "that usually means no network".
- **Step 3 — Tell us about you.** Upload (or pick) a resume → Resume row (first one turns default) → the scan runs on the progress page (`target-runs` gained `heading`/`subtitle`, so the compare page's poller serves wizard runs) → the wizard renders the draft as one paragraph: "Looks like you're a **Senior Full-Stack Engineer (PHP / Laravel / Vue)** — main tools php, laravel, vue.js, typescript, plus 29 more skills. We'll hunt for senior full-stack / backend roles using these." "Yes, that's me" applies `buildProfileDraft`'s changes to the active profile (ADR 0015 honoured: nothing persists before that click); "Let me adjust" posts into the existing fill-from-resume editor. "No file handy?" opens three questions (technologies, role words, seniority) writing the same fields.
- **Step 4 — See your first matches.** `runScoreUnscored` (in `reclassify-job.ts`, which now takes an id set + `onProgress`): every stored-unscored job that fails the base filter is dismissed in one update — no AI — and the most recent `SCORE_UNSCORED_CAP = 100` of the rest are classified with a live "12 of 100 jobs scored" line. Result: "K of N look like a match", the top five, "Score 100 more" while jobs are waiting, then **"Start the hourly watch"** (fetching on + flag set). Telegram is a quiet link when it is not set up.
- Minor: `FILE_INPUT_CLASS` hoisted into `ui.tsx` (was duplicated in four pages — a P3 from PR #60).

## Decisions worth a look

- **Step 1 counts "detected" as done, not "tested".** The probe (key present / binary on PATH) is what Settings shows too; a mandatory live call on entry would block the page for up to 90 s and spend a call on every visit. The live test is one click away and its result is a flash. Note the known limit: the Claude Code probe cannot see the keychain login, so a logged-out CLI still shows as detected until the test says otherwise.
- **The cap is on filter-passing jobs, not on rows.** On a fresh install the test search stores ~2 k jobs (blank profile = everything passes); after step 3 most of them no longer mention the profile's words. Dismissing those without AI first means the 100 calls go to jobs that can actually match, and "Score 100 more" walks the rest — the plan's "the rest catches up on the next cron ticks" was wrong (stored rows are deduped, never revisited).
- **Existing installs are backfilled**, so this PR changes nothing for a deployment that already runs — verified on the live DB (row backfilled at migration time, `/` still renders the Overview, `/welcome` shows every step done).

## Verification

- `lint:types` + **808** unit tests (new: `welcome-steps.test.ts`, `progressLine`).
- Live stack rebuilt: migration applied on boot (`Applying migration 20260901220000_add_setup_completed_at`), existing row backfilled, `/` → 200 (no redirect), `/welcome` and every `?step=` → 200.
- **Fresh-install walkthrough on a scratch database** (`jobhunter_wizard`, created next to the live one; migrations + seed + starter profile via `init()`, a second web container on :4748): `/` → 303 `/welcome`; step 1 auto-completed (Claude Code CLI detected in the image); step 2 "Run a test search" → progress page → back in setup with the verdict — `fetch-now` row OK `{fetched: 2650, sources: 32, sourcesFailed: 2, classify: false, persisted: 2237, durationMs: 89191}` — step 2 rendered "2,237 jobs are in your database. The last search saw 2,650 from 32 sources (2 did not answer) in 1.5m and stored 2,237 new."; step 3 upload of a 2 KB text resume → scan run (17 s) → summary paragraph → "Yes, that's me" filled the profile (required stack, nice-to-have, role types, seniority, name); step 4 "Score the jobs we found" → live "n of 100 jobs scored" → 2,132 off-topic rows dismissed without AI in one update, 100 filter-passing jobs queued; the page showed "n of 100 jobs scored" live. Measured pace on the `claude_code` CLI engine inside Docker at `AI_CONCURRENCY=3`: **~2.7 jobs/min** (8 scored after 3 min), i.e. ~35–40 min per 100 — the API engines are an order of magnitude faster; the plan's "measure" note in §6 now carries this number. The pass was still running when the PR was opened; its final `score-unscored` row follows as a comment.; "Start the hourly watch" → Overview with the flash, fetching on, flag set. "Skip setup" path and the "Finish setup →" chip: flag reset to NULL → `/` 303 to `/welcome`; `POST /welcome/skip` → 303 `/` with the flash "Setup skipped — everything lives in Settings…", `/` 200; the no-engine instance (AI step undone) shows the "Finish setup →" chip on its Overview, the finished one does not..
- **No-engine branch**: a third web container with the CLIs and keys blanked showed the five cards with each probe's reason.
- Screenshots at 1200 and 375 of every step state (auto-completed step 1, step 2 before/running/after, the summary card, the scoring run, the result) — **0 console errors**, no horizontal scroll at 375.
- Not verified live: a failed resume scan (the AI answered every time) — the error branch of the run page carries the "three questions" hint; the `/welcome/profile` three-question form (exercised by curl only: empty submit → 303 with "Add at least one technology or one role word."; bogus resume ids on apply/resume → error flashes; `POST /welcome/score` while a pass runs → 303 to the running progress page.).

## Follow-ups (P2/P3)

- P2: the Claude Code probe cannot detect a logged-out CLI — step 1 can show "detected" for a CLI that will fail; the test button is the only proof. A cheap `claude -p` liveness check with a short timeout would close it (Settings has the same gap).
- P3: the upload form has no double-submit guard (same as `/resumes`; §12 `resumes-page-p0` owns it).
- P3: "Send a test message" is a synchronous request of up to 90 s, like the Settings Test button.
- P3: `countWaitingUnscored` reads the titles of every unscored NEW row on each `/welcome` render — fine at fresh-install sizes, worth a `count` + sample if it ever grows.

## Release notes (draft for v1.7.0)

```
## What's new
- First-run wizard at /welcome: connect an AI → test the search → profile from your resume (or three questions) → first matches → start the hourly watch; ~4 clicks and one file pick
- / opens the wizard until setup is finished or skipped; the Overview keeps a "Finish setup" chip while a step is open
- Step 4 scores up to 100 stored jobs that mention your words per press; off-topic ones are set aside without AI
- Progress pages can carry their own heading and live counts ("12 of 100 jobs scored")

## Schema
- AppSettings.setupCompletedAt (nullable); existing deployments are backfilled so the wizard never interrupts them

## Verification
- 808 unit tests; live migration on boot; full fresh-install walkthrough on a scratch DB incl. the no-engine branch; 1200/375 screenshots, 0 console errors

## References
- docs/onboarding-plan.md §2 (steps 1–4), §5 row 3, §6 (source subset + cap decided) · TASKS §11 block 3 · CHANGELOG 1.7.0 · PR #62 (stage 2)
```

Tag after merge (release-discipline):

```
git tag -a v1.7.0 -m "welcome wizard" <merge-sha> && git push origin v1.7.0
```
