### PR TITLE
ai-key-in-db: paste an AI key into the dashboard (ADR 0027)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ DATABASE_URL=postgresql://jobhunter:jobhunter@localhost:5432/jobhunter
 # Priority order + per-engine models live on /settings → "AI engine"
 # (stored in Postgres, no restart). AI_PROVIDER only seeds the default:
 # anthropic_api | claude_code | gemini_cli | openai_api | codex_cli
+# The keys below are optional: the same page takes a pasted key and stores
+# it in Postgres (ADR 0027), which overrides the value here. Keep them here
+# if you would rather secrets stayed out of the database.
 AI_PROVIDER=anthropic_api
 
 # Anthropic API (pay per token).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -725,6 +725,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.8.0]: https://github.com/applypack/applypack/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/applypack/applypack/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/applypack/applypack/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/applypack/applypack/compare/v1.4.1...v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.8.0] — 2026-09-02
+
+### Added
+- **Paste an AI key instead of editing `.env`** ([ADR 0027](docs/adr/0027-ai-keys-in-the-database.md),
+  [docs/onboarding-plan.md §2](docs/onboarding-plan.md) Phase B, TASKS §11
+  block 4). Every engine card on `/settings` → AI engine now has a key row,
+  and so does each card in step 1 of `/welcome` — paste, Save, Test, done.
+  The key lands in the new `AppSettings.aiKeys` column, applies to the
+  dashboard immediately and to the worker on its next tick, and wins over
+  the matching `.env` variable. Four engines take one: Anthropic API
+  (`ANTHROPIC_API_KEY`), Claude Code CLI (`CLAUDE_CODE_OAUTH_TOKEN`),
+  Gemini CLI (`GEMINI_API_KEY`) and the OpenAI-compatible API
+  (`OPENAI_API_KEY`); Codex CLI stays `codex login`.
+- The stored key is never handed back: the field always renders empty, the
+  card shows only the last four characters and where the credential comes
+  from ("saved here" / "from .env"), and **Remove** deletes it.
+
+### Changed
+- `.env` keeps working exactly as before and stays the documented choice
+  for anyone who would rather keep secrets out of the database — the ADR is
+  explicit that a database dump contains a pasted key.
+- The `claude_code` badge is honest about a logged-out CLI. `claude
+  --version` answers whether or not anyone is signed in, so the engine used
+  to read "available" on `/settings` and in the wizard and then fail on its
+  first real call. The probe now reads the CLI's own auth signals (token in
+  the environment, `.credentials.json`, the recorded account) without
+  spending a call or slowing the page down.
+- Provider constructors no longer hold credentials — the key arrives per
+  call on `AiRequest`, so whether an engine can run at all is decided in one
+  place (`ai-engine.ts:providerUnusable`) instead of two.
+
 ## [1.7.0] — 2026-09-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@
 - `classifier.ts` (and `classifier-prefilter.ts`) build prompts and parse
   replies; the only thing that talks to the AI is `ai-provider.ts` — no DB.
   Engine choice (provider + models) resolves per call via `ai-runtime.ts`
-  (DB row → `.env` fallback, pure merge in `ai-engine.ts` — ADR 0013).
+  (DB row → `.env` fallback, pure merge in `ai-engine.ts` — ADR 0013), and
+  so does the credential (`ai-keys.ts`, pure — ADR 0027).
 - `jobs/process-jobs.ts` is the single source of truth for the inner
   filter → dedupe → classify → persist → alert sequence. Reused by
   `runFetchJob` and `runHnHiringJob`. `{ classify: false }` stores what
@@ -99,7 +100,7 @@
 - Do not add Express, Next.js, or any HTTP server to the worker process.
 - Do not add Redis, BullMQ, or other queues — node-cron is sufficient.
 - Do not expose the dashboard on a public interface by default — bind to `127.0.0.1` in compose.
-- Do not store secrets anywhere except `.env` (gitignored). Telegram tokens belong in `TelegramTarget` rows once `init.ts` has bootstrapped them; `.env` becomes optional after first boot.
+- Do not store secrets anywhere except `.env` (gitignored). Two carve-outs, both deliberate: Telegram tokens belong in `TelegramTarget` rows once `init.ts` has bootstrapped them, and per-engine AI keys belong in `AppSettings.aiKeys` (ADR 0027) — in both cases `.env` becomes optional after first boot. A secret in the DB is read only through its own accessor, never rendered in full, never logged.
 - Do not commit `node_modules`, `dist`, or `.env`.
 - Do not use any `--save-dev` that isn't necessary.
 - Do not scrape LinkedIn / Indeed / Glassdoor / Workday / Wellfound — see [ADR 0005](./docs/adr/0005-no-linkedin-indeed-workday.md).
@@ -154,7 +155,8 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | The Claude system prompt | `src/classifier.ts:buildSystemPrompt` |
 | Fence markers, the untrusted directive, the forged-marker sanitiser | `src/prompt-fence.ts` (pure, ADR 0022); guard `src/prompt-fence-registry.test.ts` |
 | Which AI engines run (priority chain + per-engine models, auto-failover) | `src/ai-runtime.ts:getAiRuntime().complete({role})` + pure chain merge in `src/ai-engine.ts` (ADR 0013/0014); UI on `/settings` → "AI engine" tab |
-| Adding a new AI backend | `src/ai-provider.ts` (`CliProvider` spec or fetch class) + `AI_PROVIDER_IDS`/labels/options in `src/ai-engine.ts` + probe in `src/ai-runtime.ts` |
+| Adding a new AI backend | `src/ai-provider.ts` (`CliProvider` spec or fetch class) + `AI_PROVIDER_IDS`/labels/options in `src/ai-engine.ts` + probe in `src/ai-runtime.ts` + `AI_KEY_ENV_VARS` in `src/ai-keys.ts` if it takes a key |
+| Per-engine API keys (DB-first, `.env` fallback, masking) | `src/ai-keys.ts` (pure, ADR 0027) + `settings.ts:getAiKeys/setAiKey`; resolved in `ai-runtime.ts`, spent as `AiRequest.apiKey` |
 | How users set up each engine (local + Docker) | `docs/ai-engines.md` |
 | AI usage counters (runs per engine × role) | `AppSettings.aiUsage` — incremented in `ai-runtime.ts:recordUsage`, 7-day summary on `/settings` AI tab, 60-day trim in `cleanup-job.ts` |
 | What a CLI child process may see in env | `ai-provider-parse.ts:CLI_PROVIDER_ENV_KEYS` (allowlist; ANTHROPIC_API_KEY never reaches claude_code) |
@@ -205,6 +207,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | See which boards stopped answering | `/companies` → "Quiet sources" card (Re-probe to repair) |
 | Telegram line when a source goes quiet | `/settings` Notifications tab → "Source health alerts" |
 | Pick / order AI engines + models, test them | `/settings` AI engine tab (per-engine cards: Enable, ↑ priority, model selects, Test) |
+| Paste an AI key without touching `.env` | `/settings` AI engine tab → the key row on each engine card, or step 1 of `/welcome` (ADR 0027) |
 | Add / remove tracked company | `/companies` (with manual probe before save) |
 | Bulk-add a curated segment of companies | `/companies` → "Add a starter pack" (preview → confirm → added disabled → "Enable all") |
 | Disable whole ATS family (e.g. all Workable) | `/settings` Sources tab |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -756,8 +756,9 @@ Telegram explicitly optional.
       `AppSettings.setupCompletedAt` null, skip link, Overview chip;
       ~4 clicks + one file pick end-to-end — done 2026-09-01, branch
       `welcome-wizard`; step 4 scores the best 10 per press ("Score 10 more")
-- [ ] `ai-key-in-db` — paste API key in UI, DB-stored, masked
-      (**ADR**: extends 0013 + secrets policy; TelegramTarget precedent)
+- [x] `ai-key-in-db` — paste API key in UI, DB-stored, masked — done
+      2026-09-02, branch `ai-key-in-db` (ADR 0027: `AppSettings.aiKeys`,
+      four key-bearing engines, `.env` stays the fallback)
 - [ ] `profile-resume-link` — `Profile.resumeId` + one-click "Create
       profile from this resume"
 - [ ] `multi-profile-search` — multiple active profiles, union base

--- a/docs/adr/0027-ai-keys-in-the-database.md
+++ b/docs/adr/0027-ai-keys-in-the-database.md
@@ -76,6 +76,13 @@ dashboard binds to `127.0.0.1` by default (config.ts `WEB_HOST`), Postgres
 is not published beyond the compose network, and the dashboard is
 single-user. What does not bound it: nothing else. A user who wants the key
 off the disk keeps using `.env` — that path is not deprecated.
+❌ The save route has no CSRF protection, because no route in this dashboard
+does. A page open in the same browser can POST a key of its own choosing to
+`127.0.0.1:4747` — it cannot read the stored one, but it can point the user's
+AI calls at an account it controls. That is the same class of exposure as
+every other unauthenticated POST here (delete a Telegram target, change the
+profile); this ADR does not fix it, it records that adding credentials to the
+surface makes fixing it worth scheduling.
 ❌ Encryption at rest was rejected, not overlooked: the decryption key would
 have to live in `.env`, which moves the secret rather than removing it, and
 reintroduces the file edit this ADR exists to delete. An OS keychain does

--- a/docs/adr/0027-ai-keys-in-the-database.md
+++ b/docs/adr/0027-ai-keys-in-the-database.md
@@ -1,0 +1,111 @@
+# 0027 — Per-engine AI keys live in the database, in plaintext, with `.env` as fallback
+
+**Status:** Accepted (2026-09-02). Extends 0013/0014 (engine configuration
+resolves DB-row-first with `.env` as fallback; this adds the credential to
+what resolves that way) and the CLAUDE.md secrets rule, whose one existing
+carve-out is `TelegramTarget.botToken`.
+
+## Context
+
+The onboarding plan's target user is explicitly non-technical — someone who
+can install Docker from a README but has never edited a config file. The
+wizard's first step asked them to do exactly that: open `.env`, add
+`ANTHROPIC_API_KEY=…`, run `docker compose up -d`, come back and press
+"Check again". Every other step of the wizard is a button. Step 1 was a
+detour through a text editor and a terminal, and it is the step that gates
+all three steps after it — nothing scores until an engine answers.
+
+The rest of the engine's configuration already moved into Postgres: which
+backends run, in what order, with which model per role (ADR 0013, 0014). The
+credential was the one field left behind, so "switch engines from the
+dashboard" stopped working the moment the new engine needed a key the old
+one did not.
+
+The precedent is already in the repo. `TelegramTarget.botToken` is a bearer
+token that grants full control of a Telegram bot, stored as a plain column
+since phase 3, precisely so the dashboard can add a target without a restart.
+CLAUDE.md names it as the exception to "secrets live in `.env`".
+
+## Decision
+
+- One nullable JSONB column, `AppSettings.aiKeys`: `{ <provider id>:
+  "<secret>" }`, **plaintext**. Hand-written migration, no backfill — a
+  missing entry means "use `.env`", so every existing deployment keeps
+  working with no action.
+- Four engines take a key, each mirroring the `.env` variable the backend
+  already reads: `anthropic_api` → `ANTHROPIC_API_KEY`, `claude_code` →
+  `CLAUDE_CODE_OAUTH_TOKEN`, `gemini_cli` → `GEMINI_API_KEY`, `openai_api` →
+  `OPENAI_API_KEY`. `codex_cli` is login-only and gets no field.
+- **Stored key wins, `.env` is the fallback.** Resolution is one pure
+  function, `ai-keys.ts:resolveAiKey`, unit-tested for all three states.
+- The key travels through the two places that already existed, not new ones:
+  - `AiEngineEnv` (from `getAiEngineEnv(keys)`) — so `providerUnusable`
+    stays the single decision on whether an engine can run at all, and the
+    chain, the "skipped" list and the badges all follow from it;
+  - `AiRequest.apiKey` — resolved per engine in `ai-runtime`, handed to the
+    provider for that one call. The API backends use it instead of the
+    `config` value; the CLI backends receive it as their own auth variable
+    in the child environment, still filtered through the existing
+    `buildCliEnv` allowlist. Provider constructors no longer hold secrets,
+    which also removes the second place that decided "no key ⇒ unusable".
+- **The key is never handed back.** The paste field always renders empty;
+  a stored key is only ever *described* — last four characters via the
+  same `maskToken` the Telegram table uses, plus where it came from. There
+  is no edit-in-place field a mask could be saved over. Removal is its own
+  button.
+- Reads go through `settings.ts:getAiKeys()`, deliberately **not** through
+  `AppSettingsView`. An ordinary settings read cannot carry a secret into a
+  log line or a rendered page, because it does not contain one. Writes log
+  the engine id and whether a key is now stored — never the value.
+
+## Consequences
+
+✅ The non-technical persona finishes step 1 without a terminal: paste,
+Save, Test. The worker picks the key up on its next tick — same live-toggle
+model as every other setting (gotcha 9).
+✅ `.env`-only deployments are unchanged and untested-against-nothing: the
+fallback is the same code path, and the CLI scripts that build a provider
+directly still work with no key plumbing at all.
+✅ A fifth backend needs no migration — one more entry in `AI_KEY_ENV_VARS`.
+
+❌ **The key sits in Postgres in plaintext.** Anyone who can read the
+database can read it: `psql`, a `pg_dump`, a stolen volume, a backup copied
+somewhere careless. This is a real widening of the blast radius versus a
+gitignored `.env`, and it is the price of the feature. What bounds it: the
+dashboard binds to `127.0.0.1` by default (config.ts `WEB_HOST`), Postgres
+is not published beyond the compose network, and the dashboard is
+single-user. What does not bound it: nothing else. A user who wants the key
+off the disk keeps using `.env` — that path is not deprecated.
+❌ Encryption at rest was rejected, not overlooked: the decryption key would
+have to live in `.env`, which moves the secret rather than removing it, and
+reintroduces the file edit this ADR exists to delete. An OS keychain does
+not exist in an alpine container.
+❌ We cannot revoke a leaked key, only forget it. The "Remove" button
+deletes our copy; rotation happens in the provider's console, and the UI
+says so.
+❌ A key pasted for `claude_code` or `gemini_cli` is exported into a child
+process environment. That is how those CLIs read credentials, and the
+allowlist already limited which variables a child sees, but it does mean the
+secret exists in another process's environment for the duration of a call.
+
+## Alternatives rejected
+
+- **Keys inside the existing `aiEngine` JSON.** `setAiEngineConfig` rewrites
+  that column wholesale from a zod-parsed shape that drops unknown fields,
+  so saving a model would silently delete the key — and the same object is
+  logged on every save.
+- **One column per engine.** ADR 0013's stated extension path for a new
+  backend is "one provider spec + enum value + probe entry"; a migration per
+  backend contradicts it.
+- **Key in the DB, but only for the API engines.** The CLI engines are the
+  ones the wizard recommends first (a subscription, not a metered key), so
+  leaving them out would leave the persona stuck on exactly the path we
+  point them at.
+
+## When to revisit
+
+- If the dashboard ever binds to a non-loopback interface by default, or
+  grows real multi-user accounts — the plaintext trade-off was priced for a
+  single-user, loopback-only deployment and does not survive either change.
+- If a hosted deployment appears, the column becomes the seam an external
+  secret store would plug into (`getAiKeys` is already the only reader).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0024 — Funnel history is an append-only stage ledger](./0024-append-only-stage-ledger.md)
 - [0025 — Work columns are user-defined; fixed entry and exits](./0025-custom-work-stages.md)
 - [0026 — Database tables are snake_case, mapped with `@@map()`](./0026-snake-case-table-names.md)
+- [0027 — Per-engine AI keys live in the database, `.env` as fallback](./0027-ai-keys-in-the-database.md)
 
 ## When to write a new one
 

--- a/docs/ai-engines.md
+++ b/docs/ai-engines.md
@@ -17,6 +17,30 @@ Every engine card has a **Test** button — it sends one tiny live request
 through that engine and reports success or the exact failure. Use it after
 every setup step below.
 
+## Two ways to hand over a key
+
+Every setup below shows the `.env` line, because that always works. Since
+ADR 0027 there is a shorter path for the four engines that take a key:
+**paste it into the engine's card on `/settings` → AI engine** (or into
+step 1 of `/welcome`) and press Save. No file to edit, no restart — the
+dashboard applies it at once and the worker on its next tick.
+
+| Engine | Key | `.env` equivalent |
+| --- | --- | --- |
+| Anthropic API | API key | `ANTHROPIC_API_KEY` |
+| Claude Code CLI | `claude setup-token` token | `CLAUDE_CODE_OAUTH_TOKEN` |
+| Gemini CLI | AI Studio API key | `GEMINI_API_KEY` |
+| OpenAI-compatible API | API key | `OPENAI_API_KEY` |
+| Codex CLI | — (`codex login` only) | — |
+
+A pasted key **wins over** the `.env` variable and is stored in your own
+Postgres, in plaintext, exactly like the Telegram bot tokens. The dashboard
+binds to `127.0.0.1` by default, so it never leaves the machine — but a
+database dump contains it. If you would rather keep secrets out of the
+database, use `.env`: that path is unchanged and not going away. The card
+only ever shows the last four characters, and **Remove** deletes the stored
+copy (rotate the key itself in the provider's console).
+
 | Engine | What it is | Billing | Needs |
 | --- | --- | --- | --- |
 | Anthropic API | Messages API via SDK | per token | `ANTHROPIC_API_KEY` |
@@ -39,12 +63,9 @@ Pay-per-token Messages API. Fastest option (no process spawn, prompt cache).
 
 **Local:**
 1. Get a key at <https://console.anthropic.com/settings/keys>.
-2. Add to `.env`:
-   ```
-   ANTHROPIC_API_KEY=sk-ant-...
-   ```
-3. Restart the app (`npm run dev` / your process manager). Enable the engine
-   on `/settings` → AI engine and press **Test**.
+2. Paste it into the engine card on `/settings` → AI engine, or add
+   `ANTHROPIC_API_KEY=sk-ant-...` to `.env` and restart.
+3. Enable the engine and press **Test**.
 
 **Docker:** same `.env` line — both containers read `.env` via `env_file`.
 Recreate them so the new variable lands:
@@ -66,8 +87,11 @@ Runs `claude -p` per call on the subscription the CLI is logged into. Slower
 login in the Keychain, so mounting `~/.claude` does **not** carry auth into
 the container. Instead:
 1. On the host: `claude setup-token` (opens a browser login, prints a token).
-2. Add to `.env`: `CLAUDE_CODE_OAUTH_TOKEN=...`
-3. `docker compose up -d`
+2. Paste the token into the engine card on `/settings`, or add
+   `CLAUDE_CODE_OAUTH_TOKEN=...` to `.env` and `docker compose up -d`.
+
+The card's badge tells the two apart: an installed-but-logged-out CLI reads
+"not detected", because `claude --version` answers either way.
 
 ## Gemini CLI (Google account or API key)
 

--- a/docs/onboarding-plan.md
+++ b/docs/onboarding-plan.md
@@ -8,9 +8,9 @@
 > [CLAUDE.md](../CLAUDE.md), the testing-gate / commit-discipline skills and
 > the ADR register in [docs/adr](./adr/).
 >
-> **Status:** stages 1–3 of §5 shipped (`profile-tab-quickwins` v1.5.0,
-> `fetch-now` v1.6.0, `welcome-wizard` v1.7.0); stages 4–7 are analysis
-> only. Constants
+> **Status:** stages 1–4 of §5 shipped (`profile-tab-quickwins` v1.5.0,
+> `fetch-now` v1.6.0, `welcome-wizard` v1.7.0, `ai-key-in-db` v1.8.0);
+> stages 5–7 are analysis only. Constants
 > (batch caps, source subsets, timings) are starting hypotheses to
 > re-measure at implementation time.
 
@@ -134,14 +134,13 @@ principle 2.
   compatible"), each with the exact `.env` line to paste and a "Check
   again" button. This is the weakest step for the non-technical persona
   until Phase B lands:
-- **Phase B (separate stage, ADR required):** paste the API key directly
-  into the wizard/Settings, stored in the DB, masked like Telegram bot
-  tokens. Precedent: `TelegramTarget` tokens already live in DB rows and
-  CLAUDE.md's secrets rule carves that exception explicitly; ADR 0013
-  already resolves engine config DB-row-first with `.env` fallback. The
-  ADR extends both to per-engine keys. Dashboard binds to 127.0.0.1 by
-  default, which bounds the exposure. Until then the wizard shows the
-  `.env` path honestly.
+- **Phase B — shipped in stage 4 (ADR 0027).** The four key-bearing
+  engines take a pasted key on the wizard card itself and on
+  `/settings` → AI engine; it lands in `AppSettings.aiKeys`, wins over the
+  matching `.env` variable, and is only ever shown back as its last four
+  characters. `.env` stays a first-class path for anyone who wants secrets
+  off the database. The same stage made the `claude_code` badge honest — a
+  logged-out CLI answers `--version` and used to read "available".
 
 ### Step 2 — Test the search (no AI, no profile needed)
 
@@ -302,7 +301,7 @@ hand-written migrations verified through a container rebuild.
 | 1 | `profile-tab-quickwins` | §3 quick wins + reorder, inline upload in Fill card | — | — | dashboard matrix; profile save round-trip; chip editor no-JS path |
 | 2 | `fetch-now` | "Fetch now" button + `{classify: false}` seam + background run + progress page (standalone value) | — | — | smoke `fetch:once`; run visible on `/runs`; unscored jobs stored; dashboard matrix |
 | 3 | `welcome-wizard` | `/welcome` steps 1–4, redirect, skip, Overview chip | `setupCompletedAt` | — | migration via container rebuild; full wizard walkthrough on a wiped DB (docker volume rm) at 1200/375; every step's auto-complete branch |
-| 4 | `ai-key-in-db` | per-engine API key in DB, masked; wizard step 1 upgrade | engine-key column/JSON | **yes** (extends 0013 + secrets policy) | probe/test with DB key and with `.env` fallback; key never logged; masked render |
+| 4 | `ai-key-in-db` ✅ v1.8.0 | per-engine API key in DB, masked; wizard step 1 upgrade | `aiKeys` JSONB | **0027** | probe/test with DB key and with `.env` fallback; key never logged; masked render |
 | 5 | `profile-resume-link` | Stage A | `Profile.resumeId` | — | create-from-resume flow; preselect unit test in `pick.test.ts` scope |
 | 6 | `multi-profile-search` | Stage B | `JobScore`, `Profile.active` | **yes** | prompt/parser unit tests; live smoke on 2 profiles; alert routing test send; jobs-list filters |
 | 7 | `applied-resume` | Stage C | 3 columns on `Job` | — | mark-applied round-trip; digest line render test |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.4.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.4.1",
+      "version": "1.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/prisma/migrations/20260902090000_add_ai_keys/migration.sql
+++ b/prisma/migrations/20260902090000_add_ai_keys/migration.sql
@@ -1,0 +1,5 @@
+-- Per-engine API keys pasted in the dashboard (ADR 0027):
+-- { "anthropic_api": "sk-ant-…", "openai_api": "…" }. NULL, or a missing
+-- entry, means the engine falls back to its .env variable — every existing
+-- deployment keeps working with no backfill and no user action.
+ALTER TABLE app_settings ADD COLUMN "aiKeys" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -193,6 +193,12 @@ model AppSettings {
   // serves each call; the rest are automatic fallbacks. NULL = follow .env
   // (AI_PROVIDER seeds a one-engine chain).
   aiEngine                       Json?
+  // Per-engine credentials (ADR 0027): { <provider id>: "<secret>" }, stored
+  // in plaintext so the dashboard can take a pasted key instead of a .env
+  // edit. NULL / a missing entry = fall back to the .env variable. Read only
+  // through settings.ts:getAiKeys — never joined into AppSettingsView, so a
+  // secret cannot ride along with an ordinary settings read.
+  aiKeys                         Json?
   // Lightweight AI usage counters: { "YYYY-MM-DD": { <provider>: {
   // classifier: n, resume: n } } }. Incremented atomically per successful
   // call (ai-runtime.ts:recordUsage), trimmed to 60 days by the cleanup

--- a/src/ai-keys.test.ts
+++ b/src/ai-keys.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AI_KEY_PROVIDER_IDS,
+  MAX_AI_KEY_LENGTH,
+  aiKeySource,
+  parseAiKeys,
+  providerTakesKey,
+  resolveAiKey,
+  withAiKey,
+} from './ai-keys';
+
+describe('providerTakesKey', () => {
+  it('covers the four key-bearing engines and not codex', () => {
+    assert.deepEqual(AI_KEY_PROVIDER_IDS, [
+      'anthropic_api',
+      'claude_code',
+      'gemini_cli',
+      'openai_api',
+    ]);
+    assert.equal(providerTakesKey('codex_cli'), false);
+  });
+});
+
+describe('parseAiKeys', () => {
+  it('returns an empty map for null, junk and wrong shapes', () => {
+    assert.deepEqual(parseAiKeys(null), {});
+    assert.deepEqual(parseAiKeys('nope'), {});
+    assert.deepEqual(parseAiKeys({ openai_api: 42 }), {});
+  });
+
+  it('keeps known engines, drops unknown ids and blanks', () => {
+    const keys = parseAiKeys({
+      anthropic_api: ' sk-ant-live ',
+      codex_cli: 'not-a-key-engine',
+      gemini_cli: '   ',
+      made_up: 'x',
+    });
+    assert.deepEqual(keys, { anthropic_api: 'sk-ant-live' });
+  });
+
+  it('truncates an oversized paste instead of storing it whole', () => {
+    const keys = parseAiKeys({ openai_api: 'k'.repeat(MAX_AI_KEY_LENGTH + 50) });
+    assert.equal(keys.openai_api?.length, MAX_AI_KEY_LENGTH);
+  });
+});
+
+describe('withAiKey', () => {
+  it('adds, replaces and clears without touching the other engines', () => {
+    const one = withAiKey({}, 'openai_api', ' sk-openai ');
+    assert.deepEqual(one, { openai_api: 'sk-openai' });
+    const two = withAiKey(one, 'gemini_cli', 'gm');
+    assert.deepEqual(two, { openai_api: 'sk-openai', gemini_cli: 'gm' });
+    assert.deepEqual(withAiKey(two, 'openai_api', '   '), { gemini_cli: 'gm' });
+  });
+
+  it('does not mutate the input', () => {
+    const before = { openai_api: 'a' };
+    withAiKey(before, 'openai_api', '');
+    assert.deepEqual(before, { openai_api: 'a' });
+  });
+});
+
+describe('resolveAiKey', () => {
+  const env = { ANTHROPIC_API_KEY: 'from-env', OPENAI_API_KEY: '  ' };
+
+  it('prefers the stored key over .env', () => {
+    assert.equal(resolveAiKey('anthropic_api', { anthropic_api: 'from-db' }, env), 'from-db');
+  });
+
+  it('falls back to .env when nothing is stored', () => {
+    assert.equal(resolveAiKey('anthropic_api', {}, env), 'from-env');
+  });
+
+  it('treats a blank .env value as absent', () => {
+    assert.equal(resolveAiKey('openai_api', {}, env), undefined);
+  });
+
+  it('has nothing to resolve for a login-only engine', () => {
+    assert.equal(resolveAiKey('codex_cli', {}, { OPENAI_API_KEY: 'x' }), undefined);
+  });
+});
+
+describe('aiKeySource', () => {
+  it('names where the credential comes from', () => {
+    const env = { GEMINI_API_KEY: 'g' };
+    assert.equal(aiKeySource('gemini_cli', { gemini_cli: 'db' }, env), 'db');
+    assert.equal(aiKeySource('gemini_cli', {}, env), 'env');
+    assert.equal(aiKeySource('openai_api', {}, env), 'none');
+    assert.equal(aiKeySource('codex_cli', {}, env), 'none');
+  });
+});

--- a/src/ai-keys.test.ts
+++ b/src/ai-keys.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  AI_KEY_PROVIDER_IDS,
+  AI_KEY_ENV_VARS,
   MAX_AI_KEY_LENGTH,
   aiKeySource,
   parseAiKeys,
@@ -12,7 +12,7 @@ import {
 
 describe('providerTakesKey', () => {
   it('covers the four key-bearing engines and not codex', () => {
-    assert.deepEqual(AI_KEY_PROVIDER_IDS, [
+    assert.deepEqual(Object.keys(AI_KEY_ENV_VARS), [
       'anthropic_api',
       'claude_code',
       'gemini_cli',

--- a/src/ai-keys.test.ts
+++ b/src/ai-keys.test.ts
@@ -39,9 +39,11 @@ describe('parseAiKeys', () => {
     assert.deepEqual(keys, { anthropic_api: 'sk-ant-live' });
   });
 
-  it('truncates an oversized paste instead of storing it whole', () => {
-    const keys = parseAiKeys({ openai_api: 'k'.repeat(MAX_AI_KEY_LENGTH + 50) });
-    assert.equal(keys.openai_api?.length, MAX_AI_KEY_LENGTH);
+  it('drops an oversized entry whole rather than truncating a credential', () => {
+    const keys = parseAiKeys({ openai_api: 'k'.repeat(MAX_AI_KEY_LENGTH + 1) });
+    assert.deepEqual(keys, {});
+    const atLimit = parseAiKeys({ openai_api: 'k'.repeat(MAX_AI_KEY_LENGTH) });
+    assert.equal(atLimit.openai_api?.length, MAX_AI_KEY_LENGTH);
   });
 });
 
@@ -52,6 +54,11 @@ describe('withAiKey', () => {
     const two = withAiKey(one, 'gemini_cli', 'gm');
     assert.deepEqual(two, { openai_api: 'sk-openai', gemini_cli: 'gm' });
     assert.deepEqual(withAiKey(two, 'openai_api', '   '), { gemini_cli: 'gm' });
+  });
+
+  it('keeps a long key intact — the routes reject one before it gets here', () => {
+    const long = 'k'.repeat(MAX_AI_KEY_LENGTH + 10);
+    assert.equal(withAiKey({}, 'openai_api', long).openai_api, long);
   });
 
   it('does not mutate the input', () => {

--- a/src/ai-keys.ts
+++ b/src/ai-keys.ts
@@ -27,7 +27,9 @@ export type AiKeyProviderId = keyof typeof AI_KEY_ENV_VARS;
 export type AiKeys = Partial<Record<AiKeyProviderId, string>>;
 
 // A pasted credential is a single line; anything longer is a paste accident
-// (a whole .env file, a PEM block) that would bloat the settings row.
+// (a whole .env file, a PEM block) that would bloat the settings row. The
+// routes reject an over-long paste outright — silently storing a truncated
+// key would fail authentication with no hint as to why.
 export const MAX_AI_KEY_LENGTH = 500;
 
 export function providerTakesKey(id: AiProviderId): id is AiKeyProviderId {
@@ -49,8 +51,11 @@ export function parseAiKeys(raw: unknown): AiKeys {
   if (!parsed.success) return {};
   const keys: AiKeys = {};
   for (const [id, value] of Object.entries(parsed.data)) {
-    const key = value.trim().slice(0, MAX_AI_KEY_LENGTH);
-    if (key.length > 0 && providerTakesKey(id as AiProviderId)) keys[id as AiKeyProviderId] = key;
+    const key = value.trim();
+    // An over-long entry can only come from a hand-edited row: drop it whole
+    // rather than hand a truncated credential to a provider.
+    if (key.length === 0 || key.length > MAX_AI_KEY_LENGTH) continue;
+    if (providerTakesKey(id as AiProviderId)) keys[id as AiKeyProviderId] = key;
   }
   return keys;
 }
@@ -58,7 +63,7 @@ export function parseAiKeys(raw: unknown): AiKeys {
 /** Stores a pasted key, or removes it when the value is blank. */
 export function withAiKey(keys: AiKeys, id: AiKeyProviderId, value: string): AiKeys {
   const next = { ...keys };
-  const key = value.trim().slice(0, MAX_AI_KEY_LENGTH);
+  const key = value.trim();
   if (key.length === 0) delete next[id];
   else next[id] = key;
   return next;

--- a/src/ai-keys.ts
+++ b/src/ai-keys.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+import { AI_PROVIDER_IDS, type AiProviderId } from './ai-engine';
+
+/*
+ * Per-engine credentials (ADR 0027): the key an engine needs, stored in
+ * AppSettings.aiKeys so a non-technical user can paste it into the dashboard
+ * instead of editing .env. Pure — parsing, merging and env resolution only;
+ * the row itself is read and written through settings.ts. No I/O, no logging:
+ * a secret must never leave this module by any path but its return value.
+ */
+
+/**
+ * The .env variable each engine's key mirrors — also the variable name the
+ * CLI backends read from their child environment. Engines missing here take
+ * no key at all (codex_cli authenticates with `codex login`).
+ */
+export const AI_KEY_ENV_VARS = {
+  anthropic_api: 'ANTHROPIC_API_KEY',
+  claude_code: 'CLAUDE_CODE_OAUTH_TOKEN',
+  gemini_cli: 'GEMINI_API_KEY',
+  openai_api: 'OPENAI_API_KEY',
+} as const satisfies Partial<Record<AiProviderId, string>>;
+
+export type AiKeyProviderId = keyof typeof AI_KEY_ENV_VARS;
+
+/** Resolved secrets per engine — never rendered, never logged. */
+export type AiKeys = Partial<Record<AiKeyProviderId, string>>;
+
+// A pasted credential is a single line; anything longer is a paste accident
+// (a whole .env file, a PEM block) that would bloat the settings row.
+export const MAX_AI_KEY_LENGTH = 500;
+
+export function providerTakesKey(id: AiProviderId): id is AiKeyProviderId {
+  return id in AI_KEY_ENV_VARS;
+}
+
+/** Engines that accept a pasted key, in the roster's own order. */
+export const AI_KEY_PROVIDER_IDS: AiKeyProviderId[] = AI_PROVIDER_IDS.filter(providerTakesKey);
+
+const StoredKeysSchema = z.record(z.string(), z.string());
+
+/**
+ * Parses the raw AppSettings.aiKeys JSON. Tolerant like the engine config:
+ * never throws, drops unknown ids and blanks, so a hand-edited row cannot
+ * put a non-string where a secret is expected.
+ */
+export function parseAiKeys(raw: unknown): AiKeys {
+  const parsed = StoredKeysSchema.safeParse(raw ?? {});
+  if (!parsed.success) return {};
+  const keys: AiKeys = {};
+  for (const [id, value] of Object.entries(parsed.data)) {
+    const key = value.trim().slice(0, MAX_AI_KEY_LENGTH);
+    if (key.length > 0 && providerTakesKey(id as AiProviderId)) keys[id as AiKeyProviderId] = key;
+  }
+  return keys;
+}
+
+/** Stores a pasted key, or removes it when the value is blank. */
+export function withAiKey(keys: AiKeys, id: AiKeyProviderId, value: string): AiKeys {
+  const next = { ...keys };
+  const key = value.trim().slice(0, MAX_AI_KEY_LENGTH);
+  if (key.length === 0) delete next[id];
+  else next[id] = key;
+  return next;
+}
+
+/**
+ * The credential an engine uses for one call: the pasted key wins, `.env` is
+ * the fallback. That order is the whole point — a .env deployment keeps
+ * working untouched, and pasting a key overrides it without a restart.
+ */
+export function resolveAiKey(
+  id: AiProviderId,
+  keys: AiKeys,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (!providerTakesKey(id)) return undefined;
+  const stored = keys[id];
+  if (stored) return stored;
+  const fromEnv = env[AI_KEY_ENV_VARS[id]]?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
+}
+
+/** Where an engine's credential comes from — for UI copy, never the value. */
+export type AiKeySource = 'db' | 'env' | 'none';
+
+export function aiKeySource(
+  id: AiProviderId,
+  keys: AiKeys,
+  env: NodeJS.ProcessEnv = process.env,
+): AiKeySource {
+  if (!providerTakesKey(id)) return 'none';
+  if (keys[id]) return 'db';
+  return resolveAiKey(id, {}, env) ? 'env' : 'none';
+}

--- a/src/ai-keys.ts
+++ b/src/ai-keys.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { AI_PROVIDER_IDS, type AiProviderId } from './ai-engine';
+import type { AiProviderId } from './ai-engine';
 
 /*
  * Per-engine credentials (ADR 0027): the key an engine needs, stored in
@@ -35,9 +35,6 @@ export const MAX_AI_KEY_LENGTH = 500;
 export function providerTakesKey(id: AiProviderId): id is AiKeyProviderId {
   return id in AI_KEY_ENV_VARS;
 }
-
-/** Engines that accept a pasted key, in the roster's own order. */
-export const AI_KEY_PROVIDER_IDS: AiKeyProviderId[] = AI_PROVIDER_IDS.filter(providerTakesKey);
 
 const StoredKeysSchema = z.record(z.string(), z.string());
 

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -18,6 +18,7 @@ import {
   type CliOutcome,
 } from './ai-provider-parse';
 import type { AiProviderId } from './ai-engine';
+import { AI_KEY_ENV_VARS } from './ai-keys';
 
 /**
  * The single seam between the callers and whatever runs the AI (ADR 0013/0014).
@@ -52,6 +53,11 @@ export interface AiRequest {
    * the API, WebSearch/WebFetch on the CLI). Only the final text comes back.
    */
   webTools?: boolean;
+  /**
+   * Credential for this engine, already resolved DB-key-first (ADR 0027).
+   * Absent means "whatever .env holds" — the path scripts still take.
+   */
+  apiKey?: string;
 }
 
 export interface AiProvider {
@@ -79,16 +85,24 @@ const execFileAsync = promisify(execFile);
 
 class AnthropicApiProvider implements AiProvider {
   readonly name = 'anthropic_api';
-  private readonly client: Anthropic;
+  // The key can change under a running process (ADR 0027), so the SDK client
+  // is rebuilt when it does — one slot, because it changes about never.
+  private cached: { key: string; client: Anthropic } | null = null;
 
-  constructor(apiKey: string) {
-    this.client = new Anthropic({ apiKey });
+  private clientFor(key: string): Anthropic {
+    if (this.cached?.key !== key) this.cached = { key, client: new Anthropic({ apiKey: key }) };
+    return this.cached.client;
   }
 
   async complete(req: AiRequest): Promise<string | null> {
+    const key = req.apiKey ?? config.ANTHROPIC_API_KEY;
+    if (!key) {
+      logger.error({ label: req.label }, 'ai: no Anthropic API key — paste one on /settings');
+      return null;
+    }
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       try {
-        return await this.run(req);
+        return await this.run(req, this.clientFor(key));
       } catch (err) {
         const status = err instanceof Anthropic.APIError ? err.status : undefined;
         if (status === 429 && attempt < MAX_ATTEMPTS - 1) {
@@ -103,7 +117,7 @@ class AnthropicApiProvider implements AiProvider {
     return null;
   }
 
-  private async run(req: AiRequest): Promise<string> {
+  private async run(req: AiRequest, client: Anthropic): Promise<string> {
     const messages: Anthropic.MessageParam[] = [{ role: 'user', content: req.user }];
     const tools = req.webTools
       ? [
@@ -112,7 +126,7 @@ class AnthropicApiProvider implements AiProvider {
         ]
       : undefined;
     for (let resumes = 0; ; resumes++) {
-      const resp = await this.client.messages.create({
+      const resp = await client.messages.create({
         model: req.model ?? config.CLAUDE_MODEL,
         max_tokens: req.maxTokens,
         system: [{ type: 'text', text: req.system, cache_control: { type: 'ephemeral' } }],
@@ -135,12 +149,14 @@ class AnthropicApiProvider implements AiProvider {
 class OpenAiApiProvider implements AiProvider {
   readonly name = 'openai_api';
 
-  constructor(
-    private readonly apiKey: string,
-    private readonly baseUrl: string,
-  ) {}
+  constructor(private readonly baseUrl: string) {}
 
   async complete(req: AiRequest): Promise<string | null> {
+    const apiKey = req.apiKey ?? config.OPENAI_API_KEY;
+    if (!apiKey) {
+      logger.error({ label: req.label }, 'ai: no OpenAI API key — paste one on /settings');
+      return null;
+    }
     const model = req.model || config.OPENAI_MODEL || OPENAI_FALLBACK_MODEL;
     // api.openai.com rejects max_tokens for reasoning models; most
     // compatible servers (OpenRouter, Groq, local) only know max_tokens.
@@ -167,7 +183,7 @@ class OpenAiApiProvider implements AiProvider {
         const resp = await fetch(`${this.baseUrl}/chat/completions`, {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${this.apiKey}`,
+            Authorization: `Bearer ${apiKey}`,
             'Content-Type': 'application/json',
           },
           body,
@@ -204,6 +220,8 @@ interface CliSpec {
   defaultModel: string;
   /** Auth variables this provider's child may see (buildCliEnv allowlist). */
   envKeys: readonly string[];
+  /** Which of those carries a pasted key, when the request brings one. */
+  keyEnv?: string;
   /** Working directory — set to keep the CLI away from workspace context. */
   cwd?: string;
 }
@@ -230,7 +248,7 @@ class CliProvider implements AiProvider {
           timeout: req.timeoutMs ?? CLI_TIMEOUT_MS,
           maxBuffer: CLI_MAX_BUFFER,
           cwd: this.spec.cwd,
-          env: buildCliEnv(this.spec.envKeys),
+          env: buildCliEnv(this.spec.envKeys, this.envSource(req)),
         }));
       } catch (err) {
         logger.error({ err, label: req.label, provider: this.name }, 'ai: cli process failed');
@@ -251,32 +269,40 @@ class CliProvider implements AiProvider {
     }
     return null;
   }
+
+  /**
+   * A pasted key reaches the CLI the only way it reads one: as its own auth
+   * variable in the child env, still filtered by the buildCliEnv allowlist.
+   */
+  private envSource(req: AiRequest): NodeJS.ProcessEnv {
+    const { keyEnv } = this.spec;
+    if (!keyEnv || !req.apiKey) return process.env;
+    return { ...process.env, [keyEnv]: req.apiKey };
+  }
 }
 
 const providers = new Map<AiProviderId, AiProvider>();
 
 /**
- * Lazily constructs and caches the backend. Throws for anthropic_api without
- * an API key — ai-runtime's resolution never selects it in that case.
+ * Lazily constructs and caches the backend. Credentials are not baked in: a
+ * key arrives per call on AiRequest (ADR 0027), and whether an engine has one
+ * at all is decided in one place — ai-engine.ts:providerUnusable.
  */
 export function getAiProviderById(id: AiProviderId): AiProvider {
   const cached = providers.get(id);
   if (cached) return cached;
   let provider: AiProvider;
   switch (id) {
-    case 'anthropic_api': {
-      if (!config.ANTHROPIC_API_KEY) {
-        throw new Error('ANTHROPIC_API_KEY is required for the anthropic_api provider');
-      }
-      provider = new AnthropicApiProvider(config.ANTHROPIC_API_KEY);
+    case 'anthropic_api':
+      provider = new AnthropicApiProvider();
       break;
-    }
     case 'claude_code':
       provider = new CliProvider('claude_code', config.CLAUDE_CODE_BIN, {
         buildArgs: buildClaudeCodeArgs,
         parse: parseClaudeCodeOutput,
         defaultModel: config.CLAUDE_MODEL,
         envKeys: CLI_PROVIDER_ENV_KEYS.claude_code ?? [],
+        keyEnv: AI_KEY_ENV_VARS.claude_code,
       });
       break;
     case 'gemini_cli':
@@ -285,18 +311,15 @@ export function getAiProviderById(id: AiProviderId): AiProvider {
         parse: parseGeminiCliOutput,
         defaultModel: 'gemini-2.5-flash',
         envKeys: CLI_PROVIDER_ENV_KEYS.gemini_cli ?? [],
+        keyEnv: AI_KEY_ENV_VARS.gemini_cli,
         // gemini has no --tools '' switch; an empty cwd keeps it from
         // ingesting workspace files (GEMINI.md, sources) as context.
         cwd: tmpdir(),
       });
       break;
-    case 'openai_api': {
-      if (!config.OPENAI_API_KEY) {
-        throw new Error('OPENAI_API_KEY is required for the openai_api provider');
-      }
-      provider = new OpenAiApiProvider(config.OPENAI_API_KEY, config.OPENAI_BASE_URL);
+    case 'openai_api':
+      provider = new OpenAiApiProvider(config.OPENAI_BASE_URL);
       break;
-    }
     case 'codex_cli':
       provider = new CliProvider('codex_cli', config.CODEX_CLI_BIN, {
         buildArgs: buildCodexCliArgs,

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -8,6 +8,7 @@ import { logger } from './logger';
 import { prisma } from './db';
 import { getAiProviderById, type AiProvider } from './ai-provider';
 import { SETTINGS_ID } from './settings';
+import { aiKeySource, parseAiKeys, resolveAiKey, type AiKeys, type AiKeySource } from './ai-keys';
 import { createCooldownTracker } from './ai-cooldown';
 import {
   PROVIDER_WEB_TOOLS,
@@ -32,16 +33,18 @@ const DEFAULT_ATTEMPT_TIMEOUT_MS = 180_000;
 const cooldowns = createCooldownTracker();
 
 /**
- * The .env side of the engine merge — computed per call: CLI auth can appear
+ * The host side of the engine merge — computed per call: CLI auth can appear
  * while the process runs (login / mounted creds), and the resolver should
- * see it immediately.
+ * see it immediately. `keys` are the credentials pasted in the dashboard
+ * (ADR 0027); they win over the matching .env variable, so the usability
+ * rules in ai-engine.ts stay the single place that decides.
  */
-export function getAiEngineEnv(): AiEngineEnv {
+export function getAiEngineEnv(keys: AiKeys = {}): AiEngineEnv {
   return {
     provider: config.AI_PROVIDER,
-    hasAnthropicKey: Boolean(config.ANTHROPIC_API_KEY),
-    hasOpenAiKey: Boolean(config.OPENAI_API_KEY),
-    geminiUsable: geminiAuthConfigured(),
+    hasAnthropicKey: Boolean(resolveAiKey('anthropic_api', keys)),
+    hasOpenAiKey: Boolean(resolveAiKey('openai_api', keys)),
+    geminiUsable: Boolean(keys.gemini_cli) || geminiAuthConfigured(),
     codexUsable: codexAuthConfigured(),
     classifierModel: config.CLAUDE_MODEL,
     resumeModel: config.CLAUDE_MODEL_RESUME,
@@ -87,26 +90,29 @@ export interface AiRuntime {
  */
 export async function getAiRuntime(): Promise<AiRuntime> {
   let raw: unknown = null;
+  let keys: AiKeys = {};
   try {
     const row = await prisma.appSettings.findUnique({
       where: { id: SETTINGS_ID },
-      select: { aiEngine: true },
+      select: { aiEngine: true, aiKeys: true },
     });
     raw = row?.aiEngine ?? null;
+    keys = parseAiKeys(row?.aiKeys ?? null);
   } catch (err) {
     logger.warn({ err }, 'ai: settings read failed, using .env engine');
   }
-  const resolved = resolveAiEngine(raw, getAiEngineEnv());
+  const resolved = resolveAiEngine(raw, getAiEngineEnv(keys));
   return {
     chain: resolved.chain,
     skipped: resolved.skipped,
     modelFor: resolved.modelFor,
-    complete: (req) => completeWithFailover(resolved, req),
+    complete: (req) => completeWithFailover(resolved, keys, req),
   };
 }
 
 async function completeWithFailover(
   engine: ResolvedAiEngine,
+  keys: AiKeys,
   req: AiCallRequest,
 ): Promise<AiCallResult | null> {
   // Verification asks for web tools — prefer engines that have them, but a
@@ -149,6 +155,7 @@ async function completeWithFailover(
       model,
       timeoutMs: Math.min(perAttemptMs, remainingMs),
       webTools: req.webTools,
+      apiKey: resolveAiKey(id, keys),
     });
     if (text !== null) {
       cooldowns.success(id);
@@ -213,24 +220,54 @@ let probeCache: { at: number; statuses: Record<AiProviderId, AiProviderStatus> }
  */
 export async function probeAiProviders(): Promise<Record<AiProviderId, AiProviderStatus>> {
   if (probeCache && Date.now() - probeCache.at < PROBE_TTL_MS) return probeCache.statuses;
-  const [claude, gemini, codex] = await Promise.all([
+  const [claude, gemini, codex, keys] = await Promise.all([
     probeCliBin(config.CLAUDE_CODE_BIN),
     probeCliBin(config.GEMINI_CLI_BIN),
     probeCliBin(config.CODEX_CLI_BIN),
+    readAiKeys(),
   ]);
+  const from = (id: AiProviderId): AiKeySource => aiKeySource(id, keys);
   const statuses: Record<AiProviderId, AiProviderStatus> = {
-    anthropic_api: config.ANTHROPIC_API_KEY
-      ? { ok: true, detail: 'API key set' }
-      : { ok: false, detail: 'set ANTHROPIC_API_KEY in .env' },
-    claude_code: withClaudeAuth(claude),
-    gemini_cli: withGeminiAuth(gemini),
-    openai_api: config.OPENAI_API_KEY
-      ? { ok: true, detail: `API key set · ${baseUrlHost()}` }
-      : { ok: false, detail: `set OPENAI_API_KEY in .env (endpoint: ${baseUrlHost()})` },
+    anthropic_api:
+      from('anthropic_api') === 'none'
+        ? { ok: false, detail: 'paste an API key below, or set ANTHROPIC_API_KEY in .env' }
+        : { ok: true, detail: `API key ${keyOrigin(from('anthropic_api'))}` },
+    claude_code: withClaudeAuth(claude, from('claude_code')),
+    gemini_cli: withGeminiAuth(gemini, from('gemini_cli')),
+    openai_api:
+      from('openai_api') === 'none'
+        ? {
+            ok: false,
+            detail: `paste an API key below, or set OPENAI_API_KEY in .env (endpoint: ${baseUrlHost()})`,
+          }
+        : { ok: true, detail: `API key ${keyOrigin(from('openai_api'))} · ${baseUrlHost()}` },
     codex_cli: withCodexAuth(codex),
   };
   probeCache = { at: Date.now(), statuses };
   return statuses;
+}
+
+/** Invalidates the probe cache so a just-saved key shows up immediately. */
+export function forgetAiProbe(): void {
+  probeCache = null;
+}
+
+/** Never the key itself — only where it came from. */
+function keyOrigin(source: AiKeySource): string {
+  return source === 'db' ? 'saved here' : 'from .env';
+}
+
+async function readAiKeys(): Promise<AiKeys> {
+  try {
+    const row = await prisma.appSettings.findUnique({
+      where: { id: SETTINGS_ID },
+      select: { aiKeys: true },
+    });
+    return parseAiKeys(row?.aiKeys ?? null);
+  } catch (err) {
+    logger.warn({ err }, 'ai: key read failed, probing .env only');
+    return {};
+  }
 }
 
 function baseUrlHost(): string {
@@ -255,11 +292,13 @@ async function probeCliBin(bin: string): Promise<AiProviderStatus> {
  * mode, so an installed binary alone is not usable. Auth is file/env
  * detectable (unlike Claude Code's keychain), so surface it here.
  */
-function withGeminiAuth(bin: AiProviderStatus): AiProviderStatus {
-  if (!bin.ok || geminiAuthConfigured()) return bin;
+function withGeminiAuth(bin: AiProviderStatus, keySource: AiKeySource): AiProviderStatus {
+  if (!bin.ok) return bin;
+  if (keySource === 'db') return { ok: true, detail: `${bin.detail} · API key saved here` };
+  if (geminiAuthConfigured()) return bin;
   return {
     ok: false,
-    detail: `${bin.detail} installed — set GEMINI_API_KEY in .env, or log in once with \`gemini\` (mount ~/.gemini in Docker)`,
+    detail: `${bin.detail} installed — paste an API key below, or log in once with \`gemini\` (mount ~/.gemini in Docker)`,
   };
 }
 
@@ -303,11 +342,13 @@ function codexAuthConfigured(): boolean {
  * this reads the signals the CLI leaves on disk instead of spending a live
  * call on every settings render — the Test button stays the ground truth.
  */
-function withClaudeAuth(bin: AiProviderStatus): AiProviderStatus {
-  if (!bin.ok || claudeAuthConfigured()) return bin;
+function withClaudeAuth(bin: AiProviderStatus, keySource: AiKeySource): AiProviderStatus {
+  if (!bin.ok) return bin;
+  if (keySource === 'db') return { ok: true, detail: `${bin.detail} · token saved here` };
+  if (claudeAuthConfigured()) return bin;
   return {
     ok: false,
-    detail: `${bin.detail} installed, but not logged in — run \`claude\` once, or paste a token from \`claude setup-token\` (mount ~/.claude in Docker)`,
+    detail: `${bin.detail} installed, but not logged in — run \`claude\` once, or paste a \`claude setup-token\` token below`,
   };
 }
 

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -230,7 +230,7 @@ export async function probeAiProviders(): Promise<Record<AiProviderId, AiProvide
   const statuses: Record<AiProviderId, AiProviderStatus> = {
     anthropic_api:
       from('anthropic_api') === 'none'
-        ? { ok: false, detail: 'paste an API key below, or set ANTHROPIC_API_KEY in .env' }
+        ? { ok: false, detail: 'paste an API key, or set ANTHROPIC_API_KEY in .env' }
         : { ok: true, detail: `API key ${keyOrigin(from('anthropic_api'))}` },
     claude_code: withClaudeAuth(claude, from('claude_code')),
     gemini_cli: withGeminiAuth(gemini, from('gemini_cli')),
@@ -238,7 +238,7 @@ export async function probeAiProviders(): Promise<Record<AiProviderId, AiProvide
       from('openai_api') === 'none'
         ? {
             ok: false,
-            detail: `paste an API key below, or set OPENAI_API_KEY in .env (endpoint: ${baseUrlHost()})`,
+            detail: `paste an API key, or set OPENAI_API_KEY in .env (endpoint: ${baseUrlHost()})`,
           }
         : { ok: true, detail: `API key ${keyOrigin(from('openai_api'))} · ${baseUrlHost()}` },
     codex_cli: withCodexAuth(codex),
@@ -298,7 +298,7 @@ function withGeminiAuth(bin: AiProviderStatus, keySource: AiKeySource): AiProvid
   if (geminiAuthConfigured()) return bin;
   return {
     ok: false,
-    detail: `${bin.detail} installed — paste an API key below, or log in once with \`gemini\` (mount ~/.gemini in Docker)`,
+    detail: `${bin.detail} installed — paste an API key, or log in once with \`gemini\` (mount ~/.gemini in Docker)`,
   };
 }
 
@@ -348,7 +348,7 @@ function withClaudeAuth(bin: AiProviderStatus, keySource: AiKeySource): AiProvid
   if (claudeAuthConfigured()) return bin;
   return {
     ok: false,
-    detail: `${bin.detail} installed, but not logged in — run \`claude\` once, or paste a \`claude setup-token\` token below`,
+    detail: `${bin.detail} installed, but not logged in — run \`claude\` once, or paste a \`claude setup-token\` token`,
   };
 }
 

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -362,8 +362,10 @@ function claudeConfigDir(): string {
 const CLAUDE_CONFIG_MAX_BYTES = 8 * 1024 * 1024;
 
 function claudeAuthConfigured(): boolean {
-  // Both are read by the CLI itself and are how Docker deployments log in.
-  if (process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.ANTHROPIC_API_KEY) return true;
+  // Only the OAuth token: ANTHROPIC_API_KEY is deliberately kept out of this
+  // child's environment (ai-provider-parse.ts:CLI_PROVIDER_ENV_KEYS), so
+  // counting it here would call a logged-out CLI "available" again.
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) return true;
   // Linux (and Docker) write the OAuth credentials next to the config.
   if (existsSync(join(claudeConfigDir(), '.credentials.json'))) return true;
   // macOS keeps the tokens in the Keychain but records the logged-in account

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -222,7 +222,7 @@ export async function probeAiProviders(): Promise<Record<AiProviderId, AiProvide
     anthropic_api: config.ANTHROPIC_API_KEY
       ? { ok: true, detail: 'API key set' }
       : { ok: false, detail: 'set ANTHROPIC_API_KEY in .env' },
-    claude_code: claude,
+    claude_code: withClaudeAuth(claude),
     gemini_cli: withGeminiAuth(gemini),
     openai_api: config.OPENAI_API_KEY
       ? { ok: true, detail: `API key set · ${baseUrlHost()}` }
@@ -294,4 +294,47 @@ function withCodexAuth(bin: AiProviderStatus): AiProviderStatus {
 
 function codexAuthConfigured(): boolean {
   return existsSync(join(homedir(), '.codex', 'auth.json'));
+}
+
+/**
+ * `claude --version` answers from a logged-out CLI too, so the binary alone
+ * said "available" for an engine that fails on its first call. Auth is not
+ * fully detectable (macOS keeps the interactive login in the Keychain), so
+ * this reads the signals the CLI leaves on disk instead of spending a live
+ * call on every settings render — the Test button stays the ground truth.
+ */
+function withClaudeAuth(bin: AiProviderStatus): AiProviderStatus {
+  if (!bin.ok || claudeAuthConfigured()) return bin;
+  return {
+    ok: false,
+    detail: `${bin.detail} installed, but not logged in — run \`claude\` once, or paste a token from \`claude setup-token\` (mount ~/.claude in Docker)`,
+  };
+}
+
+/** Where the CLI keeps its config: CLAUDE_CONFIG_DIR wins, else ~/.claude. */
+function claudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+}
+
+// ~/.claude.json also holds per-project history, so it can grow large. Above
+// this size the probe stops rather than parse megabytes once a minute.
+const CLAUDE_CONFIG_MAX_BYTES = 8 * 1024 * 1024;
+
+function claudeAuthConfigured(): boolean {
+  // Both are read by the CLI itself and are how Docker deployments log in.
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.ANTHROPIC_API_KEY) return true;
+  // Linux (and Docker) write the OAuth credentials next to the config.
+  if (existsSync(join(claudeConfigDir(), '.credentials.json'))) return true;
+  // macOS keeps the tokens in the Keychain but records the logged-in account
+  // in the config file — enough to tell "logged in" from "never logged in".
+  for (const file of [join(claudeConfigDir(), '.claude.json'), join(homedir(), '.claude.json')]) {
+    try {
+      if (statSync(file).size > CLAUDE_CONFIG_MAX_BYTES) continue;
+      const parsed = JSON.parse(readFileSync(file, 'utf8')) as { oauthAccount?: unknown };
+      if (parsed.oauthAccount) return true;
+    } catch {
+      // Missing or unreadable: try the next candidate.
+    }
+  }
+  return false;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import type { Prisma, TelegramTarget } from '@prisma/client';
 import { prisma } from './db';
 import { logger } from './logger';
 import type { AiEngineConfig } from './ai-engine';
+import { parseAiKeys, withAiKey, type AiKeyProviderId, type AiKeys } from './ai-keys';
 
 export const SETTINGS_ID = 1;
 const TELEGRAM_API = 'https://api.telegram.org';
@@ -110,6 +111,32 @@ export async function setAiEngineConfig(engine: AiEngineConfig): Promise<void> {
     create: { id: SETTINGS_ID, aiEngine: value },
   });
   logger.info({ engine }, 'settings: ai engine updated');
+}
+
+/**
+ * The pasted per-engine credentials (ADR 0027). Deliberately NOT part of
+ * AppSettingsView: a secret is only ever read by the code that is about to
+ * use it, so an ordinary settings read can never carry one into a log line
+ * or a rendered page.
+ */
+export async function getAiKeys(): Promise<AiKeys> {
+  const row = await prisma.appSettings.findUnique({
+    where: { id: SETTINGS_ID },
+    select: { aiKeys: true },
+  });
+  return parseAiKeys(row?.aiKeys ?? null);
+}
+
+/** Stores a pasted key, or removes it when `key` is blank. Logs the engine only. */
+export async function setAiKey(id: AiKeyProviderId, key: string): Promise<void> {
+  const next = withAiKey(await getAiKeys(), id, key);
+  const value = next as unknown as Prisma.InputJsonValue;
+  await prisma.appSettings.upsert({
+    where: { id: SETTINGS_ID },
+    update: { aiKeys: value },
+    create: { id: SETTINGS_ID, aiKeys: value },
+  });
+  logger.info({ provider: id, stored: id in next }, 'settings: ai key updated');
 }
 
 export async function setTelegramEnabled(enabled: boolean): Promise<void> {

--- a/src/web/ai-test.ts
+++ b/src/web/ai-test.ts
@@ -1,7 +1,13 @@
 import { getAiProviderById } from '../ai-provider';
-import { AI_PROVIDER_LABELS, resolveAiEngine, type AiProviderId } from '../ai-engine';
+import {
+  AI_PROVIDER_LABELS,
+  providerUnusable,
+  resolveAiEngine,
+  type AiProviderId,
+} from '../ai-engine';
+import { resolveAiKey } from '../ai-keys';
 import { getAiEngineEnv } from '../ai-runtime';
-import { getSettings } from '../settings';
+import { getAiKeys, getSettings } from '../settings';
 
 const ENGINE_TEST_TIMEOUT_MS = 90_000;
 
@@ -22,8 +28,12 @@ export async function testAiEngine(provider: AiProviderId): Promise<EngineTestRe
       text: `${label} test failed: ${err instanceof Error ? err.message : 'not configured'}.`,
     };
   }
-  const settings = await getSettings();
-  const engine = resolveAiEngine(settings.aiEngine, getAiEngineEnv());
+  const [settings, keys] = await Promise.all([getSettings(), getAiKeys()]);
+  const env = getAiEngineEnv(keys);
+  if (providerUnusable(provider, env)) {
+    return { ok: false, text: `${label} has no credentials yet — paste a key, or set it in .env.` };
+  }
+  const engine = resolveAiEngine(settings.aiEngine, env);
   const model = engine.modelFor(provider, 'classifier');
   const started = Date.now();
   const text = await backend.complete({
@@ -33,6 +43,7 @@ export async function testAiEngine(provider: AiProviderId): Promise<EngineTestRe
     label: 'engine-test',
     model,
     timeoutMs: ENGINE_TEST_TIMEOUT_MS,
+    apiKey: resolveAiKey(provider, keys),
   });
   const seconds = ((Date.now() - started) / 1000).toFixed(1);
   if (text !== null) {

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -64,6 +64,12 @@ export interface AiEngineRow {
   freeTextModels: boolean;
   /** Metered billing — every call costs money (vs a flat subscription). */
   paid: boolean;
+  /** The .env variable this engine's key mirrors; null = login-only engine. */
+  keyEnvVar: string | null;
+  /** Where the credential comes from right now (ADR 0027). */
+  keySource: 'db' | 'env' | 'none';
+  /** Last four characters of the stored key — never the key itself. */
+  maskedKey: string;
 }
 
 export interface AiStatusSummary {
@@ -726,6 +732,65 @@ export const SettingsPage: FC<SettingsProps> = ({
   </Layout>
 );
 
+/**
+ * Paste-a-credential row (ADR 0027). The field is always empty: a stored key
+ * is only ever described (last four characters, where it came from), so the
+ * page can never hand the secret back or have a mask saved over the real one.
+ */
+const EngineKeyRow: FC<{ engine: AiEngineRow }> = ({ engine: e }) => {
+  const label = e.keyEnvVar?.endsWith('_TOKEN') ? 'Access token' : 'API key';
+  return (
+    <div class="mt-3 rounded-md border border-line bg-surface-raised px-3.5 py-3">
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-[13px] font-medium text-ink">{label}</span>
+        {e.keySource === 'db' && (
+          <>
+            <Badge tone="ok">saved</Badge>
+            <span class="font-mono text-xs text-ink-muted">{e.maskedKey}</span>
+          </>
+        )}
+        {e.keySource === 'env' && <Badge tone="neutral">from .env</Badge>}
+        {e.keySource === 'db' && (
+          <ActionForm
+            action="/settings/ai/key"
+            hidden={{ provider: e.id, clear: '1' }}
+            confirm={`Remove the saved ${e.label} ${label.toLowerCase()}?`}
+            class="ml-auto"
+          >
+            <Button size="sm" variant="danger">
+              Remove
+            </Button>
+          </ActionForm>
+        )}
+      </div>
+      <form method="post" action="/settings/ai/key" class="mt-2.5 flex flex-wrap items-end gap-2">
+        <input type="hidden" name="provider" value={e.id} />
+        <Input
+          type="password"
+          name="key"
+          required
+          autocomplete="off"
+          spellcheck="false"
+          aria-label={`${e.label} ${label.toLowerCase()}`}
+          placeholder={e.keySource === 'db' ? 'Paste a new one to replace it' : 'Paste it here'}
+          mono
+          class="min-w-[16rem] flex-1"
+        />
+        <Button size="sm" variant="secondary">
+          Save
+        </Button>
+      </form>
+      <Hint class="mt-2">
+        {e.keySource === 'db'
+          ? `Saved in the database and used instead of ${e.keyEnvVar} from .env.`
+          : e.keySource === 'env'
+            ? `Currently read from ${e.keyEnvVar} in .env. A key pasted here overrides it, no restart needed.`
+            : `Stored in the database — the same place as Telegram tokens. ${e.keyEnvVar} in .env still works instead.`}
+      </Hint>
+    </div>
+  );
+};
+
 const AiEngineCard: FC<{ engine: AiEngineRow }> = ({ engine: e }) => (
   <Card class={e.enabled ? '' : 'opacity-75'}>
     <div class="flex flex-wrap items-center gap-2">
@@ -756,6 +821,7 @@ const AiEngineCard: FC<{ engine: AiEngineRow }> = ({ engine: e }) => (
     <p class="mt-1.5 text-[13px] leading-5 text-ink-faint">
       {e.desc} ({e.detail})
     </p>
+    {e.keyEnvVar && <EngineKeyRow engine={e} />}
     {e.enabled && (
       <form
         method="post"

--- a/src/web/pages/welcome.tsx
+++ b/src/web/pages/welcome.tsx
@@ -36,6 +36,8 @@ export interface EngineStatusRow {
   label: string;
   ok: boolean;
   detail: string;
+  /** The .env variable this engine's key mirrors; null = login-only (ADR 0027). */
+  keyEnvVar: string | null;
 }
 
 export interface LastSearch {
@@ -108,26 +110,26 @@ const ENGINE_CARDS: { id: AiProviderId; title: string; how: string; env: string 
   {
     id: 'claude_code',
     title: 'I have a Claude subscription',
-    how: 'Run `claude setup-token` on your computer, paste the token into .env, then `docker compose up -d`.',
-    env: 'CLAUDE_CODE_OAUTH_TOKEN=…',
+    how: 'Run `claude setup-token` on your computer — it opens a browser and prints a token.',
+    env: 'CLAUDE_CODE_OAUTH_TOKEN',
   },
   {
     id: 'anthropic_api',
     title: 'I have an Anthropic API key',
     how: 'Keys live at console.anthropic.com → API keys. Pays per token — the classifier is cheap.',
-    env: 'ANTHROPIC_API_KEY=sk-ant-…',
+    env: 'ANTHROPIC_API_KEY',
   },
   {
     id: 'gemini_cli',
     title: 'I have a Gemini key — the free tier works',
     how: 'Get one at aistudio.google.com/apikey.',
-    env: 'GEMINI_API_KEY=…',
+    env: 'GEMINI_API_KEY',
   },
   {
     id: 'openai_api',
     title: 'OpenAI, OpenRouter, Groq or a local model',
-    how: 'Any server that speaks /chat/completions; add OPENAI_BASE_URL for the non-OpenAI ones.',
-    env: 'OPENAI_API_KEY=…',
+    how: 'Any server that speaks /chat/completions; add OPENAI_BASE_URL to .env for the non-OpenAI ones.',
+    env: 'OPENAI_API_KEY',
   },
   {
     id: 'codex_cli',
@@ -255,8 +257,8 @@ const AiStep: FC<WelcomeProps> = ({ ai, steps }) => {
         <>
           <p class="text-sm text-ink-muted">
             An AI reads every job and scores how well it matches you. Nothing usable was detected
-            yet — pick the one you have, add the line to <Code>.env</Code>, restart with{' '}
-            <Code>docker compose up -d</Code> and press Check again.
+            yet — pick the one you have and paste its key below. It is saved in your own
+            database: no file to edit, no restart.
           </p>
           <ul class="mt-4 grid gap-3 lg:grid-cols-2">
             {ENGINE_CARDS.map((card) => {
@@ -265,13 +267,36 @@ const AiStep: FC<WelcomeProps> = ({ ai, steps }) => {
                 <li class="rounded-md border border-line px-4 py-3">
                   <div class="text-sm font-medium text-ink">{card.title}</div>
                   <p class="mt-1 text-[13px] leading-5 text-ink-faint">{card.how}</p>
-                  {card.env && (
-                    <pre class="mt-2 overflow-x-auto rounded bg-surface-overlay px-2.5 py-1.5 font-mono text-xs text-ink">
-                      {card.env}
-                    </pre>
+                  {status?.keyEnvVar && (
+                    <form
+                      method="post"
+                      action="/welcome/ai/key"
+                      class="mt-2.5 flex flex-wrap items-end gap-2"
+                    >
+                      <input type="hidden" name="provider" value={card.id} />
+                      <Input
+                        type="password"
+                        name="key"
+                        required
+                        autocomplete="off"
+                        spellcheck="false"
+                        aria-label={`${status.label} key`}
+                        placeholder="Paste it here"
+                        mono
+                        class="min-w-[12rem] flex-1"
+                      />
+                      <Button size="sm" variant="secondary">
+                        Save
+                      </Button>
+                    </form>
                   )}
                   {status && (
                     <p class="mt-2 text-xs text-ink-faint">Right now: {status.detail}</p>
+                  )}
+                  {card.env && (
+                    <p class="mt-1 text-xs text-ink-faint">
+                      Prefer a file? <Code>{card.env}</Code> in <Code>.env</Code> works too.
+                    </p>
                   )}
                 </li>
               );

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -48,12 +48,7 @@ import {
   type AiProviderId,
 } from '../../ai-engine';
 import { forgetAiProbe, getAiEngineEnv, probeAiProviders } from '../../ai-runtime';
-import {
-  AI_KEY_ENV_VARS,
-  aiKeySource,
-  providerTakesKey,
-  type AiKeyProviderId,
-} from '../../ai-keys';
+import { AI_KEY_ENV_VARS, aiKeySource, providerTakesKey } from '../../ai-keys';
 import { testAiEngine } from '../ai-test';
 import {
   createProfile,
@@ -151,6 +146,7 @@ async function loadSettingsProps() {
     const position = enabledOrder.indexOf(id);
     const classifierDefault = defaultModelFor(id, 'classifier', aiEnv) || 'CLI default';
     const resumeDefault = defaultModelFor(id, 'resume', aiEnv) || 'CLI default';
+    const storedKey = providerTakesKey(id) ? aiKeys[id] : undefined;
     return {
       id,
       label: AI_PROVIDER_LABELS[id],
@@ -173,7 +169,7 @@ async function loadSettingsProps() {
       // last four characters of what is stored, and where it came from.
       keyEnvVar: providerTakesKey(id) ? AI_KEY_ENV_VARS[id] : null,
       keySource: aiKeySource(id, aiKeys),
-      maskedKey: aiKeys[id as AiKeyProviderId] ? maskToken(aiKeys[id as AiKeyProviderId]!) : '',
+      maskedKey: storedKey ? maskToken(storedKey) : '',
     };
   }).sort((a, b) => {
     if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -6,10 +6,12 @@ import { logger } from '../../logger';
 import {
   addTelegramTarget,
   deleteTelegramTarget,
+  getAiKeys,
   getSettings,
   listTelegramTargets,
   maskToken,
   setAiEngineConfig,
+  setAiKey,
   setApplicationTrackingEnabled,
   setClassifierMode,
   setDisabledSources,
@@ -45,7 +47,13 @@ import {
   type AiEngineConfig,
   type AiProviderId,
 } from '../../ai-engine';
-import { getAiEngineEnv, probeAiProviders } from '../../ai-runtime';
+import { forgetAiProbe, getAiEngineEnv, probeAiProviders } from '../../ai-runtime';
+import {
+  AI_KEY_ENV_VARS,
+  aiKeySource,
+  providerTakesKey,
+  type AiKeyProviderId,
+} from '../../ai-keys';
 import { testAiEngine } from '../ai-test';
 import {
   createProfile,
@@ -116,7 +124,7 @@ export const settingsRoute = new Hono();
 /** Everything the settings page needs except activeTab/flash/profileDraft —
  *  shared by the GET and by POSTs that render a draft instead of redirecting. */
 async function loadSettingsProps() {
-  const [settings, targets, profiles, active, resumes, aiStatuses, stageCounts] =
+  const [settings, targets, profiles, active, resumes, aiStatuses, aiKeys, stageCounts] =
     await Promise.all([
       getSettings(),
       listTelegramTargets(),
@@ -124,6 +132,7 @@ async function loadSettingsProps() {
       getActiveProfile(),
       listResumes(),
       probeAiProviders(),
+      getAiKeys(),
       prisma.job.groupBy({
         by: ['pipelineStage'],
         _count: { _all: true },
@@ -133,7 +142,7 @@ async function loadSettingsProps() {
   const countByStage = new Map(
     stageCounts.map((row) => [row.pipelineStage, row._count._all]),
   );
-  const aiEnv = getAiEngineEnv();
+  const aiEnv = getAiEngineEnv(aiKeys);
   const engine = resolveAiEngine(settings.aiEngine, aiEnv);
   const aiConfig = parseAiEngineConfig(settings.aiEngine);
   // With no stored config the .env-seeded chain is shown as enabled.
@@ -160,6 +169,11 @@ async function loadSettingsProps() {
       options: PROVIDER_MODEL_OPTIONS[id],
       freeTextModels: id === 'openai_api',
       paid: PROVIDER_PAID[id],
+      // ADR 0027: the field takes a key, it never hands one back — only the
+      // last four characters of what is stored, and where it came from.
+      keyEnvVar: providerTakesKey(id) ? AI_KEY_ENV_VARS[id] : null,
+      keySource: aiKeySource(id, aiKeys),
+      maskedKey: aiKeys[id as AiKeyProviderId] ? maskToken(aiKeys[id as AiKeyProviderId]!) : '',
     };
   }).sort((a, b) => {
     if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
@@ -369,6 +383,32 @@ settingsRoute.post('/settings/ai/models', async (c) => {
   return wantsJson
     ? c.json({ ok: true })
     : flashRedirect('/settings?tab=ai', 'ok', `${label} models saved.`);
+});
+
+/**
+ * Saves or removes one engine's pasted credential (ADR 0027). The value never
+ * comes back to the browser and never reaches a log line or a flash message —
+ * the response says which engine changed, not what was stored.
+ */
+settingsRoute.post('/settings/ai/key', async (c) => {
+  const form = await c.req.parseBody();
+  const provider = typeof form.provider === 'string' ? form.provider : '';
+  if (!isAiProviderId(provider) || !providerTakesKey(provider)) {
+    return flashRedirect('/settings?tab=ai', 'err', 'That engine does not take a pasted key.');
+  }
+  const label = AI_PROVIDER_LABELS[provider];
+  const clearing = form.clear === '1';
+  const key = typeof form.key === 'string' ? form.key.trim() : '';
+  if (!clearing && key.length === 0) {
+    return flashRedirect('/settings?tab=ai', 'err', `Paste a ${label} key first.`);
+  }
+  await setAiKey(provider, clearing ? '' : key);
+  forgetAiProbe();
+  if (clearing) {
+    const fallback = aiKeySource(provider, {}) === 'env' ? ` Falling back to ${AI_KEY_ENV_VARS[provider]} from .env.` : '';
+    return flashRedirect('/settings?tab=ai', 'ok', `${label} key removed.${fallback}`);
+  }
+  return flashRedirect('/settings?tab=ai', 'ok', `${label} key saved. Press Test to prove it works.`);
 });
 
 settingsRoute.post('/settings/ai/test', async (c) => {

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -48,7 +48,12 @@ import {
   type AiProviderId,
 } from '../../ai-engine';
 import { forgetAiProbe, getAiEngineEnv, probeAiProviders } from '../../ai-runtime';
-import { AI_KEY_ENV_VARS, aiKeySource, providerTakesKey } from '../../ai-keys';
+import {
+  AI_KEY_ENV_VARS,
+  aiKeySource,
+  MAX_AI_KEY_LENGTH,
+  providerTakesKey,
+} from '../../ai-keys';
 import { testAiEngine } from '../ai-test';
 import {
   createProfile,
@@ -397,6 +402,13 @@ settingsRoute.post('/settings/ai/key', async (c) => {
   const key = typeof form.key === 'string' ? form.key.trim() : '';
   if (!clearing && key.length === 0) {
     return flashRedirect('/settings?tab=ai', 'err', `Paste a ${label} key first.`);
+  }
+  if (key.length > MAX_AI_KEY_LENGTH) {
+    return flashRedirect(
+      '/settings?tab=ai',
+      'err',
+      `That is ${key.length} characters — longer than any API key. Nothing saved.`,
+    );
   }
   await setAiKey(provider, clearing ? '' : key);
   forgetAiProbe();

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -2,13 +2,19 @@
 import { Hono } from 'hono';
 import { CronRunStatus, JobStatus, type Profile } from '@prisma/client';
 import { prisma } from '../../db';
-import { setFetchingEnabled, setSetupCompleted } from '../../settings';
+import { getAiKeys, setAiKey, setFetchingEnabled, setSetupCompleted } from '../../settings';
 import { updateProfile, type ProfileInput } from '../../profiles';
 import { passesBaseFilter } from '../../filter';
 import { parsePriorityRules } from '../../priority-rules';
 import { parseTagList, toStringArray } from '../../text-utils';
-import { getAiEngineEnv } from '../../ai-runtime';
-import { AI_PROVIDER_IDS, AI_PROVIDER_LABELS, resolveAiEngine } from '../../ai-engine';
+import { forgetAiProbe, getAiEngineEnv } from '../../ai-runtime';
+import {
+  AI_PROVIDER_IDS,
+  AI_PROVIDER_LABELS,
+  isAiProviderId,
+  resolveAiEngine,
+} from '../../ai-engine';
+import { AI_KEY_ENV_VARS, providerTakesKey } from '../../ai-keys';
 import { createResume, getResume, listResumes, type ResumeSummary } from '../../resume/store';
 import { scanResume } from '../../resume/scan';
 import { buildProfileDraft, SENIORITY_LEVELS } from '../../resume/profile-draft';
@@ -77,7 +83,12 @@ welcomeRoute.get('/welcome', async (c) => {
       fetchingEnabled={settings.fetchingEnabled}
       telegramEnabled={settings.telegramEnabled}
       ai={{
-        engines: AI_PROVIDER_IDS.map((id) => ({ id, label: AI_PROVIDER_LABELS[id], ...statuses[id] })),
+        engines: AI_PROVIDER_IDS.map((id) => ({
+          id,
+          label: AI_PROVIDER_LABELS[id],
+          keyEnvVar: providerTakesKey(id) ? AI_KEY_ENV_VARS[id] : null,
+          ...statuses[id],
+        })),
       }}
       search={{ jobCount: facts.jobCount, last: lastSearch, runningRunId: activeFetchRun()?.id ?? null }}
       profile={{
@@ -120,10 +131,34 @@ welcomeRoute.post('/welcome/finish', async () => {
   return flashRedirect('/', 'ok', 'Setup complete — the hourly watch is on. New matches land here.');
 });
 
+/**
+ * Step 1's paste-a-key path (ADR 0027): the credential lands in the database,
+ * the probe cache is dropped so the page shows the engine as connected right
+ * away, and the Test button next to it proves the connection for real.
+ */
+welcomeRoute.post('/welcome/ai/key', async (c) => {
+  const form = await c.req.parseBody();
+  const provider = typeof form.provider === 'string' ? form.provider : '';
+  if (!isAiProviderId(provider) || !providerTakesKey(provider)) {
+    return flashRedirect('/welcome?step=ai', 'err', 'That engine does not take a pasted key.');
+  }
+  const key = typeof form.key === 'string' ? form.key.trim() : '';
+  if (key.length === 0) {
+    return flashRedirect('/welcome?step=ai', 'err', 'Paste the key first.');
+  }
+  await setAiKey(provider, key);
+  forgetAiProbe();
+  return flashRedirect(
+    '/welcome?step=ai',
+    'ok',
+    `${AI_PROVIDER_LABELS[provider]} key saved. Send a test message to be sure it works.`,
+  );
+});
+
 /** Step 1's optional proof: one tiny live call through the engine that would serve the pipeline. */
 welcomeRoute.post('/welcome/ai/test', async () => {
   const { statuses, settings } = await loadWelcomeContext();
-  const chain = resolveAiEngine(settings.aiEngine, getAiEngineEnv()).chain;
+  const chain = resolveAiEngine(settings.aiEngine, getAiEngineEnv(await getAiKeys())).chain;
   const provider = chain.find((id) => statuses[id].ok) ?? AI_PROVIDER_IDS.find((id) => statuses[id].ok);
   if (!provider) return flashRedirect('/welcome?step=ai', 'err', 'No usable AI engine detected yet.');
   const result = await testAiEngine(provider);

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -14,7 +14,7 @@ import {
   isAiProviderId,
   resolveAiEngine,
 } from '../../ai-engine';
-import { AI_KEY_ENV_VARS, providerTakesKey } from '../../ai-keys';
+import { AI_KEY_ENV_VARS, MAX_AI_KEY_LENGTH, providerTakesKey } from '../../ai-keys';
 import { createResume, getResume, listResumes, type ResumeSummary } from '../../resume/store';
 import { scanResume } from '../../resume/scan';
 import { buildProfileDraft, SENIORITY_LEVELS } from '../../resume/profile-draft';
@@ -145,6 +145,13 @@ welcomeRoute.post('/welcome/ai/key', async (c) => {
   const key = typeof form.key === 'string' ? form.key.trim() : '';
   if (key.length === 0) {
     return flashRedirect('/welcome?step=ai', 'err', 'Paste the key first.');
+  }
+  if (key.length > MAX_AI_KEY_LENGTH) {
+    return flashRedirect(
+      '/welcome?step=ai',
+      'err',
+      `That is ${key.length} characters — longer than any API key. Nothing saved.`,
+    );
   }
   await setAiKey(provider, key);
   forgetAiProbe();


### PR DESCRIPTION
Stage 4 of the onboarding plan (`docs/onboarding-plan.md` §5, TASKS §11 block 4)
— **Phase B** of wizard step 1. The first step of the first-run wizard was the
only one that asked a non-technical user to open a text editor: add
`ANTHROPIC_API_KEY=…` to `.env`, restart the containers, come back. Now they
paste the key into the card and press Test.

## What changed

- **`AppSettings.aiKeys`** (new JSONB column, hand-written migration, no
  backfill): `{ <provider id>: "<secret>" }`. A stored key wins over the
  matching `.env` variable; a missing entry means "use `.env`", so every
  existing deployment keeps working with nothing to do.
- **Four engines take a key** — Anthropic API (`ANTHROPIC_API_KEY`), Claude
  Code CLI (`CLAUDE_CODE_OAUTH_TOKEN`), Gemini CLI (`GEMINI_API_KEY`),
  OpenAI-compatible API (`OPENAI_API_KEY`). Codex CLI is `codex login` only
  and gets no field.
- **The key goes through the two seams that already existed**, not new ones:
  `AiEngineEnv` (so `ai-engine.ts:providerUnusable` stays the single decision
  on whether an engine can run) and `AiRequest.apiKey` (API backends use it
  directly, CLI backends receive it as their own auth variable in the child
  env, still filtered by the `buildCliEnv` allowlist). Provider constructors
  no longer hold secrets, which removed the *second* place that decided
  "no key ⇒ unusable".
- **The key is never handed back.** The paste field always renders empty; a
  stored key is only described — `***last4` via the same `maskToken` the
  Telegram table uses, plus where it came from ("saved here" / "from .env").
  Removal is its own button. Reads go through `settings.ts:getAiKeys()` and
  deliberately *not* through `AppSettingsView`, so an ordinary settings read
  cannot carry a secret into a log line or a page.
- **Tail from v1.7.0 (PR #63 follow-up):** the `claude_code` probe was
  dishonest — `claude --version` answers from a logged-out CLI, so `/settings`
  and the wizard read "available" for an engine that fails on its first call.
  It now reads the CLI's own auth signals (OAuth token in the env,
  `.credentials.json`, the recorded `oauthAccount`) with no live call: +0.2 ms
  on a 680 ms cold probe that is cached for 60 s.

## Schema

- `20260902090000_add_ai_keys` — `ALTER TABLE app_settings ADD COLUMN "aiKeys" JSONB`.
  Applied on a live container rebuild (42 migrations found, one applied, init
  logs clean).

## Verification

- `npm run lint:types` + `npm test` (823 pass, 0 fail) + `npx prisma format --check`.
- **Three credential states, live:** DB-only (`openai_api`, no `.env` value →
  "API key saved here · api.openai.com", engine flips to available); `.env`-only
  (`claude_code` → "Access token from .env"); **both** (`anthropic_api` — a
  bogus DB key next to the working `.env` one made Test fail in 0.2 s with
  `401 API key is invalid`, i.e. the DB key was the one spent).
- **Fresh-install wizard, scratch DB, no `.env` key at all**
  (`jobhunter_wizard` + a `wizard-web` container with the key variables
  blanked): step 1 showed the paste cards and the honest "installed, but not
  logged in" line, the pasted token flipped it to done, **"Send a test message"
  ran a real CLI call in 5.0 s authenticated only by the DB key**; step 2
  fetched 2654 / stored 2239 unscored; step 3 wrote a profile (php/laravel/mysql,
  backend, senior); step 4 scored its ten and put a PHP-Laravel posting on top
  at 82; "Start the hourly watch" set `setupCompletedAt` and turned fetching
  on, and `/` stopped redirecting. Every AI call in that walkthrough was
  authenticated by the database key alone. Scratch database and container
  removed afterwards.
- **No leak:** the raw key is absent from the rendered HTML, from `web`/`app`
  container logs (grepped for the full value and its last 8 characters), from
  the flash messages and from the Anthropic SDK's own error object
  (`headers: {}`). The only new log line is `settings: ai key updated
  {provider, stored}`.
- **Dashboard matrix:** every affected route curled 200 (`/`, all five
  `/settings` tabs, all four `/welcome` steps, `/jobs`, `/runs`, `/companies`,
  `/resumes`, `/applications`); the AI tab screenshotted at 1200 / 768 / 375
  with all three key states in one frame (Anthropic "from .env", Gemini
  "saved ***9876" with Remove, OpenAI "not detected"), plus wizard step 1 at
  768 and 375; 0 console errors.

## Review follow-ups (P2/P3)

The mandatory `code-review-expert` pass over `git diff main...HEAD` found three
issues, **all fixed in this branch**:

- **P1** — `claudeAuthConfigured()` counted `ANTHROPIC_API_KEY` as Claude Code
  auth, but that variable is deliberately kept out of that child's environment
  (`CLI_PROVIDER_ENV_KEYS`, so a subscription is never silently billed as API).
  On any machine with the key in `.env` — including this one — a logged-out CLI
  would have read "available" again, re-creating the exact bug the first commit
  set out to fix.
- **P2** — an over-long paste was silently truncated into a credential that
  could only fail authentication with no hint why. Both routes now reject it
  with a plain message; `parseAiKeys` drops an over-long stored entry whole
  instead of slicing it.
- **P3** — a dead export (`AI_KEY_PROVIDER_IDS`, no caller) and a status line
  reading "paste an API key **below**" while the wizard renders that field
  *above* it. Both removed.

Left as follow-ups, deliberately:

- **P2 — no CSRF protection on the save route**, because no route in this
  dashboard has any. A page open in the same browser cannot *read* the stored
  key but can POST one of its own, pointing the user's AI calls at an account
  it controls. Same class as every other unauthenticated POST here (delete a
  Telegram target, change the profile); recorded in ADR 0027's consequences
  rather than fixed here, since a fix belongs to the whole dashboard.
- **P3 — `setAiKey` is a read-modify-write** with no locking, so two
  simultaneous saves could lose one. Matches `setAiEngineConfig`'s existing
  pattern and needs two hands on one single-user dashboard.
- **P3 — the settings page reads `aiKeys` twice** per render (once inside the
  60 s-cached probe, once for the engine rows). 0.03 ms each; worth folding
  together only if the probe ever returns its keys.

## References

- **ADR 0027** — [Per-engine AI keys live in the database, in plaintext, with `.env` as fallback](docs/adr/0027-ai-keys-in-the-database.md).
  Extends ADR 0013/0014 and the CLAUDE.md secrets rule (whose one existing
  carve-out is `TelegramTarget.botToken`). It is explicit that a database dump
  contains the key, that encryption at rest would only move the secret into
  `.env`, and that `.env` stays a first-class path.
- Plan: [docs/onboarding-plan.md §2 Step 1 "Phase B"](docs/onboarding-plan.md), §5 row 4.
- Setup guide: [docs/ai-engines.md](docs/ai-engines.md) — "Two ways to hand over a key".

---

## Release notes (draft)

```
## What's new
- Paste an AI key straight into the dashboard instead of editing .env — every
  engine card on /settings → AI engine, and step 1 of the first-run wizard.
  Save, Test, done: it applies to the dashboard at once and to the worker on
  its next tick, and it wins over the matching .env variable.
- Four engines take one: Anthropic API, Claude Code CLI (a `claude
  setup-token` token), Gemini CLI and any OpenAI-compatible API. Codex CLI
  stays `codex login`.
- The key never comes back out: the field always renders empty, the card shows
  only the last four characters and where the credential comes from, and
  Remove deletes the stored copy.
- .env keeps working exactly as before and stays the documented choice if you
  would rather keep secrets out of the database — ADR 0027 is explicit that a
  database dump contains a pasted key.
- The Claude Code CLI badge is honest about being logged out. `claude
  --version` answers either way, so the engine used to read "available" and
  then fail on its first real call.

## Schema
- 20260902090000_add_ai_keys — app_settings."aiKeys" JSONB, nullable, no backfill.

## Verification
- 823 unit tests; migration applied on a container rebuild; three credential
  states (DB-only / .env-only / both) exercised live; full wizard walkthrough
  on a fresh database with no .env key; dashboard matrix at 1200/768/375 with
  0 console errors; key absent from HTML, logs and errors.

## References
- ADR 0027 — per-engine AI keys in the database, .env as fallback
- docs/onboarding-plan.md §2 Step 1 (Phase B), §5 stage 4
```

**Tag after merge:**

```
git tag -a v1.8.0 -m "AI key in the database" <merge-sha> && git push origin v1.8.0
```
