### PR TITLE
phase-5: the resume a search hunts with (Profile.resumeId)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -201,7 +201,7 @@ src/
     fact-check.ts              ← deterministic fabrication gate for generated prose (ADR 0020), pure
     diff.ts                    ← version delta from two matches (gained/lost, components), pure
     parse-warnings.ts          ← ATS parseability checks over extracted text, pure
-    pick.ts                    ← preselect resume by skill-tag overlap, pure
+    pick.ts                    ← preselect: profile link first, then skill-tag overlap, pure
     store.ts                   ← Resume / ResumeMatch / CandidateFact / CoverLetter CRUD (Prisma)
     zip-write.ts               ← minimal STORED zip writer (docx container), pure
     docx-write.ts              ← letter → .docx, round-trip-tested against zip.ts + docx-text.ts, pure
@@ -262,6 +262,7 @@ src/
     welcome-steps.ts          ← pure first-run wizard rules (steps from data, score-run summary)
     welcome-facts.ts          ← loads what the wizard and the Overview chip derive from
     ai-test.ts                ← one live engine call — Settings Test button + wizard step 1
+    profile-from-resume.ts    ← "create a search from this resume": blank-base draft + inactive create
     public/target.mjs         ← browser keyword matcher (pure ES module, node-tested)
     public/score.mjs          ← browser mirror of resume/score.ts (parity-tested, ADR 0012)
     public/cover-letter.mjs   ← copy-to-clipboard for the letter card (import-smoke-tested)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.9.0] — 2026-09-02
+
+### Added
+- **A search can name the resume it hunts with**
+  ([docs/onboarding-plan.md §4](docs/onboarding-plan.md) stage A, TASKS §11
+  block 5). New `Profile.resumeId`: "this search is for jobs I'd apply to
+  with *this* CV". A job page found by that search preselects its resume in
+  the Resume match and Cover letter cards instead of guessing from
+  skill-tag overlap; profiles without a link behave exactly as before.
+  Editable on `/settings` → Profile → "Resume for this search", where
+  clearing it returns to the overlap pick.
+- **"Create a search from this resume"** on `/resumes/:id`. The card shows
+  the whole profile a click would produce — name from the resume's
+  headline, primary stack → required, other skills → nice-to-have, plus
+  role types and seniority — and one press saves it, linked to that resume
+  ([ADR 0015](docs/adr/0015-profile-draft-from-resume-scan.md) unchanged:
+  the draft is rendered, never written before the press). The card also
+  names the searches already hunting with that resume.
+- The same action in the wizard's step 3, once the first search exists:
+  "Another resume for a different kind of role?" takes one file (or one
+  already-uploaded resume), reads it on the usual progress page, and offers
+  the second search as a draft.
+
+### Changed
+- New profiles created from a resume are **born inactive**, like every
+  other new profile — creating a search never switches the one the pipeline
+  is scoring against. The flash and the card copy say where to activate it.
+- "Fill from a resume" now proposes that resume as the search's resume
+  alongside the fields it fills, in the same unsaved draft.
+- Deleting a resume clears the link (`ON DELETE SET NULL`) rather than
+  deleting the search or refusing the delete: a profile owns regions,
+  thresholds, priority rules and alert routing that no resume can speak
+  for. The preselect falls back to skill overlap.
+- One read of `AppSettings.aiKeys` per `/settings` render instead of two
+  (the page and the engine probe now share it).
+- `docs/TASKS.md` §11–§13 headers state what actually shipped; §11 had
+  claimed nothing was implemented while four of its seven stages were live.
+
 ## [1.8.0] — 2026-09-02
 
 ### Added
@@ -725,6 +763,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.9.0]: https://github.com/applypack/applypack/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/applypack/applypack/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/applypack/applypack/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/applypack/applypack/compare/v1.5.0...v1.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Adding a new ATS source — list + detail | `src/fetchers/smartrecruiters.ts` |
 | Where to register a new ATS | `src/fetchers/index.ts:fetchOne` switch + `prisma/schema.prisma:AtsType` enum |
 | Where to add a new toggle | `prisma/schema.prisma:AppSettings` (column) → `src/settings.ts` (getter/setter) → `src/web/pages/settings.tsx` (UI) → `src/web/routes/settings.tsx` (POST) |
+| Where to add a new profile field | `prisma/schema.prisma:Profile` → `ProfileInput` + `blankProfileInput()` in `src/profiles.ts` (the compiler then names every construction site) → `ProfileFormSchema` + the save route in `src/web/routes/settings.tsx` → the editor in `src/web/pages/settings.tsx` |
 | The Claude system prompt | `src/classifier.ts:buildSystemPrompt` |
 | Fence markers, the untrusted directive, the forged-marker sanitiser | `src/prompt-fence.ts` (pure, ADR 0022); guard `src/prompt-fence-registry.test.ts` |
 | Which AI engines run (priority chain + per-engine models, auto-failover) | `src/ai-runtime.ts:getAiRuntime().complete({role})` + pure chain merge in `src/ai-engine.ts` (ADR 0013/0014); UI on `/settings` → "AI engine" tab |
@@ -185,7 +186,8 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Version delta (gained/lost keywords, component moves) | `src/resume/diff.ts:diffMatches`, rendered in `resume-match-card.tsx` |
 | Live smoke bench of the match prompt (3 gold fixtures) | `npm run bench:resume` — `src/scripts/resume-bench-once.ts` |
 | Compare-run progress pages (async classify/scan/match) | `src/web/target-runs.ts` (in-memory registry) + `src/web/pages/target-run.tsx`; started by `/target`, `/jobs/:id/match`, `/jobs/:id/target/reupload` |
-| Which resume a job page preselects | `src/resume/pick.ts:pickResumeForJob` (skill-tag overlap) |
+| Which resume a job page preselects | `src/resume/pick.ts:preselectResume` — the active profile's `resumeId` first, then `pickResumeForJob` (skill-tag overlap) |
+| Creating a search profile from a resume (both entry points) | `src/web/profile-from-resume.ts` → `POST /resumes/:id/profile` and `POST /welcome/profile/create`; born inactive |
 | Prefill the profile from a resume scan | `src/resume/profile-draft.ts:buildProfileDraft` (pure) + `POST /settings/profiles/:id/fill-from-resume` (renders a draft, saves nothing — ADR 0015) |
 | Model for cover letters (empty = follows the resume model) | `/settings` → AI engine → "Cover letter model" (role `cover` in `ai-engine.ts`; pickers save on change) |
 | Model for resume calls | per-engine "Resume model" on `/settings` → AI engine; Claude engines fall back to `CLAUDE_MODEL_RESUME` in `.env` (default `claude-opus-5`) |
@@ -214,6 +216,8 @@ When the question is **"how does the user toggle / configure X?"**:
 | Enable two-stage classifier (cheaper, less precise) | `/settings` AI engine tab → "Classifier" |
 | Edit profile (stack, role types, regions, fit threshold) | `/settings` Profile tab (excludes, notes, priority rules, thresholds live in its "Advanced" block) |
 | Fill the profile from a resume (AI draft, review before save) | `/settings` Profile tab → "Fill from a resume" |
+| Create a second search from another resume | `/resumes/:id` → "Search profile" card, or `/welcome?step=profile` → "Another resume for a different kind of role?" |
+| Which resume a search hunts with | `/settings` Profile tab → "Resume for this search" (empty = pick by skill overlap) |
 | Switch between profiles | `/settings` Profile tab → dropdown + Activate |
 | Re-classify all jobs against new profile | `/settings` Profile tab → "Save & re-classify" in the editor (async, watch /runs) |
 | Telegram on/off | `/settings` Notifications tab |

--- a/SPEC.md
+++ b/SPEC.md
@@ -117,6 +117,10 @@ Profile fields that drive matching:
 - `minFitScore`, `minSalaryUsd`
 - `notes` — free-form prose appended to the Claude prompt
 - `telegramTargetId` — optional: route alerts to a specific bot (else broadcast)
+- `resumeId` — optional: the resume this search hunts with. A job page
+  preselects it for comparisons and cover letters; unset falls back to
+  skill-tag overlap (`src/resume/pick.ts:preselectResume`). `SET NULL` on
+  resume delete — the search survives, the preselect goes back to guessing.
 
 The editor shows the essentials (stack, role types, seniority, location);
 excludes, notes, on-site cities, priority rules, thresholds and Telegram
@@ -128,6 +132,17 @@ them is customised.
 scanned skills), `roleTypes` and `seniority` from any scanned resume —
 rendered as an unsaved draft in the editor; nothing persists until Save.
 Resumes scanned before `primarySkills` existed are re-scanned on demand.
+Filling also proposes that resume as the search's `resumeId`, in the same
+unsaved draft.
+
+**Create a search from a resume**: `/resumes/:id` renders the profile a
+click would create (name from the resume's headline, primary stack →
+required, remaining skills → nice-to-have, plus role types and seniority)
+and saves it on one press, linked to that resume. The wizard's step 3
+offers the same for a second resume once the first search exists. New
+profiles are **born inactive** — creating a search never switches the one
+the pipeline is scoring against; activation stays a deliberate press on
+`/settings` → Profile.
 
 ## Toggles in `/settings`
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -735,7 +735,7 @@ when next touching it.
 ## 11. Onboarding wizard + profile simplification + multi-resume search (analysis 2026-08-31)
 
 Full plan: [docs/onboarding-plan.md](./onboarding-plan.md). **In
-progress — 4 of 7 stages shipped** (v1.5.0, v1.6.0, v1.7.0, v1.8.0); the
+progress — 5 of 7 stages shipped** (v1.5.0–v1.9.0); the
 checklist below is the status of record.
 
 Driver: users don't find where to create a profile or upload a resume;
@@ -759,8 +759,11 @@ Telegram explicitly optional.
 - [x] `ai-key-in-db` — paste API key in UI, DB-stored, masked — done
       2026-09-02, branch `ai-key-in-db` (ADR 0027: `AppSettings.aiKeys`,
       four key-bearing engines, `.env` stays the fallback)
-- [ ] `profile-resume-link` — `Profile.resumeId` + one-click "Create
-      profile from this resume"
+- [x] `profile-resume-link` — `Profile.resumeId` + one-click "Create a
+      search from this resume" on `/resumes/:id` and in step 3 for a
+      second resume; job pages preselect the linked resume — done
+      2026-09-02, branch `profile-resume-link`; new profiles born
+      inactive, `SetNull` on resume delete
 - [ ] `multi-profile-search` — multiple active profiles, union base
       filter, **one** classifier call returning per-profile scores,
       `JobScore` table, per-profile alert routing (**ADR**)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -734,9 +734,9 @@ when next touching it.
 
 ## 11. Onboarding wizard + profile simplification + multi-resume search (analysis 2026-08-31)
 
-Full plan: [docs/onboarding-plan.md](./onboarding-plan.md). **Analysis
-only — nothing implemented yet** (written from a parallel session; do not
-start without checking §10's status first).
+Full plan: [docs/onboarding-plan.md](./onboarding-plan.md). **In
+progress — 4 of 7 stages shipped** (v1.5.0, v1.6.0, v1.7.0, v1.8.0); the
+checklist below is the status of record.
 
 Driver: users don't find where to create a profile or upload a resume;
 no way to verify the pipeline works from the UI; target persona for
@@ -770,9 +770,9 @@ Telegram explicitly optional.
 ## 12. /resumes overhaul + on-demand resume strength review (analysis 2026-08-31)
 
 Full plan: [docs/resumes-plan.md](./resumes-plan.md). **Analysis only —
-nothing implemented** (written from a parallel session: browser audit of
-the live page at desktop + 375px, plus code verification; do not start
-without checking §10/§11 status first).
+nothing implemented** (browser audit of the live page at desktop + 375px,
+plus code verification). Overlaps §11's resume work: check the §11
+checklist before starting.
 
 Driver: `/resumes` shows inventory, not effectiveness — no per-resume
 match signal, upload & scan freezes the browser ~60 s (double-submit
@@ -801,9 +801,8 @@ icon; progress visible step-by-step via the target-run registry pattern.
 ## 13. /target compare speed (30-40 s) + keyword-matcher accuracy (analysis 2026-08-31)
 
 Full plan: [docs/target-plan.md](./target-plan.md). **Analysis only —
-nothing implemented** (written from a parallel session; do not start
-without checking §10–§12 status first — §12's async-upload item overlaps
-the `/resumes` sync-scan finding, planned there, referenced here).
+nothing implemented.** §12's async-upload item overlaps the `/resumes`
+sync-scan finding, planned there, referenced here.
 
 Driver: a fresh-resume compare takes ~3 min (owner target: 30-40 s), and
 the JD pane skips important posting words. Verified causes: one

--- a/docs/onboarding-plan.md
+++ b/docs/onboarding-plan.md
@@ -257,6 +257,14 @@ Reorder (one PR):
 - Job page preselect: winning profile's resume when the link exists,
   `pickResumeForJob` fallback otherwise.
 
+Shipped 2026-09-02 (v1.9.0). What the build settled beyond the sketch:
+`onDelete: SetNull` on the link, so deleting a resume neither deletes the
+search nor is blocked by it — the preselect drops back to skill overlap.
+The link is editable in the profile editor ("Resume for this search"), and
+"Fill from a resume" proposes it alongside the fields it fills. Profiles
+created from a resume are born inactive (issue #50's rule, and creating a
+search must not switch the one that is running).
+
 ### Stage B — parallel search across active profiles (the big one, ADR)
 
 - Multiple **active** profiles replace the single `activeProfileId`
@@ -302,7 +310,7 @@ hand-written migrations verified through a container rebuild.
 | 2 | `fetch-now` | "Fetch now" button + `{classify: false}` seam + background run + progress page (standalone value) | — | — | smoke `fetch:once`; run visible on `/runs`; unscored jobs stored; dashboard matrix |
 | 3 | `welcome-wizard` | `/welcome` steps 1–4, redirect, skip, Overview chip | `setupCompletedAt` | — | migration via container rebuild; full wizard walkthrough on a wiped DB (docker volume rm) at 1200/375; every step's auto-complete branch |
 | 4 | `ai-key-in-db` ✅ v1.8.0 | per-engine API key in DB, masked; wizard step 1 upgrade | `aiKeys` JSONB | **0027** | probe/test with DB key and with `.env` fallback; key never logged; masked render |
-| 5 | `profile-resume-link` | Stage A | `Profile.resumeId` | — | create-from-resume flow; preselect unit test in `pick.test.ts` scope |
+| 5 | `profile-resume-link` ✅ v1.9.0 | Stage A | `Profile.resumeId` | — | create-from-resume flow; preselect unit test in `pick.test.ts` scope |
 | 6 | `multi-profile-search` | Stage B | `JobScore`, `Profile.active` | **yes** | prompt/parser unit tests; live smoke on 2 profiles; alert routing test send; jobs-list filters |
 | 7 | `applied-resume` | Stage C | 3 columns on `Job` | — | mark-applied round-trip; digest line render test |
 
@@ -336,5 +344,16 @@ resumes in one sitting.
   (not `fetch-test`), and classification follows the pause flag: paused →
   stored unscored, running → the hourly tick, just now.
 - Wizard copy voice pass (stop-slop skill) once screens exist.
-- Whether step 3 should offer multi-upload immediately or defer extra
-  resumes to `/resumes` until stage 5 lands.
+- ~~Whether step 3 should offer multi-upload immediately or defer extra
+  resumes to `/resumes`.~~ Decided in stage 5: **neither — one resume at a
+  time, and a second one only after the first search exists.** Step 3's
+  done state carries a collapsed "Another resume for a different kind of
+  role?" that takes exactly one file (or one already-uploaded resume) and
+  drafts a *second profile* from it, linked to that resume; `/resumes/:id`
+  carries the same action for every later resume. Multi-upload was
+  rejected on two counts: it would ask the user to choose which resume the
+  profile uses before they have seen a single match, and until stage B
+  lands only the active profile scores, so N uploads would produce N-1
+  searches that do nothing. The copy says so — the new search is born
+  inactive and the running one is untouched. That also keeps step 3's
+  primary path (upload → scan → "yes, that's me") at one screen.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/prisma/migrations/20260902120000_add_profile_resume/migration.sql
+++ b/prisma/migrations/20260902120000_add_profile_resume/migration.sql
@@ -1,0 +1,12 @@
+-- Stage A of the multi-resume search (docs/onboarding-plan.md §4): a profile
+-- can name the resume it hunts with, so a job page preselects that resume
+-- instead of guessing from skill overlap.
+--
+-- ON DELETE SET NULL, matching profile."telegramTargetId": a profile owns
+-- regions, thresholds, priority rules and alert routing that no resume can
+-- speak for, so deleting a resume must neither delete the search nor be
+-- blocked by it. A cleared link falls back to the skill-overlap pick.
+-- Existing rows start unlinked — that is exactly today's behaviour.
+ALTER TABLE "profile" ADD COLUMN "resumeId" INTEGER;
+ALTER TABLE "profile" ADD CONSTRAINT "profile_resumeId_fkey"
+  FOREIGN KEY ("resumeId") REFERENCES "resume"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -296,6 +296,13 @@ model Profile {
   // Where alerts for this profile go. null → broadcast to all active targets.
   telegramTargetId Int?
   telegramTarget   TelegramTarget? @relation(fields: [telegramTargetId], references: [id], onDelete: SetNull)
+  // The resume this search hunts with: "jobs I'd apply to with THIS CV".
+  // Preselects the resume on a job page (src/resume/pick.ts). SetNull, not
+  // Cascade — a profile owns regions, thresholds, rules and alert routing
+  // that no resume can speak for, so deleting the file must not delete the
+  // search; the preselect falls back to skill overlap, as before the link.
+  resumeId         Int?
+  resume           Resume?         @relation(fields: [resumeId], references: [id], onDelete: SetNull)
   createdAt        DateTime        @default(now())
   updatedAt        DateTime        @updatedAt
 
@@ -338,6 +345,8 @@ model Resume {
   updatedAt       DateTime      @updatedAt
   matches         ResumeMatch[]
   coverLetters    CoverLetter[]
+  // Searches that hunt with this resume (Profile.resumeId).
+  profiles        Profile[]
 
   @@map("resume")
 }

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -216,15 +216,18 @@ let probeCache: { at: number; statuses: Record<AiProviderId, AiProviderStatus> }
 /**
  * Which backends this host can actually run: key present for the APIs,
  * binary on PATH + detectable auth for the CLIs. Cached briefly — the
- * settings page calls it on every render.
+ * settings page calls it on every render. A caller that already holds the
+ * stored keys passes them in rather than paying for a second read.
  */
-export async function probeAiProviders(): Promise<Record<AiProviderId, AiProviderStatus>> {
+export async function probeAiProviders(
+  stored?: AiKeys,
+): Promise<Record<AiProviderId, AiProviderStatus>> {
   if (probeCache && Date.now() - probeCache.at < PROBE_TTL_MS) return probeCache.statuses;
   const [claude, gemini, codex, keys] = await Promise.all([
     probeCliBin(config.CLAUDE_CODE_BIN),
     probeCliBin(config.GEMINI_CLI_BIN),
     probeCliBin(config.CODEX_CLI_BIN),
-    readAiKeys(),
+    stored ?? readAiKeys(),
   ]);
   const from = (id: AiProviderId): AiKeySource => aiKeySource(id, keys);
   const statuses: Record<AiProviderId, AiProviderStatus> = {

--- a/src/init.ts
+++ b/src/init.ts
@@ -76,6 +76,7 @@ async function bootstrapDefaultProfile(): Promise<void> {
     ],
     notes: null,
     seniority: [],
+    resumeId: null,
     remoteOk: true,
     remoteRegions: [],
     onsiteCities: [],

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -59,6 +59,17 @@ export async function getProfile(id: number): Promise<Profile | null> {
   return prisma.profile.findUnique({ where: { id } });
 }
 
+/** The searches that hunt with a given resume — shown on that resume's page. */
+export async function listProfilesForResume(
+  resumeId: number,
+): Promise<Pick<Profile, 'id' | 'name'>[]> {
+  return prisma.profile.findMany({
+    where: { resumeId },
+    select: { id: true, name: true },
+    orderBy: { id: 'asc' },
+  });
+}
+
 export async function getActiveProfile(): Promise<Profile | null> {
   const settings = await prisma.appSettings.findUnique({
     where: { id: SETTINGS_ID },

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -20,7 +20,35 @@ export interface ProfileInput {
   minSalaryUsd: number;
   minFitScore: number;
   telegramTargetId: number | null;
+  /** The resume this search hunts with; null = pick by skill overlap. */
+  resumeId: number | null;
   priorityRules: PriorityRule[];
+}
+
+/**
+ * A profile with nothing said yet — what "New profile" creates, and the base
+ * a resume draft is measured against so every field the scan speaks for lands
+ * in the new search (src/resume/profile-draft.ts). Born inactive (issue #50).
+ */
+export function blankProfileInput(): ProfileInput {
+  return {
+    name: 'New profile',
+    stackRequired: [],
+    roleTypes: [],
+    stackNiceToHave: [],
+    stackExclude: ['junior', 'intern'],
+    notes: null,
+    seniority: [],
+    remoteOk: true,
+    remoteRegions: [],
+    onsiteCities: [],
+    hybridOk: false,
+    minSalaryUsd: 0,
+    minFitScore: 70,
+    telegramTargetId: null,
+    resumeId: null,
+    priorityRules: [],
+  };
 }
 
 export async function listProfiles(): Promise<Profile[]> {

--- a/src/resume/pick.test.ts
+++ b/src/resume/pick.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { countSkillHits, pickResumeForJob } from './pick';
+import { countSkillHits, pickResumeForJob, preselectResume } from './pick';
 
 test('countSkillHits matches whole tokens only', () => {
   const text = 'Senior PHP/Laravel engineer. We use Node.js, C++, CI/CD and PostgreSQL.';
@@ -23,4 +23,19 @@ test('pickResumeForJob prefers the most overlapping resume, then the default, th
     1,
   );
   assert.equal(pickResumeForJob([], 'anything'), null);
+});
+
+test('preselectResume puts the profile link ahead of the overlap heuristic', () => {
+  const resumes = [
+    { id: 1, skills: ['php', 'laravel'], isDefault: true },
+    { id: 2, skills: ['go'], isDefault: false },
+  ];
+  const laravelJob = 'Laravel engineer, PHP 8';
+  // No link → today's behaviour, unchanged.
+  assert.equal(preselectResume(resumes, laravelJob, null)?.id, 1);
+  // Linked → wins even when the other resume overlaps the posting and is default.
+  assert.equal(preselectResume(resumes, laravelJob, 2)?.id, 2);
+  // Link to a resume that is gone (deleted, or hidden scratch) → fall back.
+  assert.equal(preselectResume(resumes, laravelJob, 99)?.id, 1);
+  assert.equal(preselectResume([], laravelJob, 2), null);
 });

--- a/src/resume/pick.ts
+++ b/src/resume/pick.ts
@@ -23,6 +23,22 @@ export function pickResumeForJob<T extends PickableResume>(resumes: T[], jobText
   return scored[0]?.r ?? null;
 }
 
+/**
+ * What a job page preselects. A profile that names its resume has already
+ * answered the question — "this search hunts jobs I'd apply to with THIS CV"
+ * (docs/onboarding-plan.md §4) — so the link wins over the heuristic. A link
+ * to a resume that is gone or hidden falls back to the overlap pick, which is
+ * also what every unlinked profile gets.
+ */
+export function preselectResume<T extends PickableResume>(
+  resumes: T[],
+  jobText: string,
+  linkedResumeId: number | null,
+): T | null {
+  const linked = resumes.find((r) => r.id === linkedResumeId);
+  return linked ?? pickResumeForJob(resumes, jobText);
+}
+
 /** Number of skill tags that appear in the text as whole tokens. Exported for tests. */
 export function countSkillHits(skills: string[], text: string): number {
   const haystack = tokenise(text);

--- a/src/resume/profile-draft.test.ts
+++ b/src/resume/profile-draft.test.ts
@@ -68,3 +68,22 @@ test('unknown seniority and empty scan lists are ignored', () => {
   assert.deepEqual(d.changed, []);
   assert.equal(d.warnings.length, 1);
 });
+
+test('a blank base takes everything the scan speaks for — the new-profile case', () => {
+  const blank = { name: 'New profile', stackRequired: [], stackNiceToHave: [], roleTypes: [], seniority: [] };
+  const d = buildProfileDraft(blank, {
+    title: 'Senior Backend Engineer',
+    seniority: 'senior',
+    skills: ['PHP', 'Laravel', 'Redis'],
+    primarySkills: ['PHP', 'Laravel'],
+    roleTypes: ['backend'],
+  });
+  assert.deepEqual(d.changes, {
+    name: 'Senior Backend Engineer',
+    stackRequired: ['PHP', 'Laravel'],
+    stackNiceToHave: ['Redis'],
+    roleTypes: ['backend'],
+    seniority: ['senior'],
+  });
+  assert.equal(d.warnings.length, 0);
+});

--- a/src/web/pages/cover-letter-card.tsx
+++ b/src/web/pages/cover-letter-card.tsx
@@ -17,6 +17,8 @@ export interface CoverLetterCardProps {
   resumes: { id: number; name: string; isDefault: boolean }[];
   /** Best skill overlap for this posting — preselected, same as the match card. */
   suggestedResumeId: number | null;
+  /** Why that one is preselected: the search names it, or it overlaps the posting most. */
+  suggestedReason: 'linked' | 'overlap';
   letters: CoverLetterWithResume[];
   selected: CoverLetterWithResume | null;
   /** A stored verification snapshot exists — company facts beyond the posting. */
@@ -38,6 +40,7 @@ export const CoverLetterCard: FC<CoverLetterCardProps> = ({
   jobId,
   resumes,
   suggestedResumeId,
+  suggestedReason,
   letters,
   selected,
   hasCompanyFacts,
@@ -64,7 +67,11 @@ export const CoverLetterCard: FC<CoverLetterCardProps> = ({
                 {resumes.map((r) => (
                   <option value={r.id} selected={r.id === (suggestedResumeId ?? resumes[0]?.id)}>
                     {r.name}
-                    {r.id === suggestedResumeId ? ' · best skill overlap' : ''}
+                    {r.id === suggestedResumeId
+                      ? suggestedReason === 'linked'
+                        ? ' · your search hunts with this'
+                        : ' · best skill overlap'
+                      : ''}
                     {r.isDefault ? ' · default' : ''}
                   </option>
                 ))}

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -286,7 +286,7 @@ const SearchCard: FC<ResumeDetailProps['search'] & { resumeId: number }> = ({
             jobs you'd apply to with this resume:
           </p>
           <div class="mt-2.5 flex flex-wrap items-center gap-1.5 text-sm">
-            <span class="font-medium text-ink">"{draft.changes.name ?? 'New profile'}"</span>
+            <span class="font-medium text-ink">"{draft.changes.name}"</span>
             {(draft.changes.stackRequired ?? []).map((t) => (
               <Tag tone="ok">{t}</Tag>
             ))}

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -26,16 +26,28 @@ import { formatDate, formatRelative } from '../format';
 import type { MatchWithJob, ResumeSummary } from '../../resume/store';
 import { readIssues } from '../../resume/prompts';
 import type { ParseWarning } from '../../resume/parse-warnings';
+import type { ProfileDraft } from '../../resume/profile-draft';
 
 export interface ResumeDetailProps {
   resume: ResumeSummary;
   matches: MatchWithJob[];
   /** Deterministic ATS-parseability checks over the extracted text. */
   warnings: ParseWarning[];
+  /** Searches already linked to this resume, and the one a click would create. */
+  search: {
+    linkedProfiles: { id: number; name: string }[];
+    draft: ProfileDraft | null;
+  };
   flash?: FlashMessage | null;
 }
 
-export const ResumeDetailPage: FC<ResumeDetailProps> = ({ resume, matches, warnings, flash }) => {
+export const ResumeDetailPage: FC<ResumeDetailProps> = ({
+  resume,
+  matches,
+  warnings,
+  search,
+  flash,
+}) => {
   const issues = readIssues(resume.issues);
   return (
     <Layout title={resume.name} active="resumes">
@@ -128,6 +140,8 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({ resume, matches, warni
           )}
         </Card>
       </div>
+
+      <SearchCard resumeId={resume.id} scanned={resume.scannedAt !== null} {...search} />
 
       <Card class="mt-4">
         <SectionTitle>Upload a new version</SectionTitle>
@@ -226,6 +240,83 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({ resume, matches, warni
         </details>
       </Card>
     </Layout>
+  );
+};
+
+/**
+ * Stage A of the multi-resume search: one press turns a scanned resume into a
+ * search that hunts the jobs you'd apply to with it. The draft is shown in
+ * full first — the button saves exactly what the line above it says (ADR 0015).
+ */
+const SearchCard: FC<ResumeDetailProps['search'] & { resumeId: number; scanned: boolean }> = ({
+  resumeId,
+  scanned,
+  linkedProfiles,
+  draft,
+}) => {
+  const c = draft?.changes;
+  return (
+    <Card class="mt-4">
+      <SectionTitle>Search profile</SectionTitle>
+      {linkedProfiles.length > 0 && (
+        <p class="text-sm text-ink">
+          This resume is what{' '}
+          {linkedProfiles.map((p, i) => (
+            <>
+              {i > 0 && ', '}
+              <a
+                href={`/settings?tab=profile&profile=${p.id}`}
+                class="font-medium text-accent-strong hover:underline"
+              >
+                {p.name}
+              </a>
+            </>
+          ))}{' '}
+          {linkedProfiles.length === 1 ? 'hunts with' : 'hunt with'} — job pages preselect it for
+          those searches.
+        </p>
+      )}
+      {!scanned ? (
+        <Hint class={linkedProfiles.length > 0 ? 'mt-3' : ''}>
+          Scan the resume first — a search is built from the headline, tools and roles the scan
+          finds.
+        </Hint>
+      ) : (
+        <>
+          <p class={`text-sm text-ink-muted ${linkedProfiles.length > 0 ? 'mt-3' : ''}`}>
+            {linkedProfiles.length > 0 ? 'Add another search' : 'Create a search'} that hunts the
+            jobs you'd apply to with this resume:
+          </p>
+          <div class="mt-2.5 flex flex-wrap items-center gap-1.5 text-sm">
+            <span class="font-medium text-ink">"{c?.name ?? 'New profile'}"</span>
+            {(c?.stackRequired ?? []).map((t) => (
+              <Tag tone="ok">{t}</Tag>
+            ))}
+            {(c?.roleTypes ?? []).map((t) => (
+              <Tag tone="info">{t}</Tag>
+            ))}
+            {(c?.seniority ?? []).map((t) => (
+              <Tag tone="info">{t}</Tag>
+            ))}
+          </div>
+          {(draft?.warnings ?? []).length > 0 && (
+            <p class="mt-2 text-[13px] leading-5 text-warn">Note: {draft?.warnings.join('; ')}.</p>
+          )}
+          <div class="mt-3.5">
+            <ActionForm action={`/resumes/${resumeId}/profile`}>
+              <Button variant="violet" size="sm">
+                Create a search from this resume
+              </Button>
+            </ActionForm>
+          </div>
+          <Hint class="mt-3">
+            It starts switched off — your current search keeps running until you press Activate on
+            Settings → Profile. Location, salary and alert routing are yours to set; a resume
+            cannot know them.
+          </Hint>
+        </>
+      )}
+    </Card>
   );
 };
 

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -141,7 +141,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
         </Card>
       </div>
 
-      <SearchCard resumeId={resume.id} scanned={resume.scannedAt !== null} {...search} />
+      <SearchCard resumeId={resume.id} {...search} />
 
       <Card class="mt-4">
         <SectionTitle>Upload a new version</SectionTitle>
@@ -248,13 +248,11 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
  * search that hunts the jobs you'd apply to with it. The draft is shown in
  * full first — the button saves exactly what the line above it says (ADR 0015).
  */
-const SearchCard: FC<ResumeDetailProps['search'] & { resumeId: number; scanned: boolean }> = ({
+const SearchCard: FC<ResumeDetailProps['search'] & { resumeId: number }> = ({
   resumeId,
-  scanned,
   linkedProfiles,
   draft,
 }) => {
-  const c = draft?.changes;
   return (
     <Card class="mt-4">
       <SectionTitle>Search profile</SectionTitle>
@@ -276,7 +274,7 @@ const SearchCard: FC<ResumeDetailProps['search'] & { resumeId: number; scanned: 
           those searches.
         </p>
       )}
-      {!scanned ? (
+      {draft === null ? (
         <Hint class={linkedProfiles.length > 0 ? 'mt-3' : ''}>
           Scan the resume first — a search is built from the headline, tools and roles the scan
           finds.
@@ -288,19 +286,19 @@ const SearchCard: FC<ResumeDetailProps['search'] & { resumeId: number; scanned: 
             jobs you'd apply to with this resume:
           </p>
           <div class="mt-2.5 flex flex-wrap items-center gap-1.5 text-sm">
-            <span class="font-medium text-ink">"{c?.name ?? 'New profile'}"</span>
-            {(c?.stackRequired ?? []).map((t) => (
+            <span class="font-medium text-ink">"{draft.changes.name ?? 'New profile'}"</span>
+            {(draft.changes.stackRequired ?? []).map((t) => (
               <Tag tone="ok">{t}</Tag>
             ))}
-            {(c?.roleTypes ?? []).map((t) => (
+            {(draft.changes.roleTypes ?? []).map((t) => (
               <Tag tone="info">{t}</Tag>
             ))}
-            {(c?.seniority ?? []).map((t) => (
+            {(draft.changes.seniority ?? []).map((t) => (
               <Tag tone="info">{t}</Tag>
             ))}
           </div>
-          {(draft?.warnings ?? []).length > 0 && (
-            <p class="mt-2 text-[13px] leading-5 text-warn">Note: {draft?.warnings.join('; ')}.</p>
+          {draft.warnings.length > 0 && (
+            <p class="mt-2 text-[13px] leading-5 text-warn">Note: {draft.warnings.join('; ')}.</p>
           )}
           <div class="mt-3.5">
             <ActionForm action={`/resumes/${resumeId}/profile`}>

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -36,6 +36,8 @@ export interface ResumeMatchCardProps {
   resumes: { id: number; name: string; isDefault: boolean }[];
   /** Best skill overlap for this posting — preselected in the dropdown. */
   suggestedResumeId: number | null;
+  /** Why that one is preselected: the search names it, or it overlaps the posting most. */
+  suggestedReason: 'linked' | 'overlap';
   matches: MatchWithResume[];
   selected: MatchWithResume | null;
 }
@@ -71,6 +73,7 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
   jobId,
   resumes,
   suggestedResumeId,
+  suggestedReason,
   matches,
   selected,
 }) => (
@@ -93,7 +96,11 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
               {resumes.map((r) => (
                 <option value={r.id} selected={r.id === (suggestedResumeId ?? resumes[0]?.id)}>
                   {r.name}
-                  {r.id === suggestedResumeId ? ' · best skill overlap' : ''}
+                  {r.id === suggestedResumeId
+                    ? suggestedReason === 'linked'
+                      ? ' · your search hunts with this'
+                      : ' · best skill overlap'
+                    : ''}
                   {r.isDefault ? ' · default' : ''}
                 </option>
               ))}

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -307,6 +307,7 @@ export const SettingsPage: FC<SettingsProps> = ({
             <ProfileEditor
               profile={activeProfile}
               availableTargets={availableTargets}
+              resumes={resumes}
               draft={profileDraft}
             />
           </Card>
@@ -903,8 +904,9 @@ const ModelPicker: FC<{
 const ProfileEditor: FC<{
   profile: Profile;
   availableTargets: AvailableTarget[];
+  resumes: ResumeListItem[];
   draft?: ProfileDraftNotice | null;
-}> = ({ profile, availableTargets, draft }) => {
+}> = ({ profile, availableTargets, resumes, draft }) => {
   const rulesCount = parsePriorityRules(profile.priorityRules).length;
   // Open the advanced block only when free-form content lives in it. Salary
   // and the Telegram target deliberately don't count — init.ts seeds a salary
@@ -934,9 +936,27 @@ const ProfileEditor: FC<{
         re-classify".
       </div>
     )}
-    <Field label="Name" class="max-w-md">
-      <Input type="text" name="name" required value={profile.name} />
-    </Field>
+    <div class="grid gap-4 sm:grid-cols-2">
+      <Field label="Name">
+        <Input type="text" name="name" required value={profile.name} />
+      </Field>
+      <Field
+        label="Resume for this search"
+        hint="Preselected on every job page this search finds. Leave unset to pick by skill overlap."
+      >
+        <Select name="resumeId">
+          <option value="" selected={profile.resumeId === null}>
+            (pick by skill overlap)
+          </option>
+          {resumes.map((r) => (
+            <option value={r.id} selected={profile.resumeId === r.id}>
+              {r.name}
+              {r.isDefault ? ' (default)' : ''}
+            </option>
+          ))}
+        </Select>
+      </Field>
+    </div>
 
     <fieldset class="space-y-4">
       <legend class="text-[13px] font-medium text-ink">What are we hunting for?</legend>

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -937,7 +937,7 @@ const ProfileEditor: FC<{
       </div>
     )}
     <div class="grid gap-4 sm:grid-cols-2">
-      <Field label="Name">
+      <Field label="Name" hint="What you call this search — yours alone, nothing reads it.">
         <Input type="text" name="name" required value={profile.name} />
       </Field>
       <Field

--- a/src/web/pages/welcome.tsx
+++ b/src/web/pages/welcome.tsx
@@ -49,6 +49,10 @@ export interface LastSearch {
 }
 
 export interface ProfileDraftCard {
+  /** true = the card offers a second search; false = it fills the active profile. */
+  asNew: boolean;
+  /** What the search would be called — the resume's headline, usually. */
+  profileName: string;
   resumeId: number;
   resumeName: string;
   title: string | null;
@@ -401,28 +405,53 @@ const ProfileStep: FC<WelcomeProps> = ({ profile, steps }) => {
               </>
             )}
             {d.skillCount > 0 && <>, plus {d.skillCount} more skills</>}.{' '}
-            We'll hunt for{d.seniority ? ` ${d.seniority}` : ''}{' '}
+            {d.asNew ? (
+              <>
+                The second search would be called{' '}
+                <span class="font-medium">"{d.profileName}"</span> and hunt for
+              </>
+            ) : (
+              <>We'll hunt for</>
+            )}
+            {d.seniority ? ` ${d.seniority}` : ''}{' '}
             {d.roleTypes.length > 0 ? d.roleTypes.join(' / ') : 'matching'} roles using these.
           </p>
           {d.warnings.length > 0 && (
             <p class="mt-2 text-[13px] leading-5 text-warn">Note: {d.warnings.join('; ')}.</p>
           )}
           <div class="mt-4 flex flex-wrap items-center gap-2">
-            {d.changed.length > 0 ? (
-              <ActionForm action="/welcome/profile/apply" hidden={{ resumeId: d.resumeId }}>
-                <Button>Yes, that's me — start matching</Button>
-              </ActionForm>
+            {d.asNew ? (
+              <>
+                <ActionForm action="/welcome/profile/create" hidden={{ resumeId: d.resumeId }}>
+                  <Button>Create this second search</Button>
+                </ActionForm>
+                <Button href="/welcome?step=profile" variant="secondary">
+                  Cancel
+                </Button>
+              </>
             ) : (
-              <Button href="/welcome?step=matches">Continue →</Button>
+              <>
+                {d.changed.length > 0 ? (
+                  <ActionForm action="/welcome/profile/apply" hidden={{ resumeId: d.resumeId }}>
+                    <Button>Yes, that's me — start matching</Button>
+                  </ActionForm>
+                ) : (
+                  <Button href="/welcome?step=matches">Continue →</Button>
+                )}
+                <ActionForm
+                  action={`/settings/profiles/${profile.id}/fill-from-resume`}
+                  hidden={{ resumeId: d.resumeId }}
+                >
+                  <Button variant="secondary">Let me adjust</Button>
+                </ActionForm>
+              </>
             )}
-            <ActionForm
-              action={`/settings/profiles/${profile.id}/fill-from-resume`}
-              hidden={{ resumeId: d.resumeId }}
-            >
-              <Button variant="secondary">Let me adjust</Button>
-            </ActionForm>
           </div>
-          <Hint class="mt-3">Nothing is saved until you press one of these.</Hint>
+          <Hint class="mt-3">
+            {d.asNew
+              ? 'Nothing is saved until you press Create. The search you already set up keeps running — switch to the new one on Settings → Profile.'
+              : 'Nothing is saved until you press one of these.'}
+          </Hint>
         </>
       ) : done ? (
         <>
@@ -438,6 +467,48 @@ const ProfileStep: FC<WelcomeProps> = ({ profile, steps }) => {
               Adjust in Settings
             </Button>
           </div>
+          <details class="mt-5 rounded-md border border-line">
+            <summary class="cursor-pointer select-none px-4 py-2.5 text-[13px] font-medium text-ink hover:text-accent-strong">
+              Another resume for a different kind of role?
+            </summary>
+            <div class="space-y-3 border-t border-line px-4 py-4">
+              <Hint class="!mt-0">
+                It becomes a second search of its own, linked to that resume — one search per
+                resume. Only one runs at a time; you switch between them on Settings → Profile.
+              </Hint>
+              <form
+                method="post"
+                action="/welcome/resume"
+                enctype="multipart/form-data"
+                class="flex flex-wrap items-end gap-3"
+              >
+                <input type="hidden" name="mode" value="new" />
+                <Field label="Another resume" class="min-w-0 flex-1">
+                  <input
+                    type="file"
+                    name="file"
+                    accept={ACCEPTED_EXTENSIONS.join(',')}
+                    required
+                    class={`block w-full text-sm text-ink-muted ${FILE_INPUT_CLASS}`}
+                  />
+                </Field>
+                <Button variant="secondary">Upload &amp; read it</Button>
+              </form>
+              {profile.resumes.length > 0 && (
+                <form method="post" action="/welcome/resume" class="flex flex-wrap items-end gap-3">
+                  <input type="hidden" name="mode" value="new" />
+                  <Field label="…or one you already uploaded" class="min-w-0 flex-1">
+                    <Select name="resumeId">
+                      {profile.resumes.map((r) => (
+                        <option value={r.id}>{r.name}</option>
+                      ))}
+                    </Select>
+                  </Field>
+                  <Button variant="secondary">Use this resume</Button>
+                </form>
+              )}
+            </div>
+          </details>
         </>
       ) : (
         <>

--- a/src/web/profile-from-resume.ts
+++ b/src/web/profile-from-resume.ts
@@ -23,8 +23,12 @@ export function scanFields(resume: ResumeSummary): ScanForDraft {
   };
 }
 
+/** The draft a "create a search" button would save. `changes.name` is always set. */
 export function newProfileDraft(resume: ResumeSummary): ProfileDraft {
-  return buildProfileDraft(blankProfileInput(), scanFields(resume));
+  const draft = buildProfileDraft(blankProfileInput(), scanFields(resume));
+  // A scan with no headline leaves the base name, "New profile" — the resume's
+  // own name says more, and the user renames either one in the editor.
+  return { ...draft, changes: { ...draft.changes, name: draft.changes.name ?? resume.name } };
 }
 
 /**

--- a/src/web/profile-from-resume.ts
+++ b/src/web/profile-from-resume.ts
@@ -1,0 +1,41 @@
+/*
+ * "Create a search from this resume" — shared by /resumes/:id and the wizard's
+ * step 3. Stage A of the multi-resume search (docs/onboarding-plan.md §4).
+ *
+ * ADR 0015 still holds: the page renders the draft, and only the POST that a
+ * user presses writes a row. The draft is measured against a blank profile,
+ * not the active one, so a brand-new search takes everything the scan speaks
+ * for instead of only what differs from the search already running.
+ */
+import type { Profile } from '@prisma/client';
+import { blankProfileInput, createProfile } from '../profiles';
+import { buildProfileDraft, type ProfileDraft, type ScanForDraft } from '../resume/profile-draft';
+import type { ResumeSummary } from '../resume/store';
+
+/** The scan fields a profile can be drafted from. */
+export function scanFields(resume: ResumeSummary): ScanForDraft {
+  return {
+    title: resume.title,
+    seniority: resume.seniority,
+    skills: resume.skills,
+    primarySkills: resume.primarySkills,
+    roleTypes: resume.roleTypes,
+  };
+}
+
+export function newProfileDraft(resume: ResumeSummary): ProfileDraft {
+  return buildProfileDraft(blankProfileInput(), scanFields(resume));
+}
+
+/**
+ * Born inactive, like every other new profile (issue #50): creating a search
+ * must never silently switch the one the pipeline is scoring against. The
+ * user activates it on /settings → Profile when they want to hunt with it.
+ */
+export async function createProfileFromResume(resume: ResumeSummary): Promise<Profile> {
+  return createProfile({
+    ...blankProfileInput(),
+    ...newProfileDraft(resume).changes,
+    resumeId: resume.id,
+  });
+}

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -219,11 +219,9 @@ jobsRoute.get('/jobs/:id', async (c) => {
   // Stage A of the multi-resume search: the profile doing the hunting is the
   // active one, and its linked resume wins the preselect (§4 of the plan).
   // Stage B replaces "active" with the profile that scored this job best.
-  const suggested = preselectResume(
-    resumes,
-    `${job.title} ${job.description}`,
-    activeProfile?.resumeId ?? null,
-  );
+  const linkedResumeId = activeProfile?.resumeId ?? null;
+  const suggested = preselectResume(resumes, `${job.title} ${job.description}`, linkedResumeId);
+  const suggestedReason = suggested && suggested.id === linkedResumeId ? 'linked' : 'overlap';
 
   const flashCookie = parseFlashCookie(c.req.header('cookie'));
   return c.html(
@@ -237,6 +235,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
         jobId: id,
         resumes: resumes.map((r) => ({ id: r.id, name: r.name, isDefault: r.isDefault })),
         suggestedResumeId: suggested?.id ?? null,
+        suggestedReason,
         matches,
         selected,
       }}
@@ -244,6 +243,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
         jobId: id,
         resumes: resumes.map((r) => ({ id: r.id, name: r.name, isDefault: r.isDefault })),
         suggestedResumeId: suggested?.id ?? null,
+        suggestedReason,
         letters,
         selected: selectedLetter,
         hasCompanyFacts: Boolean(verifications[0]?.companySnapshot?.trim()),

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -35,7 +35,7 @@ import {
   updateCoverLetterEdit,
   upsertScratchResume,
 } from '../../resume/store';
-import { pickResumeForJob } from '../../resume/pick';
+import { preselectResume } from '../../resume/pick';
 import { matchResumeToJob } from '../../resume/match';
 import { generateCoverLetter } from '../../resume/cover-letter';
 import {
@@ -187,7 +187,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
 
-  const [job, settings, resumes, matches, verifications, letters] = await Promise.all([
+  const [job, settings, resumes, matches, verifications, letters, activeProfile] = await Promise.all([
     prisma.job.findUnique({
       where: { id },
       include: {
@@ -207,6 +207,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
     listMatchesForJob(id),
     listVerificationsForJob(id),
     listCoverLettersForJob(id),
+    getActiveProfile(),
   ]);
   if (!job) return c.text('Not found', 404);
 
@@ -215,7 +216,14 @@ jobsRoute.get('/jobs/:id', async (c) => {
   const selected = matches.find((m) => m.id === requestedMatch) ?? matches[0] ?? null;
   const requestedLetter = Number(c.req.query('letter'));
   const selectedLetter = letters.find((l) => l.id === requestedLetter) ?? letters[0] ?? null;
-  const suggested = pickResumeForJob(resumes, `${job.title} ${job.description}`);
+  // Stage A of the multi-resume search: the profile doing the hunting is the
+  // active one, and its linked resume wins the preselect (§4 of the plan).
+  // Stage B replaces "active" with the profile that scored this job best.
+  const suggested = preselectResume(
+    resumes,
+    `${job.title} ${job.description}`,
+    activeProfile?.resumeId ?? null,
+  );
 
   const flashCookie = parseFlashCookie(c.req.header('cookie'));
   return c.html(

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -17,6 +17,8 @@ import {
   setDefaultResume,
 } from '../../resume/store';
 import { parseWarnings } from '../../resume/parse-warnings';
+import { listProfilesForResume } from '../../profiles';
+import { createProfileFromResume, newProfileDraft } from '../profile-from-resume';
 import { ResumeDetailPage } from '../pages/resume-detail';
 import { ResumesPage } from '../pages/resumes';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
@@ -79,13 +81,23 @@ resumesRoute.post('/resumes/:id/replace', resumeUploadLimit('/resumes'), async (
 resumesRoute.get('/resumes/:id', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
-  const [resume, matches] = await Promise.all([getResume(id), listMatchesForResume(id)]);
+  const [resume, matches, linkedProfiles] = await Promise.all([
+    getResume(id),
+    listMatchesForResume(id),
+    listProfilesForResume(id),
+  ]);
   if (!resume) return c.text('Not found', 404);
   return c.html(
     <ResumeDetailPage
       resume={resume}
       matches={matches}
       warnings={parseWarnings(resume.text)}
+      // The draft the "Create a search" button would save — rendered, not
+      // stored (ADR 0015). Only a scanned resume has anything to say.
+      search={{
+        linkedProfiles,
+        draft: resume.scannedAt ? newProfileDraft(resume) : null,
+      }}
       flash={parseFlashCookie(c.req.header('cookie'))}
     />,
     200,
@@ -142,6 +154,27 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
     `/resumes/${id}`,
     scan ? 'ok' : 'err',
     scan ? `Saved as v${resume.version} (text version).` : `Saved as v${resume.version}, but the scan failed — try "Scan".`,
+  );
+});
+
+/**
+ * "Create a search from this resume" — the card above the button already
+ * showed exactly what this writes, so one press is enough (ADR 0015).
+ */
+resumesRoute.post('/resumes/:id/profile', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!Number.isFinite(id)) return c.text('Bad id', 400);
+  const resume = await getResume(id);
+  if (!resume || resume.hidden) return c.text('Not found', 404);
+  if (!resume.scannedAt) {
+    return flashRedirect(`/resumes/${id}`, 'err', 'Scan the resume first — the search is built from the scan.');
+  }
+  const profile = await createProfileFromResume(resume);
+  logger.info({ profileId: profile.id, resumeId: id }, 'profile: created from resume');
+  return flashRedirect(
+    `/settings?tab=profile&profile=${profile.id}`,
+    'ok',
+    `Created the search "${profile.name}" from "${resume.name}". It is not hunting yet — press Activate to switch to it.`,
   );
 });
 

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -96,7 +96,7 @@ resumesRoute.get('/resumes/:id', async (c) => {
       // stored (ADR 0015). Only a scanned resume has anything to say.
       search={{
         linkedProfiles,
-        draft: resume.scannedAt ? newProfileDraft(resume) : null,
+        draft: resume.scannedAt && !resume.hidden ? newProfileDraft(resume) : null,
       }}
       flash={parseFlashCookie(c.req.header('cookie'))}
     />,

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -56,6 +56,7 @@ import {
 } from '../../ai-keys';
 import { testAiEngine } from '../ai-test';
 import {
+  blankProfileInput,
   createProfile,
   deleteProfile,
   getActiveProfile,
@@ -103,6 +104,7 @@ const ProfileFormSchema = z.object({
   minSalaryUsd: z.coerce.number().int().min(0).default(0),
   minFitScore: z.coerce.number().int().min(0).max(100).default(70),
   telegramTargetId: z.string().optional().default(''),
+  resumeId: z.string().optional().default(''),
   priorityRules: z.string().optional().default(''),
   action: z.string().optional(),
 });
@@ -628,23 +630,7 @@ settingsRoute.post('/settings/targets/:id/test', async (c) => {
 // --- Profiles ---------------------------------------------------------------
 
 settingsRoute.post('/settings/profiles/new', async (c) => {
-  const profile = await createProfile({
-    name: 'New profile',
-    stackRequired: [],
-    roleTypes: [],
-    stackNiceToHave: [],
-    stackExclude: ['junior', 'intern'],
-    notes: null,
-    seniority: [],
-    remoteOk: true,
-    remoteRegions: [],
-    onsiteCities: [],
-    hybridOk: false,
-    minSalaryUsd: 0,
-    minFitScore: 70,
-    telegramTargetId: null,
-    priorityRules: [],
-  });
+  const profile = await createProfile(blankProfileInput());
   // Born inactive (issue #50): a blank profile must never become the
   // scoring profile. The first save with real content activates it.
   return flashRedirect(
@@ -722,10 +708,8 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
   }
   const f = parsed.data;
 
-  const telegramTargetId =
-    f.telegramTargetId && f.telegramTargetId.length > 0
-      ? Number(f.telegramTargetId)
-      : null;
+  const telegramTargetId = optionalId(f.telegramTargetId);
+  const resumeId = optionalId(f.resumeId);
 
   const { rules: priorityRules, errors: priorityErrors } =
     parsePriorityRulesText(f.priorityRules);
@@ -752,10 +736,8 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
     hybridOk: f.hybridOk === '1',
     minSalaryUsd: f.minSalaryUsd,
     minFitScore: f.minFitScore,
-    telegramTargetId:
-      telegramTargetId !== null && Number.isFinite(telegramTargetId)
-        ? telegramTargetId
-        : null,
+    telegramTargetId,
+    resumeId,
     priorityRules,
   };
   await updateProfile(id, input);
@@ -880,6 +862,12 @@ settingsRoute.post(
 // --- Re-classify ------------------------------------------------------------
 // Reached only through "Save & re-classify" in the profile editor — the
 // standalone top-row button was removed (docs/onboarding-plan.md §3).
+
+/** An optional `<select>` of row ids: "" (the "none" option) and junk both mean null. */
+function optionalId(value: string): number | null {
+  const n = Number(value);
+  return value.length > 0 && Number.isFinite(n) ? n : null;
+}
 
 function triggerReclassifyAsync(): void {
   if (reclassifyInFlight) return;

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -834,7 +834,10 @@ settingsRoute.post(
     primarySkills: resume.primarySkills,
     roleTypes: resume.roleTypes,
   });
-  if (draft.changed.length === 0) {
+  // Filling from a resume also proposes it as the search's resume — same
+  // review-then-save contract (ADR 0015): the select below carries it.
+  const linking = profile.resumeId !== resume.id;
+  if (draft.changed.length === 0 && !linking) {
     const note = draft.warnings[0] ? ` — ${draft.warnings[0]}` : '';
     return flashRedirect(
       '/settings?tab=profile',
@@ -849,10 +852,10 @@ settingsRoute.post(
       {...props}
       activeTab="profile"
       flash={null}
-      activeProfile={{ ...profile, ...draft.changes }}
+      activeProfile={{ ...profile, ...draft.changes, resumeId: resume.id }}
       profileDraft={{
         resumeName: resume.name,
-        changed: draft.changed,
+        changed: linking ? [...draft.changed, 'resume for this search'] : draft.changed,
         warnings: draft.warnings,
       }}
     />,

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -869,7 +869,7 @@ settingsRoute.post(
 /** An optional `<select>` of row ids: "" (the "none" option) and junk both mean null. */
 function optionalId(value: string): number | null {
   const n = Number(value);
-  return value.length > 0 && Number.isFinite(n) ? n : null;
+  return Number.isInteger(n) && n > 0 ? n : null;
 }
 
 function triggerReclassifyAsync(): void {

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -124,15 +124,16 @@ export const settingsRoute = new Hono();
 /** Everything the settings page needs except activeTab/flash/profileDraft —
  *  shared by the GET and by POSTs that render a draft instead of redirecting. */
 async function loadSettingsProps() {
-  const [settings, targets, profiles, active, resumes, aiStatuses, aiKeys, stageCounts] =
+  // The keys are read once and lent to the probe — both need them (ADR 0027).
+  const aiKeys = await getAiKeys();
+  const [settings, targets, profiles, active, resumes, aiStatuses, stageCounts] =
     await Promise.all([
       getSettings(),
       listTelegramTargets(),
       listProfiles(),
       getActiveProfile(),
       listResumes(),
-      probeAiProviders(),
-      getAiKeys(),
+      probeAiProviders(aiKeys),
       prisma.job.groupBy({
         by: ['pipelineStage'],
         _count: { _all: true },

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -362,6 +362,7 @@ function profileInput(p: Profile): ProfileInput {
     minSalaryUsd: p.minSalaryUsd,
     minFitScore: p.minFitScore,
     telegramTargetId: p.telegramTargetId,
+    resumeId: p.resumeId,
     priorityRules: parsePriorityRules(p.priorityRules),
   };
 }

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import { CronRunStatus, JobStatus, type Profile } from '@prisma/client';
 import { prisma } from '../../db';
 import { getAiKeys, setAiKey, setFetchingEnabled, setSetupCompleted } from '../../settings';
-import { blankProfileInput, updateProfile, type ProfileInput } from '../../profiles';
+import { updateProfile, type ProfileInput } from '../../profiles';
 import { passesBaseFilter } from '../../filter';
 import { parsePriorityRules } from '../../priority-rules';
 import { parseTagList, toStringArray } from '../../text-utils';
@@ -22,7 +22,7 @@ import {
   SENIORITY_LEVELS,
   type ProfileForDraft,
 } from '../../resume/profile-draft';
-import { createProfileFromResume, scanFields } from '../profile-from-resume';
+import { createProfileFromResume, newProfileDraft, scanFields } from '../profile-from-resume';
 import { recordCronRun, type CronStats } from '../../jobs/cron-run';
 import { runScoreUnscored, SCORE_BATCH } from '../../jobs/reclassify-job';
 import { activeFetchRun } from '../fetch-runs';
@@ -79,9 +79,7 @@ welcomeRoute.get('/welcome', async (c) => {
   const resumeId = Number(c.req.query('resume'));
   const asNew = c.req.query('mode') === 'new';
   const draftResume = Number.isFinite(resumeId) && profile ? await getResume(resumeId) : null;
-  const draft = draftResume && profile
-    ? draftCard(asNew ? blankProfileInput() : profile, draftResume, asNew)
-    : null;
+  const draft = draftResume && profile ? draftCard(profile, draftResume, asNew) : null;
 
   return c.html(
     <WelcomePage
@@ -348,17 +346,18 @@ async function countWaitingUnscored(profile: Profile): Promise<number> {
   return rows.filter((j) => passesBaseFilter(j, profile)).length;
 }
 
+/** asNew drafts a second search off a blank base; otherwise it fills `profile`. */
 function draftCard(
-  base: ProfileForDraft,
+  profile: ProfileForDraft,
   resume: ResumeSummary,
   asNew: boolean,
 ): ProfileDraftCard | null {
   if (!resume.scannedAt || resume.hidden) return null;
-  const draft = buildProfileDraft(base, scanFields(resume));
+  const draft = asNew ? newProfileDraft(resume) : buildProfileDraft(profile, scanFields(resume));
   const primary = draft.changes.stackRequired ?? resume.primarySkills;
   return {
     asNew,
-    profileName: draft.changes.name ?? base.name,
+    profileName: draft.changes.name ?? profile.name,
     resumeId: resume.id,
     resumeName: resume.name,
     title: resume.title,

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import { CronRunStatus, JobStatus, type Profile } from '@prisma/client';
 import { prisma } from '../../db';
 import { getAiKeys, setAiKey, setFetchingEnabled, setSetupCompleted } from '../../settings';
-import { updateProfile, type ProfileInput } from '../../profiles';
+import { blankProfileInput, updateProfile, type ProfileInput } from '../../profiles';
 import { passesBaseFilter } from '../../filter';
 import { parsePriorityRules } from '../../priority-rules';
 import { parseTagList, toStringArray } from '../../text-utils';
@@ -17,7 +17,12 @@ import {
 import { AI_KEY_ENV_VARS, MAX_AI_KEY_LENGTH, providerTakesKey } from '../../ai-keys';
 import { createResume, getResume, listResumes, type ResumeSummary } from '../../resume/store';
 import { scanResume } from '../../resume/scan';
-import { buildProfileDraft, SENIORITY_LEVELS } from '../../resume/profile-draft';
+import {
+  buildProfileDraft,
+  SENIORITY_LEVELS,
+  type ProfileForDraft,
+} from '../../resume/profile-draft';
+import { createProfileFromResume, scanFields } from '../profile-from-resume';
 import { recordCronRun, type CronStats } from '../../jobs/cron-run';
 import { runScoreUnscored, SCORE_BATCH } from '../../jobs/reclassify-job';
 import { activeFetchRun } from '../fetch-runs';
@@ -72,8 +77,11 @@ welcomeRoute.get('/welcome', async (c) => {
   ]);
 
   const resumeId = Number(c.req.query('resume'));
+  const asNew = c.req.query('mode') === 'new';
   const draftResume = Number.isFinite(resumeId) && profile ? await getResume(resumeId) : null;
-  const draft = draftResume && profile ? draftCard(profile, draftResume) : null;
+  const draft = draftResume && profile
+    ? draftCard(asNew ? blankProfileInput() : profile, draftResume, asNew)
+    : null;
 
   return c.html(
     <WelcomePage
@@ -179,6 +187,9 @@ welcomeRoute.post('/welcome/ai/test', async () => {
  */
 welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) => {
   const form = await c.req.parseBody();
+  // "A second search" (§4 stage A) drafts a new profile instead of filling
+  // the active one; the flag rides through the scan run in the result URL.
+  const back = form.mode === 'new' ? `${PROFILE_STEP}&mode=new` : PROFILE_STEP;
   let resume: ResumeSummary | null = null;
   if (form.file instanceof File && form.file.size > 0) {
     const upload = await readResumeUpload(form);
@@ -190,7 +201,7 @@ welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) 
   }
   if (!resume || resume.hidden) return flashRedirect(PROFILE_STEP, 'err', 'Pick a resume file first.');
   if (resume.scannedAt && resume.primarySkills.length > 0) {
-    return c.redirect(`${PROFILE_STEP}&resume=${resume.id}`, 303);
+    return c.redirect(`${back}&resume=${resume.id}`, 303);
   }
 
   const { id, name, text } = resume;
@@ -214,7 +225,7 @@ welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) 
     }
     updateRun(run.id, {
       stage: 'done',
-      resultUrl: `${PROFILE_STEP}&resume=${id}`,
+      resultUrl: `${back}&resume=${id}`,
       flash: `Read "${name}" — check the summary below.`,
     });
   });
@@ -228,7 +239,7 @@ welcomeRoute.post('/welcome/profile/apply', async (c) => {
   const resume = await getResume(Number(form.resumeId));
   if (!profile) return flashRedirect(PROFILE_STEP, 'err', 'No active profile — create one in Settings → Profile.');
   if (!resume || !resume.scannedAt) return flashRedirect(PROFILE_STEP, 'err', 'That resume has not been read yet.');
-  const draft = buildProfileDraft(profile, scanOf(resume));
+  const draft = buildProfileDraft(profile, scanFields(resume));
   await updateProfile(profile.id, { ...profileInput(profile), ...draft.changes });
   return flashRedirect(
     MATCHES_STEP,
@@ -236,6 +247,25 @@ welcomeRoute.post('/welcome/profile/apply', async (c) => {
     draft.changed.length > 0
       ? `Profile filled from "${resume.name}" — ${draft.changed.join(', ')}. Adjust it any time in Settings → Profile.`
       : `Profile already matched "${resume.name}".`,
+  );
+});
+
+/**
+ * Step 3's second-resume action: the card above it showed the whole draft,
+ * so one press creates the search (ADR 0015). It is born inactive — the
+ * search the wizard just set up keeps running.
+ */
+welcomeRoute.post('/welcome/profile/create', async (c) => {
+  const form = await c.req.parseBody();
+  const resume = await getResume(Number(form.resumeId));
+  if (!resume || resume.hidden || !resume.scannedAt) {
+    return flashRedirect(PROFILE_STEP, 'err', 'That resume has not been read yet.');
+  }
+  const profile = await createProfileFromResume(resume);
+  return flashRedirect(
+    PROFILE_STEP,
+    'ok',
+    `Created a second search, "${profile.name}", from "${resume.name}". Your current search keeps running — switch to it on Settings → Profile.`,
   );
 });
 
@@ -318,21 +348,17 @@ async function countWaitingUnscored(profile: Profile): Promise<number> {
   return rows.filter((j) => passesBaseFilter(j, profile)).length;
 }
 
-function scanOf(resume: ResumeSummary) {
-  return {
-    title: resume.title,
-    seniority: resume.seniority,
-    skills: resume.skills,
-    primarySkills: resume.primarySkills,
-    roleTypes: resume.roleTypes,
-  };
-}
-
-function draftCard(profile: Profile, resume: ResumeSummary): ProfileDraftCard | null {
+function draftCard(
+  base: ProfileForDraft,
+  resume: ResumeSummary,
+  asNew: boolean,
+): ProfileDraftCard | null {
   if (!resume.scannedAt || resume.hidden) return null;
-  const draft = buildProfileDraft(profile, scanOf(resume));
+  const draft = buildProfileDraft(base, scanFields(resume));
   const primary = draft.changes.stackRequired ?? resume.primarySkills;
   return {
+    asNew,
+    profileName: draft.changes.name ?? base.name,
     resumeId: resume.id,
     resumeName: resume.name,
     title: resume.title,


### PR DESCRIPTION
Stage 5 of the onboarding plan (`docs/onboarding-plan.md` §4 stage A, §5 row 5,
TASKS §11 block 5) — **the first half of the multi-resume story**. Until now a
profile and a resume knew nothing about each other: the job page guessed which
CV to compare by counting skill-tag overlap, and a second resume for a different
kind of role had nowhere to live. A profile can now say "this search is for jobs
I'd apply to with *this* CV", and a resume can become a search in one press.

## What changed

- **`Profile.resumeId`** (nullable FK, hand-written migration). The job page
  preselects the active profile's linked resume in the Resume match and Cover
  letter cards; without a link it falls back to `pickResumeForJob` exactly as
  before. The priority lives in one pure function,
  `src/resume/pick.ts:preselectResume`, so `pickResumeForJob`'s contract is
  untouched and the fallback is a unit-tested code path, not a comment.
- **`ON DELETE SET NULL`**, matching `Profile.telegramTargetId`. A profile owns
  regions, thresholds, priority rules and alert routing that no resume can speak
  for, so deleting the file must neither delete the search nor be blocked by it.
  The link clears, the preselect goes back to guessing, and nothing else moves.
- **"Create a search from this resume"** on `/resumes/:id`. The card renders the
  whole profile a press would produce — name from the resume's headline, primary
  stack → required, remaining skills → nice-to-have, plus role types and
  seniority — and names the searches already hunting with that resume.
  [ADR 0015](docs/adr/0015-profile-draft-from-resume-scan.md) is unchanged: the
  draft is rendered, and only the press writes a row.
- **The same action in the wizard's step 3**, once the first search exists:
  "Another resume for a different kind of role?" takes one file (or one already
  uploaded), reads it on the usual progress page, and offers the second search
  as a draft. Both entry points go through `src/web/profile-from-resume.ts`, so
  the card and the create can't drift.
- **The preselect label says why.** It read "· best skill overlap" for whatever
  was chosen; with a link that sentence is simply false, so a linked pick now
  reads "· your search hunts with this" on both the Resume match and the Cover
  letter card.
- **Born inactive.** Creating a search never switches the one the pipeline is
  scoring against — issue #50's rule, and the honest behaviour when only one
  profile can run at a time. The copy says where to activate it.
- **The link is visible and editable** where the profile lives: `/settings` →
  Profile → "Resume for this search", with "(pick by skill overlap)" as the
  empty option. "Fill from a resume" proposes the link alongside the fields it
  fills, in the same unsaved draft — so an existing user gets the link without
  ever visiting `/resumes`.

## Open decision closed

`docs/onboarding-plan.md` §6 asked whether step 3 should offer multi-upload
immediately. **Neither — one resume at a time, and a second only after the first
search exists.** Multi-upload would ask the user to pick which resume the
profile uses before they have seen a single match, and until stage B lands only
the active profile scores, so N uploads would build N-1 searches that do
nothing. Recorded in the plan with the reasoning.

## Schema

- `20260902120000_add_profile_resume` — `ALTER TABLE profile ADD COLUMN
  "resumeId" INTEGER` + the `SET NULL` foreign key. Hand-written (gotcha 7) and
  checked against Prisma's own `migrate diff --from-migrations
  --to-schema-datamodel`, which came back **empty**: no drift between the
  migration and the schema. No backfill — existing profiles start unlinked,
  which is today's behaviour.

## Tail from v1.8.0

- `docs/TASKS.md` §11 claimed "**Analysis only — nothing implemented yet**"
  while four of its seven stages were live, and §12/§13 told the next session
  not to start without checking a §10/§11 status that was already settled.
  Those are the first lines a new session reads. Fixed to state what shipped.
- **PR #64 P3:** `/settings` read `AppSettings.aiKeys` twice per render (once
  inside the cached probe, once for the engine rows). `probeAiProviders` now
  takes the keys the caller already holds.

## Verification

- `npm run lint:types` + `npm test` (825 pass, 0 fail) + `npx prisma format --check`.
- **Preselect priority unit test** next to `pick.test.ts`: link beats overlap
  even when the other resume overlaps the posting *and* is the default; a link
  to a resume that is gone falls back; an empty list is still null. Plus a
  `profile-draft.test.ts` case proving a blank base takes everything the scan
  speaks for — the new-profile path.
- **Migration on a live container rebuild:** `Applying migration
  20260902120000_add_profile_resume` … `All migrations have been successfully
  applied`, no errors in the init logs, and `\d profile` shows
  `profile_resumeId_fkey … ON UPDATE CASCADE ON DELETE SET NULL` next to the
  telegram one it copies.
- **Create-from-resume, both entry points, live.** `/resumes/1` → the card
  showed the whole draft, the press created profile 10 linked to resume 1 with
  the scan's stack / roles / seniority, redirected to its editor, and
  `activeProfileId` stayed 1. The wizard: `POST /welcome/resume` with
  `mode=new` carried the intent through the scan run, the card read "The second
  search would be called …" and offered only *Create this second search* /
  *Cancel*, and the press created profile 12 linked to resume 5 — active
  profile still 1. Regression: the same card without `mode=new` still shows
  "We'll hunt for …" with *Yes, that's me* and *Let me adjust*.
- **Preselect priority on a real job page** (`/jobs/1221`): with no link the
  Resume match and Cover letter selects preselected "Senior Backend PHP · best
  skill overlap · default"; after linking the active profile to resume 5 —
  neither the best overlap nor the default — both flipped to "PHP/JS/React ·
  your search hunts with this".
- **Deleting a linked resume** through the UI: profile survived with
  `resumeId` NULL, its editor still rendered 200, and the preselect went back
  to the overlap pick. No cascade, no blocked delete.
- **Link round-trip through the profile save:** set (`resumeId=1`) → stored;
  cleared (`resumeId=`) → NULL; junk (`resumeId=1.5`) → NULL, nothing written.
  "Fill from a resume" rendered the link in the select and listed "resume for
  this search" in the draft notice **while persisting nothing** — the row still
  read `resumeId` NULL after the render.
- **Dashboard matrix:** 19 routes curled 200 (`/`, `/jobs`, `/jobs/:id`,
  `/resumes`, `/resumes/:id` ×2, `/companies`, `/runs`, `/applications`,
  `/discovery`, `/welcome`, `/welcome?step=profile`, all five `/settings` tabs,
  `/target`, `/letter`). Screenshots at **1200 / 768 / 375** of the new Search
  profile card, the profile editor's Name + Resume row and the wizard's
  second-resume block; **0 console errors** and no horizontal body scroll at
  375 (`scrollWidth === innerWidth`).
- Test rows removed afterwards; the live database is back to its two profiles
  and three resumes, both profiles unlinked, `activeProfileId` 1.

## Review follow-ups

The mandatory `code-review-expert` pass over `git diff main...HEAD` found seven
issues; **four are fixed in this branch**:

- A resume whose scan found no headline produced a search literally named "New
  profile" — it now takes the resume's own name, through the shared builder so
  both entry points show and save the same thing.
- The wizard built its second-search draft by hand instead of through
  `newProfileDraft`, so the two entry points could drift. Unified.
- `optionalId` accepted any finite number, so `resumeId=1.5` (and
  `telegramTargetId=1.5`, which has been there all along) reached Prisma as an
  `Int` foreign key. Integers only now.
- The hidden `/target` scratch resume offered a "Create a search" button whose
  own POST answers 404. The card now keys off the draft the route computes, so
  there is one source of truth for "can this become a search".

Left as follow-ups, deliberately:

- **P2 — no CSRF protection**, now on two more POSTs. A page open in the same
  browser can create profile rows. Same class as every other unauthenticated
  POST here and already recorded in ADR 0027's consequences; a fix belongs to
  the whole dashboard, not to this branch.
- **P2 — a stale link 500s the profile save.** Delete a linked resume in one tab
  and save the profile in another: the stale `resumeId` hits a foreign key, and
  `ON DELETE SET NULL` does not apply to inserts. `telegramTargetId` has carried
  the identical race since it shipped, so the fix belongs to both — validate
  optional row ids against their tables in the save route, or catch P2003.
- **P3 — double-submitting "Create a search" makes two identical profiles.**
  `/settings/profiles/new` has behaved this way since it shipped and profiles
  are cheap to delete; a shared idempotency token would cover both.
- **P3 — `setAiKey` is a read-modify-write** with no locking (carried from
  PR #64; unchanged here).

## References

- `docs/onboarding-plan.md` §4 stage A, §5 row 5, §6 (decision recorded)
- [ADR 0015](docs/adr/0015-profile-draft-from-resume-scan.md) — the profile is
  drafted from the resume scan, never written by AI. Unchanged; this branch adds
  a second surface that obeys it.

---

**Release notes draft (v1.9.0 — "the resume a search hunts with"):**

```
A search profile can now name the resume it hunts with, and a resume can become
a search in one press.

- Profile.resumeId — "this search is for jobs I'd apply to with this CV". A job
  page found by that search preselects its resume in the Resume match and Cover
  letter cards, and says why; without a link it still picks by skill overlap.
- "Create a search from this resume" on /resumes/:id shows the whole profile a
  click would produce — name, required stack, role types, seniority — and saves
  it on one press, linked to that resume (ADR 0015: the draft is rendered, the
  press writes).
- The wizard's step 3 offers the same for a second resume once the first search
  exists: one file, read on the usual progress page, then a draft to confirm.
- New searches are born inactive — creating one never switches the one the
  pipeline is scoring against. Switch on Settings → Profile.
- Deleting a resume clears the link instead of deleting the search or refusing
  the delete.
- Settings → Profile shows and edits the link ("Resume for this search"), and
  "Fill from a resume" proposes it with the fields it fills.
```

**Tag after merge:**

```
git tag -a v1.9.0 -m "the resume a search hunts with" <merge-sha> && git push origin v1.9.0
```
