### PR TITLE
resumes: no write freezes the browser, and the hub survives a phone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.12.0] — 2026-09-02
+
+### Fixed
+- **No resume write freezes the browser any more**
+  ([docs/resumes-plan.md](docs/resumes-plan.md) Part A, TASKS §12 block 1).
+  Upload, "Upload a new version", Re-scan and the targeted editor's
+  "Save as vN" each awaited a ~60 s call to the resume model inline, on a form
+  whose submit button stayed live — a second click created a **duplicate
+  resume and a second AI call**. All four now run through the same run
+  registry that `/target` and Compare already used: the POST returns at once
+  and you watch a progress page you are free to close. The forms that start
+  one also disable themselves on the first press.
+- **The `/resumes` rows are usable on a phone.** The hub forced a 52 rem
+  minimum width inside a horizontal scroller, which put Skills, Scanned and
+  *both* action buttons off-screen at 375 px. Delete has left the hub for the
+  detail page — a destructive action should not be one click from a list —
+  and the remaining columns now drop out by width instead: Name, Matches and
+  Set default survive everywhere, Scanned returns at 640 px, Core stack at
+  1024, Headline at 1280.
+- **The delete confirm no longer understates what it destroys.** Deleting a
+  resume cascades its cover letters — including text the user wrote by hand —
+  and the dialog said only "and its comparisons". It now counts both:
+  *"Delete "Senior Backend" and 14 comparisons and 17 cover letters?"*
+
+### Added
+- A **Matches** column on `/resumes`: the best score a resume has ever
+  reached plus how many comparisons it has been through, so the hub answers
+  "is this one working?" and not just "does this one exist?".
+- The Skills column became **Core stack** and reads `Resume.primarySkills`.
+  The scanned `skills` list runs to ~85 entries that open the same way on
+  every resume ("php, go, javascript…"); the 2-5 core technologies actually
+  tell two resumes apart. A version badge joins the name.
+
+### Changed
+- `Table` accepts `thClasses` — the only place a responsive `hidden
+  sm:table-cell` can live, since a class on the header label still leaves the
+  cell occupying its column. Table gutters tighten below 640 px.
+
 ## [1.11.0] — 2026-09-02
 
 ### Added
@@ -872,6 +910,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.12.0]: https://github.com/applypack/applypack/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/applypack/applypack/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/applypack/applypack/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/applypack/applypack/compare/v1.8.0...v1.9.0

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -775,10 +775,10 @@ Telegram explicitly optional.
 
 ## 12. /resumes overhaul + on-demand resume strength review (analysis 2026-08-31)
 
-Full plan: [docs/resumes-plan.md](./resumes-plan.md). **Analysis only —
-nothing implemented** (browser audit of the live page at desktop + 375px,
-plus code verification). Overlaps §11's resume work: check the §11
-checklist before starting.
+Full plan: [docs/resumes-plan.md](./resumes-plan.md). **In progress —
+Part A's P0/P1 findings shipped in v1.12.0**; Part B (the strength
+review) is still analysis only. Original audit: browser pass over the
+live page at desktop + 375px, plus code verification.
 
 Driver: `/resumes` shows inventory, not effectiveness — no per-resume
 match signal, upload & scan freezes the browser ~60 s (double-submit
@@ -790,10 +790,14 @@ metric *asks* instead of invented numbers (ADR 0020 stance). Never
 auto-run on upload; discoverable as a real card with an explainer, not an
 icon; progress visible step-by-step via the target-run registry pattern.
 
-- [ ] `resumes-page-p0` — async upload/replace/rescan via the run
-      registry, mobile row fix (Delete off hub rows, responsive columns —
-      needs a small `Table` th-class extension), delete-confirm mentions
-      cover letters, `primarySkills` column, Matches/`FitBadge` column
+- [x] `resumes-page-p0` — async upload/replace/rescan **and "Save as vN"**
+      via the run registry (+ a `SUBMIT_ONCE` guard on the forms that start
+      one), mobile row fix (Delete off hub rows, columns drop out by width
+      over the new `Table` `thClasses`), delete-confirm counts comparisons
+      AND cover letters, `primarySkills` column, Matches/`FitBadge` column,
+      version badge (#6 rode along) — done 2026-09-02, branch
+      `resumes-page-p0`. Findings #7 (facts add/flip), #8 (rename) and #9
+      (polish) stay open in the quick-wins bullet below.
 - [ ] `resume-strength` — fenced `REVIEW_SYSTEM` (grades only — the model
       never outputs the score; pure `review-score.ts` applies hard caps,
       gotcha-11 guard test) + `ResumeReview` table + detail card + hub

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/resume/store.ts
+++ b/src/resume/store.ts
@@ -167,6 +167,41 @@ export async function listMatchesForResume(resumeId: number): Promise<MatchWithJ
   });
 }
 
+/**
+ * What deleting a resume takes with it. Both cascade, and the letters carry
+ * the user's own edited text — the confirm dialog has to say so.
+ */
+export async function deleteImpact(resumeId: number): Promise<{ matches: number; letters: number }> {
+  const [matches, letters] = await Promise.all([
+    prisma.resumeMatch.count({ where: { resumeId } }),
+    prisma.coverLetter.count({ where: { resumeId } }),
+  ]);
+  return { matches, letters };
+}
+
+export interface ResumeMatchStats {
+  /** Comparisons run against this resume, all versions. */
+  count: number;
+  /** The best score it has ever reached — the hub's "is this one working?" signal. */
+  best: number;
+}
+
+/**
+ * One groupBy for the whole hub, instead of a query per row. Resumes with no
+ * comparison are absent from the map rather than present with zeros: "never
+ * compared" and "compared, scored 0" are different answers.
+ */
+export async function matchStatsByResume(): Promise<Map<number, ResumeMatchStats>> {
+  const rows = await prisma.resumeMatch.groupBy({
+    by: ['resumeId'],
+    _count: { _all: true },
+    _max: { matchScore: true },
+  });
+  return new Map(
+    rows.map((r) => [r.resumeId, { count: r._count._all, best: r._max.matchScore ?? 0 }]),
+  );
+}
+
 /** A resume version made from edited text (the targeted view's "Save as vN") — a .md file, no docx. */
 export async function saveResumeTextVersion(id: number, text: string): Promise<ResumeSummary> {
   const current = await prisma.resume.findUniqueOrThrow({ where: { id }, select: { name: true, version: true } });

--- a/src/web/delete-confirm.test.ts
+++ b/src/web/delete-confirm.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { deleteConfirm } from './delete-confirm';
+
+describe('deleteConfirm', () => {
+  it('names both cascades, letters included', () => {
+    assert.equal(
+      deleteConfirm('Senior Backend', { matches: 12, letters: 3 }),
+      'Delete "Senior Backend" and 12 comparisons and 3 cover letters? This cannot be undone.',
+    );
+  });
+
+  it('drops the half that is empty', () => {
+    assert.equal(
+      deleteConfirm('Senior Backend', { matches: 4, letters: 0 }),
+      'Delete "Senior Backend" and 4 comparisons? This cannot be undone.',
+    );
+    assert.equal(
+      deleteConfirm('Senior Backend', { matches: 0, letters: 2 }),
+      'Delete "Senior Backend" and 2 cover letters? This cannot be undone.',
+    );
+  });
+
+  it('says so plainly when nothing is attached', () => {
+    assert.equal(
+      deleteConfirm('Draft', { matches: 0, letters: 0 }),
+      'Delete "Draft"? Nothing else is attached to it.',
+    );
+  });
+
+  it('speaks singular for one of each', () => {
+    assert.equal(
+      deleteConfirm('CV', { matches: 1, letters: 1 }),
+      'Delete "CV" and 1 comparison and 1 cover letter? This cannot be undone.',
+    );
+  });
+});

--- a/src/web/delete-confirm.ts
+++ b/src/web/delete-confirm.ts
@@ -1,0 +1,31 @@
+/**
+ * The confirm text for "Delete this resume". Pure so the blast radius can be
+ * unit-tested: deleting cascades every comparison AND every cover letter,
+ * including the letters the user edited by hand, and the old wording named
+ * only the comparisons.
+ */
+
+export interface DeleteImpact {
+  matches: number;
+  letters: number;
+}
+
+export function deleteConfirm(name: string, impact: DeleteImpact): string {
+  const parts = [
+    countOf(impact.matches, 'comparison', 'comparisons'),
+    countOf(impact.letters, 'cover letter', 'cover letters'),
+  ].filter((p): p is string => p !== null);
+
+  if (parts.length === 0) return `Delete "${name}"? Nothing else is attached to it.`;
+  return `Delete "${name}" and ${joinList(parts)}? This cannot be undone.`;
+}
+
+function countOf(n: number, one: string, many: string): string | null {
+  return n === 0 ? null : `${n} ${n === 1 ? one : many}`;
+}
+
+/** "a, b and c" — the last separator is a word, not another comma. */
+function joinList(parts: string[]): string {
+  if (parts.length <= 1) return parts[0] ?? '';
+  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`;
+}

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -14,6 +14,7 @@ import {
   Input,
   PageHeader,
   SectionTitle,
+  SUBMIT_ONCE,
   Table,
   Tag,
   Td,
@@ -59,7 +60,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
             <Button variant="secondary" size="sm" href={`/resumes/${resume.id}/download`}>
               Download original
             </Button>
-            <ActionForm action={`/resumes/${resume.id}/rescan`}>
+            <ActionForm action={`/resumes/${resume.id}/rescan`} once>
               <Button variant="violet" size="sm">
                 {resume.scannedAt ? 'Re-scan' : 'Scan'}
               </Button>
@@ -149,6 +150,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
           method="post"
           action={`/resumes/${resume.id}/replace`}
           enctype="multipart/form-data"
+          onsubmit={SUBMIT_ONCE}
           class="grid gap-3 sm:grid-cols-[1.6fr_auto]"
         >
           <Field label="File" hint={`${ACCEPTED_EXTENSIONS.join(', ')} · up to ${MAX_UPLOAD_MB} MB`}>

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -20,6 +20,7 @@ import {
   Td,
   Tr,
 } from '../ui';
+import { deleteConfirm } from '../delete-confirm';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
 import { MAX_UPLOAD_MB } from '../upload';
 import type { FlashMessage } from '../flash';
@@ -32,6 +33,8 @@ import type { ProfileDraft } from '../../resume/profile-draft';
 export interface ResumeDetailProps {
   resume: ResumeSummary;
   matches: MatchWithJob[];
+  /** What Delete would cascade — named in the confirm, letters included. */
+  deleteImpact: { matches: number; letters: number };
   /** Deterministic ATS-parseability checks over the extracted text. */
   warnings: ParseWarning[];
   /** Searches already linked to this resume, and the one a click would create. */
@@ -45,6 +48,7 @@ export interface ResumeDetailProps {
 export const ResumeDetailPage: FC<ResumeDetailProps> = ({
   resume,
   matches,
+  deleteImpact,
   warnings,
   search,
   flash,
@@ -74,7 +78,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
             )}
             <ActionForm
               action={`/resumes/${resume.id}/delete`}
-              confirm="Delete this resume and its comparisons?"
+              confirm={deleteConfirm(resume.name, deleteImpact)}
             >
               <Button variant="danger" size="sm">
                 Delete

--- a/src/web/pages/resumes.tsx
+++ b/src/web/pages/resumes.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
-import { ActionForm, Badge, Button, Card, Empty, Field, FILE_INPUT_CLASS, Flash, Hint, Input, PageHeader, SectionTitle, Table, Td, Tr } from '../ui';
+import { ActionForm, Badge, Button, Card, Empty, Field, FILE_INPUT_CLASS, Flash, Hint, Input, PageHeader, SectionTitle, SUBMIT_ONCE, Table, Td, Tr } from '../ui';
 import type { FlashMessage } from '../flash';
 import { formatRelative } from '../format';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
@@ -163,6 +163,7 @@ export const ResumeUploadForm: FC = () => (
     method="post"
     action="/resumes"
     enctype="multipart/form-data"
+    onsubmit={SUBMIT_ONCE}
     class="grid gap-3 sm:grid-cols-[1fr_1.4fr_auto]"
   >
     <Field label="Name" hint="Blank = taken from the file name.">
@@ -181,8 +182,9 @@ export const ResumeUploadForm: FC = () => (
       <Button class="w-full">Upload &amp; scan</Button>
     </div>
     <Hint class="sm:col-span-3">
-      The scan calls the resume model once (about a minute) and stores headline, skills and
-      job-agnostic issues. The file itself never leaves your Postgres.
+      The scan calls the resume model once and stores headline, skills and job-agnostic issues;
+      you watch it on a progress page and can leave the tab. The file itself never leaves your
+      Postgres.
     </Hint>
   </form>
 );

--- a/src/web/pages/resumes.tsx
+++ b/src/web/pages/resumes.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
-import { ActionForm, Badge, Button, Card, Empty, Field, FILE_INPUT_CLASS, Flash, Hint, Input, PageHeader, SectionTitle, SUBMIT_ONCE, Table, Td, Tr } from '../ui';
+import { ActionForm, Badge, Button, Card, Empty, Field, FILE_INPUT_CLASS, FitBadge, Flash, Hint, Input, PageHeader, SectionTitle, SUBMIT_ONCE, Table, Tag, Td, Tr } from '../ui';
 import type { FlashMessage } from '../flash';
 import { formatRelative } from '../format';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
@@ -14,8 +14,13 @@ export interface ResumeRow {
   isDefault: boolean;
   scannedAt: Date | null;
   title: string | null;
+  /** The 2-5 core technologies. Every resume's `skills` list looks the same. */
+  primarySkills: string[];
   skills: string[];
+  version: number;
   createdAt: Date;
+  /** Absent until the resume has been compared with something. */
+  matches: { count: number; best: number } | null;
 }
 
 export interface FactRow {
@@ -24,7 +29,21 @@ export interface FactRow {
   note: string | null;
 }
 
-const SKILLS_PREVIEW = 6;
+/** Core stack fits on a phone row; the long tail collapses into "+N". */
+const PRIMARY_PREVIEW = 3;
+
+/*
+ * Column visibility. The hub used to force `min-w-[52rem]`, which put Skills,
+ * Scanned and BOTH action buttons behind a horizontal scroll at 375px — the
+ * actions were effectively unreachable on a phone. Name, Matches and Set
+ * default now survive at every width; the descriptive columns drop out.
+ * Each entry pairs with the same class on its `Td`.
+ */
+const HIDE_SM = 'hidden sm:table-cell';
+const HIDE_LG = 'hidden lg:table-cell';
+const HIDE_XL = 'hidden xl:table-cell';
+/** Same idea for things that are not table cells. */
+const HIDE_SM_INLINE = 'hidden sm:inline-flex';
 
 export const ResumesPage: FC<{
   resumes: ResumeRow[];
@@ -46,81 +65,70 @@ export const ResumesPage: FC<{
       <Empty>No resumes yet. Upload one below — the first becomes the default.</Empty>
     ) : (
       <Card flush class="mb-4">
-        <div class="overflow-x-auto">
-          <div class="min-w-[52rem]">
-            <Table
-              columns={[
-                'Name',
-                'Headline',
-                'Skills',
-                'Scanned',
-                <span class="block text-right">Actions</span>,
-              ]}
-            >
-              {resumes.map((r) => (
-                <Tr>
-                  <Td class="max-w-[16rem]">
-                    <div class="flex items-center gap-2">
-                      <a
-                        href={`/resumes/${r.id}`}
-                        class="truncate font-medium text-ink transition-colors duration-150 hover:text-accent-strong"
-                        title={r.name}
-                      >
-                        {r.name}
-                      </a>
-                      {r.isDefault && <Badge tone="ok">default</Badge>}
-                    </div>
-                    <div class="mt-0.5 truncate font-mono text-xs text-ink-faint">
-                      {r.sourceFilename}
-                    </div>
-                  </Td>
-                  <Td class="max-w-[16rem] text-ink-muted">
-                    <div class="truncate" title={r.title ?? undefined}>
-                      {r.title ?? '—'}
-                    </div>
-                  </Td>
-                  <Td class="max-w-[18rem] text-[13px] text-ink-muted">
-                    <div class="truncate">
-                      {r.skills.length === 0
-                        ? '—'
-                        : `${r.skills.slice(0, SKILLS_PREVIEW).join(', ')}${
-                            r.skills.length > SKILLS_PREVIEW
-                              ? ` +${r.skills.length - SKILLS_PREVIEW}`
-                              : ''
-                          }`}
-                    </div>
-                  </Td>
-                  <Td class="whitespace-nowrap text-[13px] text-ink-faint">
-                    {r.scannedAt ? (
-                      formatRelative(r.scannedAt)
-                    ) : (
-                      <Badge tone="warn">not scanned</Badge>
-                    )}
-                  </Td>
-                  <Td>
-                    <div class="flex justify-end gap-2">
-                      {!r.isDefault && (
-                        <ActionForm action={`/resumes/${r.id}/default`}>
-                          <Button size="sm" variant="secondary">
-                            Set default
-                          </Button>
-                        </ActionForm>
-                      )}
-                      <ActionForm
-                        action={`/resumes/${r.id}/delete`}
-                        confirm="Delete this resume and its comparisons?"
-                      >
-                        <Button size="sm" variant="danger">
-                          Delete
-                        </Button>
-                      </ActionForm>
-                    </div>
-                  </Td>
-                </Tr>
-              ))}
-            </Table>
-          </div>
-        </div>
+        <Table
+          columns={[
+            'Name',
+            'Headline',
+            'Core stack',
+            'Matches',
+            'Scanned',
+            <span class="block text-right">Default</span>,
+          ]}
+          thClasses={['', HIDE_XL, HIDE_LG, '', HIDE_SM, '']}
+        >
+          {resumes.map((r) => (
+            <Tr>
+              <Td class="max-w-[16rem]">
+                <div class="flex items-center gap-2">
+                  <a
+                    href={`/resumes/${r.id}`}
+                    class="truncate font-medium text-ink transition-colors duration-150 hover:text-accent-strong"
+                    title={r.name}
+                  >
+                    {r.name}
+                  </a>
+                  {/* Both are repeated by columns of their own; at 375px the
+                      row needs every pixel for the name and the action. */}
+                  <Badge tone="info" class={HIDE_SM_INLINE}>
+                    v{r.version}
+                  </Badge>
+                  {r.isDefault && <Badge tone="ok" class={HIDE_SM_INLINE}>default</Badge>}
+                </div>
+                <div class="mt-0.5 hidden truncate font-mono text-xs text-ink-faint sm:block">
+                  {r.sourceFilename}
+                </div>
+              </Td>
+              <Td class={`max-w-[16rem] text-ink-muted ${HIDE_XL}`}>
+                <div class="truncate" title={r.title ?? undefined}>
+                  {r.title ?? '—'}
+                </div>
+              </Td>
+              <Td class={`max-w-[18rem] ${HIDE_LG}`}>
+                <PrimaryStack resume={r} />
+              </Td>
+              <Td class="whitespace-nowrap">
+                <MatchCell matches={r.matches} />
+              </Td>
+              <Td class={`whitespace-nowrap text-[13px] text-ink-faint ${HIDE_SM}`}>
+                {r.scannedAt ? formatRelative(r.scannedAt) : <Badge tone="warn">not scanned</Badge>}
+              </Td>
+              <Td>
+                <div class="flex justify-end">
+                  {r.isDefault ? (
+                    <Badge tone="ok">default</Badge>
+                  ) : (
+                    <ActionForm action={`/resumes/${r.id}/default`}>
+                      <Button size="sm" variant="secondary">
+                        <span class="sm:hidden">Use</span>
+                        <span class="hidden sm:inline">Set default</span>
+                      </Button>
+                    </ActionForm>
+                  )}
+                </div>
+              </Td>
+            </Tr>
+          ))}
+        </Table>
       </Card>
     )}
 
@@ -156,6 +164,43 @@ export const ResumesPage: FC<{
     )}
   </Layout>
 );
+
+/**
+ * The scanned `skills` list runs to ~85 entries and opens the same way on
+ * every resume ("php, go, javascript…"), so the hub reads `primarySkills` —
+ * the 2-5 core technologies — and keeps the rest as a count.
+ */
+const PrimaryStack: FC<{ resume: ResumeRow }> = ({ resume }) => {
+  const core = resume.primarySkills.slice(0, PRIMARY_PREVIEW);
+  const rest = resume.skills.length - core.length;
+  if (core.length === 0) {
+    return <span class="text-[13px] text-ink-faint">{resume.scannedAt ? '—' : 'not scanned'}</span>;
+  }
+  return (
+    <div class="flex flex-wrap items-center gap-1">
+      {core.map((skill) => (
+        <Tag>{skill}</Tag>
+      ))}
+      {rest > 0 && <span class="text-xs text-ink-faint">+{rest}</span>}
+    </div>
+  );
+};
+
+/** Is this resume actually working? Count plus the best score it has reached. */
+const MatchCell: FC<{ matches: ResumeRow['matches'] }> = ({ matches }) =>
+  matches === null ? (
+    <span class="text-[13px] text-ink-faint">
+      <span class="sm:hidden">—</span>
+      <span class="hidden sm:inline">never compared</span>
+    </span>
+  ) : (
+    <div class="flex items-center gap-2">
+      <FitBadge score={matches.best} />
+      <span class="hidden text-xs text-ink-faint sm:inline">
+        {matches.count === 1 ? '1 run' : `${matches.count} runs`}
+      </span>
+    </div>
+  );
 
 /** Shared by /resumes and the Settings card. Posts to /resumes and lands on the new resume. */
 export const ResumeUploadForm: FC = () => (

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -19,7 +19,9 @@ const STEP_VIEW: Record<RunStep, StepView> = {
     detail: 'fit score against every running search — seconds',
   },
   scan: {
-    label: 'Scan the new resume version',
+    // Also reached by a plain re-scan and a first upload, where there is no
+    // "new version" to speak of.
+    label: 'Read the resume',
     detail: 'headline, skills, ATS issues — about a minute',
   },
   match: {

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
-import { Badge, Button, Card, FitBadge, Flash, Hint } from '../ui';
+import { Badge, Button, Card, FitBadge, Flash, Hint, SUBMIT_ONCE } from '../ui';
 import type { FlashMessage } from '../flash';
 import { fitTone, formatRelative, type Tone } from '../format';
 import type { MatchWithResume } from '../../resume/store';
@@ -302,7 +302,12 @@ export const TargetPage: FC<TargetPageProps> = ({
                   </Button>
                 </form>
                 {!resume.ephemeral && (
-                  <form method="post" action={`/resumes/${resume.id}/draft`} id="save-form">
+                  <form
+                    method="post"
+                    action={`/resumes/${resume.id}/draft`}
+                    id="save-form"
+                    onsubmit={SUBMIT_ONCE}
+                  >
                     <input type="hidden" name="text" id="save-text" value="" />
                     <input type="hidden" name="jobId" value={job.id} />
                     <Button

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -7,12 +7,14 @@ import { matchResumeToJob } from '../../resume/match';
 import { prisma } from '../../db';
 import {
   createResume,
+  deleteImpact,
   deleteResume,
   getResume,
   getResumeOriginal,
   listFacts,
   listMatchesForResume,
   listResumes,
+  matchStatsByResume,
   replaceResumeFile,
   type ResumeSummary,
   saveResumeTextVersion,
@@ -37,9 +39,17 @@ const MIN_DRAFT_CHARS = 200;
 export const resumesRoute = new Hono();
 
 resumesRoute.get('/resumes', async (c) => {
-  const [resumes, facts] = await Promise.all([listResumes(), listFacts()]);
+  const [resumes, facts, stats] = await Promise.all([
+    listResumes(),
+    listFacts(),
+    matchStatsByResume(),
+  ]);
   return c.html(
-    <ResumesPage resumes={resumes} facts={facts} flash={parseFlashCookie(c.req.header('cookie'))} />,
+    <ResumesPage
+      resumes={resumes.map((r) => ({ ...r, matches: stats.get(r.id) ?? null }))}
+      facts={facts}
+      flash={parseFlashCookie(c.req.header('cookie'))}
+    />,
     200,
     { 'Set-Cookie': clearFlashCookie() },
   );
@@ -79,16 +89,18 @@ resumesRoute.post('/resumes/:id/replace', resumeUploadLimit('/resumes'), async (
 resumesRoute.get('/resumes/:id', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
-  const [resume, matches, linkedProfiles] = await Promise.all([
+  const [resume, matches, linkedProfiles, impact] = await Promise.all([
     getResume(id),
     listMatchesForResume(id),
     listProfilesForResume(id),
+    deleteImpact(id),
   ]);
   if (!resume) return c.text('Not found', 404);
   return c.html(
     <ResumeDetailPage
       resume={resume}
       matches={matches}
+      deleteImpact={impact}
       warnings={parseWarnings(resume.text)}
       // The draft the "Create a search" button would save — rendered, not
       // stored (ADR 0015). Only a scanned resume has anything to say.

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -1,7 +1,8 @@
 /** @jsxImportSource hono/jsx */
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { logger } from '../../logger';
 import { scanResume } from '../../resume/scan';
+import type { ResumeScan } from '../../resume/prompts';
 import { matchResumeToJob } from '../../resume/match';
 import { prisma } from '../../db';
 import {
@@ -13,6 +14,7 @@ import {
   listMatchesForResume,
   listResumes,
   replaceResumeFile,
+  type ResumeSummary,
   saveResumeTextVersion,
   setDefaultResume,
 } from '../../resume/store';
@@ -22,6 +24,7 @@ import { createProfileFromResume, newProfileDraft } from '../profile-from-resume
 import { ResumeDetailPage } from '../pages/resume-detail';
 import { ResumesPage } from '../pages/resumes';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
+import { createRun, startRun, updateRun } from '../target-runs';
 import {
   MAX_RESUME_NAME_CHARS,
   nameFromFilename,
@@ -51,18 +54,12 @@ resumesRoute.post('/resumes', resumeUploadLimit('/resumes'), async (c) => {
       ? form.name.trim().slice(0, MAX_RESUME_NAME_CHARS)
       : nameFromFilename(upload.sourceFilename);
   const resume = await createResume({ name, ...upload });
-  const scan = await scanResume(resume);
-  return scan
-    ? flashRedirect(
-        `/resumes/${resume.id}`,
-        'ok',
-        `Uploaded and scanned "${name}". Tip: Settings → Profile → "Fill from a resume" updates your search profile from it.`,
-      )
-    : flashRedirect(
-        `/resumes/${resume.id}`,
-        'err',
-        `Uploaded "${name}", but the AI scan failed — check the web logs and try "Scan".`,
-      );
+  return startScanRun(c, resume, {
+    subtitle: `"${name}" — headline, tools, seniority. About a minute.`,
+    onScanned: () =>
+      `Uploaded and scanned "${name}". Tip: Settings → Profile → "Fill from a resume" updates your search profile from it.`,
+    onFailed: `Uploaded "${name}", but the AI scan failed — check the web logs, then try "Scan".`,
+  });
 });
 
 resumesRoute.post('/resumes/:id/replace', resumeUploadLimit('/resumes'), async (c) => {
@@ -72,10 +69,11 @@ resumesRoute.post('/resumes/:id/replace', resumeUploadLimit('/resumes'), async (
   const upload = await readResumeUpload(await c.req.parseBody());
   if ('error' in upload) return flashRedirect(`/resumes/${id}`, 'err', upload.error);
   const resume = await replaceResumeFile(id, upload);
-  const scan = await scanResume(resume);
-  return scan
-    ? flashRedirect(`/resumes/${id}`, 'ok', `Version ${resume.version} uploaded and scanned. Now re-run Compare on the job.`)
-    : flashRedirect(`/resumes/${id}`, 'err', `Version ${resume.version} uploaded, but the AI scan failed — try "Scan".`);
+  return startScanRun(c, resume, {
+    subtitle: `"${resume.name}" v${resume.version} — re-reading headline, tools, seniority.`,
+    onScanned: () => `Version ${resume.version} uploaded and scanned. Now re-run Compare on the job.`,
+    onFailed: `Version ${resume.version} uploaded, but the AI scan failed — try "Scan".`,
+  });
 });
 
 resumesRoute.get('/resumes/:id', async (c) => {
@@ -129,12 +127,32 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
     return flashRedirect(`/resumes/${id}`, 'err', 'The draft is too short to be a resume.');
   }
   const resume = await saveResumeTextVersion(id, text);
-  const scan = await scanResume(resume);
   const jobId = Number(form.jobId);
   const job = Number.isFinite(jobId)
     ? await prisma.job.findUnique({ where: { id: jobId }, include: { company: { select: { name: true } } } })
     : null;
-  if (job) {
+
+  // The version is already saved; scan and match are the slow part. Two AI
+  // calls back to back is the worst wait on the site, so it gets a run too.
+  const run = createRun({
+    steps: job ? ['scan', 'match'] : ['scan'],
+    jobTitle: job?.title ?? '',
+    resumeName: resume.name,
+    jobId: job?.id,
+    heading: { running: 'Re-reading your edited resume', failed: 'Could not read the edited resume' },
+    subtitle: `Saved as v${resume.version}.${job ? ' Reading it, then scoring it against the posting.' : ''}`,
+    backUrl: `/resumes/${id}`,
+    backLabel: 'Back to the resume',
+  });
+  startRun(run.id, async () => {
+    const scan = await scanResume(resume);
+    if (!job) {
+      updateRun(run.id, scan
+        ? { stage: 'done', resultUrl: `/resumes/${id}`, flash: `Saved as v${resume.version} (text version).` }
+        : { stage: 'error', error: `Saved as v${resume.version}, but the scan failed — try "Scan".` });
+      return;
+    }
+    updateRun(run.id, { stage: 'match' });
     const match = await matchResumeToJob(resume, {
       id: job.id,
       title: job.title,
@@ -142,19 +160,18 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
       location: job.location,
       description: job.description,
     });
-    if (match) {
-      return flashRedirect(
-        `/jobs/${job.id}/target?match=${match.id}`,
-        'ok',
-        `Saved as v${resume.version} (text) and re-analyzed: AI match ${match.matchScore}/100.`,
-      );
-    }
-  }
-  return flashRedirect(
-    `/resumes/${id}`,
-    scan ? 'ok' : 'err',
-    scan ? `Saved as v${resume.version} (text version).` : `Saved as v${resume.version}, but the scan failed — try "Scan".`,
-  );
+    updateRun(run.id, match
+      ? {
+          stage: 'done',
+          resultUrl: `/jobs/${job.id}/target?match=${match.id}`,
+          flash: `Saved as v${resume.version} (text) and re-analyzed: AI match ${match.matchScore}/100.`,
+        }
+      : {
+          stage: 'error',
+          error: `Saved as v${resume.version}, but the comparison failed — see the web logs.`,
+        });
+  });
+  return c.redirect(`/target/runs/${run.id}`, 303);
 });
 
 /**
@@ -183,10 +200,11 @@ resumesRoute.post('/resumes/:id/rescan', async (c) => {
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const resume = await getResume(id);
   if (!resume) return c.text('Not found', 404);
-  const scan = await scanResume(resume);
-  return scan
-    ? flashRedirect(`/resumes/${id}`, 'ok', `Scanned: ${scan.skills.length} skills, ${scan.issues.length} issues.`)
-    : flashRedirect(`/resumes/${id}`, 'err', 'Scan failed — see the web logs.');
+  return startScanRun(c, resume, {
+    subtitle: `"${resume.name}" — headline, tools, seniority. About a minute.`,
+    onScanned: (scan) => `Scanned: ${scan.skills.length} skills, ${scan.issues.length} issues.`,
+    onFailed: 'Scan failed — see the web logs.',
+  });
 });
 
 resumesRoute.post('/resumes/:id/default', async (c) => {
@@ -204,5 +222,37 @@ resumesRoute.post('/resumes/:id/delete', async (c) => {
   logger.info({ id }, 'resume: deleted');
   return flashRedirect('/resumes', 'ok', 'Resume deleted.');
 });
+
+/**
+ * Upload, replace and rescan all end in the same ~60 s call to the resume
+ * model. Awaiting it inline froze the browser on a live form: the submit
+ * button stayed enabled, so a second click created a duplicate resume *and*
+ * a second AI call. The run registry — already carrying /target and
+ * /jobs/:id/match — returns the POST immediately and shows real progress.
+ */
+function startScanRun(
+  c: Context,
+  resume: ResumeSummary,
+  copy: { subtitle: string; onScanned: (scan: ResumeScan) => string; onFailed: string },
+): Response {
+  const { id, name, text } = resume;
+  const run = createRun({
+    steps: ['scan'],
+    jobTitle: '',
+    resumeName: name,
+    heading: { running: 'Reading your resume', failed: 'Could not read the resume' },
+    subtitle: copy.subtitle,
+    // The row exists either way, so the error state has somewhere real to go.
+    backUrl: `/resumes/${id}`,
+    backLabel: 'Back to the resume',
+  });
+  startRun(run.id, async () => {
+    const scan = await scanResume({ id, text });
+    updateRun(run.id, scan
+      ? { stage: 'done', resultUrl: `/resumes/${id}`, flash: copy.onScanned(scan) }
+      : { stage: 'error', error: copy.onFailed });
+  });
+  return c.redirect(`/target/runs/${run.id}`, 303);
+}
 
 /** "Alex_Doe_Senior_Backend_Resume.docx" → "Alex Doe Senior Backend Resume". */

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -292,8 +292,15 @@ export const Table: FC<
     stickyHeader?: boolean;
     /** Proportional column widths (`w-[34%]`, …) with table-fixed layout. */
     widths?: string[];
+    /**
+     * Per-column classes on the `th` itself — the only place a responsive
+     * `hidden sm:table-cell` can live, since a class on the label inside
+     * still leaves the cell occupying its column. Pair each entry with the
+     * same class on that column's `Td`.
+     */
+    thClasses?: string[];
   }>
-> = ({ columns, stickyHeader = false, widths, children }) => {
+> = ({ columns, stickyHeader = false, widths, thClasses, children }) => {
   const table = (
     <table class={`w-full text-sm ${widths ? 'table-fixed' : ''}`}>
       <thead>
@@ -301,9 +308,9 @@ export const Table: FC<
           {columns.map((c, i) => (
             <th
               scope="col"
-              class={`bg-surface-overlay px-4 py-2.5 font-medium first:rounded-tl-none first:pl-5 last:pr-5 ${
+              class={`bg-surface-overlay px-2.5 py-2.5 font-medium first:rounded-tl-none first:pl-3.5 last:pr-3.5 sm:px-4 sm:first:pl-5 sm:last:pr-5 ${
                 widths?.[i] ?? ''
-              } ${
+              } ${thClasses?.[i] ?? ''} ${
                 stickyHeader
                   ? 'sticky top-0 z-10 shadow-[inset_0_-1px_0_rgb(var(--line))]'
                   : 'border-b border-line'
@@ -334,7 +341,7 @@ export const Td: FC<PropsWithChildren<{ class?: string; title?: string }>> = ({
   class: className = '',
   title,
 }) => (
-  <td class={`px-4 py-3 first:pl-5 last:pr-5 ${className}`} title={title}>
+  <td class={`px-2.5 py-3 first:pl-3.5 last:pr-3.5 sm:px-4 sm:first:pl-5 sm:last:pr-5 ${className}`} title={title}>
     {children}
   </td>
 );

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -480,7 +480,6 @@ export const Button: FC<
   );
 };
 
-/** One-button POST form — the dashboard's main mutation idiom. */
 /**
  * `onsubmit` guard for a form whose POST starts real work — an upload, an AI
  * run. The redirect to the progress page is fast but not instant, and a
@@ -492,6 +491,7 @@ export const SUBMIT_ONCE =
   "if(this.dataset.sent)return false;this.dataset.sent='1';" +
   "this.querySelectorAll('button').forEach(function(b){b.disabled=true});";
 
+/** One-button POST form — the dashboard's main mutation idiom. */
 export const ActionForm: FC<
   PropsWithChildren<{
     action: string;

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -474,19 +474,35 @@ export const Button: FC<
 };
 
 /** One-button POST form — the dashboard's main mutation idiom. */
+/**
+ * `onsubmit` guard for a form whose POST starts real work — an upload, an AI
+ * run. The redirect to the progress page is fast but not instant, and a
+ * second click inside that window used to create a second resume and a
+ * second AI call. Disabling after the submit event fired does not cancel the
+ * submission, and with JS off the form still works as before.
+ */
+export const SUBMIT_ONCE =
+  "if(this.dataset.sent)return false;this.dataset.sent='1';" +
+  "this.querySelectorAll('button').forEach(function(b){b.disabled=true});";
+
 export const ActionForm: FC<
   PropsWithChildren<{
     action: string;
     confirm?: string;
     hidden?: Record<string, string | number>;
     class?: string;
+    /** Disable the buttons once pressed — for POSTs that start an AI run. */
+    once?: boolean;
   }>
-> = ({ action, confirm, hidden, children, class: className = '' }) => (
+> = ({ action, confirm, hidden, children, class: className = '', once }) => (
   <form
     method="post"
     action={action}
     class={className}
-    onsubmit={confirm ? `return confirm(${JSON.stringify(confirm)});` : undefined}
+    onsubmit={
+      [confirm ? `if(!confirm(${JSON.stringify(confirm)}))return false;` : '', once ? SUBMIT_ONCE : '']
+        .join('') || undefined
+    }
   >
     {hidden &&
       Object.entries(hidden).map(([k, v]) => <input type="hidden" name={k} value={String(v)} />)}


### PR DESCRIPTION
Part A of [docs/resumes-plan.md](docs/resumes-plan.md) — the P0 and P1 findings
from the `/resumes` audit, TASKS §12 block 1. Part B (the resume strength
review) stays analysis only.

## The bug that mattered

`POST /resumes` awaited `scanResume` — a ~60 s call to the resume model —
before redirecting, on a form whose submit button stayed enabled. A second
click created **a duplicate resume and a second AI call**. The same shape sat
in `/replace`, `/rescan` and `/draft`, and `/draft` with a job was the worst on
the site: scan *and* match, back to back, in one blocking request.

All four now go through the run registry that `/target` and `/jobs/:id/match`
have used since v0.2 — a shared `startScanRun` helper for the three
single-step paths, and a two-step `['scan','match']` run for `/draft`. The
POST returns immediately; the user watches a progress page and can close it.
On top of that, `SUBMIT_ONCE` disables a form's buttons on first press, which
closes the remaining window (the redirect is fast but a multi-MB upload is
not instant).

Measured live: a re-scan returned the progress page instantly, ran 35 s, and
landed back on `/resumes/5` with the same flash the blocking route used to
produce — `Scanned: 81 skills, 10 issues.`

## The phone

The hub forced `min-w-[52rem]` inside a horizontal scroller, so at 375 px it
showed Name and a truncated Headline; Skills, Scanned and **both action
buttons** were behind the scroll — the actions unreachable on a phone.

Delete has left the hub rows entirely (it lives on the detail page; a
destructive action should not be one click from a list), and the rest now drop
out by width. Verified by measuring the real table against its container, not
by eye:

| width | columns | table / container |
|---|---|---|
| 375 | Name · Matches · Default | 341 / 341 — no scroll |
| 768 | + Scanned | 643 / 643 |
| 1200 | + Core stack | fits |
| 1440 | + Headline | fits |

`Table` gained `thClasses` for this: a responsive class on the header *label*
still leaves the cell occupying its column, so the class has to reach the `th`
itself — the audit called this out as a gap in the primitive. Table gutters
also tighten below 640 px; that was the last 16 px between fitting and
scrolling. The other table pages (`/jobs`, `/runs`, `/companies`,
`/discovery`) keep their own `overflow-x-auto` design and were re-checked at
375 px for regressions.

## Two smaller findings

- **The delete confirm understated the blast radius.** Deleting a resume
  cascades its cover letters — including text the user edited by hand — and
  the dialog said only "and its comparisons". `deleteConfirm` (pure, unit
  tested, four cases) now counts both: on the live database it reads *"Delete
  "Senior Backend PHP" and 14 comparisons and 17 cover letters? This cannot
  be undone."*
- **The Skills column differentiated nothing.** It showed the first 6 of ~85
  scanned skills, and both real resumes read `php, go, javascript,
  typescript…`. It now reads `primarySkills` — the 2-5 core technologies the
  scan already extracts and nothing displayed — as tags, plus `+N`. A
  **Matches** column (best score ever reached + run count, one `groupBy` for
  the whole page) answers whether a resume is working at all; a version badge
  rode along.

## Verification

- `npm run lint:types` + `npm test` (864 pass, 4 new) + `npx prisma format --check`.
- No schema change.
- Web rebuilt; `/resumes`, `/resumes/:id`, `/jobs`, `/jobs/:id`,
  `/applications`, `/settings`, `/runs` all 200; 375 / 768 / 1200 / 1440
  screenshots; 0 console errors on a clean tab.
- Live async round-trip through the UI (above).
- The confirm string now interpolates a user-supplied resume name into an
  inline `onsubmit`, so I checked the escaping with a hostile name rather
  than reasoning about it: `" onmouseover=alert(1) x="<script>a</script>`
  renders as `\&quot;` and `&lt;script&gt;` inside the attribute, with no
  break-out and no raw tag on the hub. The name was restored afterwards.

## Review findings applied in-branch

One P1, mine: inserting `SUBMIT_ONCE` split the `/** One-button POST form … */`
comment from `ActionForm`. Moved back.

## Follow-ups

From this branch:
- **`SUBMIT_ONCE` is inline JS**, so with scripting off the double-submit
  window returns (narrowed to the redirect, not 60 s). A server-side
  idempotency key would close it properly.
- **`thClasses` and the `Td` classes must be kept in sync by hand** — the
  parallel-array shape follows the existing `widths` prop, but nothing checks
  that column *i*'s header and cell agree.
- Findings **#7 (add/flip a fact), #8 (rename a resume)** and **#9 (polish)**
  from the audit stay open in the plan's quick-wins bullet.

Still open from #66 / #67:
- **CSRF on the dashboard's POST routes** — the one finding with a security
  smell; this PR adds no new route but does add a new form.
- `setProfileActive` check-then-act against the 8-search ceiling.
- Deleting a search cascades its `JobScore` while `Job.fitScore` keeps that
  search's numbers (ADR 0028 accepts this).
- `setAiKey` read-modify-write loses a key when two tabs save.
- A stale `resumeId` / `telegramTargetId` fails a profile save with a raw FK error.
- `appliedResumeText` still has no reader; only "Mark applied" records a resume,
  so the board's drag-to-Applied leaves the columns NULL.
