### PR TITLE
compare: one AI call on the critical path, free repeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.13.0] — 2026-09-02
+
+### Changed
+- **A compare waits for one AI call, not three**
+  ([docs/target-plan.md](docs/target-plan.md) §3.1, TASKS §13 block 1). On
+  `/target` the posting's fit score is now classified in the background while
+  the resume-model call runs — the comparison never read it, and that leg
+  alone measured 49–55 s on the `claude_code` engine. On "Upload vN &
+  re-analyze" the new version's scan runs the same way instead of ahead of
+  the match (26–33 s measured). Known cost of the second one: until the
+  background scan lands, the resume's headline / skills / core stack still
+  describe the previous version — `scannedAt: null` marks it, and nothing but
+  `/resumes` and other resumes' "elsewhere" hints read those fields.
+- **Repeating a comparison is free.** A double submit, a back button, a
+  re-paste or a re-upload whose text did not change no longer buys a second
+  resume-model call: when the latest stored analysis for that resume and
+  posting judged the identical text under the same prompt version, the page
+  shows it with *"Unchanged since the last analysis (3m ago)"* and a
+  **Re-run anyway** button for the rare time a fresh call is wanted. Plain
+  string equality — a one-character edit is a new analysis
+  (`src/resume/match-reuse.ts`, unit-tested).
+- **The progress page tells the truth about time.** Every step shows the
+  seconds it took once done and a live count while it runs, next to a total
+  that ticks every second. Step copy now quotes measured durations instead of
+  "about a minute": the match is 1½–2 minutes on Opus (83–109 s measured), a
+  scan about half a minute, posting-fact detection 10–40 s on a CLI engine.
+  The same numbers replaced the promises on the job page, the targeted
+  editor, `/welcome` and Settings.
+- Per-step timing logs: `resume: scanned`, `posting-extract: done`,
+  `classify-existing: scored` and `run: step finished` all carry `ms`, so the
+  next optimisation round starts from numbers, not estimates.
+
+### Notes
+- `ResumeMatch` has no prompt-version column and this release changes no
+  schema, so the version rides inside the `breakdown` JSON (written by
+  `createMatch` / `updateMatchScoring`). Rows from before this release carry
+  no marker and are never reused. No migration.
+
 ## [1.12.0] — 2026-09-02
 
 ### Fixed
@@ -910,6 +948,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.13.0]: https://github.com/applypack/applypack/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/applypack/applypack/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/applypack/applypack/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/applypack/applypack/compare/v1.9.0...v1.10.0

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -810,8 +810,9 @@ icon; progress visible step-by-step via the target-run registry pattern.
 
 ## 13. /target compare speed (30-40 s) + keyword-matcher accuracy (analysis 2026-08-31)
 
-Full plan: [docs/target-plan.md](./target-plan.md). **Analysis only —
-nothing implemented.** §12's async-upload item overlaps the `/resumes`
+Full plan: [docs/target-plan.md](./target-plan.md). **Block 1 shipped
+2026-09-02 (measured numbers in the plan's §2.3); blocks 2–6 open.** §12's
+async-upload item overlaps the `/resumes`
 sync-scan finding, planned there, referenced here.
 
 Driver: a fresh-resume compare takes ~3 min (owner target: 30-40 s), and
@@ -826,10 +827,15 @@ sticky). Speed strategy: instant no-AI check against the stored frame
 (the live-editor machinery already does it), keywords-only fast AI mode,
 Sonnet bench for the resume role — not "make Opus stream faster".
 
-- [ ] `target-speed-p0` — classify off the critical path (parallel,
+- [x] `target-speed-p0` — classify off the critical path (background,
       `{classify:false}`), scan → background on reupload, memoize
-      identical (job, resumeText) re-runs, honest `STEP_VIEW` copy +
-      per-step ms logging
+      identical (job, resumeText, prompt version) re-runs with a "Re-run
+      anyway" escape, per-step times on the run page, `STEP_VIEW` copy from
+      measured runs + per-step ms logging — done 2026-09-02, branch
+      `target-speed-p0` (PR #78). Measured on the CLI engine: a fresh
+      `/target` compare 158 → 128 s, a repeat 158 → 38 s, Compare repeat
+      109 → 0 s, re-upload 117 → 95 s; the match call itself is 78–109 s
+      (p50 ≈ 94 s) — 30–40 s needs blocks 3–4.
 - [ ] `keyword-matcher-v2` — persist-time verbatim guard, deterministic
       alias table (`keyword-aliases.ts`, pure), plural + separator
       tolerance in `termPattern`, tiered keyword budget (all must/

--- a/docs/target-plan.md
+++ b/docs/target-plan.md
@@ -97,6 +97,23 @@ scan / extract / classify log lines and log a per-stage delta in
 `updateRun` (`stageAt` already exists) — one log pass over a week of real
 runs replaces every estimate above. No schema change.
 
+**Measured 2026-09-02** (block 1, `claude_code` CLI engine, Opus for the
+resume role, Haiku 4.5 single-stage classifier, one run at a time; 12 runs):
+
+| Call | Samples (s) | Note |
+| --- | --- | --- |
+| match | 78 · 83 · 85 · 94 · 94 · 96 · 109 | p50 ≈ 94, p90 ≈ 109 — the whole critical path after P0 |
+| scan | 26 · 33 · 36 | half the "about a minute" the copy promised |
+| extract | 12 · 32 · 37 | high variance on the CLI engine |
+| classify | 49 · 55 | single-stage; off the critical path since block 1 |
+
+Critical-path wall time, before → after block 1: fresh `/target` compare
+158 → 128 s, the same paste again 158 → 38 s (extract, then the stored row),
+Compare 109 → 79 s and a repeat 109 → 0 s, re-upload 117 → 95 s and the same
+file again 117 → 2 s. §2.2's "~150-300 s" first-compare estimate was right
+for the CLI engine; the API-engine column stays unmeasured (not in the
+owner's chain).
+
 ---
 
 ## 3. Speed plan

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/jobs/classify-existing.ts
+++ b/src/jobs/classify-existing.ts
@@ -7,6 +7,8 @@ import { getSettings } from '../settings';
 import { buildVerdicts, mergeVerdicts } from './verdict-merge';
 import { saveJobScores } from './score-store';
 
+export type ClassifiableJob = Job & { company: { name: string; atsType: AtsType } };
+
 /**
  * Classifies one stored job against every active search and writes the scores
  * back (ADR 0028). Used by the per-job "Re-classify" button and by manual job
@@ -17,7 +19,7 @@ import { saveJobScores } from './score-store';
  * Returns false when no search is active or the classifier failed.
  */
 export async function classifyExistingJob(
-  job: Job & { company: { name: string; atsType: AtsType } },
+  job: ClassifiableJob,
   opts: { keepStatus: boolean },
 ): Promise<boolean> {
   const started = Date.now();
@@ -59,4 +61,15 @@ export async function classifyExistingJob(
     'classify-existing: scored',
   );
   return true;
+}
+
+/**
+ * The same call with nobody waiting on it — for a pasted posting whose
+ * reader wants the comparison, not the fit score. The score lands on the job
+ * page whenever the classifier answers; a failure is logged, never surfaced.
+ */
+export function classifyInBackground(job: ClassifiableJob): void {
+  void classifyExistingJob(job, { keepStatus: true }).catch((err) => {
+    logger.error({ err, jobId: job.id }, 'classify-existing: background run failed');
+  });
 }

--- a/src/jobs/classify-existing.ts
+++ b/src/jobs/classify-existing.ts
@@ -20,6 +20,7 @@ export async function classifyExistingJob(
   job: Job & { company: { name: string; atsType: AtsType } },
   opts: { keepStatus: boolean },
 ): Promise<boolean> {
+  const started = Date.now();
   // Blank searches are dropped here exactly as in the tick and in
   // "Re-classify all" (issue #50) — otherwise this path, and only this path,
   // would store a vibes-based verdict next to the real ones.
@@ -53,5 +54,9 @@ export async function classifyExistingJob(
   }
 
   await saveJobScores(job, merged, verdicts, status);
+  logger.info(
+    { jobId: job.id, searches: profiles.length, kept: merged.kept, ms: Date.now() - started },
+    'classify-existing: scored',
+  );
   return true;
 }

--- a/src/jobs/manual-job.ts
+++ b/src/jobs/manual-job.ts
@@ -5,7 +5,7 @@ import { prisma } from '../db';
 import { decodeHtmlEntities } from '../http';
 import { logger } from '../logger';
 import { hashShortId } from '../text-utils';
-import { classifyExistingJob } from './classify-existing';
+import { classifyExistingJob, type ClassifiableJob } from './classify-existing';
 
 /*
  * Pasted postings (the /jobs/new form and the /target compare page) become
@@ -36,7 +36,7 @@ export type ManualJobInput = z.infer<typeof ManualJobSchema>;
 
 export type ManualJobResult =
   | { kind: 'existing'; job: Job }
-  | { kind: 'created'; job: Job; classified: boolean };
+  | { kind: 'created'; job: ClassifiableJob; classified: boolean };
 
 /**
  * `classify: false` skips the fit-score call — the cover-letter path never

--- a/src/jobs/posting-extract.ts
+++ b/src/jobs/posting-extract.ts
@@ -110,6 +110,7 @@ export function fallbackTitle(description: string): string {
 export async function extractPostingFacts(description: string): Promise<PostingFacts | null> {
   const { system, user } = buildExtractPrompt(description);
   const ai = await getAiRuntime();
+  const started = Date.now();
   const out = await ai.complete({
     system,
     user,
@@ -120,5 +121,6 @@ export async function extractPostingFacts(description: string): Promise<PostingF
   if (!out) return null;
   const facts = parseExtractReply(out.text);
   if (!facts) logger.warn({ head: out.text.slice(0, 120) }, 'posting-extract: unparseable reply');
+  logger.info({ ok: facts !== null, ms: Date.now() - started }, 'posting-extract: done');
   return facts;
 }

--- a/src/resume/match-reuse.test.ts
+++ b/src/resume/match-reuse.test.ts
@@ -31,8 +31,8 @@ test('readPromptVersion reads the marker and nothing else', () => {
   assert.equal(readPromptVersion(null), null);
 });
 
-test('reuseNotice names the age and says nothing was spent', () => {
+test('reuseNotice names the age and says the model was not called', () => {
   const notice = reuseNotice('3m ago');
   assert.match(notice, /3m ago/);
-  assert.match(notice, /no AI call/);
+  assert.match(notice, /not called again/);
 });

--- a/src/resume/match-reuse.test.ts
+++ b/src/resume/match-reuse.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { canReuseMatch, readPromptVersion, reuseNotice } from './match-reuse';
+
+const TEXT = 'Nazar Boyko\nSenior Software Engineer\n## SKILLS\nPHP, Laravel, React';
+const stored = { resumeText: TEXT, promptVersion: 5 };
+
+test('identical text under the same prompt reuses the stored row', () => {
+  assert.equal(canReuseMatch(stored, TEXT, 5), true);
+});
+
+test('a one-character edit is a new analysis', () => {
+  assert.equal(canReuseMatch(stored, `${TEXT}.`, 5), false);
+  assert.equal(canReuseMatch(stored, TEXT.replace('React', 'react'), 5), false);
+});
+
+test('a prompt bump is a new analysis', () => {
+  assert.equal(canReuseMatch(stored, TEXT, 6), false);
+});
+
+test('no previous row, or one without a version marker, never reuses', () => {
+  assert.equal(canReuseMatch(null, TEXT, 5), false);
+  assert.equal(canReuseMatch({ resumeText: TEXT, promptVersion: null }, TEXT, 5), false);
+});
+
+test('readPromptVersion reads the marker and nothing else', () => {
+  assert.equal(readPromptVersion({ v: 3, score: 71, promptVersion: 5 }), 5);
+  assert.equal(readPromptVersion({ v: 3, score: 71 }), null, 'pre-marker rows');
+  assert.equal(readPromptVersion({ promptVersion: '5' }), null, 'a string is not a version');
+  assert.equal(readPromptVersion({}), null);
+  assert.equal(readPromptVersion(null), null);
+});
+
+test('reuseNotice names the age and says nothing was spent', () => {
+  const notice = reuseNotice('3m ago');
+  assert.match(notice, /3m ago/);
+  assert.match(notice, /no AI call/);
+});

--- a/src/resume/match-reuse.ts
+++ b/src/resume/match-reuse.ts
@@ -28,5 +28,5 @@ export function readPromptVersion(breakdown: unknown): number | null {
 
 /** The flash shown instead of a run; `when` is the stored row's age ("3m ago"). */
 export function reuseNotice(when: string): string {
-  return `Unchanged since the last analysis (${when}) — showing that result; no AI call was spent.`;
+  return `Unchanged since the last analysis (${when}) — showing that result; the resume model was not called again.`;
 }

--- a/src/resume/match-reuse.ts
+++ b/src/resume/match-reuse.ts
@@ -1,0 +1,32 @@
+/*
+ * When a stored comparison already answers a request (docs/target-plan.md
+ * §3.1 item 3): the latest row for (job, resume) judged the identical text
+ * under the same prompt. Plain string equality — a one-character edit is a
+ * new analysis, and so is a prompt bump. This is what makes a double submit,
+ * a back button or a re-paste free instead of a full resume-model call.
+ *
+ * ResumeMatch has no prompt-version column; the version rides inside the
+ * `breakdown` JSON (written by store.ts, read here). Rows from before that
+ * marker read as null and are never reused.
+ */
+
+export interface StoredMatch {
+  resumeText: string;
+  promptVersion: number | null;
+}
+
+export function canReuseMatch(previous: StoredMatch | null, text: string, promptVersion: number): boolean {
+  return previous !== null && previous.promptVersion === promptVersion && previous.resumeText === text;
+}
+
+/** The prompt version a stored `breakdown` JSON carries, if any. */
+export function readPromptVersion(breakdown: unknown): number | null {
+  if (typeof breakdown !== 'object' || breakdown === null) return null;
+  const v = (breakdown as { promptVersion?: unknown }).promptVersion;
+  return Number.isInteger(v) ? (v as number) : null;
+}
+
+/** The flash shown instead of a run; `when` is the stored row's age ("3m ago"). */
+export function reuseNotice(when: string): string {
+  return `Unchanged since the last analysis (${when}) — showing that result; no AI call was spent.`;
+}

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -11,8 +11,15 @@ import {
   type MatchJobInput,
 } from './prompts';
 import { annotateElsewhere, applyFacts } from './facts';
+import { canReuseMatch, readPromptVersion } from './match-reuse';
 import { scoreMatch } from './score';
-import { createMatch, getLatestMatchForJob, listFacts, listOtherResumeSkills } from './store';
+import {
+  createMatch,
+  getLatestMatchForJob,
+  getLatestMatchForResumeAndJob,
+  listFacts,
+  listOtherResumeSkills,
+} from './store';
 
 const PREVIOUS_KEYWORDS_MAX = 40;
 
@@ -81,6 +88,7 @@ export async function matchResumeToJob(
         model,
         result: { ...parsed.data, keywords },
         breakdown,
+        promptVersion: PROMPT_VERSION,
       });
       logger.info(
         {
@@ -104,4 +112,19 @@ export async function matchResumeToJob(
     );
   }
   return null;
+}
+
+/**
+ * The stored comparison that already answers this request, or null. Callers
+ * check it before starting a run so a repeat costs nothing (match-reuse.ts).
+ */
+export async function findReusableMatch(
+  jobId: number,
+  resumeId: number,
+  text: string,
+): Promise<ResumeMatch | null> {
+  const previous = await getLatestMatchForResumeAndJob(jobId, resumeId);
+  if (!previous) return null;
+  const stored = { resumeText: previous.resumeText, promptVersion: readPromptVersion(previous.breakdown) };
+  return canReuseMatch(stored, text, PROMPT_VERSION) ? previous : null;
 }

--- a/src/resume/scan.ts
+++ b/src/resume/scan.ts
@@ -11,6 +11,7 @@ export async function scanResume(resume: { id: number; text: string }): Promise<
   const prompt = buildScanPrompt(resume.text);
   const ai = await getAiRuntime();
   for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
+    const started = Date.now();
     const out = await ai.complete({
       ...prompt,
       maxTokens: SCAN_MAX_TOKENS,
@@ -23,7 +24,13 @@ export async function scanResume(resume: { id: number; text: string }): Promise<
     if (parsed.ok) {
       await saveResumeScan(resume.id, parsed.data);
       logger.info(
-        { id: resume.id, skills: parsed.data.skills.length, issues: parsed.data.issues.length },
+        {
+          id: resume.id,
+          skills: parsed.data.skills.length,
+          issues: parsed.data.issues.length,
+          attempt,
+          ms: Date.now() - started,
+        },
         'resume: scanned',
       );
       return parsed.data;

--- a/src/resume/scan.ts
+++ b/src/resume/scan.ts
@@ -39,3 +39,16 @@ export async function scanResume(resume: { id: number; text: string }): Promise<
   }
   return null;
 }
+
+/**
+ * The scan with nobody waiting on it. Until it lands, the row's headline /
+ * skills / primary stack still describe the previous version (scannedAt:
+ * null already marks that) — read by /resumes and by other resumes'
+ * "elsewhere" hints, never by the match that runs next to it
+ * (docs/target-plan.md §3.1 item 2). A failure is logged, never surfaced.
+ */
+export function scanInBackground(resume: { id: number; text: string }): void {
+  void scanResume(resume).catch((err) => {
+    logger.error({ err, id: resume.id }, 'resume: background scan failed');
+  });
+}

--- a/src/resume/store.ts
+++ b/src/resume/store.ts
@@ -224,6 +224,8 @@ export async function createMatch(input: {
   result: ResumeMatchResult;
   /** Computed by score.ts — the model never sets the number (ADR 0012). */
   breakdown: ScoreBreakdown;
+  /** Rides inside the breakdown JSON — the memo key (match-reuse.ts). */
+  promptVersion: number;
 }): Promise<ResumeMatch> {
   const r = input.result;
   return prisma.resumeMatch.create({
@@ -242,7 +244,7 @@ export async function createMatch(input: {
       keywords: r.keywords as Prisma.InputJsonValue,
       actions: r.actions as Prisma.InputJsonValue,
       removals: r.removals as Prisma.InputJsonValue,
-      breakdown: input.breakdown as unknown as Prisma.InputJsonValue,
+      breakdown: { ...input.breakdown, promptVersion: input.promptVersion } as unknown as Prisma.InputJsonValue,
       hardRequirements: r.hard_requirements as Prisma.InputJsonValue,
     },
   });
@@ -260,13 +262,13 @@ export async function getLatestMatchForJob(jobId: number): Promise<ResumeMatch |
 /** A fact flip recomputes the stored score deterministically — no AI call. */
 export async function updateMatchScoring(
   id: number,
-  input: { keywords: MatchKeyword[]; breakdown: ScoreBreakdown },
+  input: { keywords: MatchKeyword[]; breakdown: ScoreBreakdown; promptVersion: number | null },
 ): Promise<ResumeMatch> {
   return prisma.resumeMatch.update({
     where: { id },
     data: {
       keywords: input.keywords as Prisma.InputJsonValue,
-      breakdown: input.breakdown as unknown as Prisma.InputJsonValue,
+      breakdown: { ...input.breakdown, promptVersion: input.promptVersion } as unknown as Prisma.InputJsonValue,
       matchScore: input.breakdown.score,
     },
   });

--- a/src/web/flash.ts
+++ b/src/web/flash.ts
@@ -8,12 +8,19 @@ export type FlashKind = 'ok' | 'warn' | 'err';
 export interface FlashMessage {
   kind: FlashKind;
   text: string;
+  /** The result shown is a stored analysis — the page offers "Re-run anyway". */
+  rerun?: boolean;
 }
 
 const FLASH_TTL_SECONDS = 5;
 
-export function flashRedirect(location: string, kind: FlashMessage['kind'], text: string): Response {
-  const value = encodeURIComponent(JSON.stringify({ kind, text }));
+export function flashRedirect(
+  location: string,
+  kind: FlashMessage['kind'],
+  text: string,
+  opts: { rerun?: boolean } = {},
+): Response {
+  const value = encodeURIComponent(JSON.stringify({ kind, text, ...(opts.rerun ? { rerun: true } : {}) }));
   return new Response(null, {
     status: 303,
     headers: {
@@ -35,7 +42,7 @@ export function parseFlashCookie(cookieHeader: string | undefined): FlashMessage
       (parsed.kind === 'ok' || parsed.kind === 'warn' || parsed.kind === 'err') &&
       typeof parsed.text === 'string'
     ) {
-      return parsed;
+      return { kind: parsed.kind, text: parsed.text, ...(parsed.rerun === true ? { rerun: true } : {}) };
     }
   } catch {
     return null;

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -111,7 +111,17 @@ export const JobDetailPage: FC<JobDetailProps> = ({
 }) => (
   <Layout title={job.title} active="jobs">
     <PageHeaderBlock job={job} />
-    <Flash flash={flash} />
+    <Flash flash={flash}>
+      {flash?.rerun && resumeMatch.selected && (
+        <form method="post" action={`/jobs/${job.id}/match`}>
+          <input type="hidden" name="resumeId" value={resumeMatch.selected.resumeId} />
+          <input type="hidden" name="force" value="1" />
+          <Button variant="secondary" size="sm">
+            Re-run anyway
+          </Button>
+        </form>
+      )}
+    </Flash>
     <CrossListingNotice job={job} />
 
     <div class="grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_340px]">

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -7,6 +7,7 @@ import {
   Card,
   FitBadge,
   Hint,
+  SUBMIT_ONCE,
   Input,
   MarkIcon,
   SectionTitle,
@@ -89,7 +90,7 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
           to see what to change before applying here.
         </Hint>
       ) : (
-        <form method="post" action={`/jobs/${jobId}/match`} class="flex flex-wrap items-end gap-3">
+        <form method="post" action={`/jobs/${jobId}/match`} class="flex flex-wrap items-end gap-3" onsubmit={SUBMIT_ONCE}>
           <label class="block min-w-0 max-w-full">
             <span class="block text-[13px] font-medium text-ink">Resume</span>
             <Select name="resumeId" class="mt-1.5 !w-auto max-w-full">

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -109,7 +109,7 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
           </label>
           <Button variant="violet">Compare</Button>
           <Hint class="basis-full">
-            One call to the resume model, about a minute. The score itself is computed
+            One call to the resume model — 1½ to 2 minutes on Opus. The score itself is computed
             deterministically from the reply — same facts, same number, every time.
           </Hint>
         </form>

--- a/src/web/pages/run-steps.tsx
+++ b/src/web/pages/run-steps.tsx
@@ -17,7 +17,10 @@ export const RunSteps: FC<{
   steps: string[];
   currentIdx: number;
   view: Record<string, StepView>;
-}> = ({ steps, currentIdx, view }) => (
+  /** Time already spent: finished steps from the registry, the active one as of this render. */
+  stepMs?: Partial<Record<string, number>>;
+  activeMs?: number;
+}> = ({ steps, currentIdx, view, stepMs = {}, activeMs }) => (
   <>
     <ol class="mt-5 space-y-5" aria-label="Progress">
       {steps.map((s, i) => (
@@ -34,7 +37,12 @@ export const RunSteps: FC<{
             <span class="i i-pending h-2 w-2 rounded-full bg-line-strong"></span>
           </span>
           <span class="min-w-0 flex-1">
-            <span class="t-label block text-sm">{view[s]?.label ?? s}</span>
+            <span class="flex items-baseline gap-2">
+              <span class="t-label text-sm">{view[s]?.label ?? s}</span>
+              <span class="text-xs tabular-nums text-ink-faint" data-step-time>
+                {formatElapsed(i < currentIdx ? stepMs[s] : i === currentIdx ? activeMs : undefined)}
+              </span>
+            </span>
             <span class="t-detail block text-xs">{view[s]?.detail}</span>
             <span
               class="t-activity mt-1.5 block text-[13px] leading-5 text-violet transition-opacity duration-300"
@@ -48,6 +56,13 @@ export const RunSteps: FC<{
     <style dangerouslySetInnerHTML={{ __html: RUN_CSS }} />
   </>
 );
+
+/** "4s" / "1m 16s" — the same shape target-run.mjs paints once it polls. */
+function formatElapsed(ms: number | undefined): string {
+  if (ms === undefined) return '';
+  const s = Math.max(0, Math.round(ms / 1000));
+  return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
+}
 
 /* Step visuals are CSS-driven off data-state so the poller only flips attributes. */
 const RUN_CSS = `

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -281,7 +281,7 @@ export const SettingsPage: FC<SettingsProps> = ({
                   No resumes yet — pick a file ({ACCEPTED_EXTENSIONS.join(', ')} · up to{' '}
                   {MAX_UPLOAD_MB} MB) and AI maps its stack onto the profile: primary stack →
                   required, other skills → nice-to-have, plus role types and seniority. Takes
-                  about a minute; the file also lands in Resumes. The result appears below as
+                  about half a minute; the file also lands in Resumes. The result appears below as
                   a draft; nothing is saved until you press "Save profile".
                 </Hint>
                 <form

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -86,7 +86,13 @@ export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
             </div>
           ) : (
             <>
-              <RunSteps steps={run.steps} currentIdx={currentIdx} view={STEP_VIEW} />
+              <RunSteps
+                steps={run.steps}
+                currentIdx={currentIdx}
+                view={STEP_VIEW}
+                stepMs={run.stepMs}
+                activeMs={Date.now() - run.stageAt}
+              />
               <div class="mt-5 flex items-center justify-between gap-3 border-t border-line pt-3">
                 <Hint>
                   You can close this page — the run keeps going and the result lands{' '}

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -12,7 +12,7 @@ const STEP_VIEW: Record<RunStep, StepView> = {
   },
   extract: {
     label: 'Detect posting facts',
-    detail: 'company, title, location, salary from the description — 10 to 30 s on a CLI engine, seconds on an API one',
+    detail: 'company, title, location, salary from the description — 10 to 40 s on a CLI engine, seconds on an API one',
   },
   scan: {
     // Also reached by a plain re-scan and a first upload, where there is no

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -14,10 +14,6 @@ const STEP_VIEW: Record<RunStep, StepView> = {
     label: 'Detect posting facts',
     detail: 'company, title, location, salary from the description — seconds',
   },
-  classify: {
-    label: 'Classify the posting',
-    detail: 'fit score against every running search — seconds',
-  },
   scan: {
     // Also reached by a plain re-scan and a first upload, where there is no
     // "new version" to speak of.

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -12,17 +12,17 @@ const STEP_VIEW: Record<RunStep, StepView> = {
   },
   extract: {
     label: 'Detect posting facts',
-    detail: 'company, title, location, salary from the description — seconds',
+    detail: 'company, title, location, salary from the description — 10 to 30 s on a CLI engine, seconds on an API one',
   },
   scan: {
     // Also reached by a plain re-scan and a first upload, where there is no
     // "new version" to speak of.
     label: 'Read the resume',
-    detail: 'headline, skills, ATS issues — about a minute',
+    detail: 'headline, skills, ATS issues — about half a minute',
   },
   match: {
     label: 'AI match',
-    detail: 'the resume model reads both texts — about a minute',
+    detail: 'the resume model reads both texts and writes the full report — 1½ to 2 minutes on Opus',
   },
   verify: {
     label: 'Research the company',

--- a/src/web/pages/target-start.tsx
+++ b/src/web/pages/target-start.tsx
@@ -1,7 +1,20 @@
 /** @jsxImportSource hono/jsx */
 import type { FC, PropsWithChildren } from 'hono/jsx';
 import { Layout } from '../layout';
-import { Button, Card, Field, FILE_INPUT_CLASS, Flash, Hint, Input, PageHeader, SectionTitle, Select, Textarea } from '../ui';
+import {
+  Button,
+  Card,
+  Field,
+  FILE_INPUT_CLASS,
+  Flash,
+  Hint,
+  Input,
+  PageHeader,
+  SectionTitle,
+  Select,
+  SUBMIT_ONCE,
+  Textarea,
+} from '../ui';
 import type { FlashMessage } from '../flash';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
 import { MAX_UPLOAD_MB } from '../upload';
@@ -38,6 +51,7 @@ export const TargetStartPage: FC<TargetStartProps> = ({ resumes, flash }) => {
         action="/target"
         enctype="multipart/form-data"
         class="w-full"
+        onsubmit={SUBMIT_ONCE}
       >
         <div class="grid items-start gap-4 lg:grid-cols-2">
           <Card>

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -289,8 +289,8 @@ export const TargetPage: FC<TargetPageProps> = ({
                   </Button>
                   <Hint>
                     {resume.ephemeral
-                      ? 'Replaces this comparison with a fresh analysis — nothing lands in your Resumes (~1 min).'
-                      : 'New version, scan and AI match in one go — about 2 minutes.'}
+                      ? 'Replaces this comparison with a fresh analysis — nothing lands in your Resumes (~2 min).'
+                      : 'New version and AI match — about 2 minutes; the resume scan runs in the background.'}
                   </Hint>
                 </form>
               </div>
@@ -311,7 +311,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                   <input type="hidden" name="resumeId" value={resume.id} />
                   <input type="hidden" name="draftText" id="reanalyze-text" value="" />
                   <input type="hidden" name="next" value="target" />
-                  <Button variant="violet" class="w-full" title="Sends the text in the editor to the resume model (~1 min)">
+                  <Button variant="violet" class="w-full" title="Sends the text in the editor to the resume model (~2 min)">
                     Re-analyze with AI
                   </Button>
                 </form>

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -145,7 +145,20 @@ export const TargetPage: FC<TargetPageProps> = ({
           Resume match
         </span>
       </nav>
-      <Flash flash={flash} />
+      <Flash flash={flash}>
+        {flash?.rerun && (
+          <Button
+            form="reanalyze-form"
+            name="force"
+            value="1"
+            variant="secondary"
+            size="sm"
+            title="Spend a fresh resume-model call on the text in the editor"
+          >
+            Re-run anyway
+          </Button>
+        )}
+      </Flash>
 
       <div class="mb-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div class="min-w-0 lg:min-w-[15rem] lg:shrink-0">
@@ -261,6 +274,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                   action={`/jobs/${job.id}/target/reupload`}
                   enctype="multipart/form-data"
                   class="mt-2 space-y-2"
+                  onsubmit={SUBMIT_ONCE}
                 >
                   <input type="hidden" name="resumeId" value={resume.id} />
                   <input
@@ -293,7 +307,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                 </svg>
               </summary>
               <div class={`${MENU_PANEL} space-y-2`}>
-                <form method="post" action={`/jobs/${job.id}/match`} id="reanalyze-form">
+                <form method="post" action={`/jobs/${job.id}/match`} id="reanalyze-form" onsubmit={SUBMIT_ONCE}>
                   <input type="hidden" name="resumeId" value={resume.id} />
                   <input type="hidden" name="draftText" id="reanalyze-text" value="" />
                   <input type="hidden" name="next" value="target" />

--- a/src/web/pages/welcome.tsx
+++ b/src/web/pages/welcome.tsx
@@ -513,8 +513,8 @@ const ProfileStep: FC<WelcomeProps> = ({ profile, steps }) => {
       ) : (
         <>
           <p class="text-sm text-ink-muted">
-            Upload your resume and we'll read the tools you use and the roles you do. Takes about a
-            minute; the file stays on your Resumes page for later comparisons and cover letters.
+            Upload your resume and we'll read the tools you use and the roles you do. Takes about
+            half a minute; the file stays on your Resumes page for later comparisons and cover letters.
           </p>
           <form
             method="post"

--- a/src/web/public/target-run.mjs
+++ b/src/web/public/target-run.mjs
@@ -18,10 +18,6 @@ const ACTIVITIES = {
     'Reading the pasted posting…',
     'Picking out company, title, location and salary…',
   ],
-  classify: [
-    'Reading the posting…',
-    'Scoring fit against the active profile — stack, role type, region, salary…',
-  ],
   scan: [
     'Extracting the text an ATS parser would see…',
     'Cataloguing skills, seniority and job-agnostic issues…',

--- a/src/web/public/target-run.mjs
+++ b/src/web/public/target-run.mjs
@@ -79,6 +79,13 @@ export function formatElapsed(ms) {
   return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
 }
 
+/** The time slot next to a step: its final time once done, a live count while active. */
+export function stepTime(stepState, step, state) {
+  if (stepState === 'active') return formatElapsed(state.stageElapsedMs);
+  if (stepState === 'done' && state.stepMs && state.stepMs[step] != null) return formatElapsed(state.stepMs[step]);
+  return '';
+}
+
 export function init(data, activity = defaultActivity) {
   const steps = [...document.querySelectorAll('[data-step]')];
   const elapsedEl = document.getElementById('run-elapsed');
@@ -92,6 +99,8 @@ export function init(data, activity = defaultActivity) {
       const i = state.steps.indexOf(li.dataset.step);
       // idx === -1 means a terminal stage: everything reads done while we reload.
       li.dataset.state = idx === -1 || i < idx ? 'done' : i === idx ? 'active' : 'pending';
+      const timeEl = li.querySelector('[data-step-time]');
+      if (timeEl) timeEl.textContent = stepTime(li.dataset.state, li.dataset.step, state);
     }
     const active = steps.find((li) => li.dataset.state === 'active');
     if (!active) return;

--- a/src/web/routes/facts.ts
+++ b/src/web/routes/facts.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { applyFacts } from '../../resume/facts';
+import { readPromptVersion } from '../../resume/match-reuse';
 import { readKeywords } from '../../resume/prompts';
 import { readBreakdown, scoreMatch } from '../../resume/score';
 import { deleteFact, getMatch, updateMatchScoring, upsertFact } from '../../resume/store';
@@ -43,7 +44,11 @@ factsRoute.post('/facts', async (c) => {
       const bd = readBreakdown(match.breakdown);
       if (changed > 0 && bd) {
         const newBd = scoreMatch(next, bd.alignment, match.redFlags.length);
-        await updateMatchScoring(match.id, { keywords: next, breakdown: newBd });
+        await updateMatchScoring(match.id, {
+          keywords: next,
+          breakdown: newBd,
+          promptVersion: readPromptVersion(match.breakdown),
+        });
         return flashRedirect(
           back,
           'ok',

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -20,6 +20,7 @@ import { previousFor } from '../pages/resume-match-card';
 import { nameFromFilename, readResumeUpload, resumeUploadLimit } from '../upload';
 import { scanInBackground } from '../../resume/scan';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
+import { formatRelative } from '../format';
 import { createRun, startRun, updateRun } from '../target-runs';
 import {
   deleteCoverLettersForResume,
@@ -36,7 +37,8 @@ import {
   upsertScratchResume,
 } from '../../resume/store';
 import { preselectAppliedResume, preselectResume } from '../../resume/pick';
-import { matchResumeToJob } from '../../resume/match';
+import { findReusableMatch, matchResumeToJob } from '../../resume/match';
+import { reuseNotice } from '../../resume/match-reuse';
 import { generateCoverLetter } from '../../resume/cover-letter';
 import {
   countWords,
@@ -436,14 +438,26 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
   // The targeted view posts its edited text; a non-empty draft is judged instead of the stored version.
   const draftText = typeof form.draftText === 'string' ? form.draftText.replace(/\r\n/g, '\n').trim() : '';
   const draft = draftText.length > 0 && draftText !== resume.text;
+  const text = draft ? draftText : resume.text;
   const toTarget = form.next === 'target';
+  const resultUrl = (matchId: number) =>
+    toTarget ? `/jobs/${id}/target?match=${matchId}` : `/jobs/${id}?match=${matchId}#resume-match`;
+
+  // The same text was already judged: show that analysis instead of paying
+  // for it again — unless "Re-run anyway" asked for a fresh call.
+  if (form.force !== '1') {
+    const reused = await findReusableMatch(job.id, resume.id, text);
+    if (reused) {
+      return flashRedirect(resultUrl(reused.id), 'warn', reuseNotice(formatRelative(reused.createdAt)), { rerun: true });
+    }
+  }
 
   const run = createRun({ steps: ['match'], jobTitle: job.title, resumeName: resume.name, jobId: id });
   startRun(run.id, async () => {
     // Ephemeral (scratch) compares keep only the current analysis.
     if (resume.hidden) await deleteMatchesForResume(resume.id);
     const row = await matchResumeToJob(
-      { id: resume.id, version: resume.version, text: draft ? draftText : resume.text },
+      { id: resume.id, version: resume.version, text },
       { id: job.id, title: job.title, companyName: job.company.name, location: job.location, description: job.description },
       { draft },
     );
@@ -453,7 +467,7 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
     }
     updateRun(run.id, {
       stage: 'done',
-      resultUrl: toTarget ? `/jobs/${id}/target?match=${row.id}` : `/jobs/${id}?match=${row.id}#resume-match`,
+      resultUrl: resultUrl(row.id),
       flash: `${draft ? 'Draft' : `"${resume.name}"`} compared — AI match ${row.matchScore}/100.`,
     });
   });
@@ -651,14 +665,27 @@ jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit
     let resume;
     if (ephemeral) {
       resume = await upsertScratchResume({ name: newName, ...upload });
-      await deleteMatchesForResume(resume.id);
-      await deleteCoverLettersForResume(resume.id);
     } else {
       resume = await replaceResumeFile(resumeId, upload);
       // The match never reads the scan, so the new version's scan runs
       // alongside it instead of ahead of it — a whole resume-model call off
       // the wait. Cost: Resume.skills stay one version stale until it lands.
       scanInBackground(resume);
+    }
+    // A file whose text did not change is already answered.
+    const reused = await findReusableMatch(job.id, resume.id, resume.text);
+    if (reused) {
+      updateRun(run.id, {
+        stage: 'done',
+        resultUrl: `/jobs/${id}/target?match=${reused.id}`,
+        flash: `${ephemeral ? `"${newName}"` : `v${resume.version}`} uploaded. ${reuseNotice(formatRelative(reused.createdAt))}`,
+        reused: true,
+      });
+      return;
+    }
+    if (ephemeral) {
+      await deleteMatchesForResume(resume.id);
+      await deleteCoverLettersForResume(resume.id);
     }
     const row = await matchResumeToJob(resume, {
       id: job.id,

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -18,7 +18,7 @@ import { JobNewPage } from '../pages/job-new';
 import { TargetPage } from '../pages/target';
 import { previousFor } from '../pages/resume-match-card';
 import { nameFromFilename, readResumeUpload, resumeUploadLimit } from '../upload';
-import { scanResume } from '../../resume/scan';
+import { scanInBackground } from '../../resume/scan';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { createRun, startRun, updateRun } from '../target-runs';
 import {
@@ -646,12 +646,7 @@ jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit
   // history — a fresh upload means a fresh analysis, nothing saved.
   const ephemeral = existing.hidden;
   const newName = ephemeral ? nameFromFilename(upload.sourceFilename) : existing.name;
-  const run = createRun({
-    steps: ephemeral ? ['match'] : ['scan', 'match'],
-    jobTitle: job.title,
-    resumeName: newName,
-    jobId: id,
-  });
+  const run = createRun({ steps: ['match'], jobTitle: job.title, resumeName: newName, jobId: id });
   startRun(run.id, async () => {
     let resume;
     if (ephemeral) {
@@ -660,8 +655,10 @@ jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit
       await deleteCoverLettersForResume(resume.id);
     } else {
       resume = await replaceResumeFile(resumeId, upload);
-      await scanResume(resume);
-      updateRun(run.id, { stage: 'match' });
+      // The match never reads the scan, so the new version's scan runs
+      // alongside it instead of ahead of it — a whole resume-model call off
+      // the wait. Cost: Resume.skills stay one version stale until it lands.
+      scanInBackground(resume);
     }
     const row = await matchResumeToJob(resume, {
       id: job.id,

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -65,7 +65,7 @@ resumesRoute.post('/resumes', resumeUploadLimit('/resumes'), async (c) => {
       : nameFromFilename(upload.sourceFilename);
   const resume = await createResume({ name, ...upload });
   return startScanRun(c, resume, {
-    subtitle: `"${name}" — headline, tools, seniority. About a minute.`,
+    subtitle: `"${name}" — headline, tools, seniority. About half a minute.`,
     onScanned: () =>
       `Uploaded and scanned "${name}". Tip: Settings → Profile → "Fill from a resume" updates your search profile from it.`,
     onFailed: `Uploaded "${name}", but the AI scan failed — check the web logs, then try "Scan".`,
@@ -213,7 +213,7 @@ resumesRoute.post('/resumes/:id/rescan', async (c) => {
   const resume = await getResume(id);
   if (!resume) return c.text('Not found', 404);
   return startScanRun(c, resume, {
-    subtitle: `"${resume.name}" — headline, tools, seniority. About a minute.`,
+    subtitle: `"${resume.name}" — headline, tools, seniority. About half a minute.`,
     onScanned: (scan) => `Scanned: ${scan.skills.length} skills, ${scan.issues.length} issues.`,
     onFailed: 'Scan failed — see the web logs.',
   });

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -4,7 +4,8 @@ import { z } from 'zod';
 import { classifyInBackground } from '../../jobs/classify-existing';
 import { createManualJob, ManualJobSchema, MAX_FIELD_CHARS, MIN_DESCRIPTION_CHARS } from '../../jobs/manual-job';
 import { extractPostingFacts, fallbackTitle } from '../../jobs/posting-extract';
-import { matchResumeToJob } from '../../resume/match';
+import { findReusableMatch, matchResumeToJob } from '../../resume/match';
+import { reuseNotice } from '../../resume/match-reuse';
 import {
   deleteCoverLettersForResume,
   deleteMatchesForResume,
@@ -15,6 +16,7 @@ import {
 import { TargetStartPage } from '../pages/target-start';
 import { TargetRunPage } from '../pages/target-run';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
+import { formatRelative } from '../format';
 import { createRun, getRun, startRun, updateRun, type RunStep } from '../target-runs';
 import {
   MAX_RESUME_NAME_CHARS,
@@ -82,7 +84,7 @@ targetRoute.get('/target/runs/:id', (c) => {
     return flashRedirect('/target', 'err', 'That comparison run is gone (runs live ~30 min). Start again.');
   }
   if (run.stage === 'done' && run.resultUrl) {
-    return flashRedirect(run.resultUrl, 'ok', run.flash ?? 'Done.');
+    return flashRedirect(run.resultUrl, run.reused ? 'warn' : 'ok', run.flash ?? 'Done.', { rerun: run.reused });
   }
   return c.html(<TargetRunPage run={run} />);
 });
@@ -189,13 +191,26 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
     if (result.kind === 'created') classifyInBackground(result.job);
     updateRun(run.id, { jobId: job.id });
 
-    // 2. Ephemeral compares keep only the current analysis.
+    // 2. The same text against the same posting is already answered — a
+    //    double submit or a re-paste shows the stored analysis instead.
+    const reused = await findReusableMatch(job.id, resume.id, resume.text);
+    if (reused) {
+      updateRun(run.id, {
+        stage: 'done',
+        resultUrl: `/jobs/${job.id}/target?match=${reused.id}`,
+        flash: reuseNotice(formatRelative(reused.createdAt)),
+        reused: true,
+      });
+      return;
+    }
+
+    // 3. Ephemeral compares keep only the current analysis.
     if (resume.ephemeral) {
       await deleteMatchesForResume(resume.id);
       await deleteCoverLettersForResume(resume.id);
     }
 
-    // 3. One resume-model call, then straight into the targeted workspace.
+    // 4. One resume-model call, then straight into the targeted workspace.
     const row = await matchResumeToJob(
       { id: resume.id, version: resume.version, text: resume.text },
       {

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { classifyInBackground } from '../../jobs/classify-existing';
 import { createManualJob, ManualJobSchema, MAX_FIELD_CHARS, MIN_DESCRIPTION_CHARS } from '../../jobs/manual-job';
 import { extractPostingFacts, fallbackTitle } from '../../jobs/posting-extract';
 import { matchResumeToJob } from '../../resume/match';
@@ -142,7 +143,7 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
     };
   }
 
-  const steps: RunStep[] = needExtract ? ['extract', 'classify', 'match'] : ['classify', 'match'];
+  const steps: RunStep[] = needExtract ? ['extract', 'match'] : ['match'];
   const run = createRun({
     steps,
     jobTitle: title || 'Detecting the role…',
@@ -165,21 +166,28 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
         const label = workplace === 'onsite' ? 'on-site' : workplace;
         location = location ? `${location} (${label})` : label;
       }
-      updateRun(run.id, { stage: 'classify', jobTitle: title });
+      updateRun(run.id, { stage: 'match', jobTitle: title });
     }
 
-    // 1. The posting becomes a normal MANUAL job (deduped, classified when new).
-    const result = await createManualJob({
-      companyName,
-      title,
-      url: f.url,
-      location,
-      description: f.description,
-      salaryMin,
-      salaryMax,
-    });
+    // 1. The posting becomes a normal MANUAL job (deduped). A new one is
+    //    classified in the background: the comparison never reads the fit
+    //    score, and that leg alone was ~50 s on a CLI engine
+    //    (docs/target-plan.md §3.1).
+    const result = await createManualJob(
+      {
+        companyName,
+        title,
+        url: f.url,
+        location,
+        description: f.description,
+        salaryMin,
+        salaryMax,
+      },
+      { classify: false },
+    );
     const job = result.job;
-    updateRun(run.id, { stage: 'match', jobId: job.id });
+    if (result.kind === 'created') classifyInBackground(result.job);
+    updateRun(run.id, { jobId: job.id });
 
     // 2. Ephemeral compares keep only the current analysis.
     if (resume.ephemeral) {
@@ -208,7 +216,9 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
     updateRun(run.id, {
       stage: 'done',
       resultUrl: `/jobs/${job.id}/target?match=${row.id}`,
-      flash: `AI match ${row.matchScore}/100 — "${resume.name}" vs "${job.title}".`,
+      flash:
+        `AI match ${row.matchScore}/100 — "${resume.name}" vs "${job.title}".` +
+        (result.kind === 'created' ? ' The fit score is still being scored; it lands on the job page in about a minute.' : ''),
     });
   });
 

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -72,6 +72,7 @@ targetRoute.get('/target/runs/:id/state', (c) => {
     steps: run.steps,
     jobTitle: run.jobTitle,
     progress: run.progress ?? null,
+    stepMs: run.stepMs,
     stageElapsedMs: Date.now() - run.stageAt,
     elapsedMs: Date.now() - run.startedAt,
   });

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -208,7 +208,7 @@ welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) 
     jobTitle: '',
     resumeName: name,
     heading: { running: 'Reading your resume', failed: 'Could not read the resume' },
-    subtitle: `"${name}" — headline, tools, seniority. About a minute.`,
+    subtitle: `"${name}" — headline, tools, seniority. About half a minute.`,
     backUrl: PROFILE_STEP,
     backLabel: 'Back to setup',
   });

--- a/src/web/target-run.test.ts
+++ b/src/web/target-run.test.ts
@@ -7,6 +7,7 @@ const page = import('./public/target-run.mjs') as Promise<{
   activityFor: (step: string, stageElapsedMs: number) => string;
   formatElapsed: (ms: number) => string;
   progressLine: (step: string, progress: { done: number; total: number }) => string;
+  stepTime: (stepState: string, step: string, state: Record<string, unknown>) => string;
   init: unknown;
 }>;
 
@@ -38,4 +39,14 @@ test('progressLine names the unit per step', async () => {
   assert.equal(progressLine('score', { done: 12, total: 100 }), '12 of 100 jobs scored');
   assert.equal(progressLine('nope', { done: 1, total: 2 }), '1 of 2 done');
   assert.notEqual(activityFor('score', 0), '', 'the score step narrates before counts arrive');
+});
+
+test('stepTime counts the active step live and freezes finished ones', async () => {
+  const { stepTime } = await page;
+  const state = { stageElapsedMs: 4_000, stepMs: { scan: 76_000 } };
+  assert.equal(stepTime('active', 'match', state), '4s');
+  assert.equal(stepTime('done', 'scan', state), '1m 16s');
+  assert.equal(stepTime('done', 'extract', state), '', 'no recorded time, no number');
+  assert.equal(stepTime('pending', 'match', state), '');
+  assert.equal(stepTime('done', 'scan', { stageElapsedMs: 0 }), '', 'a registry without stepMs (fetch page)');
 });

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -34,6 +34,8 @@ export interface TargetRun {
   /** Set on done: where to send the user, with the flash to show there. */
   resultUrl?: string;
   flash?: string;
+  /** Done with a stored analysis, not a fresh one — the flash warns and offers "Re-run anyway". */
+  reused?: boolean;
   error?: string;
 }
 

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -19,6 +19,8 @@ export interface TargetRun {
   startedAt: number;
   /** When the current stage began — paces the progress page's activity line. */
   stageAt: number;
+  /** How long each finished step took — shown next to it on the progress page. */
+  stepMs: Partial<Record<RunStep, number>>;
   jobTitle: string;
   resumeName: string;
   /** Where the error state sends the user back to — the launcher that started it. */
@@ -52,6 +54,7 @@ export function createRun(
     stage: fields.steps[0] ?? 'match',
     startedAt: Date.now(),
     stageAt: Date.now(),
+    stepMs: {},
     backUrl: '/target',
     backLabel: 'Back to Target',
     ...fields,
@@ -65,8 +68,10 @@ export function updateRun(id: string, patch: Partial<Omit<TargetRun, 'id'>>): vo
   if (!run) return;
   if (patch.stage && patch.stage !== run.stage) {
     const now = Date.now();
+    const ms = now - run.stageAt;
+    if (run.stage !== 'done' && run.stage !== 'error') run.stepMs[run.stage] = ms;
     logger.info(
-      { runId: id, step: run.stage, ms: now - run.stageAt, next: patch.stage, totalMs: now - run.startedAt },
+      { runId: id, step: run.stage, ms, next: patch.stage, totalMs: now - run.startedAt },
       'run: step finished',
     );
     run.stageAt = now;

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -2,14 +2,14 @@ import { randomUUID } from 'node:crypto';
 import { logger } from '../logger';
 
 /*
- * In-memory registry for long compare runs (classify → scan → match). The
+ * In-memory registry for long compare runs (extract → scan → match). The
  * POST returns immediately with a redirect to /target/runs/:id; the page
  * polls /target/runs/:id/state until the async chain flips the run to done
  * or error. Web-process-only state; a restart simply forgets unfinished
  * runs (node-cron philosophy: no queue, ADR 0003).
  */
 
-export type RunStep = 'fetch' | 'extract' | 'classify' | 'scan' | 'match' | 'verify' | 'letter' | 'score';
+export type RunStep = 'fetch' | 'extract' | 'scan' | 'match' | 'verify' | 'letter' | 'score';
 export type RunStage = RunStep | 'done' | 'error';
 
 export interface TargetRun {

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -61,7 +61,14 @@ export function createRun(
 export function updateRun(id: string, patch: Partial<Omit<TargetRun, 'id'>>): void {
   const run = runs.get(id);
   if (!run) return;
-  if (patch.stage && patch.stage !== run.stage) run.stageAt = Date.now();
+  if (patch.stage && patch.stage !== run.stage) {
+    const now = Date.now();
+    logger.info(
+      { runId: id, step: run.stage, ms: now - run.stageAt, next: patch.stage, totalMs: now - run.startedAt },
+      'run: step finished',
+    );
+    run.stageAt = now;
+  }
   Object.assign(run, patch);
 }
 

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -91,9 +91,8 @@ const FLASH_TONE: Record<FlashKind, string> = {
   err: 'border-danger/25 bg-danger/5 text-danger',
 };
 
-export const Flash: FC<{
-  flash?: FlashMessage | null;
-}> = ({ flash }) =>
+/** `children` is the message's one action, if any — a form or a button after the text. */
+export const Flash: FC<PropsWithChildren<{ flash?: FlashMessage | null }>> = ({ flash, children }) =>
   flash ? (
     <div
       role="status"
@@ -128,7 +127,8 @@ export const Flash: FC<{
           </>
         )}
       </svg>
-      <span class="min-w-0">{flash.text}</span>
+      <span class="min-w-0 flex-1">{flash.text}</span>
+      {children}
     </div>
   ) : null;
 


### PR DESCRIPTION
§13 block 1 of [docs/target-plan.md](docs/target-plan.md) (§2.3 timing logs + §3.1 items 1–4). No schema change, no prompt change, `PROMPT_VERSION` untouched.

The plan's rule was **measure first, then optimise** — its §2.2 numbers were hypotheses. The first commit is therefore timing logs (`ms` on `resume: scanned`, `posting-extract: done`, `classify-existing: scored`, and a `run: step finished` line per stage from `updateRun`); every number below comes from them, on the owner's actual setup (`claude_code` CLI engine, Opus for the resume role, Haiku 4.5 for the classifier, single-stage).

## Measured: before → after

Same resume (Senior Backend PHP, 6 k chars), real postings of 3.5–6 k chars, one run at a time unless noted. Wall = what the progress page showed from POST to redirect.

| Scenario | Before (serial chain) | After | Wall before → after |
|---|---|---|---|
| `/target`, paste + URL, company/title left empty, fresh posting | extract 12.4 s → classify 49.5 s → match 95.9 s | extract 32.1 s → match 94.0 s; classify 54.9 s **in the background** | **158 s → 128 s** (the classify leg is gone; extract varied 12–37 s between runs, see below) |
| `/target`, the same paste again | full chain again | extract 37.5 s → **stored row, 5 ms** | 158 s → **38 s** |
| `/jobs/:id/match` (Compare), first time | match 108.7 s | match 78.3 s ¹ | 109 s → 79 s ¹ |
| `/jobs/:id/match`, same resume again | full call again | **direct 303 with the stored row, 11 ms** | 109 s → **0 s** |
| `/jobs/:id/target/reupload`, named resume, new text | scan 32.9 s → match 83.1 s | match 93.9 s; scan 36.2 s **in the background** | **117 s → 95 s** |
| reupload, same file again | scan → match again | replace + **stored row, 9 ms** | 117 s → **2 s** (one poll interval) |

¹ Two Compare runs overlapped here (71.7 s and 78.3 s) because the first repeat did not hit the memo — its stored row predated the version marker (see "Memo key" below). Both are still within the single-run range.

Per-call samples across the session (CLI engine): **match 78 / 83 / 85 / 94 / 94 / 96 / 109 s** (p50 ≈ 94 s, p90 ≈ 109 s), **scan 26 / 33 / 36 s**, **extract 12 / 32 / 37 s**, **classify 49 / 55 s**. So "about a minute" for the match was optimistic by 2×, and the scan is half a minute, not a minute — the copy now says so (§3.1 item 4).

What did **not** change: the match call itself. A fresh compare is now one resume-model call long (~1½–2 min on Opus), which is what P0 could deliver; 30–40 s needs §3.2 (blocks 3–4: instant check, fast mode, the Sonnet bench).

## What changed

1. **Classify off the critical path on `/target`.** `createManualJob({ classify: false })`, then `classifyInBackground(job)` (new, in `classify-existing.ts`) runs alongside `matchResumeToJob`. The comparison never reads the fit score; it lands on the job page a minute later, and the done-flash says so. The `classify` step left the run page (no run uses it any more — the type, `STEP_VIEW` entry and activity lines went with it).
2. **Scan off the critical path on reupload.** `POST /jobs/:id/target/reupload`, named-resume branch: `replaceResumeFile` → `scanInBackground(resume)` (new, in `scan.ts`) → match. **Known cost, in the code comment too:** until the background scan lands, `Resume.skills` / headline / core stack describe the previous version — `scannedAt: null` already marks that, and only `/resumes` and other resumes' "elsewhere" hints read those fields. The v1.12.0 `/resumes/*` routes were not touched (they already run through the registry).
3. **Memo for identical work** — `src/resume/match-reuse.ts` (pure, 6 tests: identical text → hit; one character changed → miss; other prompt version → miss; no previous row / no marker → miss). `findReusableMatch(jobId, resumeId, text)` in `match.ts` runs before every run on `/target`, `/jobs/:id/match` and reupload; a hit redirects to the stored row with the warn flash *"Unchanged since the last analysis (3m ago) — showing that result; the resume model was not called again."* and a **Re-run anyway** button (`force=1`) on both the job page and the targeted editor. On the ephemeral paths the check runs *before* the old scratch rows are deleted, so a re-paste keeps its letters too.
4. **Honest progress.** `TargetRun.stepMs` records each finished step; the run page shows the final time next to done steps and a live count next to the active one (SSR + the poller, `stepTime` tested), on top of the existing total counter. Durations in `STEP_VIEW`, the Compare card, the targeted editor's upload/Re-analyze hints, `/welcome` and Settings now quote the measured ranges.
5. `SUBMIT_ONCE` on the four forms that start a match (`/target`, Compare, Re-analyze, reupload) — the memo covers a repeat *after* completion; the JS guard covers the in-flight window (#76 tracks the server-side key).

### Memo key without a schema change

`ResumeMatch` has no prompt-version column and this block bars schema changes, so `createMatch` / `updateMatchScoring` write `promptVersion` **inside the `breakdown` JSON**; `readPromptVersion` reads it back and the fact-flip route carries it through a recompute. `readBreakdown` (zod, non-strict) strips it for the UI. Rows from before this branch carry no marker and are never reused — that is what happened in footnote ¹.

## Verification

- `npm run lint:types` · `npm test` (871 pass, 7 new) · `npx prisma format --check`.
- Live runs above, all through the real routes with curl against the rebuilt container; the memo hit on `/jobs/:id/match` returns the 303 with the flash cookie carrying `rerun: true`, and the job page renders the Re-run anyway form from it.
- Web rebuilt; every touched route curls 200 (`/target`, `/jobs`, `/jobs/:id`, `/jobs/:id/target`, `/resumes`, `/resumes/:id`, `/applications`, `/settings`, `/welcome`, `/runs`, `/letter`); a gone run 303s home, its state route 404s.
- Run page screenshots at 1200 / 768 / 375 during a live match (per-step time next to the active step, total counter ticking); 0 console errors in a fresh tab.
- Test rows created for the measurements (two MANUAL postings, a throwaway resume, their match rows) were removed from the live DB afterwards.

## Review (code-review-expert over `git diff main...HEAD`)

P0/P1: the reuse notice said "no AI call was spent" while `/target` still spends the extract call before the memo check — reworded (commit "fix reuse notice wording"). Nothing else at P1: the memo compares against the latest row for (job, resume) regardless of `draft`, which is the intended "same text" semantics; the reupload hit shows the previous version's row for the new version number and the flash says so.

## Follow-ups (P2/P3)

- **`ResumeMatch.promptVersion` as a real column** (migration + backfill from the JSON marker); `readPromptVersion` then goes away.
- `/resumes/:id/draft` ("Save as vN" → scan → match) and `/letter`'s optional match do not use the memo; `/draft` would want a version-stamped copy of the row rather than the old row, which is a different feature.
- `/jobs/new` ("Paste a job") still classifies inline — ~50 s on a CLI engine on a frozen form; the same background call would fix it.
- A reupload whose text did not change still re-scans the new version in the background (the previous version's scan would do; `replaceResumeFile` clears `scannedAt` unconditionally).
- `formatElapsed` exists twice (SSR in `run-steps.tsx`, browser in `target-run.mjs`); 3 lines, mirrored by hand.
- The "Fetch now" page shares `RunSteps`, so its active step now shows a live counter too; its registry records no per-step times, so done steps show none there.
- The follow-ups carried since #66/#67/#68 are now issues: #69 CSRF · #70 `setProfileActive` race · #71 `Job.fitScore` after a search is deleted (ADR 0028, recorded) · #72 `setAiKey` read-modify-write · #73 stale FK on profile save · #74 `appliedResumeText` has no reader · #75 applied resume only from "Mark applied" · #76 server-side idempotency for run POSTs · #77 `thClasses` / `Td` sync.

## Release notes (draft for v1.13.0)

**What's new**
- A compare waits for one AI call, not three: on `/target` the fit score is classified in the background; on "Upload vN & re-analyze" the resume scan runs in the background. Measured on the CLI engine: 158 → 128 s for a fresh `/target` compare, 117 → 95 s for a re-upload.
- Repeating a comparison is free: a double submit, a back button, a re-paste or an unchanged re-upload shows the stored analysis ("Unchanged since the last analysis") with a Re-run anyway button.
- The progress page shows the time each step took and a live count on the active one; step copy quotes measured durations (match 1½–2 min on Opus, scan about half a minute).
- Per-step `ms` in the web logs for scan, extract, classify and every run stage.

**Schema** — no schema changes (the prompt version rides inside the match's `breakdown` JSON).

**Verification** — 871 unit tests (7 new), 12 live runs measured before/after, run page at 1200/768/375, 0 console errors.

**References** — [docs/target-plan.md](docs/target-plan.md) §2.3 + §3.1, TASKS §13 block 1.

After merge:

```
git tag -a v1.13.0 -m "compare: one AI call on the critical path" <merge-sha>
git push origin v1.13.0
```
