### PR TITLE
keyword matcher v2: plural/separator tolerance, alias table, persist-time anchor (§13 block 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.14.0] — 2026-09-02
+
+### Changed
+- **Keyword highlights tolerate spellings, plurals and separators**
+  ([docs/target-plan.md](docs/target-plan.md) §4 F3–F6, TASKS §13 block 2).
+  The matcher behind the `/target` panes and the live score now treats the
+  separators inside a multi-word term as interchangeable and optional
+  (`CI/CD` = `CI / CD` = `CI-CD`, `Node.js` = `NodeJS`, `front-end` =
+  `front end` = `frontend`), matches the regular plural of a term and the
+  singular of a plural one (`microservice(s)`, `API(s)`, `query` /
+  `queries`, `patch(es)`), and unions a curated table of 170 spelling groups
+  (`node.js` / `node` / `nodejs`, `go` / `golang`, `postgresql` / `postgres` /
+  `pgsql`, `k8s` / `kubernetes`, `ci/cd` / `continuous integration` …) into
+  every keyword — when an analysis is stored and again when one is loaded, so
+  earlier analyses highlight the same way. The whole-token guards stay: `C`
+  is not `C++`, `Java` is not `JavaScript`, a Capitalised name that ends in
+  s (`Rails`, `Windows`, `Kubernetes`) is not a plural, and there is no
+  stemming beyond plurals.
+- **Every keyword is anchored to the posting when the analysis is stored.**
+  A term the model paraphrased is rewritten to the longest verbatim phrase of
+  itself the posting contains, spelled as the posting spells it; one the
+  posting contains in no recognisable form is flagged — the keyword table
+  shows *not in posting*, and the `resume: matched` log line counts
+  `anchored` / `unanchored`, the regression metric for future prompt
+  changes. No prompt change and no schema change (an optional field in the
+  keyword JSON).
+- The job-description pane says that benefits, perks and legal boilerplate
+  are never keywords, so an unmarked paragraph there stops reading as a miss.
+
+### Added
+- `npm run keywords:audit` — read-only: lists every stored keyword row that
+  highlights nowhere, as stored and with the alias table. Measured on the 15
+  stored comparisons: rows with no highlight in the posting 54 → 53 of 305,
+  `present` rows with no highlight in the resume 36 → 35 of 181 — what
+  remains are paraphrases from analyses older than the verbatim rule.
+
 ## [1.13.0] — 2026-09-02
 
 ### Changed
@@ -948,6 +984,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.14.0]: https://github.com/applypack/applypack/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/applypack/applypack/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/applypack/applypack/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/applypack/applypack/compare/v1.10.0...v1.11.0

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -810,8 +810,8 @@ icon; progress visible step-by-step via the target-run registry pattern.
 
 ## 13. /target compare speed (30-40 s) + keyword-matcher accuracy (analysis 2026-08-31)
 
-Full plan: [docs/target-plan.md](./target-plan.md). **Block 1 shipped
-2026-09-02 (measured numbers in the plan's §2.3); blocks 2–6 open.** §12's
+Full plan: [docs/target-plan.md](./target-plan.md). **Blocks 1–2 shipped
+2026-09-02 (measured numbers in the plan's §2.3 and §4); blocks 3–6 open.** §12's
 async-upload item overlaps the `/resumes`
 sync-scan finding, planned there, referenced here.
 
@@ -836,15 +836,28 @@ Sonnet bench for the resume role — not "make Opus stream faster".
       `/target` compare 158 → 128 s, a repeat 158 → 38 s, Compare repeat
       109 → 0 s, re-upload 117 → 95 s; the match call itself is 78–109 s
       (p50 ≈ 94 s) — 30–40 s needs blocks 3–4.
-- [ ] `keyword-matcher-v2` — persist-time verbatim guard, deterministic
-      alias table (`keyword-aliases.ts`, pure), plural + separator
-      tolerance in `termPattern`, tiered keyword budget (all must/
-      preferred always listed); table-driven tests
+- [x] `keyword-matcher-v2` — persist-time verbatim guard
+      (`keyword-anchor.ts`: a paraphrased term is re-anchored to the longest
+      verbatim phrase of itself the posting contains, else flagged
+      `unanchored` — "not in posting" in the keyword table, counted on the
+      `resume: matched` log line), deterministic alias table
+      (`keyword-aliases.ts`, 170 spelling groups, applied at persist time
+      and when a stored match loads), plural + separator tolerance in
+      `termPattern`; table-driven tests — done 2026-09-02, branch
+      `keyword-matcher-v2` (PR #80). Measured on the 15 stored comparisons
+      (`npm run keywords:audit`, no AI): rows with no highlight in the
+      posting 54 → 53 of 305, `present` rows with no highlight in the
+      resume 36 → 35 of 181; what remains are paraphrases from pre-v5
+      analyses — on the current prompt no stored row misses the posting.
+      The tiered keyword budget (F1) is a prompt change and moved to
+      `match-fast-mode` below; "Rebuild keywords" (F7) is issue #79.
 - [ ] `target-instant-check` — reupload → parse-only dirty draft in the
       target editor (~2-5 s, zero AI), "Re-analyze" upgrades on demand
 - [ ] `match-fast-mode` — keywords-only prompt variant (score-complete
       subset, ~¼ output tokens) + `bench:resume` Sonnet-vs-Opus decision
-      (**PROMPT_VERSION bump**; possibly ADR)
+      + the tiered keyword budget from §4 F1 (every must/preferred term
+      listed, the soft cap only on nice/context) — one
+      **PROMPT_VERSION bump** for all three; possibly ADR
 - [ ] `keyword-priority-ui` — per-keyword user overrides (re-level /
       exclude / add own term) via existing `updateMatchScoring`, visual
       weight for must+primary misses, posting-frequency tiebreaker

--- a/docs/target-plan.md
+++ b/docs/target-plan.md
@@ -1,6 +1,7 @@
 # /target compare flow: speed (30-40 s target) + keyword-matching accuracy
 
-> **Analysis only — nothing implemented.** Written 2026-08-31 from a parallel
+> **Analysis written 2026-08-31; blocks 1–2 of §7 shipped 2026-09-02 (measured
+> numbers in §2.3 and §4).** Written from a parallel
 > session (full source pass over the compare pipeline: `src/web/routes/target.tsx`,
 > `jobs.tsx`, `src/resume/{match,scan,prompts,score}.ts`, `src/web/public/{target,score,target-page}.mjs`,
 > `src/ai-{runtime,provider}.ts`, `src/jobs/{manual-job,posting-extract,classify-existing}.ts`)
@@ -286,6 +287,22 @@ earlier-starting mark (cosmetic); benefits/EEO/marketing text is *deliberately*
 never keyworded (NOISE rule) — worth one line in the pane legend so it stops
 looking like a miss.
 
+**Measured 2026-09-02** (block 2, `npm run keywords:audit` over the 15 stored
+comparisons — the same `findTerm` the panes use, no AI call):
+
+| Rows | Before | After F3–F5 |
+| --- | --- | --- |
+| keyword rows with no highlight in the posting (of 305) | 54 (9 title-only) | 53 |
+| `present` rows with no highlight in the resume (of 181) | 36 | 35 |
+
+Every remaining miss comes from the seven analyses written before the
+VERBATIM rule (prompt v5): slash-joined paraphrases such as "Mentoring / team
+lead" or "startup / fast-paced environment" that no matcher can place. On the
+current prompt no stored row misses the posting, so F2 acts as the safety net
+and the metric (`anchored` / `unanchored` on the `resume: matched` line), not
+as a repair of today's output. F1 moved to `match-fast-mode` (block 4) — it is
+a prompt change; F7 is issue #79; F8 stays open (§8).
+
 ## 5. Keyword priorities — present vs missing
 
 Already there: `priority` 1-4, `requirement` must/preferred/nice/context
@@ -341,11 +358,12 @@ Sources: [jobscan.co](https://www.jobscan.co/blog/top-resume-keywords-boost-resu
 2. `keyword-matcher-v2` — F2 verbatim guard + F3 alias module + F4/F5
    pattern tolerance + tests (table-driven pairs in `target.test.ts`,
    alias-module unit tests). Pure-module work; `PROMPT_VERSION` untouched
-   (post-processing).
+   (post-processing). **Shipped 2026-09-02** (PR #80, numbers in §4).
 3. `target-instant-check` — §3.2 item 5 (parse-only reupload → dirty draft
    in the editor). UX copy honest about "estimate vs frame".
 4. `match-fast-mode` — §3.2 items 6-7: keywords-only prompt variant +
-   `bench:resume` Sonnet-vs-Opus numbers + default/model-select decision.
+   `bench:resume` Sonnet-vs-Opus numbers + default/model-select decision,
+   plus the F1 tiered keyword budget (same prompt, same bump).
    `PROMPT_VERSION` bump; gotcha-11 guard tests extended to the short
    prompt. Possibly an ADR (second match mode).
 5. `keyword-priority-ui` — §5 overrides + visual weight + frequency. Reuses

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "discovery:once": "tsx src/scripts/discovery-once.ts",
     "priority:dryrun": "tsx src/scripts/priority-rules-dryrun.ts",
     "bench:resume": "tsx src/scripts/resume-bench-once.ts",
+    "keywords:audit": "tsx src/scripts/keyword-audit.ts",
     "test:telegram": "tsx src/scripts/test-telegram.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:deploy": "prisma migrate deploy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/site/public/demo/target.mjs
+++ b/site/public/demo/target.mjs
@@ -31,8 +31,11 @@ const NOT_AFTER = '(?![\\w+#])(?!\\.\\w)';
  * in the original — spans found here are applied to the original verbatim.
  */
 export function normalise(s) {
+  return foldChars(s).toLowerCase();
+}
+
+function foldChars(s) {
   return s
-    .toLowerCase()
     .replace(/[\u2018\u2019]/g, "'")
     .replace(/[\u201c\u201d]/g, '"')
     .replace(/[\u00a0\t]/g, ' ');
@@ -42,26 +45,69 @@ function escapeRegex(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// Separators between the tokens of a multi-token term are interchangeable and
+// optional: "CI/CD" = "CI / CD" = "CI-CD", "Node.js" = "NodeJS", "front-end" =
+// "front end" = "frontend". Leading and trailing ones stay literal (".NET").
+const SEPARATOR = '[\\s/.\\-]*';
+const SEPARATOR_RUN = /[\s/.\-]+/;
+const EDGES = /^([\s/.\-]*)(.*?)([\s/.\-]*)$/s;
+
+/**
+ * Regex fragment for the last token of a term: the token plus its regular
+ * plural ("pipeline" → pipelines, "query" → queries, "class" → classes) and,
+ * for a plural token, its singular ("microservices" → microservice, "APIs" →
+ * API, "patches" → patch). A plural is a lowercase word or an acronym ending
+ * in a lowercase s — Capitalised names that end in s (Rails, Windows,
+ * Kubernetes) stay exact, and so do the two names whose lowercase alias
+ * would otherwise light unrelated text ("light rail", "window functions").
+ * No other stemming: irregular pairs belong in the alias table
+ * (src/resume/keyword-aliases.ts).
+ */
+const NOT_PLURAL = new Set(['rails', 'windows']);
+
+function pluralTolerant(token) {
+  const t = token.toLowerCase();
+  const literal = escapeRegex(t);
+  if (t.length < 3 || !/[a-z]$/.test(t) || NOT_PLURAL.has(t)) return literal;
+  if (t.endsWith('ss')) return `${literal}(?:es)?`;
+  if (/^[a-z]{3,}s$/.test(token) || /^[A-Z0-9]{2,}s$/.test(token)) {
+    if (t.endsWith('ies') && t.length >= 6) return `${escapeRegex(t.slice(0, -3))}(?:y|ie|ies)`;
+    const stem = t.slice(0, -2);
+    if (t.endsWith('es') && stem.length >= 4 && /(?:[sxz]|[cs]h)$/.test(stem)) return `${escapeRegex(stem)}(?:e|es)?`;
+    return `${escapeRegex(t.slice(0, -1))}(?:e?s)?`;
+  }
+  if (t.length >= 4 && /[^aeiou]y$/.test(t)) return `${escapeRegex(t.slice(0, -1))}(?:y|ies)`;
+  return `${literal}(?:e?s)?`;
+}
+
 /** Regex matching `term` as a whole token (no letters/digits/./+/# glued to it). */
 export function termPattern(term) {
-  // Runs of whitespace inside a term ("continuous  delivery") match any run in the text.
-  const t = escapeRegex(normalise(term).trim()).replace(/ +/g, '\\s+');
-  if (t.length === 0) return null;
+  const [, lead, core, trail] = EDGES.exec(foldChars(term).trim());
+  const tokens = core.split(SEPARATOR_RUN).filter((t) => t.length > 0);
+  if (tokens.length === 0) return null;
+  const parts = tokens.map((t) => escapeRegex(t.toLowerCase()));
+  if (trail === '') parts[parts.length - 1] = pluralTolerant(tokens[tokens.length - 1]);
+  const body = escapeRegex(lead) + parts.join(SEPARATOR) + escapeRegex(trail);
   // Terms that start/end with a symbol (".net", "c++") cannot use \b; use lookarounds on token chars.
-  return new RegExp(`${NOT_BEFORE}${t}${NOT_AFTER}`, 'g');
+  return new RegExp(`${NOT_BEFORE}${body}${NOT_AFTER}`, 'g');
 }
 
 /** All occurrences of term + aliases in text → [{start, end}] on the ORIGINAL text (same length after normalise). */
 export function findTerm(text, term, aliases = []) {
   const hay = normalise(text);
+  const seen = new Set();
   const spans = [];
   for (const candidate of new Set([term, ...aliases])) {
     const re = termPattern(candidate);
     if (!re) continue;
     let m;
     while ((m = re.exec(hay)) !== null) {
-      spans.push({ start: m.index, end: m.index + m[0].length });
       if (m[0].length === 0) re.lastIndex++;
+      const key = `${m.index}:${m.index + m[0].length}`;
+      // Aliases that spell the same span ("front end" / "frontend") count it once.
+      if (seen.has(key)) continue;
+      seen.add(key);
+      spans.push({ start: m.index, end: m.index + m[0].length });
     }
   }
   return spans.sort((a, b) => a.start - b.start);

--- a/src/resume/keyword-aliases.test.ts
+++ b/src/resume/keyword-aliases.test.ts
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ALIAS_GROUPS, aliasesFor, withTableAliases } from './keyword-aliases';
+import { loadKeywordMatcher } from './keyword-matcher';
+
+test('alias table: lowercase trimmed spellings, unique across groups, two or more per group', () => {
+  const seen = new Set<string>();
+  for (const group of ALIAS_GROUPS) {
+    assert.ok(group.length >= 2, `group too small: ${group.join(', ')}`);
+    for (const s of group) {
+      assert.equal(s, s.trim().toLowerCase(), `not canonical: "${s}"`);
+      assert.ok(s.length > 0);
+      assert.ok(!seen.has(s), `"${s}" appears in two groups`);
+      seen.add(s);
+    }
+  }
+  assert.ok(ALIAS_GROUPS.length >= 100);
+});
+
+test('aliasesFor: case-insensitive lookup, never the term itself, empty when unknown', () => {
+  assert.deepEqual(aliasesFor('Node.js'), ['node', 'nodejs']);
+  assert.deepEqual(aliasesFor('  GOLANG '), ['go']);
+  assert.deepEqual(aliasesFor('K8s'), ['kubernetes']);
+  assert.deepEqual(aliasesFor('Laravel'), []);
+  assert.deepEqual(aliasesFor(''), []);
+});
+
+test('withTableAliases merges table spellings of the term and of its aliases, keeps the model ones', () => {
+  const k = { term: 'PostgreSQL', aliases: ['postgres', 'pg'], status: 'present' };
+  assert.deepEqual(withTableAliases(k), { ...k, aliases: ['postgres', 'pg', 'psql', 'pgsql'] });
+  // Reached through a model alias: the term itself is unknown to the table.
+  assert.deepEqual(withTableAliases({ term: 'ECMAScript 2020', aliases: ['javascript'] }).aliases, ['javascript', 'js', 'ecmascript']);
+  // Nothing to add → the same object, so callers can tell.
+  const untouched = { term: 'Laravel', aliases: [] };
+  assert.equal(withTableAliases(untouched), untouched);
+  const complete = { term: 'Go', aliases: ['golang'] };
+  assert.equal(withTableAliases(complete), complete);
+});
+
+test('F6: the table connects both granularities through findTerm', async () => {
+  const { findTerm } = await loadKeywordMatcher();
+  const both: [term: string, text: string][] = [
+    ['React', 'React.js'],
+    ['React.js', 'React'],
+    ['Node', 'Node.js'],
+    ['Node.js', 'node'],
+    ['PostgreSQL', 'PGSQL'],
+    ['Kubernetes', 'K8s'],
+    ['Golang', 'Go'],
+    ['CI/CD', 'continuous integration'],
+    ['Amazon Web Services', 'AWS'],
+  ];
+  for (const [term, text] of both) {
+    assert.equal(findTerm(text, term, aliasesFor(term)).length, 1, `${term} in ${text}`);
+  }
+  // Related is not the same: no group crosses a sibling technology.
+  assert.equal(findTerm('Vue', 'React', aliasesFor('React')).length, 0);
+  assert.equal(findTerm('Laravel', 'Rails', aliasesFor('Rails')).length, 0);
+});

--- a/src/resume/keyword-aliases.ts
+++ b/src/resume/keyword-aliases.ts
@@ -1,0 +1,225 @@
+import { canonicalTerm } from './facts';
+
+/*
+ * Deterministic spelling variants for keyword matching (target-plan.md §4,
+ * F3/F6). The model lists aliases only when it remembers to; this table is
+ * unioned into every keyword at persist time (match.ts) and when a stored
+ * match is loaded on the target page, so "Node.js" finds "node", "K8s" finds
+ * "Kubernetes" and "PostgreSQL" finds "PGSQL" whatever the reply said.
+ *
+ * Membership means the SAME thing spelled differently — never a related
+ * technology (Vue is not React, gotcha 11). Plurals and separator variants
+ * ("front-end" / "front end" / "frontend", "APIs" / "API") are handled by
+ * termPattern in src/web/public/target.mjs and do not belong here. Pure.
+ */
+
+const GROUPS: readonly (readonly string[])[] = [
+  // languages and runtimes
+  ['javascript', 'js', 'ecmascript'],
+  ['typescript', 'ts'],
+  ['node.js', 'node', 'nodejs'],
+  ['go', 'golang'],
+  ['c#', 'csharp', 'c sharp'],
+  ['c++', 'cpp'],
+  ['objective-c', 'objc'],
+  ['ruby on rails', 'rails', 'ror'],
+  ['.net', 'dotnet', 'dot net'],
+  ['.net core', 'dotnet core'],
+  ['asp.net', 'aspnet'],
+  ['t-sql', 'transact-sql'],
+  ['pl/sql', 'plsql'],
+  ['html', 'html5'],
+  ['css', 'css3'],
+  ['sass', 'scss'],
+  ['tailwind', 'tailwind css'],
+  ['powershell', 'power shell'],
+  ['yaml', 'yml'],
+  ['regex', 'regexp', 'regular expression'],
+  // frontend
+  ['react', 'react.js'],
+  ['vue', 'vue.js'],
+  ['angular', 'angular.js'],
+  ['express', 'express.js'],
+  ['nuxt', 'nuxt.js'],
+  ['ember', 'ember.js'],
+  ['backbone', 'backbone.js'],
+  ['d3', 'd3.js'],
+  ['socket.io', 'socketio'],
+  ['websocket', 'web socket'],
+  ['webhook', 'web hook'],
+  ['frontend', 'front end'],
+  ['backend', 'back end'],
+  ['fullstack', 'full stack'],
+  ['pwa', 'progressive web app'],
+  ['spa', 'single page application'],
+  ['ssr', 'server side rendering'],
+  ['seo', 'search engine optimization', 'search engine optimisation'],
+  ['a11y', 'accessibility'],
+  ['i18n', 'internationalization', 'internationalisation'],
+  ['l10n', 'localization', 'localisation'],
+  ['ui', 'user interface'],
+  ['ux', 'user experience'],
+  ['ui/ux', 'ux/ui'],
+  // apis and auth
+  ['api', 'application programming interface'],
+  ['rest', 'restful'],
+  ['rest api', 'restful api'],
+  ['oauth', 'oauth2', 'oauth 2.0'],
+  ['jwt', 'json web token'],
+  ['sso', 'single sign-on'],
+  ['oidc', 'openid connect'],
+  ['2fa', 'two-factor authentication'],
+  ['mfa', 'multi-factor authentication'],
+  ['rbac', 'role-based access control'],
+  ['ssl', 'tls', 'ssl/tls'],
+  ['protobuf', 'protocol buffers'],
+  ['openapi', 'swagger'],
+  ['pub/sub', 'publish/subscribe'],
+  // data
+  ['postgresql', 'postgres', 'psql', 'pgsql'],
+  ['mongodb', 'mongo'],
+  ['sql server', 'mssql', 'ms sql', 'microsoft sql server'],
+  ['dynamodb', 'dynamo db', 'amazon dynamodb'],
+  ['elasticsearch', 'elastic search'],
+  ['opensearch', 'open search'],
+  ['orm', 'object-relational mapping'],
+  ['kafka', 'apache kafka'],
+  ['spark', 'apache spark'],
+  ['airflow', 'apache airflow'],
+  ['hadoop', 'apache hadoop'],
+  ['flink', 'apache flink'],
+  ['cassandra', 'apache cassandra'],
+  ['solr', 'apache solr'],
+  ['rabbitmq', 'rabbit mq'],
+  ['activemq', 'active mq'],
+  ['etl', 'extract transform load', 'extract, transform, load'],
+  ['data warehouse', 'data warehousing', 'dwh'],
+  ['vector database', 'vector db'],
+  ['caching', 'cache'],
+  ['bigquery', 'big query'],
+  // ai
+  ['ml', 'machine learning'],
+  ['ai', 'artificial intelligence'],
+  ['llm', 'large language model'],
+  ['nlp', 'natural language processing'],
+  ['genai', 'generative ai'],
+  ['rag', 'retrieval-augmented generation'],
+  ['scikit-learn', 'sklearn'],
+  // cloud and infrastructure
+  ['aws', 'amazon web services'],
+  ['gcp', 'google cloud', 'google cloud platform'],
+  ['azure', 'microsoft azure'],
+  ['lambda', 'aws lambda'],
+  ['s3', 'amazon s3'],
+  ['ec2', 'amazon ec2'],
+  ['rds', 'amazon rds'],
+  ['sqs', 'amazon sqs'],
+  ['ecs', 'amazon ecs'],
+  ['eks', 'amazon eks'],
+  ['gke', 'google kubernetes engine'],
+  ['gcs', 'google cloud storage'],
+  ['cloudformation', 'cloud formation'],
+  ['cloudwatch', 'cloud watch'],
+  ['iam', 'identity and access management'],
+  ['kubernetes', 'k8s'],
+  ['helm', 'helm charts'],
+  ['iac', 'infrastructure as code'],
+  ['cdn', 'content delivery network'],
+  ['linux', 'gnu/linux'],
+  ['macos', 'mac os', 'os x'],
+  ['devops', 'dev ops'],
+  ['sre', 'site reliability engineering', 'site reliability engineer'],
+  ['on-call', 'oncall'],
+  ['new relic', 'newrelic'],
+  ['elk', 'elk stack', 'elastic stack'],
+  ['opentelemetry', 'open telemetry', 'otel'],
+  ['monorepo', 'mono repo'],
+  ['load balancing', 'load balancer'],
+  ['scalability', 'scalable', 'scaling'],
+  ['microservices', 'micro services'],
+  ['soa', 'service-oriented architecture'],
+  ['performance optimization', 'performance optimisation', 'performance tuning'],
+  // delivery and quality
+  ['ci/cd', 'ci', 'cd', 'continuous integration', 'continuous delivery', 'continuous deployment'],
+  ['github actions', 'gh actions'],
+  ['gitlab ci', 'gitlab ci/cd'],
+  ['circleci', 'circle ci'],
+  ['travis ci', 'travis'],
+  ['argocd', 'argo cd'],
+  ['version control', 'source control', 'vcs'],
+  ['pull request', 'merge request'],
+  ['unit testing', 'unit test'],
+  ['integration testing', 'integration test'],
+  ['e2e', 'end-to-end'],
+  ['e2e testing', 'end-to-end testing'],
+  ['tdd', 'test-driven development'],
+  ['bdd', 'behavior-driven development', 'behaviour-driven development'],
+  ['ddd', 'domain-driven design'],
+  ['qa', 'quality assurance'],
+  ['automated testing', 'test automation'],
+  ['a/b testing', 'split testing'],
+  ['phpunit', 'php unit'],
+  ['pytest', 'py.test'],
+  ['penetration testing', 'pen testing', 'pentesting', 'pen test'],
+  ['oop', 'object-oriented programming', 'object-oriented'],
+  ['fp', 'functional programming'],
+  ['solid', 'solid principles'],
+  ['pci', 'pci dss'],
+  ['soc 2', 'soc ii'],
+  // frameworks
+  ['fastapi', 'fast api'],
+  ['spring', 'spring framework'],
+  ['jvm', 'java virtual machine'],
+  ['entity framework', 'ef core'],
+  ['swiftui', 'swift ui'],
+  // domains and work
+  ['ecommerce', 'e-commerce'],
+  ['fintech', 'financial technology'],
+  ['saas', 'software as a service'],
+  ['b2b', 'business-to-business'],
+  ['b2c', 'business-to-consumer'],
+  ['crm', 'customer relationship management'],
+  ['erp', 'enterprise resource planning'],
+  ['cms', 'content management system'],
+  ['pos', 'point of sale'],
+  ['iot', 'internet of things'],
+  ['cs', 'computer science'],
+  ['salesforce', 'sfdc'],
+  ['startup', 'start-up'],
+  ['remote', 'remotely'],
+  ['wfh', 'work from home'],
+  ['fulltime', 'full-time'],
+  ['parttime', 'part-time'],
+  ['tech lead', 'technical lead'],
+  ['team lead', 'team leader'],
+  ['mentoring', 'mentorship', 'mentor', 'mentored'],
+];
+
+const BY_SPELLING = new Map<string, readonly string[]>();
+for (const group of GROUPS) {
+  for (const spelling of group) BY_SPELLING.set(spelling, group);
+}
+
+export const ALIAS_GROUPS = GROUPS;
+
+/** The other spellings of `term` (lowercase), or [] when the table does not know it. */
+export function aliasesFor(term: string): string[] {
+  const key = canonicalTerm(term);
+  const group = BY_SPELLING.get(key);
+  return group ? group.filter((s) => s !== key) : [];
+}
+
+/**
+ * The keyword with every table spelling of its term and aliases merged into
+ * `aliases`. Returns the same object when the table adds nothing.
+ */
+export function withTableAliases<K extends { term: string; aliases: string[] }>(k: K): K {
+  const key = canonicalTerm(k.term);
+  const merged = new Set(k.aliases);
+  for (const name of [key, ...k.aliases]) {
+    for (const alias of aliasesFor(name)) {
+      if (alias !== key) merged.add(alias);
+    }
+  }
+  return merged.size === k.aliases.length ? k : { ...k, aliases: [...merged] };
+}

--- a/src/resume/keyword-anchor.test.ts
+++ b/src/resume/keyword-anchor.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { anchorKeywords } from './keyword-anchor';
+import { loadKeywordMatcher } from './keyword-matcher';
+import type { MatchKeyword } from './prompts';
+
+const POSTING = [
+  'Senior Full-stack Angular & PHP Developer',
+  'We have different projects for Senior Full-Stack Developers, so if you have',
+  '4+ years of software development experience, unit tests and Go, apply now.',
+].join('\n');
+
+function keyword(term: string, aliases: string[] = []): MatchKeyword {
+  return { term, priority: 1, requirement: 'must', primary: false, status: 'present', aliases, where: null, note: null, elsewhere: null };
+}
+
+test('anchorKeywords keeps verbatim rows and rows an alias finds untouched', async () => {
+  const matcher = await loadKeywordMatcher();
+  const rows = [keyword('PHP Developer'), keyword('Golang', ['go']), keyword('unit test')];
+  const r = anchorKeywords(rows, POSTING, matcher);
+  assert.deepEqual(r, { keywords: rows, anchored: 0, unanchored: 0 });
+  assert.equal(r.keywords[0], rows[0]);
+});
+
+test('anchorKeywords rewrites a paraphrase to the longest verbatim phrase, spelled as the posting spells it', async () => {
+  const matcher = await loadKeywordMatcher();
+  const r = anchorKeywords(
+    [keyword('Senior Full-stack Developer (4+ years software development)'), keyword('Testing (unit tests)')],
+    POSTING,
+    matcher,
+  );
+  assert.equal(r.anchored, 2);
+  assert.equal(r.unanchored, 0);
+  assert.deepEqual(
+    r.keywords.map((k) => k.term),
+    ['Senior Full-Stack Developers', 'unit tests'],
+  );
+  assert.equal(r.keywords[0]?.status, 'present', 'everything but the term is kept');
+  assert.equal('unanchored' in (r.keywords[0] ?? {}), false);
+});
+
+test('anchorKeywords marks rows the posting does not contain, never on a single word', async () => {
+  const matcher = await loadKeywordMatcher();
+  const r = anchorKeywords(
+    [keyword('Agile'), keyword('Mentoring / team lead', ['mentored']), keyword('code review')],
+    POSTING,
+    matcher,
+  );
+  assert.equal(r.unanchored, 3);
+  assert.equal(r.anchored, 0);
+  for (const k of r.keywords) assert.equal(k.unanchored, true, k.term);
+});
+
+test('anchorKeywords leaves a row unanchored when its phrase is another row already', async () => {
+  const matcher = await loadKeywordMatcher();
+  const r = anchorKeywords([keyword('unit tests'), keyword('Testing (unit tests)')], POSTING, matcher);
+  assert.deepEqual(r.keywords.map((k) => [k.term, k.unanchored ?? false]), [['unit tests', false], ['Testing (unit tests)', true]]);
+});

--- a/src/resume/keyword-anchor.ts
+++ b/src/resume/keyword-anchor.ts
@@ -1,0 +1,61 @@
+import { canonicalTerm } from './facts';
+import type { KeywordMatcher } from './keyword-matcher';
+import type { MatchKeyword } from './prompts';
+
+/*
+ * Persist-time verbatim guard (target-plan.md §4 F2). The prompt wants every
+ * keyword copied character-for-character from the posting because the panes
+ * highlight by literal search; when the model paraphrases anyway, the row
+ * sits in the table and highlights nowhere. This pass runs the matcher over
+ * the posting: a keyword with no span is re-anchored to the longest verbatim
+ * phrase of itself (two or more of its words in a row) the posting does
+ * contain — the term becomes that phrase, spelled as the posting spells it —
+ * and one with none is marked `unanchored`, so the UI can say so and the log
+ * can count it: the regression metric for every PROMPT_VERSION bump. Pure —
+ * the matcher comes in as an argument.
+ */
+
+const WORD_BOUNDARY = /[^\p{L}\p{N}+#.]+/u;
+
+export interface AnchorReport {
+  keywords: MatchKeyword[];
+  /** Terms rewritten to a verbatim phrase of the posting. */
+  anchored: number;
+  /** Terms the posting contains in no recognisable form. */
+  unanchored: number;
+}
+
+export function anchorKeywords(
+  keywords: MatchKeyword[],
+  posting: string,
+  matcher: KeywordMatcher,
+): AnchorReport {
+  const taken = new Set(keywords.map((k) => canonicalTerm(k.term)));
+  let anchored = 0;
+  let unanchored = 0;
+  const next = keywords.map((k) => {
+    if (matcher.findTerm(posting, k.term, k.aliases).length > 0) return k;
+    const phrase = longestVerbatimPhrase(k.term, posting, matcher);
+    // A phrase another row already owns would make two rows of one keyword.
+    if (phrase !== null && !taken.has(canonicalTerm(phrase))) {
+      taken.add(canonicalTerm(phrase));
+      anchored++;
+      return { ...k, term: phrase };
+    }
+    unanchored++;
+    return { ...k, unanchored: true };
+  });
+  return { keywords: next, anchored, unanchored };
+}
+
+/** The longest run of two or more consecutive words of `term` the posting contains, as the posting spells it. */
+function longestVerbatimPhrase(term: string, posting: string, matcher: KeywordMatcher): string | null {
+  const words = term.split(WORD_BOUNDARY).filter((w) => /[\p{L}\p{N}]/u.test(w));
+  for (let length = words.length; length >= 2; length--) {
+    for (let start = 0; start + length <= words.length; start++) {
+      const [span] = matcher.findTerm(posting, words.slice(start, start + length).join(' '));
+      if (span) return posting.slice(span.start, span.end).replace(/\s+/g, ' ');
+    }
+  }
+  return null;
+}

--- a/src/resume/keyword-matcher.ts
+++ b/src/resume/keyword-matcher.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+
+/*
+ * The keyword matcher is the browser module src/web/public/target.mjs — ONE
+ * implementation for the /target page, node:test and the server, nothing to
+ * mirror. Loaded from the working directory, the same way web/server.ts serves
+ * that directory as /static/ (the runtime image copies it next to dist/).
+ */
+
+export interface Span {
+  start: number;
+  end: number;
+}
+
+export interface KeywordMatcher {
+  /** Every occurrence of term + aliases in text as whole tokens (see target.mjs). */
+  findTerm(text: string, term: string, aliases?: string[]): Span[];
+}
+
+const MATCHER_PATH = path.resolve('src/web/public/target.mjs');
+
+let matcher: Promise<KeywordMatcher> | undefined;
+
+export function loadKeywordMatcher(): Promise<KeywordMatcher> {
+  matcher ??= import(MATCHER_PATH) as Promise<KeywordMatcher>;
+  return matcher;
+}

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -11,6 +11,9 @@ import {
   type MatchJobInput,
 } from './prompts';
 import { annotateElsewhere, applyFacts } from './facts';
+import { withTableAliases } from './keyword-aliases';
+import { anchorKeywords } from './keyword-anchor';
+import { loadKeywordMatcher } from './keyword-matcher';
 import { canReuseMatch, readPromptVersion } from './match-reuse';
 import { scoreMatch } from './score';
 import {
@@ -40,10 +43,11 @@ export async function matchResumeToJob(
   job: MatchJobInput & { id: number },
   opts: { draft?: boolean } = {},
 ): Promise<ResumeMatch | null> {
-  const [facts, otherSkills, previousMatch] = await Promise.all([
+  const [facts, otherSkills, previousMatch, matcher] = await Promise.all([
     listFacts(),
     listOtherResumeSkills(resume.id),
     getLatestMatchForJob(job.id),
+    loadKeywordMatcher(),
   ]);
   const context: MatchContext = {
     confirmedFacts: facts.filter((f) => f.status === 'confirmed').map((f) => ({ term: f.term, note: f.note })),
@@ -74,9 +78,16 @@ export async function matchResumeToJob(
     const model = (out.model || out.providerId) + (out.viaFallback ? ' · fallback' : '');
     const parsed = parseMatchResponse(out.text);
     if (parsed.ok) {
-      // Deterministic guarantees on top of the model's judgment: stored facts
-      // always win, and unclaimable terms point at the resume that has them.
-      const withFacts = applyFacts(parsed.data.keywords, facts).keywords;
+      // Deterministic guarantees on top of the model's judgment: the alias
+      // table joins the model's spellings, every term is anchored to the
+      // posting (or flagged), stored facts always win, and unclaimable terms
+      // point at the resume that has them.
+      const anchor = anchorKeywords(
+        parsed.data.keywords.map(withTableAliases),
+        `${job.title}\n${job.description}`,
+        matcher,
+      );
+      const withFacts = applyFacts(anchor.keywords, facts).keywords;
       const keywords = annotateElsewhere(withFacts, otherSkills);
       const breakdown = scoreMatch(keywords, parsed.data.alignment, parsed.data.red_flags.length);
       const row = await createMatch({
@@ -99,6 +110,9 @@ export async function matchResumeToJob(
           draft: row.draft,
           score: row.matchScore,
           cap: breakdown.cap,
+          keywords: keywords.length,
+          anchored: anchor.anchored,
+          unanchored: anchor.unanchored,
           promptVersion: PROMPT_VERSION,
           ms: Date.now() - started,
         },

--- a/src/resume/prompts.ts
+++ b/src/resume/prompts.ts
@@ -103,6 +103,9 @@ export const MatchSchema = z.object({
         note: nullableText,
         // Set by post-processing when another stored resume evidences the term.
         elsewhere: nullableText,
+        // Set by post-processing when the posting contains the term in no
+        // recognisable spelling — the panes cannot highlight it (F2 guard).
+        unanchored: z.boolean().optional(),
       }),
     )
     .max(80)

--- a/src/scripts/keyword-audit.ts
+++ b/src/scripts/keyword-audit.ts
@@ -1,0 +1,82 @@
+import { prisma } from '../db';
+import { loadKeywordMatcher } from '../resume/keyword-matcher';
+import { readKeywords } from '../resume/prompts';
+
+/*
+ * Read-only audit of the keyword matcher over every stored comparison: runs
+ * findTerm(term + aliases) — the function the /target page highlights with —
+ * against the posting and the judged resume text, and lists every keyword row
+ * that highlights nowhere. Before/after numbers for matcher changes (TASKS §13
+ * block 2) without an AI call. Never writes.
+ *
+ *   npm run keywords:audit                       (locally)
+ *   docker compose exec web node dist/scripts/keyword-audit.js
+ */
+
+interface Totals {
+  matches: number;
+  rows: number;
+  postingMiss: number;
+  titleOnly: number;
+  present: number;
+  resumeMiss: number;
+  noResumeText: number;
+}
+
+function pct(part: number, whole: number): string {
+  return whole === 0 ? '—' : `${Math.round((part / whole) * 100)}%`;
+}
+
+async function main(): Promise<void> {
+  const { findTerm } = await loadKeywordMatcher();
+  const matches = await prisma.resumeMatch.findMany({
+    orderBy: { id: 'asc' },
+    select: {
+      id: true,
+      jobId: true,
+      resumeId: true,
+      resumeVersion: true,
+      keywords: true,
+      resumeText: true,
+      job: { select: { title: true, description: true } },
+    },
+  });
+
+  const t: Totals = { matches: matches.length, rows: 0, postingMiss: 0, titleOnly: 0, present: 0, resumeMiss: 0, noResumeText: 0 };
+  for (const m of matches) {
+    const keywords = readKeywords(m.keywords);
+    const hasResume = m.resumeText.length > 0;
+    if (!hasResume) t.noResumeText++;
+    console.log(`match#${m.id} job#${m.jobId} resume#${m.resumeId} v${m.resumeVersion} — ${keywords.length} keywords, posting ${m.job.description.length} chars${hasResume ? '' : ', NO resume snapshot'}`);
+    for (const k of keywords) {
+      t.rows++;
+      const label = `"${k.term}"${k.aliases.length > 0 ? ` aliases=[${k.aliases.join(', ')}]` : ''} · ${k.requirement} · ${k.status}`;
+      if (findTerm(m.job.description, k.term, k.aliases).length === 0) {
+        t.postingMiss++;
+        const inTitle = findTerm(m.job.title, k.term, k.aliases).length > 0;
+        if (inTitle) t.titleOnly++;
+        console.log(`    posting miss${inTitle ? ' (title only)' : ''}: ${label}`);
+      }
+      if (k.status !== 'present' || !hasResume) continue;
+      t.present++;
+      if (findTerm(m.resumeText, k.term, k.aliases).length === 0) {
+        t.resumeMiss++;
+        console.log(`    resume miss: ${label} · where: ${k.where ?? '—'}`);
+      }
+    }
+  }
+
+  console.log('');
+  console.log(`matches: ${t.matches} (${t.noResumeText} without a resume snapshot)`);
+  console.log(`keyword rows: ${t.rows}`);
+  console.log(`  0 spans in the posting: ${t.postingMiss} (${pct(t.postingMiss, t.rows)}), of which found in the title only: ${t.titleOnly}`);
+  console.log(`status=present rows with a resume snapshot: ${t.present}`);
+  console.log(`  0 spans in the resume: ${t.resumeMiss} (${pct(t.resumeMiss, t.present)})`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/scripts/keyword-audit.ts
+++ b/src/scripts/keyword-audit.ts
@@ -1,4 +1,5 @@
 import { prisma } from '../db';
+import { withTableAliases } from '../resume/keyword-aliases';
 import { loadKeywordMatcher } from '../resume/keyword-matcher';
 import { readKeywords } from '../resume/prompts';
 
@@ -6,8 +7,10 @@ import { readKeywords } from '../resume/prompts';
  * Read-only audit of the keyword matcher over every stored comparison: runs
  * findTerm(term + aliases) — the function the /target page highlights with —
  * against the posting and the judged resume text, and lists every keyword row
- * that highlights nowhere. Before/after numbers for matcher changes (TASKS §13
- * block 2) without an AI call. Never writes.
+ * that highlights nowhere — with the aliases as stored, and again with the
+ * alias table applied on top (what the target page does at read time).
+ * Before/after numbers for matcher changes (TASKS §13 block 2) without an AI
+ * call. Never writes.
  *
  *   npm run keywords:audit                       (locally)
  *   docker compose exec web node dist/scripts/keyword-audit.js
@@ -17,9 +20,11 @@ interface Totals {
   matches: number;
   rows: number;
   postingMiss: number;
+  postingMissTable: number;
   titleOnly: number;
   present: number;
   resumeMiss: number;
+  resumeMissTable: number;
   noResumeText: number;
 }
 
@@ -42,7 +47,7 @@ async function main(): Promise<void> {
     },
   });
 
-  const t: Totals = { matches: matches.length, rows: 0, postingMiss: 0, titleOnly: 0, present: 0, resumeMiss: 0, noResumeText: 0 };
+  const t: Totals = { matches: matches.length, rows: 0, postingMiss: 0, postingMissTable: 0, titleOnly: 0, present: 0, resumeMiss: 0, resumeMissTable: 0, noResumeText: 0 };
   for (const m of matches) {
     const keywords = readKeywords(m.keywords);
     const hasResume = m.resumeText.length > 0;
@@ -50,18 +55,23 @@ async function main(): Promise<void> {
     console.log(`match#${m.id} job#${m.jobId} resume#${m.resumeId} v${m.resumeVersion} — ${keywords.length} keywords, posting ${m.job.description.length} chars${hasResume ? '' : ', NO resume snapshot'}`);
     for (const k of keywords) {
       t.rows++;
-      const label = `"${k.term}"${k.aliases.length > 0 ? ` aliases=[${k.aliases.join(', ')}]` : ''} · ${k.requirement} · ${k.status}`;
+      const tabled = withTableAliases(k);
+      const label = `"${k.term}"${k.aliases.length > 0 ? ` aliases=[${k.aliases.join(', ')}]` : ''} · ${k.requirement} · ${k.status}${k.unanchored ? ' · UNANCHORED' : ''}`;
       if (findTerm(m.job.description, k.term, k.aliases).length === 0) {
         t.postingMiss++;
         const inTitle = findTerm(m.job.title, k.term, k.aliases).length > 0;
         if (inTitle) t.titleOnly++;
-        console.log(`    posting miss${inTitle ? ' (title only)' : ''}: ${label}`);
+        const rescued = findTerm(m.job.description, tabled.term, tabled.aliases).length > 0;
+        if (!rescued) t.postingMissTable++;
+        console.log(`    posting miss${inTitle ? ' (title only)' : ''}${rescued ? ' (table rescues)' : ''}: ${label}`);
       }
       if (k.status !== 'present' || !hasResume) continue;
       t.present++;
       if (findTerm(m.resumeText, k.term, k.aliases).length === 0) {
         t.resumeMiss++;
-        console.log(`    resume miss: ${label} · where: ${k.where ?? '—'}`);
+        const rescued = findTerm(m.resumeText, tabled.term, tabled.aliases).length > 0;
+        if (!rescued) t.resumeMissTable++;
+        console.log(`    resume miss${rescued ? ' (table rescues)' : ''}: ${label} · where: ${k.where ?? '—'}`);
       }
     }
   }
@@ -69,9 +79,9 @@ async function main(): Promise<void> {
   console.log('');
   console.log(`matches: ${t.matches} (${t.noResumeText} without a resume snapshot)`);
   console.log(`keyword rows: ${t.rows}`);
-  console.log(`  0 spans in the posting: ${t.postingMiss} (${pct(t.postingMiss, t.rows)}), of which found in the title only: ${t.titleOnly}`);
+  console.log(`  0 spans in the posting: ${t.postingMiss} (${pct(t.postingMiss, t.rows)}) as stored, ${t.postingMissTable} with the alias table; found in the title only: ${t.titleOnly}`);
   console.log(`status=present rows with a resume snapshot: ${t.present}`);
-  console.log(`  0 spans in the resume: ${t.resumeMiss} (${pct(t.resumeMiss, t.present)})`);
+  console.log(`  0 spans in the resume: ${t.resumeMiss} (${pct(t.resumeMiss, t.present)}) as stored, ${t.resumeMissTable} with the alias table`);
 }
 
 main()

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -552,6 +552,11 @@ const KeywordRow: FC<{ k: MatchKeyword }> = ({ k }) => (
       <span class="inline-flex flex-wrap items-center gap-1">
         <Badge tone={STATUS_VIEW[k.status].tone}>{STATUS_VIEW[k.status].label}</Badge>
         {k.elsewhere && <Badge tone="violet">in "{k.elsewhere}"</Badge>}
+        {k.unanchored && (
+          <span title="The AI worded this keyword differently from the posting, so the description pane cannot highlight it.">
+            <Badge>not in posting</Badge>
+          </span>
+        )}
       </span>
     </Td>
     <Td class="text-xs text-ink-muted">{k.where ?? '—'}</Td>

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -5,6 +5,7 @@ import { Badge, Button, Card, FitBadge, Flash, Hint, SUBMIT_ONCE } from '../ui';
 import type { FlashMessage } from '../flash';
 import { fitTone, formatRelative, type Tone } from '../format';
 import type { MatchWithResume } from '../../resume/store';
+import { withTableAliases } from '../../resume/keyword-aliases';
 import { readActions, readHardRequirements, readKeywords, readRemovals } from '../../resume/prompts';
 import { readBreakdown } from '../../resume/score';
 import {
@@ -98,7 +99,8 @@ export const TargetPage: FC<TargetPageProps> = ({
   resumeText,
   flash,
 }) => {
-  const keywords = readKeywords(match.keywords);
+  // Table spellings apply on read too, so matches stored before the table (or before an entry) highlight the same way.
+  const keywords = readKeywords(match.keywords).map(withTableAliases);
   const actions = readActions(match.actions);
   const removals = readRemovals(match.removals);
   const hard = readHardRequirements(match.hardRequirements);
@@ -417,6 +419,9 @@ export const TargetPage: FC<TargetPageProps> = ({
             id="jd"
             class="max-h-[70vh] overflow-auto whitespace-pre-wrap break-words font-sans text-sm leading-7 text-ink-muted"
           ></div>
+          <Hint class="mt-2">
+            Highlights follow the AI's keyword list — benefits, perks and legal boilerplate are deliberately never keywords.
+          </Hint>
         </Card>
 
         <Card class="pane-resume">

--- a/src/web/public/target.mjs
+++ b/src/web/public/target.mjs
@@ -31,8 +31,11 @@ const NOT_AFTER = '(?![\\w+#])(?!\\.\\w)';
  * in the original — spans found here are applied to the original verbatim.
  */
 export function normalise(s) {
+  return foldChars(s).toLowerCase();
+}
+
+function foldChars(s) {
   return s
-    .toLowerCase()
     .replace(/[\u2018\u2019]/g, "'")
     .replace(/[\u201c\u201d]/g, '"')
     .replace(/[\u00a0\t]/g, ' ');
@@ -42,26 +45,69 @@ function escapeRegex(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// Separators between the tokens of a multi-token term are interchangeable and
+// optional: "CI/CD" = "CI / CD" = "CI-CD", "Node.js" = "NodeJS", "front-end" =
+// "front end" = "frontend". Leading and trailing ones stay literal (".NET").
+const SEPARATOR = '[\\s/.\\-]*';
+const SEPARATOR_RUN = /[\s/.\-]+/;
+const EDGES = /^([\s/.\-]*)(.*?)([\s/.\-]*)$/s;
+
+/**
+ * Regex fragment for the last token of a term: the token plus its regular
+ * plural ("pipeline" → pipelines, "query" → queries, "class" → classes) and,
+ * for a plural token, its singular ("microservices" → microservice, "APIs" →
+ * API, "patches" → patch). A plural is a lowercase word or an acronym ending
+ * in a lowercase s — Capitalised names that end in s (Rails, Windows,
+ * Kubernetes) stay exact, and so do the two names whose lowercase alias
+ * would otherwise light unrelated text ("light rail", "window functions").
+ * No other stemming: irregular pairs belong in the alias table
+ * (src/resume/keyword-aliases.ts).
+ */
+const NOT_PLURAL = new Set(['rails', 'windows']);
+
+function pluralTolerant(token) {
+  const t = token.toLowerCase();
+  const literal = escapeRegex(t);
+  if (t.length < 3 || !/[a-z]$/.test(t) || NOT_PLURAL.has(t)) return literal;
+  if (t.endsWith('ss')) return `${literal}(?:es)?`;
+  if (/^[a-z]{3,}s$/.test(token) || /^[A-Z0-9]{2,}s$/.test(token)) {
+    if (t.endsWith('ies') && t.length >= 6) return `${escapeRegex(t.slice(0, -3))}(?:y|ie|ies)`;
+    const stem = t.slice(0, -2);
+    if (t.endsWith('es') && stem.length >= 4 && /(?:[sxz]|[cs]h)$/.test(stem)) return `${escapeRegex(stem)}(?:e|es)?`;
+    return `${escapeRegex(t.slice(0, -1))}(?:e?s)?`;
+  }
+  if (t.length >= 4 && /[^aeiou]y$/.test(t)) return `${escapeRegex(t.slice(0, -1))}(?:y|ies)`;
+  return `${literal}(?:e?s)?`;
+}
+
 /** Regex matching `term` as a whole token (no letters/digits/./+/# glued to it). */
 export function termPattern(term) {
-  // Runs of whitespace inside a term ("continuous  delivery") match any run in the text.
-  const t = escapeRegex(normalise(term).trim()).replace(/ +/g, '\\s+');
-  if (t.length === 0) return null;
+  const [, lead, core, trail] = EDGES.exec(foldChars(term).trim());
+  const tokens = core.split(SEPARATOR_RUN).filter((t) => t.length > 0);
+  if (tokens.length === 0) return null;
+  const parts = tokens.map((t) => escapeRegex(t.toLowerCase()));
+  if (trail === '') parts[parts.length - 1] = pluralTolerant(tokens[tokens.length - 1]);
+  const body = escapeRegex(lead) + parts.join(SEPARATOR) + escapeRegex(trail);
   // Terms that start/end with a symbol (".net", "c++") cannot use \b; use lookarounds on token chars.
-  return new RegExp(`${NOT_BEFORE}${t}${NOT_AFTER}`, 'g');
+  return new RegExp(`${NOT_BEFORE}${body}${NOT_AFTER}`, 'g');
 }
 
 /** All occurrences of term + aliases in text → [{start, end}] on the ORIGINAL text (same length after normalise). */
 export function findTerm(text, term, aliases = []) {
   const hay = normalise(text);
+  const seen = new Set();
   const spans = [];
   for (const candidate of new Set([term, ...aliases])) {
     const re = termPattern(candidate);
     if (!re) continue;
     let m;
     while ((m = re.exec(hay)) !== null) {
-      spans.push({ start: m.index, end: m.index + m[0].length });
       if (m[0].length === 0) re.lastIndex++;
+      const key = `${m.index}:${m.index + m[0].length}`;
+      // Aliases that spell the same span ("front end" / "frontend") count it once.
+      if (seen.has(key)) continue;
+      seen.add(key);
+      spans.push({ start: m.index, end: m.index + m[0].length });
     }
   }
   return spans.sort((a, b) => a.start - b.start);

--- a/src/web/target.test.ts
+++ b/src/web/target.test.ts
@@ -129,3 +129,71 @@ test('resumeSpans marks keywords and quoted edits, edits first on ties', async (
     ['edit-change', 'kw-present', 'edit-remove'],
   );
 });
+
+// F4 — plural tolerance on the last token, both directions. F5 — separators
+// between the tokens of a multi-token term are interchangeable and optional.
+// Guards keep the whole-token rule (C ≠ C++, Java ≠ JavaScript) and rule out
+// stemming: a Capitalised name ending in s is not a plural.
+const TOLERANCE: [term: string, text: string, hits: number][] = [
+  // F4: singular term, plural text
+  ['microservice', 'microservices architecture', 1],
+  ['API', 'REST APIs', 1],
+  ['query', 'SQL queries', 1],
+  ['class', 'PHP classes', 1],
+  ['unit test', 'unit tests', 1],
+  ['proxy', 'reverse proxies', 1],
+  // F4: plural term, singular text
+  ['microservices', 'a microservice', 1],
+  ['APIs', 'REST API design', 1],
+  ['LLMs', 'an LLM', 1],
+  ['queries', 'one query', 1],
+  ['patches', 'a security patch', 1],
+  ['releases', 'each release', 1],
+  ['databases', 'the database', 1],
+  ['unit tests', 'unit test coverage', 1],
+  // F4 guards
+  ['Rails', 'light rail', 0],
+  ['rails', 'light rail', 0],
+  ['Windows', 'window functions', 0],
+  ['Kubernetes', 'Kubernetes', 1],
+  ['AWS', 'aw', 0],
+  ['Go', 'goes', 0],
+  ['Sass', 'SAS', 0],
+  ['scaling', 'scale', 0],
+  ['Java', 'JavaScript', 0],
+  ['C', 'C++', 0],
+  ['Node', 'Node.js', 0],
+  // F5: separators
+  ['CI/CD', 'CI / CD', 1],
+  ['CI/CD', 'CI-CD', 1],
+  ['CI / CD', 'CI/CD', 1],
+  ['Node.js', 'NodeJS', 1],
+  ['Node.js', 'Node js', 1],
+  ['front-end', 'front end', 1],
+  ['front-end', 'frontend', 1],
+  ['front end', 'front-end', 1],
+  ['docker-compose', 'Docker Compose', 1],
+  ['ASP.NET', 'aspnet', 1],
+  ['A/B testing', 'AB testing', 1],
+  ['test-driven development', 'Test Driven Development', 1],
+  // F5 guards: edge symbols stay literal, single tokens stay whole
+  ['.NET', 'ASP.NET', 0],
+  ['.NET', '.NET Core', 1],
+  ['C#', 'C', 0],
+  ['C++', 'C++ and C', 1],
+  ['PHP', 'x.php', 0],
+  ['PHP', 'PHP.', 1],
+  ['NodeJS', 'Node.js', 0],
+];
+
+test('findTerm tolerates plurals and separators and keeps the whole-token guards', async () => {
+  const { findTerm } = await matcher;
+  for (const [term, text, hits] of TOLERANCE) {
+    assert.equal(findTerm(text, term).length, hits, `${JSON.stringify(term)} in ${JSON.stringify(text)}`);
+  }
+});
+
+test('findTerm counts a span once when the term and an alias both spell it', async () => {
+  const { findTerm } = await matcher;
+  assert.deepEqual(findTerm('frontend work', 'front end', ['frontend']), [{ start: 0, end: 8 }]);
+});


### PR DESCRIPTION
§13 block 2 of [docs/target-plan.md](docs/target-plan.md) §4 (F2–F6): the keyword matcher behind the `/target` panes and the live score stops missing spellings it should recognise, and every stored analysis is checked against the posting it came from. Pure-module work — no prompt change (`PROMPT_VERSION` stays 5), no schema change.

## What changed

- **F4/F5 in `termPattern`** (`src/web/public/target.mjs`, the single implementation for browser, node:test and now the server): separators between the tokens of a multi-word term are interchangeable and optional (`CI/CD` = `CI / CD` = `CI-CD`, `Node.js` = `NodeJS`, `front-end` = `front end` = `frontend`); the last token matches its regular plural and, for a plural token, its singular (`microservice(s)`, `API(s)`, `query`/`queries`, `patch(es)`, `release(s)`). Guards: `C` ≠ `C++`, `Java` ≠ `JavaScript`, `Go` ≠ `goes`, `Sass` ≠ `SAS`, a Capitalised name ending in s (`Rails`, `Windows`, `Kubernetes`) is not a plural, no stemming beyond plurals. 46 table-driven pairs in `target.test.ts`.
- **F3/F6 alias table** (`src/resume/keyword-aliases.ts`, pure, 170 spelling groups / ~380 spellings): unioned into every keyword at persist time and again when the target page loads a stored match, so old analyses highlight the same way and a new table entry never needs a backfill. Membership is "the same thing spelled differently", never a sibling technology (gotcha 11) — the hygiene test enforces lowercase, uniqueness across groups and ≥2 spellings per group.
- **F2 persist-time guard** (`src/resume/keyword-anchor.ts`, pure): after parsing, every keyword is searched in title + description with the same `findTerm`. A paraphrased term is rewritten to the longest verbatim phrase of itself (two or more of its words in a row) the posting contains, spelled as the posting spells it; one the posting contains in no recognisable form gets `unanchored: true` (optional field in the keyword JSON — `readKeywords` keeps it, older readers ignore it), shows *not in posting* in the keyword table, and is counted on the `resume: matched` log line (`keywords`, `anchored`, `unanchored`) — the regression metric for every future prompt bump.
- **Server loads the browser matcher** (`src/resume/keyword-matcher.ts`): `import()` of `src/web/public/target.mjs` resolved from the working directory, the same convention `serveStatic` already uses; compiled output goes through Node's `require(esm)` (verified on Node 24 in the image and on the live compare below).
- **`npm run keywords:audit`** (read-only): every stored keyword row that highlights nowhere, as stored and with the table applied — the before/after instrument for this and every future matcher change, no AI call.
- Pane legend: one line under the job description says benefits/perks/legal boilerplate are never keywords, so an unmarked paragraph stops reading as a miss.

## Measured (`npm run keywords:audit`, the 15 stored comparisons)

| Rows | Before | After F3–F5 |
| --- | --- | --- |
| keyword rows with no highlight in the posting (of 305) | 54 (9 title-only) | 53 |
| `present` rows with no highlight in the resume (of 181) | 36 | 35 |

Modest on purpose: every remaining miss comes from the seven analyses written before the VERBATIM rule (prompt v5) — slash-joined paraphrases such as "Mentoring / team lead" or "startup / fast-paced environment" that no matcher can place. On the current prompt **no stored row misses the posting**; the two rescued rows are `Senior Full-stack Developer` ↔ *Senior Full-Stack Developers* (F4+F5) and `React` ↔ *React.js* (F3). The read-time table application was kept despite rescuing one row: it costs nothing and makes every future table entry retroactive.

**Live compare** (job #1393 "Backend Software Engineer | Node.js | AI Builder" × resume #5, `claude_code` engine): 77 s, 26 keywords, `anchored: 0, unanchored: 0`; the stored rows carry the merged spellings (`PostgreSQL · [postgres, pgsql, psql]`, `Kubernetes · [k8s]`, `CI/CD pipeline · [ci/cd, continuous integration, continuous delivery, …]`, `Microservices architecture · [microservices, microservice, micro services]`), and both panes highlight through them. The *not in posting* badge has no live row to show yet (the current prompt produced none) — it is covered by the anchor tests and the render path only.

## Verification

- `npm run lint:types`, `npm test` (881 tests: +46 tolerance pairs, alias-table hygiene/lookup/merge/F6, anchor guard ×4, site-demo parity), `npx prisma format --check`.
- `docker compose build web && up -d web`; `/jobs/:id`, `/jobs/:id/target` → 200; screenshots of `/jobs/1214/target` (stored match, read-time aliases) and `/jobs/1393/target` (live compare) at 1200 / 768 / 375; console 0 errors (the Tailwind CDN warning is pre-existing).
- The parallel-session trap from the previous PR was avoided: the site demo vendors `target.mjs` byte-for-byte (`site-vendor.test.ts`) — the copy is synced in the same commit.

## Review pass (`code-review-expert`, `git diff main...HEAD`)

No P0/P1. Fixed in-branch: the `bi` alias group (would have lit `bi-weekly`). Follow-ups, none blocking:

- **P2** — a Capitalised plural term (`Databases`, `Microservices` at the start of a bullet) stays exact because a Capitalised token ending in s is treated as a name (Redis, Kubernetes, Prometheus — the stored data has 7 of those and 3 Capitalised plurals). Revisit if the audit shows Capitalised plurals missing on the resume side.
- **P2** — `NOT_PLURAL` in `target.mjs` is a two-entry exception list (`rails`, `windows`) for lowercase aliases whose stem is a common word; a third entry means the rule wants rethinking, not a fourth entry.
- **P3** — `keyword-anchor.ts` keeps a trailing `.` on a word when splitting a term into words, so a phrase ending in a sentence dot cannot anchor.
- **P3** — `scoreKeywords().count` counts overlapping alias spans twice (`CI/CD` + `ci`); nothing renders `count` today.

Out of scope, tracked elsewhere: F1 tiered keyword budget → block 4 `match-fast-mode` (prompt change, one bump for all three); F7 "Rebuild keywords" → #79; F8 lexicon stays the open question in §8; #69–#77 unchanged.

## Release notes (draft for v1.14.0)

### What's new
- Keyword highlights on the compare page tolerate spellings, plurals and separators: `CI/CD` = `CI / CD`, `Node.js` = `NodeJS`, `microservice(s)`, `API(s)`, plus a curated table of 170 spelling groups (`postgres`/`pgsql`, `k8s`/`kubernetes`, `go`/`golang`…) applied to new and stored analyses alike.
- Every keyword is anchored to the posting when an analysis is stored — paraphrases are rewritten to the posting's own wording, the rest are marked *not in posting* and counted in the log.
- The job-description pane says which text is deliberately never a keyword.
- `npm run keywords:audit` measures the matcher over stored analyses without an AI call.

### Schema
- no schema changes (one optional field in the keyword JSON)

### Verification
- 881 tests, live compare on the `claude_code` engine, screenshots at 1200/768/375, 0 console errors

### References
- docs/target-plan.md §4 (measured table) and §7 item 2; TASKS §13; #79 (F7 follow-up)

After merge: `git tag -a v1.14.0 -m "keyword matcher v2" <merge-sha> && git push origin v1.14.0`, then the release from the notes above.
