### PR TITLE
target instant check: re-upload → draft in the editor in ms, AI on demand (§13 block 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.15.0] — 2026-09-02
+
+### Added
+- **Instant check: a re-uploaded resume is scored in the editor before the
+  AI is asked** ([docs/target-plan.md](docs/target-plan.md) §3.2 item 5,
+  TASKS §13 block 3). "Re-upload resume" on the targeted view now defaults
+  to **Upload & check**: the file (.pdf / .docx / .md / .txt) is parsed and
+  opens in the editor as an unsaved draft over the analysis the page showed
+  — live estimate, missing-keyword chips and highlights, the same formula as
+  the AI score. Nothing is written: no new version, no scan, no match row;
+  the draft lives in the browser tab (a reload keeps it) until **Re-analyze
+  with AI** makes it official or **Save as vN** keeps the text. The page
+  says what the number is — *"Estimate vs the analysis from 40m ago"*: the
+  text confirms what is present, while add / confirm / can't-claim keep the
+  AI's verdict on the analysed version until the re-analysis. **Upload as
+  vN & analyze with AI** keeps the previous behaviour (new version with the
+  file, AI match, scan in the background) one click away. `/target` answers
+  the same way when the pasted posting dedupes to a job this resume was
+  analysed against before and its text changed since.
+- Measured on the stored originals: parsing takes 0–2 ms (.docx) and
+  10–15 ms (.pdf, 64 ms cold); a re-upload lands on the rendered page in
+  ~30 ms server-side (POST + redirect + GET) and ~155 ms to `load` in the
+  browser, against the 95 s of the full run measured in 1.13.0. The
+  `resume: upload parsed` and `resume: instant check` log lines carry the
+  `ms`.
+
+### Notes
+- Known cost, stated on the page: after an instant check **Save as vN**
+  stores the text as a text version — the uploaded file itself does not
+  become the version's original. *Upload as vN & analyze with AI* (or
+  "Upload a new version" on `/resumes/:id`) is the path when the file must
+  be kept.
+- The draft waits between the POST and the page in web-process memory
+  (`src/web/draft-stash.ts`: 10-minute TTL, taken once) and is copied into
+  `localStorage` on first render. No schema change, no migration.
+
 ## [1.14.0] — 2026-09-02
 
 ### Changed
@@ -984,6 +1020,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.15.0]: https://github.com/applypack/applypack/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/applypack/applypack/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/applypack/applypack/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/applypack/applypack/compare/v1.11.0...v1.12.0

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -810,8 +810,8 @@ icon; progress visible step-by-step via the target-run registry pattern.
 
 ## 13. /target compare speed (30-40 s) + keyword-matcher accuracy (analysis 2026-08-31)
 
-Full plan: [docs/target-plan.md](./target-plan.md). **Blocks 1–2 shipped
-2026-09-02 (measured numbers in the plan's §2.3 and §4); blocks 3–6 open.** §12's
+Full plan: [docs/target-plan.md](./target-plan.md). **Blocks 1–3 shipped
+2026-09-02 (measured numbers in the plan's §2.3, §3.4 and §4); blocks 4–6 open.** §12's
 async-upload item overlaps the `/resumes`
 sync-scan finding, planned there, referenced here.
 
@@ -851,8 +851,19 @@ Sonnet bench for the resume role — not "make Opus stream faster".
       analyses — on the current prompt no stored row misses the posting.
       The tiered keyword budget (F1) is a prompt change and moved to
       `match-fast-mode` below; "Rebuild keywords" (F7) is issue #79.
-- [ ] `target-instant-check` — reupload → parse-only dirty draft in the
-      target editor (~2-5 s, zero AI), "Re-analyze" upgrades on demand
+- [x] `target-instant-check` — reupload → parse-only dirty draft in the
+      target editor, "Re-analyze" upgrades on demand — done 2026-09-02,
+      branch `target-instant-check` (PR #81). "Upload & check" is the default of
+      "Re-upload resume" on `/jobs/:id/target` (no AI, no new version,
+      nothing written; the draft lives in the tab and survives a reload);
+      the full run stays as "Upload as vN & analyze with AI". `/target`
+      answers the same way when the posting dedupes to a job this resume
+      was analysed against and its text changed since. Measured on the
+      stored originals: parse 0–2 ms (.docx) / 10–15 ms (.pdf, 64 ms
+      cold); POST → rendered page ~30 ms server-side, ~155 ms to `load`
+      in the browser — the plan's "~2–5 s" was two orders too pessimistic,
+      the AI upgrade stays the 78–109 s of block 1. Known cost, stated on
+      the page: "Save as vN" after a check keeps the text, not the file.
 - [ ] `match-fast-mode` — keywords-only prompt variant (score-complete
       subset, ~¼ output tokens) + `bench:resume` Sonnet-vs-Opus decision
       + the tiered keyword budget from §4 F1 (every must/preferred term

--- a/docs/target-plan.md
+++ b/docs/target-plan.md
@@ -1,7 +1,7 @@
 # /target compare flow: speed (30-40 s target) + keyword-matching accuracy
 
-> **Analysis written 2026-08-31; blocks 1–2 of §7 shipped 2026-09-02 (measured
-> numbers in §2.3 and §4).** Written from a parallel
+> **Analysis written 2026-08-31; blocks 1–3 of §7 shipped 2026-09-02 (measured
+> numbers in §2.3, §3.4 and §4).** Written from a parallel
 > session (full source pass over the compare pipeline: `src/web/routes/target.tsx`,
 > `jobs.tsx`, `src/resume/{match,scan,prompts,score}.ts`, `src/web/public/{target,score,target-page}.mjs`,
 > `src/ai-{runtime,provider}.ts`, `src/jobs/{manual-job,posting-extract,classify-existing}.ts`)
@@ -206,7 +206,7 @@ second HTTP server.
 
 | Scenario after the plan | Chain | est. wall time |
 | --- | --- | --- |
-| Re-upload vs analyzed job, instant check (5) | parse only | **~2-5 s** |
+| Re-upload vs analyzed job, instant check (5) | parse only | **~2-5 s** → measured 2026-09-02: parse 0–2 ms (.docx) / 10–15 ms (.pdf, 64 ms cold), POST → rendered page ~30 ms server-side, ~155 ms to `load` in the browser |
 | Quick AI check (6) on Sonnet (7) | match-lite | **~10-25 s** ✅ |
 | Quick AI check (6) on Opus | match-lite | ~20-40 s ✅ (borderline) |
 | Full analysis, Sonnet, P0 ordering | match | ~30-70 s (close; suggestions arrive with it) |
@@ -360,7 +360,9 @@ Sources: [jobscan.co](https://www.jobscan.co/blog/top-resume-keywords-boost-resu
    alias-module unit tests). Pure-module work; `PROMPT_VERSION` untouched
    (post-processing). **Shipped 2026-09-02** (PR #80, numbers in §4).
 3. `target-instant-check` — §3.2 item 5 (parse-only reupload → dirty draft
-   in the editor). UX copy honest about "estimate vs frame".
+   in the editor). UX copy honest about "estimate vs frame". **Shipped
+   2026-09-02** (PR #81, numbers in §3.4; §8 question 2 decided: the check is the
+   default, the AI never auto-runs, the full run stays an explicit button).
 4. `match-fast-mode` — §3.2 items 6-7: keywords-only prompt variant +
    `bench:resume` Sonnet-vs-Opus numbers + default/model-select decision,
    plus the F1 tiered keyword budget (same prompt, same bump).
@@ -374,6 +376,10 @@ Sources: [jobscan.co](https://www.jobscan.co/blog/top-resume-keywords-boost-resu
 
 - After the bench: flip the resume-role default to Sonnet, or keep Opus and
   surface a "fast/thorough" choice per compare?
-- Should reupload land on the instant check by default (AI never auto-runs),
-  or instant check + full analysis auto-started in the background?
+- ~~Should reupload land on the instant check by default (AI never auto-runs),
+  or instant check + full analysis auto-started in the background?~~ Decided
+  2026-09-02 (block 3): instant check by default, nothing auto-runs — every
+  auto-started analysis is 78–109 s of Opus on the CLI engine and the memo
+  only saves repeats. The background variant stays a separate branch if
+  ever wanted.
 - Is the F8 curated lexicon worth its maintenance, or are F1-F7 enough?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/draft-stash.test.ts
+++ b/src/web/draft-stash.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDraftStash } from './draft-stash';
+
+test('a draft is taken once', () => {
+  const stash = createDraftStash(() => 1000);
+  const id = stash.put({ matchId: 55, text: 'new text' });
+  assert.deepEqual(stash.take(id), { matchId: 55, text: 'new text' });
+  assert.equal(stash.take(id), null, 'a reload does not get the upload back');
+  assert.equal(stash.take('missing'), null);
+});
+
+test('drafts expire after the TTL', () => {
+  let clock = 0;
+  const stash = createDraftStash(() => clock);
+  const id = stash.put({ matchId: 55, text: 'x' });
+  clock = 10 * 60_000 + 1;
+  assert.equal(stash.take(id), null);
+});
+
+test('each draft gets its own id', () => {
+  const stash = createDraftStash(() => 0);
+  const a = stash.put({ matchId: 1, text: 'a' });
+  const b = stash.put({ matchId: 1, text: 'b' });
+  assert.notEqual(a, b);
+  assert.equal(stash.take(b)?.text, 'b');
+});

--- a/src/web/draft-stash.ts
+++ b/src/web/draft-stash.ts
@@ -1,0 +1,37 @@
+import { randomUUID } from 'node:crypto';
+
+/*
+ * A parsed re-upload waits here between the POST and the page that shows it
+ * as a draft (instant-check.ts). Same shape as target-runs.ts: web-process
+ * memory with a TTL, nothing persisted. Each draft is taken once — the page
+ * copies it into localStorage on first render, so a reload must not bring
+ * the uploaded text back over the edits made since.
+ */
+
+export interface StashedDraft {
+  matchId: number;
+  text: string;
+}
+
+const DRAFT_TTL_MS = 10 * 60_000;
+
+export function createDraftStash(now: () => number = Date.now) {
+  const drafts = new Map<string, StashedDraft & { at: number }>();
+  return {
+    put(draft: StashedDraft): string {
+      const cutoff = now() - DRAFT_TTL_MS;
+      for (const [id, d] of drafts) if (d.at < cutoff) drafts.delete(id);
+      const id = randomUUID();
+      drafts.set(id, { ...draft, at: now() });
+      return id;
+    },
+    take(id: string): StashedDraft | null {
+      const d = drafts.get(id);
+      if (!d) return null;
+      drafts.delete(id);
+      return now() - d.at > DRAFT_TTL_MS ? null : { matchId: d.matchId, text: d.text };
+    },
+  };
+}
+
+export const draftStash = createDraftStash();

--- a/src/web/instant-check.test.ts
+++ b/src/web/instant-check.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { decideInstantCheck, draftTextForPage, instantCheckNotice, unchangedNotice } from './instant-check';
+
+const frame = { id: 55, resumeText: 'Senior PHP engineer\nLaravel, Vue', createdAt: new Date('2026-09-02T13:08:11Z') };
+
+test('no frame means the full analysis', () => {
+  assert.deepEqual(decideInstantCheck(null, 'anything'), { kind: 'analyze' });
+});
+
+test('the analysed text is unchanged, anything else is a draft', () => {
+  assert.deepEqual(decideInstantCheck(frame, frame.resumeText), { kind: 'unchanged', frame });
+  assert.equal(decideInstantCheck(frame, frame.resumeText + '\nReact').kind, 'draft');
+  assert.equal(decideInstantCheck(frame, frame.resumeText + '\n').kind, 'draft', 'a whitespace edit is a draft');
+});
+
+test('the draft notice names the file, the frame and the inherited statuses', () => {
+  const text = instantCheckNotice('cv-v3.pdf', '2h ago', 24);
+  assert.match(text, /"cv-v3\.pdf" checked in 24 ms — no AI call/);
+  assert.match(text, /analysis from 2h ago/);
+  assert.match(text, /confirms what is present/);
+  assert.match(text, /add \/ confirm \/ can't-claim keep the AI's verdict/);
+  assert.match(unchangedNotice('cv.pdf', '3m ago'), /"cv\.pdf" has the same text .* \(3m ago\)/);
+});
+
+test('a stashed draft loads only over the match it was checked against', () => {
+  assert.equal(draftTextForPage({ matchId: 55, text: 'new' }, 55), 'new');
+  assert.equal(draftTextForPage({ matchId: 55, text: 'new' }, 46), null);
+  assert.equal(draftTextForPage(null, 55), null);
+});

--- a/src/web/instant-check.ts
+++ b/src/web/instant-check.ts
@@ -1,0 +1,50 @@
+/*
+ * Instant check (docs/target-plan.md §3.2 item 5): a re-uploaded resume is
+ * parsed and shown as an unsaved draft over the latest analysis of the
+ * posting — no AI call, no new version, nothing saved. The live estimate on
+ * the page reads that analysis as its frame: the text confirms what is
+ * `present`, while `add` / `ask_user` / `cannot_claim` stay the AI's verdict
+ * on the resume it analysed, until "Re-analyze with AI" makes the draft
+ * official. Pure — the routes decide what to fetch and where to redirect.
+ */
+
+/** The stored analysis a draft is checked against. */
+export interface Frame {
+  id: number;
+  resumeText: string;
+  createdAt: Date;
+}
+
+export type InstantDecision =
+  /** Nothing to check against: the full analysis is the only option. */
+  | { kind: 'analyze' }
+  /** The file's text is the analysed text — the stored analysis already answers it. */
+  | { kind: 'unchanged'; frame: Frame }
+  /** New text: show it as a dirty draft over the frame. */
+  | { kind: 'draft'; frame: Frame };
+
+export function decideInstantCheck(frame: Frame | null, text: string): InstantDecision {
+  if (!frame) return { kind: 'analyze' };
+  return frame.resumeText === text ? { kind: 'unchanged', frame } : { kind: 'draft', frame };
+}
+
+/** The flash over a checked draft; `when` is the frame's age ("2h ago"). */
+export function instantCheckNotice(filename: string, when: string, ms: number): string {
+  return (
+    `"${filename}" checked in ${ms} ms — no AI call. The estimate is measured against the analysis ` +
+    `from ${when}: the text confirms what is present; add / confirm / can't-claim keep the AI's ` +
+    `verdict on the analysed version until you Re-analyze.`
+  );
+}
+
+export function unchangedNotice(filename: string, when: string): string {
+  return `"${filename}" has the same text as the analysed version (${when}) — nothing new to check.`;
+}
+
+/** A stashed draft loads into the page only over the analysis it was checked against. */
+export function draftTextForPage(
+  stashed: { matchId: number; text: string } | null,
+  matchId: number,
+): string | null {
+  return stashed && stashed.matchId === matchId ? stashed.text : null;
+}

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -45,6 +45,8 @@ export interface TargetPageProps {
   previous: MatchWithResume | null;
   /** The text the selected match analysed (not necessarily the resume's current text). */
   resumeText: string;
+  /** An instant check's parsed upload — opens in the editor as the unsaved draft (target-page.mjs). */
+  draftText?: string | null;
   flash?: FlashMessage | null;
 }
 
@@ -97,6 +99,7 @@ export const TargetPage: FC<TargetPageProps> = ({
   matches,
   previous,
   resumeText,
+  draftText,
   flash,
 }) => {
   // Table spellings apply on read too, so matches stored before the table (or before an entry) highlight the same way.
@@ -116,6 +119,7 @@ export const TargetPage: FC<TargetPageProps> = ({
     matchId: match.id,
     aiScore: match.matchScore,
     resumeText,
+    draftText: draftText ?? null,
     jobText: job.description,
     keywords,
     actions,
@@ -279,6 +283,11 @@ export const TargetPage: FC<TargetPageProps> = ({
                   onsubmit={SUBMIT_ONCE}
                 >
                   <input type="hidden" name="resumeId" value={resume.id} />
+                  <input type="hidden" name="matchId" value={match.id} />
+                  {/* Set by the second button's click, not by the submitter's value: SUBMIT_ONCE
+                      disables the buttons in the submit event, and a disabled submitter is left
+                      out of the form data. */}
+                  <input type="hidden" name="mode" value="check" />
                   <input
                     type="file"
                     name="file"
@@ -286,13 +295,29 @@ export const TargetPage: FC<TargetPageProps> = ({
                     accept={ACCEPTED_EXTENSIONS.join(',')}
                     class="block w-full text-xs text-ink file:mr-2 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink"
                   />
-                  <Button size="sm" class="w-full">
-                    {resume.ephemeral ? 'Upload & re-analyze' : `Upload v${resume.version + 1} & re-analyze`}
+                  <Button size="sm" class="w-full" title="Parses the file into the editor and scores it against this analysis — no AI call">
+                    Upload & check (seconds)
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    class="w-full"
+                    onclick="this.form.elements.mode.value='analyze'"
+                    title={
+                      resume.ephemeral
+                        ? 'Replaces this comparison with a fresh AI analysis (~2 min)'
+                        : `Saves the file as v${resume.version + 1} and runs the AI analysis (~2 min); the scan runs in the background`
+                    }
+                  >
+                    {resume.ephemeral ? 'Upload & analyze with AI' : `Upload as v${resume.version + 1} & analyze with AI`}
                   </Button>
                   <Hint>
+                    Check opens the new text as an unsaved draft scored against this analysis: the text confirms
+                    what is present, while add / confirm / can't-claim keep the AI's verdict on the analysed
+                    version until you Re-analyze.{' '}
                     {resume.ephemeral
-                      ? 'Replaces this comparison with a fresh analysis — nothing lands in your Resumes (~2 min).'
-                      : 'New version and AI match — about 2 minutes; the resume scan runs in the background.'}
+                      ? 'Nothing lands in your Resumes either way.'
+                      : `Nothing is saved — Save as v${resume.version + 1} keeps the text, not the file.`}
                   </Hint>
                 </form>
               </div>
@@ -331,7 +356,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                       class="w-full"
                       id="save-button"
                       disabled
-                      title="Enabled once you edit the text"
+                      title={`Saves the text as v${resume.version + 1} (a text version, not a file), re-scans and re-analyzes (~2 min)`}
                     >
                       Save as v{resume.version + 1}
                     </Button>
@@ -344,7 +369,7 @@ export const TargetPage: FC<TargetPageProps> = ({
             {/* Appears only while the text differs from the analyzed version. */}
             <div id="live-est" hidden class="lg:max-w-[280px] lg:text-right">
               <div class="flex items-center gap-2 text-[13px] font-medium text-ink-muted lg:justify-end">
-                {breakdown ? 'Estimate after your edits' : 'Keyword coverage after edits'}
+                {breakdown ? `Estimate vs the analysis from ${formatRelative(match.createdAt)}` : 'Keyword coverage after edits'}
                 <span id="live-delta" class="text-xs font-medium"></span>
               </div>
               <div class="mt-1 flex items-center gap-2.5 lg:justify-end">
@@ -360,7 +385,7 @@ export const TargetPage: FC<TargetPageProps> = ({
               </div>
               <Hint class="mt-1">
                 {breakdown
-                  ? 'Same formula as the AI score, live as you type — "can\'t claim" terms never count. Re-analyze to make it official.'
+                  ? "Same formula as the AI score, live as you type — the text confirms what is present; add / confirm / can't-claim keep the AI's verdict on the analysed version. Re-analyze to make it official."
                   : 'Keywords only, live as you type. Re-analyze to get the full score.'}
               </Hint>
             </div>
@@ -499,7 +524,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                 variant="secondary"
                 size="sm"
                 form="save-form"
-                title="Saves a text version, re-scans and re-analyzes (~2 min)"
+                title={`Saves the text as v${resume.version + 1} (a text version, not a file), re-scans and re-analyzes (~2 min)`}
               >
                 Save as v{resume.version + 1}
               </Button>

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -358,7 +358,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                       class="w-full"
                       id="save-button"
                       disabled
-                      title={`Saves the text as v${resume.version + 1} (a text version, not a file), re-scans and re-analyzes (~2 min)`}
+                      title={`Enabled once you edit the text — saves it as v${resume.version + 1} (a text version, not a file), re-scans and re-analyzes (~2 min)`}
                     >
                       Save as v{resume.version + 1}
                     </Button>

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -199,8 +199,9 @@ export const TargetPage: FC<TargetPageProps> = ({
 
       <Card class="mb-4">
         {/* Proportional columns instead of a scattered flex row: score | why (owns
-            the middle) | actions rail. The gates line spans the full width below. */}
-        <div class="grid grid-cols-1 items-start gap-x-8 gap-y-4 lg:grid-cols-[auto_minmax(0,1fr)_auto]">
+            the middle, never under 14rem — the rail grows while editing) | actions
+            rail. The gates line spans the full width below. */}
+        <div class="grid grid-cols-1 items-start gap-x-8 gap-y-4 lg:grid-cols-[auto_minmax(14rem,1fr)_auto]">
           {/* Primary: the honest score — the AI rubric verdict. Static until Re-analyze. */}
           <div class="flex items-center gap-4">
             <svg viewBox="0 0 96 96" class="h-20 w-20 -rotate-90" aria-hidden="true">
@@ -223,7 +224,8 @@ export const TargetPage: FC<TargetPageProps> = ({
                 {match.matchScore}
                 <span class="text-base font-normal text-ink-faint">/100</span>
               </div>
-              <div class="flex items-center gap-2 text-[13px] font-medium text-ink-muted">
+              {/* Wraps: the stale marker must not widen this auto column and squeeze the summary. */}
+              <div class="flex flex-wrap items-center gap-x-2 text-[13px] font-medium text-ink-muted">
                 AI match ·{' '}
                 <span class={AI_TONE[fitTone(match.matchScore)]}>{matchQuality(match.matchScore)}</span>
                 <span id="ai-stale" hidden class="font-medium text-warn">
@@ -368,7 +370,7 @@ export const TargetPage: FC<TargetPageProps> = ({
 
             {/* Appears only while the text differs from the analyzed version. */}
             <div id="live-est" hidden class="lg:max-w-[280px] lg:text-right">
-              <div class="flex items-center gap-2 text-[13px] font-medium text-ink-muted lg:justify-end">
+              <div class="flex flex-wrap items-center gap-x-2 text-[13px] font-medium text-ink-muted lg:justify-end">
                 {breakdown ? `Estimate vs the analysis from ${formatRelative(match.createdAt)}` : 'Keyword coverage after edits'}
                 <span id="live-delta" class="text-xs font-medium"></span>
               </div>

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -189,6 +189,8 @@ export function init(data) {
     });
   }
 
-  editor.value = load() ?? data.resumeText;
+  // An instant check hands over its parsed upload: it becomes this tab's draft
+  // in place of whatever the tab held, and lives in localStorage from here on.
+  editor.value = typeof data.draftText === 'string' ? data.draftText : (load() ?? data.resumeText);
   render();
 }

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -18,6 +18,8 @@ import { JobNewPage } from '../pages/job-new';
 import { TargetPage } from '../pages/target';
 import { previousFor } from '../pages/resume-match-card';
 import { nameFromFilename, readResumeUpload, resumeUploadLimit } from '../upload';
+import { decideInstantCheck, draftTextForPage, instantCheckNotice, unchangedNotice } from '../instant-check';
+import { draftStash } from '../draft-stash';
 import { scanInBackground } from '../../resume/scan';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
@@ -27,6 +29,8 @@ import {
   deleteMatchesForResume,
   getCoverLetter,
   getLatestCompanySnapshot,
+  getLatestMatchForResumeAndJob,
+  getMatch,
   getResume,
   listCoverLettersForJob,
   listFacts,
@@ -627,6 +631,9 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
   }
   const resume = await getResume(match.resumeId);
   if (!resume) return c.text('Not found', 404);
+  // An instant check arrives with its parsed upload — taken once; from then on the browser holds it.
+  const draftKey = c.req.query('draft');
+  const draftText = draftTextForPage(draftKey ? draftStash.take(draftKey) : null, match.id);
   return c.html(
     <TargetPage
       job={{ id: job.id, title: job.title, companyName: job.company.name, location: job.location, description: job.description }}
@@ -635,6 +642,7 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
       matches={matches}
       previous={previousFor(match, matches)}
       resumeText={match.resumeText || resume.text}
+      draftText={draftText}
       flash={parseFlashCookie(c.req.header('cookie'))}
     />,
     200,
@@ -643,6 +651,7 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
 });
 
 jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit(`/jobs/${c.req.param('id')}/target`)(c, next), async (c) => {
+  const started = Date.now();
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const form = await c.req.parseBody();
@@ -655,6 +664,28 @@ jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit
   if (!job || !existing) return c.text('Not found', 404);
   const upload = await readResumeUpload(form);
   if ('error' in upload) return flashRedirect(`/jobs/${id}/target`, 'err', upload.error);
+
+  // The default is the instant check: the new text becomes an unsaved draft
+  // over the analysis the page showed — no AI call, no new version, nothing
+  // written (docs/target-plan.md §3.2 item 5). "Upload & analyze" opts into
+  // the full run below.
+  if (form.mode !== 'analyze') {
+    const decision = decideInstantCheck(await frameFor(id, resumeId, Number(form.matchId)), upload.text);
+    if (decision.kind !== 'analyze') {
+      const when = formatRelative(decision.frame.createdAt);
+      const page = `/jobs/${id}/target?match=${decision.frame.id}`;
+      if (decision.kind === 'unchanged') {
+        return flashRedirect(page, 'warn', unchangedNotice(upload.sourceFilename, when));
+      }
+      const key = draftStash.put({ matchId: decision.frame.id, text: upload.text });
+      const ms = Date.now() - started;
+      logger.info(
+        { jobId: id, matchId: decision.frame.id, resumeId, file: upload.sourceFilename, chars: upload.text.length, ms },
+        'resume: instant check',
+      );
+      return flashRedirect(`${page}&draft=${key}`, 'ok', instantCheckNotice(upload.sourceFilename, when, ms));
+    }
+  }
 
   // Scratch (ephemeral) resumes are replaced in place with no scan and no
   // history — a fresh upload means a fresh analysis, nothing saved.
@@ -713,6 +744,13 @@ jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit
   });
   return c.redirect(`/target/runs/${run.id}`, 303);
 });
+
+/** The analysis a re-upload is checked against: the one the page showed, else the resume's latest for the job. */
+async function frameFor(jobId: number, resumeId: number, matchId: number) {
+  const shown = Number.isFinite(matchId) ? await getMatch(matchId) : null;
+  if (shown && shown.jobId === jobId && shown.resumeId === resumeId) return shown;
+  return getLatestMatchForResumeAndJob(jobId, resumeId);
+}
 
 function sortToOrderBy(sort: string): Prisma.JobOrderByWithRelationInput[] {
   switch (sort) {

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -9,10 +9,13 @@ import { reuseNotice } from '../../resume/match-reuse';
 import {
   deleteCoverLettersForResume,
   deleteMatchesForResume,
+  getLatestMatchForResumeAndJob,
   getResume,
   listResumes,
   upsertScratchResume,
 } from '../../resume/store';
+import { draftStash } from '../draft-stash';
+import { decideInstantCheck, instantCheckNotice } from '../instant-check';
 import { TargetStartPage } from '../pages/target-start';
 import { TargetRunPage } from '../pages/target-run';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
@@ -176,6 +179,7 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
     //    classified in the background: the comparison never reads the fit
     //    score, and that leg alone was ~50 s on a CLI engine
     //    (docs/target-plan.md §3.1).
+    const checkStarted = Date.now();
     const result = await createManualJob(
       {
         companyName,
@@ -203,6 +207,23 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
         reused: true,
       });
       return;
+    }
+
+    // 2b. This resume was analysed against the posting before and its text
+    //     changed since (a new version, another file on the scratch row):
+    //     the instant check — the new text as a draft over that analysis,
+    //     the AI on demand (docs/target-plan.md §3.2 item 5).
+    if (result.kind === 'existing') {
+      const decision = decideInstantCheck(await getLatestMatchForResumeAndJob(job.id, resume.id), resume.text);
+      if (decision.kind === 'draft') {
+        const key = draftStash.put({ matchId: decision.frame.id, text: resume.text });
+        updateRun(run.id, {
+          stage: 'done',
+          resultUrl: `/jobs/${job.id}/target?match=${decision.frame.id}&draft=${key}`,
+          flash: instantCheckNotice(resume.name, formatRelative(decision.frame.createdAt), Date.now() - checkStarted),
+        });
+        return;
+      }
     }
 
     // 3. Ephemeral compares keep only the current analysis.

--- a/src/web/upload.ts
+++ b/src/web/upload.ts
@@ -1,5 +1,6 @@
 import { extname } from 'node:path';
 import { bodyLimit } from 'hono/body-limit';
+import { logger } from '../logger';
 import { ResumeTextError } from '../resume/docx-text';
 import { ACCEPTED_EXTENSIONS, extractResumeText } from '../resume/resume-text';
 import { flashRedirect } from './flash';
@@ -40,11 +41,18 @@ export async function readResumeUpload(
   }
   const original = Buffer.from(await file.arrayBuffer());
   try {
+    const started = Date.now();
+    const text = await extractResumeText(file.name, original);
+    // The parse is the whole cost of an instant check (docs/target-plan.md §3.4).
+    logger.info(
+      { file: file.name, bytes: original.length, chars: text.length, ms: Date.now() - started },
+      'resume: upload parsed',
+    );
     return {
       sourceFilename: file.name,
       mimeType: file.type || MIME_BY_EXT[extname(file.name).toLowerCase()] || 'application/octet-stream',
       original,
-      text: await extractResumeText(file.name, original),
+      text,
     };
   } catch (err) {
     if (err instanceof ResumeTextError) return { error: err.message };


### PR DESCRIPTION
§13 block 3 of [docs/target-plan.md](docs/target-plan.md) (§3.2 item 5, §7 item 3): a re-uploaded resume is parsed and scored in the editor before any AI is asked.

## What changed

- **"Re-upload resume" on `/jobs/:id/target` defaults to _Upload & check_** — `readResumeUpload` → no run, no AI, no new version, nothing written. The new text lands in the editor as an unsaved draft over the analysis the page showed: live estimate, missing-keyword chips, highlights (the same `score.mjs` formula). The draft rides from the POST to the page through `src/web/draft-stash.ts` (web-process memory, 10-min TTL, taken once) and is copied into `localStorage` under the existing `target-draft:<matchId>` key on first render, so a reload keeps it and never overwrites edits made since.
- **Honest copy, per the plan's "limit to be honest about":** flash `"file.pdf" checked in 56 ms — no AI call. The estimate is measured against the analysis from 40m ago: the text confirms what is present; add / confirm / can't-claim keep the AI's verdict on the analysed version until you Re-analyze.` The same sentence sits next to the live number ("Estimate vs the analysis from 40m ago") and in the upload menu's hint. An upload whose text equals the analysed text answers with a warn flash ("nothing new to check").
- **The full run is one click away:** _Upload as vN & analyze with AI_ (or _Upload & analyze with AI_ on a scratch resume) keeps today's path (new version with the file, match, scan in the background). The mode travels in a hidden input set by the button's click — SUBMIT_ONCE disables the buttons in the submit event and a disabled submitter is dropped from the form data.
- **Second entry on `/target`:** when the pasted posting dedupes to a job this resume was analysed against before and the resume text changed since, the run finishes with the instant check instead of a resume-model call (`getLatestMatchForResumeAndJob` → `decideInstantCheck`). Same text under a different prompt version still falls through to the full run.
- Pure modules with `node:test`: `instant-check.ts` (frame / unchanged / draft decision, notices, which page a stashed draft belongs to) and `draft-stash.ts` (injected clock: taken once, TTL, unique ids).
- Layout: the dirty state is now the landing state after an upload, so the summary column keeps at least 14rem and the "edited — Re-analyze to refresh" marker wraps instead of squeezing the middle column to ~100px (pre-existing in the dirty state).
- Timing logs: `resume: upload parsed` (ms per file) and `resume: instant check` (whole POST).

## Measured (2026-09-02, web container, `claude_code` CLI engine for the AI leg)

| What | Number |
| --- | --- |
| Parse of the stored originals (5 rounds each) | .docx 43 KB: 2 · 1 · 0 · 0 · 0 ms · .txt: 0 ms · .pdf 123 KB: 64 (cold) · 15 · 14 · 12 · 12 ms · .pdf 269 KB: 13 · 11 · 11 · 10 · 10 ms |
| POST reupload → 303 (curl, resume-8.pdf) | 25–38 ms |
| GET the target page with the draft | 6 ms |
| POST + redirect + GET (`curl -L`) | 28–30 ms |
| Browser (navigation timing): redirect / responseEnd / load | 64 / 81 / 155 ms |
| `/target` second entry (paste, deduped posting, edited scratch text) | run done in ~1.1 s incl. the 1 s poll; the match step 7 ms |
| Re-analyze with AI from the draft (the upgrade) | 77 s — match #56 (draft), official 68 against the instant estimate of 70 |

The plan's "~2–5 s" row in §3.4 was two orders too pessimistic; §3.4, §7 and §8 (question 2: the check is the default, nothing auto-runs) are updated, TASKS §13 marks block 3 done.

## Known cost (stated on the page, not decided silently)

After an instant check, **Save as vN** keeps the text as a text version — the uploaded file itself does not become `Resume.original`. The Save buttons say so; _Upload as vN & analyze with AI_ (or "Upload a new version" on `/resumes/:id`) is the path when the file must be kept. If the original must survive the instant path too, that is a separate item: stash the bytes alongside the text and let Save consume them.

## Verification

- `npm run lint:types && npm test` (888 tests) and `npx prisma format --check` green; no schema change.
- curl matrix: `/jobs/1393/target` and `/jobs/1393` 200; identical file → 303 + warn flash; new file → 303 with `draft=` → page carries `draftText`, a second GET carries `null` (taken once).
- Browser (playwright, 0 console errors): upload resume-8.pdf on match #55 → draft in the editor, estimate 70 (+4 vs AI, 21/26 keywords), dirty bar + "Re-analyze" / "Save as v2"; reload without `?draft=` keeps it from `localStorage`; the analyze button flips the hidden mode to `analyze` (form-value inspection — the full run itself is unchanged code and was not re-run on a named resume). Screenshots at 1200 / 768 / 375 in the dirty state.
- Live cycle on job #1393 / match #55: upload resume-8.pdf → draft with estimate 70 in 155 ms → Re-analyze with AI → match #56, AI match 68/100 in 77 s (`resume: matched` … `ms: 77185`, 26 keywords, 0 unanchored).
- `/target` second entry exercised against job #1214 / match #46 (scratch text edited, then restored).

## Follow-ups (P2/P3 from the pre-merge review)

- P2 — scratch resume after an instant check: the page header and the draft match keep the previous file's name until a full run replaces the scratch row (the brief keeps `upsertScratchResume` off the instant path). Options: adopt the uploaded name on Re-analyze, or upsert the scratch row at check time (one DB write, no AI).
- P3 — `/target` with a stored resume whose latest match for the job is a _draft_ match: the check runs against that draft's frame (harmless, but the flash then names the analysis of an edited draft).
- P3 — the draft stash is pruned on `put` only and bounded by the 5 MB upload limit × 10 min; fine for a single-user dashboard on 127.0.0.1, worth a cap if the dashboard ever goes multi-user.
- P3 — a hand-edited `?match=` next to `?draft=` drops the upload (the draft loads only over the match it was checked against).
- Earlier follow-ups stay in issues #69–#77 and #79.

## Release notes (draft)

**v1.15.0 — instant check on re-upload**

A re-uploaded resume opens in the targeted editor in well under a second as an unsaved draft over the last analysis — live estimate, missing keywords, highlights — with no AI call; "Re-analyze with AI" makes it official on demand and "Upload as vN & analyze with AI" keeps the full run one click away. The page says exactly what the number is: an estimate against the analysis from a given time, where the text confirms what is present and the AI's add / confirm / can't-claim verdicts are inherited until the re-analysis. Measured: parsing 0–15 ms, POST → rendered page ~30 ms server-side and ~155 ms in the browser, against the 78–109 s of a resume-model call.
