### PR TITLE
keyword priority UI: your say over every keyword (§13 block 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.17.0] — 2026-09-02
+
+### Added
+- **Your say over every keyword** ([docs/target-plan.md](docs/target-plan.md)
+  §5, TASKS §13 block 5). Each row of the keyword table now carries three
+  edits: **re-level** what the posting demands (must ↔ preferred ↔ nice ↔
+  context), **ignore** a term as noise, or **add** a word the model missed.
+  All three are arithmetic over the stored analysis — the score is recomputed
+  by `score.ts` on the spot, the same free path a confirmed ask_user fact
+  takes. No AI call is made, and the flash says so: *"system scalability" is
+  now nice — score 66 → 67, no AI call.*
+- An added term's status is **read from your resume, never guessed**: written
+  in → matched; not written → a confirm question the existing ask_user flow
+  answers. A term the posting does not literally contain is flagged *not in
+  posting*, exactly as a paraphrase from the model would be.
+- **Overrides stick to the posting.** They ride in the comparison's own
+  `keywords` JSON, go into the next run's keyword frame, and are re-applied to
+  the fresh reply afterwards — including a hand-added term the model did not
+  repeat, whose status is re-read against the current resume text. An override
+  is kept even when the model comes to agree, because the point of it is that
+  the level stops depending on the next reply.
+- **Visual weight in the panes.** A missing must-have no longer looks like a
+  missing nice-to-have: every mark and chip is graded `kw-w0` (context) to
+  `kw-w4` (a primary-stack must) from one shared function, with the legend
+  showing the three tiers.
+- **Frequency as a tiebreaker.** Equal-weight keywords are ordered by how
+  often the posting repeats the term, the count shows in the keyword table
+  (*×4*) and in every pane tooltip (*×4 in the posting*). It costs nothing:
+  the panes already had every occurrence in hand.
+
+### Changed
+- The keyword table orders through the matcher — hardest requirement first,
+  then frequency, then priority — instead of sorting by requirement alone, and
+  gained a third group for ignored rows so they can be brought back.
+- `PROMPT_VERSION` is untouched: this is post-processing, not a prompt change.
+
 ## [1.16.0] — 2026-09-02
 
 ### Added
@@ -1076,6 +1112,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.17.0]: https://github.com/applypack/applypack/compare/v1.16.0...v1.17.0
 [1.16.0]: https://github.com/applypack/applypack/compare/v1.15.0...v1.16.0
 [1.15.0]: https://github.com/applypack/applypack/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/applypack/applypack/compare/v1.13.0...v1.14.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,8 @@
   (unpdf, ADR 0011), `resume-text.ts`, `prompts.ts`, `pick.ts`, `score.ts`
   (ADR 0012), `facts.ts`, `diff.ts`, `parse-warnings.ts`, `match-mode.ts`,
   `match-reuse.ts`, `bench-report.ts`,
-  `profile-draft.ts` (ADR 0015), `fact-check.ts` (ADR 0020) are pure (tested);
+  `profile-draft.ts` (ADR 0015), `fact-check.ts` (ADR 0020),
+  `keyword-overrides.ts` are pure (tested);
   `scan.ts` / `match.ts` / `suggestions.ts` / `cover-letter.ts` call the AI
   provider (the letter is gated by `fact-check.ts` and generates from stored
   inputs only — ADR 0021); `store.ts` is the only file that touches Prisma.
@@ -195,6 +196,8 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Comparing models / modes on the gold fixtures | `npm run bench:resume -- --model <id> --mode fast\|full --out f.json`, then `--table a.json b.json` (pure renderer `src/resume/bench-report.ts`) |
 | What counts as primary stack / sibling-tech rules (prompt side) | `src/resume/prompts.ts:MATCH_SYSTEM` steps 3-4 — guard-tested in `prompts.test.ts` |
 | ask_user confirmations (CandidateFact rows, instant re-score) | `src/resume/facts.ts` (pure) + `src/web/routes/facts.ts` (POST /facts), managed on `/resumes` |
+| Per-keyword overrides (re-level / ignore / add your own term) | `src/resume/keyword-overrides.ts` (pure): `effectiveKeywords` feeds the score, `carryOverrides` re-applies them to the next reply; route `src/web/routes/keywords.ts` |
+| Keyword display order + mark intensity (weight, then posting frequency) | `src/web/public/target.mjs:keywordRank` / `orderKeywords` — one implementation for the panes, the chips and the server-rendered table |
 | Anti-hallucination gate for generated prose (pass/warn/block) | `src/resume/fact-check.ts:factCheck` (pure, ADR 0020) — sources arrive as arguments, `store.ts` loads them |
 | Cover letter generation (gated, stored-inputs-only) | `src/resume/cover-letter.ts` + `COVER_SYSTEM` in `prompts.ts` (ADR 0021); card `src/web/pages/cover-letter-card.tsx` |
 | Letter → .pdf / .docx bytes | `src/resume/pdf-write.ts`, `docx-write.ts` (over `zip-write.ts`) — all pure, no dependencies |
@@ -249,6 +252,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | Upload / scan a resume | `/resumes` (the Settings card only lists + links) |
 | Compare a resume with a posting | `/jobs/:id` → "Resume match" card — **Compare** = quick check (keywords, gates, score), **Full analysis** = also the edit suggestions (ADR 0029) |
 | Get the edit suggestions for a quick check | the comparison → "Get suggestions" (second call, reuses the stored verdicts, score unchanged) |
+| Re-level, ignore or add a keyword by hand | the keyword table on `/jobs/:id` or `/jobs/:id/target` → the "Wants it" select, `ignore` / `reset`, and "Add a keyword" (instant re-score, no AI call; the edit sticks to the posting across re-runs) |
 | Paste a posting the fetchers don't see | `/jobs` → "+ Paste a job" (`/jobs/new`) |
 | Compare a pasted posting with any resume in one step | menu → Compare (`/target`): paste posting, pick / upload / paste resume, Compare |
 | Check whether a posting is real | `/jobs/:id` → "Is this job real?" → Verify (web search, 2-4 min) |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -810,8 +810,9 @@ icon; progress visible step-by-step via the target-run registry pattern.
 
 ## 13. /target compare speed (30-40 s) + keyword-matcher accuracy (analysis 2026-08-31)
 
-Full plan: [docs/target-plan.md](./target-plan.md). **Blocks 1–3 shipped
-2026-09-02 (measured numbers in the plan's §2.3, §3.4 and §4); blocks 4–6 open.** §12's
+Full plan: [docs/target-plan.md](./target-plan.md). **Blocks 1–5 shipped
+2026-09-02 (measured numbers in the plan's §2.3, §3.4, §4 and §5); block 6
+opens only if the numbers demand it.** §12's
 async-upload item overlaps the `/resumes`
 sync-scan finding, planned there, referenced here.
 
@@ -882,8 +883,22 @@ Sonnet bench for the resume role — not "make Opus stream faster".
       (v5: p50 40 s vs Opus 22 s, 95% status agreement, 74% term overlap),
       so `CLAUDE_MODEL_RESUME` stays `claude-opus-5` and §8 question 1 is
       answered by the numbers.
-- [ ] `keyword-priority-ui` — per-keyword user overrides (re-level /
-      exclude / add own term) via existing `updateMatchScoring`, visual
-      weight for must+primary misses, posting-frequency tiebreaker
+- [x] `keyword-priority-ui` — per-keyword user overrides (re-level /
+      ignore / add own term) through the existing `updateMatchScoring` path,
+      visual weight for must+primary misses, posting-frequency tiebreaker —
+      done 2026-09-02, branch `keyword-priority-ui` (PR #83). The override
+      rides beside the model's verdict in the comparison's own `keywords`
+      JSON (no schema change, no ADR, `PROMPT_VERSION` untouched);
+      `effectiveKeywords()` is what the score, the panes and the live editor
+      read, so **`score.ts` never changed** and the score.mjs parity test
+      stayed green on its own. Weight and frequency come from
+      `keywordRank()` / `orderKeywords()` in `target.mjs` — one
+      implementation for the panes, the chips and the server-rendered table.
+      Measured live on job #1393: **2–15 ms per edit, no `resume:` line in
+      the web log** (must → nice 66 → 67, ignore 67 → 68, add-and-present
+      68 → 68, add-and-missing 68 → 67, five resets back to 66); a forced
+      re-run logged `overrides: 3, readded: 1`, so the edits survived into
+      the fresh reply. An added term's status is read from the resume, and
+      the `override` field is stripped from every model reply on the way in.
 - [ ] (only if still short of target) `match-split-frame` — per-job cached
       keyword frame + statuses-only judge call (**ADR**)

--- a/docs/target-plan.md
+++ b/docs/target-plan.md
@@ -364,6 +364,38 @@ Worth adding (all deterministic, no AI):
   it and show "×4 in the posting" in the tooltip. Matches the
   "mentioned-multiple-times matters" practice at zero AI cost.
 
+**Shipped 2026-09-02** (block 5, PR #83). All three, all deterministic:
+
+- Overrides live in the comparison's own `keywords` JSON as an `override`
+  object beside the model's verdict (`src/resume/keyword-overrides.ts`, pure),
+  so nothing is overwritten and "reset" always has somewhere to go back to.
+  `effectiveKeywords()` — the user's levels, minus the rows they ignored — is
+  what the score, the panes and the live editor read; **`score.ts` did not
+  change**, an override is a different input, not a different formula. No
+  schema change and no ADR: the JSON absorbed it, exactly as the mode marker
+  did (ADR 0029).
+- The write path is `POST /jobs/:id/matches/:matchId/keywords` →
+  `updateMatchScoring`, the same free path a confirmed fact takes. **Measured
+  live on job #1393 (match #59): 2–15 ms per edit, zero `resume:` lines in the
+  web log** — must → nice 66 → 67, ignoring a `cannot_claim` nice 67 → 68,
+  adding a term the resume already had 68 → 68, adding one it lacked 68 → 67,
+  and five resets back to exactly 66. An added term's status is read from the
+  resume text (present) or asked (ask_user); one the posting does not contain
+  is flagged `unanchored`, the same badge a model paraphrase gets.
+- Carrying works: a forced re-run of the quick check on the same posting
+  logged `overrides: 3, readded: 1` in 50 s — two re-levelled/ignored rows and
+  one hand-added term the model had adopted came back on its fresh reply, and
+  the one it did not repeat was put back with its status re-read against the
+  current resume. A carried level is kept even when that reply agrees: an
+  override exists precisely so the level stops depending on the next one.
+  `override` is stripped from every reply on the way in — the field is the
+  user's, and a posting cannot talk the model into dropping a must-have.
+- Weight and frequency come from `keywordRank()` / `orderKeywords()` in
+  `target.mjs` — the module the panes, the chips and the server-rendered table
+  all share, so there is nothing to mirror. Marks are graded `kw-w0`…`kw-w4`
+  (a primary-stack must), the legend shows three of the tiers, and a tooltip
+  reads `system scalability · nice · missing · ×5 in the posting`.
+
 ## 6. Best-practice cross-check
 
 Current guidance (Jobscan, uppl.ai, PassTheScan, TailorCV, ResumeAdapter,
@@ -414,6 +446,10 @@ Sources: [jobscan.co](https://www.jobscan.co/blog/top-resume-keywords-boost-resu
    below.
 5. `keyword-priority-ui` — §5 overrides + visual weight + frequency. Reuses
    `updateMatchScoring`; ADR only if overrides outgrow the keywords JSON.
+   **Shipped 2026-09-02** (PR #83, numbers in §5). The JSON absorbed them, so
+   no ADR and no schema change; `PROMPT_VERSION` untouched — this is
+   post-processing. `score.ts` untouched too, so the score.mjs parity test
+   stayed green without a mirrored edit.
 6. (only if measurements demand) `match-split-frame` — §3.3 item 8 + ADR.
 
 ## 8. Open questions for the owner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/site/public/demo/target.mjs
+++ b/site/public/demo/target.mjs
@@ -15,9 +15,63 @@ import { SCORING } from './score.mjs';
 // Fallback for keyword rows that predate requirement levels (ADR 0012).
 const PRIORITY_WEIGHT = { 1: 3, 2: 2, 3: 1, 4: 1 };
 
+/**
+ * The requirement level in force. A row the user re-levelled by hand carries
+ * their choice in `override` (src/resume/keyword-overrides.ts); the panes and
+ * the live editor are handed lists with that already applied, the
+ * server-rendered keyword table is not — so read both here and neither caller
+ * has to care.
+ */
+function levelOf(k) {
+  return k.override?.requirement ?? k.requirement;
+}
+
 function keywordWeight(k) {
-  if (k.requirement) return SCORING.requirementWeight[k.requirement] ?? 0;
+  const level = levelOf(k);
+  if (level) return SCORING.requirementWeight[level] ?? 0;
   return PRIORITY_WEIGHT[k.priority] ?? 1;
+}
+
+/**
+ * How loudly the posting asks for a term: 4 a primary-stack must · 3 must ·
+ * 2 preferred · 1 nice · 0 context. One source for both the display order and
+ * the intensity of the mark, so a missing must-have can never look like a
+ * missing nice-to-have (target-plan.md §5).
+ */
+export function keywordRank(k) {
+  const weight = keywordWeight(k);
+  return k.primary === true && levelOf(k) === 'must' ? weight + 1 : weight;
+}
+
+/** Intensity class for a mark or a chip: kw-w0 (context) … kw-w4 (primary must). */
+export function weightClass(k) {
+  return 'kw-w' + keywordRank(k);
+}
+
+/** The requirement in words, for tooltips and chip titles. */
+function wantsLabel(k) {
+  const level = levelOf(k) ?? 'P' + k.priority;
+  return k.primary === true ? level + ' · primary stack' : level;
+}
+
+/**
+ * Display order for keyword lists: what the posting insists on hardest first,
+ * ties broken by how often the posting repeats the term — a word said four
+ * times outranks one said once at the same level. Every row comes back with
+ * that `count`, so callers can say "×4 in the posting" without searching
+ * again. Used by the panes, the missing chips and the server-rendered keyword
+ * table: one implementation, nothing to mirror.
+ */
+export function orderKeywords(keywords, jobText) {
+  return keywords
+    .map((k) => ({ ...k, count: findTerm(jobText, k.term, k.aliases ?? []).length }))
+    .sort(
+      (a, b) =>
+        keywordRank(b) - keywordRank(a) ||
+        b.count - a.count ||
+        (a.priority ?? 4) - (b.priority ?? 4) ||
+        a.term.localeCompare(b.term),
+    );
 }
 // A hit must not be glued to token characters: "C" is not "C++", "Java" is
 // not "JavaScript", "x.php" is a file. A trailing "." before a space or the
@@ -194,8 +248,12 @@ export function jobSpans(keywords, jobText, scored) {
       : found ? 'kw-found'
       : k.status === 'ask_user' ? 'kw-ask'
       : 'kw-missing';
-    for (const s of findTerm(jobText, k.term, k.aliases ?? [])) {
-      spans.push({ ...s, cls, title: `${k.term} · P${k.priority} · ${LABEL[cls]}` });
+    // Every occurrence is already in hand, so the frequency costs nothing.
+    const hits = findTerm(jobText, k.term, k.aliases ?? []);
+    const often = hits.length > 1 ? ` · ×${hits.length} in the posting` : '';
+    const title = `${k.term} · ${wantsLabel(k)} · ${LABEL[cls]}${often}`;
+    for (const s of hits) {
+      spans.push({ ...s, cls: `${cls} ${weightClass(k)}`, title });
     }
   }
   return spans;
@@ -204,9 +262,11 @@ export function jobSpans(keywords, jobText, scored) {
 /** Spans for the resume pane: present keywords, quoted removals, quoted actions. */
 export function resumeSpans(keywords, actions, removals, resumeText) {
   const spans = [];
+  // No weight class here: everything marked in the resume is a keyword the
+  // resume HAS, and the sort below keys off a single class per span.
   for (const k of keywords) {
     for (const s of findTerm(resumeText, k.term, k.aliases ?? [])) {
-      spans.push({ ...s, cls: 'kw-present', title: `${k.term} · P${k.priority}` });
+      spans.push({ ...s, cls: 'kw-present', title: `${k.term} · ${wantsLabel(k)}` });
     }
   }
   for (const r of removals) {

--- a/site/public/demo/target.mjs
+++ b/site/public/demo/target.mjs
@@ -48,8 +48,8 @@ export function weightClass(k) {
   return 'kw-w' + keywordRank(k);
 }
 
-/** The requirement in words, for tooltips and chip titles. */
-function wantsLabel(k) {
+/** The requirement in words — one vocabulary for the pane tooltips and the chips. */
+export function wantsLabel(k) {
   const level = levelOf(k) ?? 'P' + k.priority;
   return k.primary === true ? level + ' · primary stack' : level;
 }

--- a/src/resume/keyword-matcher.ts
+++ b/src/resume/keyword-matcher.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import type { MatchKeyword } from './prompts';
 
 /*
  * The keyword matcher is the browser module src/web/public/target.mjs — ONE
@@ -12,9 +13,22 @@ export interface Span {
   end: number;
 }
 
+/** A keyword row plus how many times the posting says it — what orderKeywords returns. */
+export type CountedKeyword = MatchKeyword & { count: number };
+
 export interface KeywordMatcher {
   /** Every occurrence of term + aliases in text as whole tokens (see target.mjs). */
   findTerm(text: string, term: string, aliases?: string[]): Span[];
+  /**
+   * Keyword rows in display order — hardest requirement first, ties broken by
+   * how often the posting repeats the term — each carrying that `count`
+   * (target-plan.md §5). The panes, the chips and the server-rendered keyword
+   * table all order through this one function.
+   */
+  orderKeywords<T extends { term: string; aliases?: string[] }>(
+    keywords: T[],
+    jobText: string,
+  ): (T & { count: number })[];
 }
 
 const MATCHER_PATH = path.resolve('src/web/public/target.mjs');

--- a/src/resume/keyword-overrides.test.ts
+++ b/src/resume/keyword-overrides.test.ts
@@ -110,6 +110,7 @@ test('reset clears an override on a model row and deletes a row the user added',
   const gone = editKeyword(clean.keywords, { op: 'reset', term: 'Kafka' });
   assert.ok(gone.ok);
   assert.equal(gone.keywords.length, LIST.length);
+  assert.equal(gone.removed, true, 'the row is gone, not reverted — the flash has to say so');
 });
 
 test('an added term reads its status from the resume, never from a guess', async () => {

--- a/src/resume/keyword-overrides.test.ts
+++ b/src/resume/keyword-overrides.test.ts
@@ -192,6 +192,14 @@ test('when the model finally lists a hand-added term, the row is its own but the
   assert.equal(r.keywords[0]?.override?.added, undefined);
 });
 
+test('an override the model now agrees with is still kept — that is what makes it stick', async () => {
+  const previous = [kw({ term: 'Laravel', requirement: 'must', override: { requirement: 'nice' } })];
+  // The frame told the model "nice", so it says nice this time. Dropping the
+  // override here would leave the level at the mercy of the next reply.
+  const r = carryOverrides([kw({ term: 'Laravel', requirement: 'nice' })], previous, await context());
+  assert.equal(r.keywords[0]?.override?.requirement, 'nice');
+});
+
 test('an override in the reply is stripped — only the user writes that field', async () => {
   const fresh = [kw({ term: 'Laravel', requirement: 'must', override: { excluded: true } })];
   const r = carryOverrides(fresh, [], await context());

--- a/src/resume/keyword-overrides.test.ts
+++ b/src/resume/keyword-overrides.test.ts
@@ -1,0 +1,200 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  addKeyword,
+  carryOverrides,
+  editKeyword,
+  effectiveKeywords,
+  effectiveRequirement,
+  isIgnored,
+} from './keyword-overrides';
+import type { MatchKeyword } from './prompts';
+import { scoreMatch } from './score';
+import { loadKeywordMatcher } from './keyword-matcher';
+
+/*
+ * §5 overrides: the user re-levels, ignores and adds keywords, and the score
+ * follows — deterministically, with no AI call. The matcher is the browser
+ * module the panes use, loaded here the same way the server loads it.
+ */
+
+const RESUME = 'Senior PHP engineer. Laravel, PostgreSQL, Docker and CI/CD pipelines.';
+const POSTING = 'We need Laravel, Kafka and a lot of Docker. Free snacks and a ping-pong table.';
+
+/** The matcher is the browser module the panes use — loaded as the server loads it. */
+async function context(resumeText = RESUME) {
+  return { resumeText, posting: POSTING, matcher: await loadKeywordMatcher() };
+}
+
+function kw(over: Partial<MatchKeyword> & { term: string }): MatchKeyword {
+  return {
+    priority: 2,
+    requirement: 'preferred',
+    primary: false,
+    status: 'present',
+    aliases: [],
+    where: null,
+    note: null,
+    elsewhere: null,
+    ...over,
+  };
+}
+
+const LIST: MatchKeyword[] = [
+  kw({ term: 'Laravel', requirement: 'must', primary: true, priority: 1 }),
+  kw({ term: 'ping-pong table', requirement: 'nice', priority: 4, status: 'cannot_claim' }),
+];
+
+test('re-levelling stores the user level beside the model verdict, and back again resets it', () => {
+  const up = editKeyword(LIST, { op: 'level', term: 'ping-pong table', requirement: 'must' });
+  assert.ok(up.ok);
+  const row = up.keywords[1]!;
+  assert.equal(row.requirement, 'nice', "the model's own verdict is never overwritten");
+  assert.equal(effectiveRequirement(row), 'must');
+
+  const back = editKeyword(up.keywords, { op: 'level', term: 'ping-pong table', requirement: 'nice' });
+  assert.ok(back.ok);
+  assert.equal(back.keywords[1]?.override, undefined, 'the model level again means no override at all');
+});
+
+test('an alias addresses the same row as the term', () => {
+  const list = [kw({ term: 'PostgreSQL', aliases: ['postgres'] })];
+  const r = editKeyword(list, { op: 'ignore', term: 'POSTGRES' });
+  assert.ok(r.ok);
+  assert.equal(r.term, 'PostgreSQL');
+  assert.ok(isIgnored(r.keywords[0]!));
+});
+
+test('an unknown term is refused rather than silently added', () => {
+  const r = editKeyword(LIST, { op: 'ignore', term: 'Kafka' });
+  assert.equal(r.ok, false);
+});
+
+test('ignore drops the row from the effective list; restore brings it back', () => {
+  const off = editKeyword(LIST, { op: 'ignore', term: 'ping-pong table' });
+  assert.ok(off.ok);
+  assert.equal(effectiveKeywords(off.keywords).length, 1);
+  assert.equal(off.keywords.length, 2, 'the row stays stored so the user can undo it');
+
+  const on = editKeyword(off.keywords, { op: 'restore', term: 'ping-pong table' });
+  assert.ok(on.ok);
+  assert.equal(effectiveKeywords(on.keywords).length, 2);
+});
+
+test('ignoring a keyword raises the score without touching the formula', () => {
+  const alignment = { title: 'strong', summary: 'strong', recent_role: 'strong' } as const;
+  const list = [
+    kw({ term: 'Laravel', requirement: 'must', primary: true, status: 'present' }),
+    kw({ term: 'ping-pong table', requirement: 'must', status: 'cannot_claim' }),
+  ];
+  const before = scoreMatch(effectiveKeywords(list), alignment, 0);
+  const after = scoreMatch(
+    effectiveKeywords((editKeyword(list, { op: 'ignore', term: 'ping-pong table' }) as { keywords: MatchKeyword[] }).keywords),
+    alignment,
+    0,
+  );
+  assert.ok(after.score > before.score, `${before.score} → ${after.score}`);
+});
+
+test('reset clears an override on a model row and deletes a row the user added', async () => {
+  const added = addKeyword(LIST, { term: 'Kafka', requirement: 'must' }, await context());
+  assert.ok(added.ok);
+  const levelled = editKeyword(added.keywords, { op: 'level', term: 'Laravel', requirement: 'nice' });
+  assert.ok(levelled.ok);
+
+  const clean = editKeyword(levelled.keywords, { op: 'reset', term: 'Laravel' });
+  assert.ok(clean.ok);
+  assert.equal(clean.keywords[0]?.override, undefined);
+  assert.equal(effectiveRequirement(clean.keywords[0]!), 'must');
+
+  const gone = editKeyword(clean.keywords, { op: 'reset', term: 'Kafka' });
+  assert.ok(gone.ok);
+  assert.equal(gone.keywords.length, LIST.length);
+});
+
+test('an added term reads its status from the resume, never from a guess', async () => {
+  const known = addKeyword(LIST, { term: 'Docker', requirement: 'must' }, await context());
+  assert.ok(known.ok);
+  const docker = known.keywords.at(-1)!;
+  assert.equal(docker.status, 'present', 'written in the resume');
+  assert.equal(docker.override?.added, true);
+  assert.equal(docker.unanchored, undefined, 'the posting says Docker too');
+
+  const missing = addKeyword(LIST, { term: 'Kafka', requirement: 'must' }, await context());
+  assert.ok(missing.ok);
+  assert.equal(missing.keywords.at(-1)?.status, 'ask_user', 'not in the resume — a question, not a claim');
+});
+
+test('an added term the posting never mentions is flagged unanchored', async () => {
+  const r = addKeyword(LIST, { term: 'Kubernetes', requirement: 'nice' }, await context());
+  assert.ok(r.ok);
+  assert.equal(r.keywords.at(-1)?.unanchored, true);
+});
+
+test('an added term picks up the alias table, so k8s finds Kubernetes', async () => {
+  const r = addKeyword([], { term: 'k8s', requirement: 'nice' }, await context('Ran Kubernetes in prod.'));
+  assert.ok(r.ok);
+  assert.equal(r.keywords[0]?.status, 'present');
+});
+
+test('a duplicate is refused, and an ignored duplicate says so', async () => {
+  const dup = addKeyword(LIST, { term: 'laravel', requirement: 'must' }, await context());
+  assert.equal(dup.ok, false);
+  const off = editKeyword(LIST, { op: 'ignore', term: 'Laravel' });
+  assert.ok(off.ok);
+  const again = addKeyword(off.keywords, { term: 'Laravel', requirement: 'must' }, await context());
+  assert.equal(again.ok, false);
+  assert.match((again as { error: string }).error, /restore/);
+});
+
+test('an empty term is refused', async () => {
+  assert.equal(addKeyword(LIST, { term: '   ', requirement: 'must' }, await context()).ok, false);
+});
+
+/* ---------- carrying overrides into the next run ---------- */
+
+test('the next run gets the stored levels and exclusions back', async () => {
+  const previous: MatchKeyword[] = [
+    kw({ term: 'Laravel', requirement: 'must', override: { requirement: 'nice' } }),
+    kw({ term: 'ping-pong table', requirement: 'nice', override: { excluded: true } }),
+    kw({ term: 'Docker', requirement: 'preferred' }),
+  ];
+  const fresh: MatchKeyword[] = [
+    kw({ term: 'Laravel', requirement: 'must' }),
+    kw({ term: 'ping-pong table', requirement: 'preferred' }),
+    kw({ term: 'Docker', requirement: 'must' }),
+  ];
+  const r = carryOverrides(fresh, previous, await context());
+  assert.equal(r.carried, 2);
+  assert.equal(r.readded, 0);
+  assert.equal(effectiveRequirement(r.keywords[0]!), 'nice');
+  assert.ok(isIgnored(r.keywords[1]!));
+  assert.equal(r.keywords[2]?.override, undefined, 'a row the user never touched carries nothing');
+});
+
+test('a hand-added term the model did not repeat comes back, re-read against the new resume', async () => {
+  const previous = (addKeyword([], { term: 'Kafka', requirement: 'must' }, await context()) as { keywords: MatchKeyword[] }).keywords;
+  assert.equal(previous[0]?.status, 'ask_user');
+  const r = carryOverrides([kw({ term: 'Laravel' })], previous, await context(`${RESUME} Also ran Kafka.`));
+  assert.equal(r.readded, 1);
+  assert.equal(r.keywords.at(-1)?.term, 'Kafka');
+  assert.equal(r.keywords.at(-1)?.status, 'present', 'written in since the last run');
+  assert.equal(r.keywords.at(-1)?.override?.added, true);
+});
+
+test('when the model finally lists a hand-added term, the row is its own but the level stays the user\'s', async () => {
+  const previous = (addKeyword([], { term: 'Kafka', requirement: 'must' }, await context()) as { keywords: MatchKeyword[] }).keywords;
+  const r = carryOverrides([kw({ term: 'Kafka', requirement: 'nice', status: 'cannot_claim' })], previous, await context());
+  assert.equal(r.readded, 0, 'no duplicate row');
+  assert.equal(r.keywords.length, 1);
+  assert.equal(r.keywords[0]?.status, 'cannot_claim', "the model's fresh verdict wins");
+  assert.equal(effectiveRequirement(r.keywords[0]!), 'must', 'the level the user picked is still theirs');
+  assert.equal(r.keywords[0]?.override?.added, undefined);
+});
+
+test('an override in the reply is stripped — only the user writes that field', async () => {
+  const fresh = [kw({ term: 'Laravel', requirement: 'must', override: { excluded: true } })];
+  const r = carryOverrides(fresh, [], await context());
+  assert.equal(r.keywords[0]?.override, undefined);
+  assert.equal(effectiveKeywords(r.keywords).length, 1, 'a prompt-injected exclusion cannot drop a must-have');
+});

--- a/src/resume/keyword-overrides.test.ts
+++ b/src/resume/keyword-overrides.test.ts
@@ -148,8 +148,11 @@ test('a duplicate is refused, and an ignored duplicate says so', async () => {
   assert.match((again as { error: string }).error, /restore/);
 });
 
-test('an empty term is refused', async () => {
-  assert.equal(addKeyword(LIST, { term: '   ', requirement: 'must' }, await context()).ok, false);
+test('an empty term is refused, and so is one too long to match anything', async () => {
+  const ctx = await context();
+  assert.equal(addKeyword(LIST, { term: '   ', requirement: 'must' }, ctx).ok, false);
+  const long = addKeyword(LIST, { term: 'x'.repeat(61), requirement: 'must' }, ctx);
+  assert.equal(long.ok, false, 'refused, not silently truncated to something that highlights nowhere');
 });
 
 /* ---------- carrying overrides into the next run ---------- */

--- a/src/resume/keyword-overrides.ts
+++ b/src/resume/keyword-overrides.ts
@@ -1,0 +1,235 @@
+import { canonicalTerm } from './facts';
+import { withTableAliases } from './keyword-aliases';
+import type { KeywordMatcher } from './keyword-matcher';
+import type { MatchKeyword } from './prompts';
+import type { RequirementLevel } from './score';
+
+/*
+ * The user's own say over the keyword list (target-plan.md §5). Three edits,
+ * all deterministic and free: re-level what the posting demands (must ↔
+ * preferred ↔ nice ↔ context), ignore a term as noise, add a term the model
+ * missed. The model's own verdict is never overwritten — an override rides
+ * beside it in the same `keywords` JSON, so the table can show both, "reset"
+ * has something to go back to, and carryOverrides can re-apply the user's
+ * edits to the next run's fresh list (the frame is per posting).
+ *
+ * `effectiveKeywords` is what everything downstream scores and highlights:
+ * ignored rows dropped, re-levelled rows carrying the user's requirement.
+ * score.ts is untouched — an override is a different input, not a different
+ * formula. Pure: tested in keyword-overrides.test.ts.
+ */
+
+export interface KeywordOverride {
+  /** Replaces the model's requirement level in every score and pane. */
+  requirement?: RequirementLevel;
+  /** Noise: out of the score, out of the highlights, kept in the table to undo. */
+  excluded?: boolean;
+  /** The user typed this row themselves — "reset" deletes it rather than restoring a verdict. */
+  added?: boolean;
+}
+
+export type KeywordEditOp = 'level' | 'ignore' | 'restore' | 'reset';
+
+export interface KeywordEdit {
+  op: KeywordEditOp;
+  term: string;
+  /** Required by `level`, ignored by the rest. */
+  requirement?: RequirementLevel;
+}
+
+export type EditResult =
+  | { ok: true; keywords: MatchKeyword[]; term: string }
+  | { ok: false; error: string };
+
+/** Context the two text-reading edits need; the matcher is the browser module (keyword-matcher.ts). */
+export interface KeywordEditContext {
+  resumeText: string;
+  posting: string;
+  matcher: KeywordMatcher;
+}
+
+const MAX_TERM_CHARS = 60;
+
+/** A hand-added row still needs a priority: the same order the levels imply. */
+const PRIORITY_BY_REQUIREMENT: Record<RequirementLevel, number> = {
+  must: 1,
+  preferred: 2,
+  nice: 3,
+  context: 4,
+};
+
+/** All names a keyword answers to, lowercase — the term plus its aliases. */
+function names(k: MatchKeyword): string[] {
+  return [canonicalTerm(k.term), ...k.aliases];
+}
+
+/** Empty overrides are not stored: `{}` and "no override" must read the same. */
+function tidy(o: KeywordOverride): KeywordOverride | undefined {
+  const next: KeywordOverride = {};
+  if (o.requirement) next.requirement = o.requirement;
+  if (o.excluded) next.excluded = true;
+  if (o.added) next.added = true;
+  return next.requirement !== undefined || next.excluded || next.added ? next : undefined;
+}
+
+function withOverride(k: MatchKeyword, patch: KeywordOverride): MatchKeyword {
+  const next = tidy({ ...k.override, ...patch });
+  return next ? { ...k, override: next } : withoutOverride(k);
+}
+
+function withoutOverride(k: MatchKeyword): MatchKeyword {
+  if (!k.override) return k;
+  const { override, ...rest } = k;
+  return rest;
+}
+
+/** The level in force: the user's if they set one, the model's otherwise. */
+export function effectiveRequirement(k: MatchKeyword): RequirementLevel {
+  return k.override?.requirement ?? k.requirement;
+}
+
+export function isIgnored(k: MatchKeyword): boolean {
+  return k.override?.excluded === true;
+}
+
+/**
+ * What the score, the panes and the live editor work from: the user's levels,
+ * without the rows they ignored. Everything else in the pipeline keeps taking
+ * a plain keyword list and needs no idea overrides exist.
+ */
+export function effectiveKeywords<K extends MatchKeyword>(keywords: K[]): K[] {
+  const kept = keywords.filter((k) => !isIgnored(k));
+  return kept.map((k) => (k.override?.requirement ? { ...k, requirement: k.override.requirement } : k));
+}
+
+/** Re-level / ignore / restore / reset one row, addressed by term or alias. */
+export function editKeyword(keywords: MatchKeyword[], edit: KeywordEdit): EditResult {
+  const key = canonicalTerm(edit.term);
+  const index = keywords.findIndex((k) => names(k).includes(key));
+  const current = keywords[index];
+  if (!current) return { ok: false, error: `"${edit.term}" is not in this comparison.` };
+
+  if (edit.op === 'reset' && current.override?.added) {
+    return { ok: true, keywords: keywords.filter((_, i) => i !== index), term: current.term };
+  }
+  const patch: KeywordOverride =
+    edit.op === 'level'
+      ? // Choosing the model's own level again is a reset, not a "yours" badge.
+        { requirement: edit.requirement === current.requirement ? undefined : edit.requirement }
+      : edit.op === 'ignore'
+        ? { excluded: true }
+        : edit.op === 'restore'
+          ? { excluded: false }
+          : { requirement: undefined, excluded: false };
+  const next = [...keywords];
+  next[index] = withOverride(current, patch);
+  return { ok: true, keywords: next, term: current.term };
+}
+
+/**
+ * A term the user says the posting wants. Status is read from the text, never
+ * guessed: written in the resume → "present"; not written → "confirm you have
+ * it", which the existing ask_user flow can then answer. A term the posting
+ * does not literally contain is flagged `unanchored`, the same as a
+ * paraphrase the model produced (keyword-anchor.ts).
+ */
+export function addKeyword(
+  keywords: MatchKeyword[],
+  input: { term: string; requirement: RequirementLevel },
+  ctx: KeywordEditContext,
+): EditResult {
+  const term = input.term.trim().replace(/\s+/g, ' ').slice(0, MAX_TERM_CHARS);
+  if (term.length === 0) return { ok: false, error: 'Type the keyword first.' };
+  const key = canonicalTerm(term);
+  const clash = keywords.find((k) => names(k).includes(key));
+  if (clash) {
+    return {
+      ok: false,
+      error: isIgnored(clash)
+        ? `"${clash.term}" is already in the list — restore it instead.`
+        : `"${clash.term}" is already in the list.`,
+    };
+  }
+  const row = withTableAliases({
+    term,
+    priority: PRIORITY_BY_REQUIREMENT[input.requirement],
+    requirement: input.requirement,
+    primary: false,
+    status: 'ask_user' as const,
+    aliases: [] as string[],
+    where: null,
+    note: null,
+    elsewhere: null,
+    override: { added: true },
+  });
+  const found = ctx.matcher.findTerm(ctx.resumeText, row.term, row.aliases).length > 0;
+  const inPosting = ctx.matcher.findTerm(ctx.posting, row.term, row.aliases).length > 0;
+  const added: MatchKeyword = {
+    ...row,
+    status: found ? 'present' : 'ask_user',
+    note: found ? 'added by you — already in this resume' : 'added by you — confirm whether you have it',
+    ...(inPosting ? {} : { unanchored: true }),
+  };
+  return { ok: true, keywords: [...keywords, added], term: added.term };
+}
+
+export interface CarryReport {
+  keywords: MatchKeyword[];
+  /** Rows of the fresh list that got a stored override back. */
+  carried: number;
+  /** Hand-added rows the fresh list did not contain, put back. */
+  readded: number;
+}
+
+/**
+ * Re-apply the stored overrides to a fresh reply, so they stick to the posting
+ * across runs the way CONSISTENCY ACROSS RUNS makes the terms stick. The fresh
+ * rows are stripped first: `override` is the user's field, and a posting that
+ * talks the model into emitting one must not be able to drop a must-have from
+ * the score (ADR 0022 covers the prompt, this covers the reply).
+ *
+ * Hand-added rows the model did not repeat are put back with their status read
+ * from the CURRENT resume text — a term written in since the last run counts.
+ */
+export function carryOverrides(
+  fresh: MatchKeyword[],
+  previous: MatchKeyword[],
+  ctx: KeywordEditContext,
+): CarryReport {
+  const stored = new Map<string, MatchKeyword>();
+  for (const k of previous) {
+    if (!k.override) continue;
+    for (const name of names(k)) if (!stored.has(name)) stored.set(name, k);
+  }
+  let carried = 0;
+  const seen = new Set<MatchKeyword>();
+  const keywords = fresh.map((raw) => {
+    const k = withoutOverride(raw);
+    const hit = names(k)
+      .map((n) => stored.get(n))
+      .find((s) => s !== undefined);
+    if (!hit) return k;
+    seen.add(hit);
+    // The model judged this one itself now, so "added" retires — but the level
+    // the user picked for it is still theirs and rides on as an override.
+    const next = tidy({
+      requirement: hit.override?.requirement ?? (hit.override?.added ? hit.requirement : undefined),
+      excluded: hit.override?.excluded,
+    });
+    if (!next) return k;
+    carried++;
+    return { ...k, override: next };
+  });
+  let readded = 0;
+  for (const k of previous) {
+    if (!k.override?.added || seen.has(k)) continue;
+    readded++;
+    const found = ctx.matcher.findTerm(ctx.resumeText, k.term, k.aliases).length > 0;
+    keywords.push({
+      ...k,
+      status: found ? 'present' : 'ask_user',
+      note: found ? 'added by you — already in this resume' : 'added by you — confirm whether you have it',
+    });
+  }
+  return { keywords, carried, readded };
+}

--- a/src/resume/keyword-overrides.ts
+++ b/src/resume/keyword-overrides.ts
@@ -211,7 +211,9 @@ export function carryOverrides(
     if (!hit) return k;
     seen.add(hit);
     // The model judged this one itself now, so "added" retires — but the level
-    // the user picked for it is still theirs and rides on as an override.
+    // the user picked for it is still theirs and rides on as an override. It
+    // is kept even when this reply happens to agree: the point of an override
+    // is that the level stops depending on what the model says next time.
     const next = tidy({
       requirement: hit.override?.requirement ?? (hit.override?.added ? hit.requirement : undefined),
       excluded: hit.override?.excluded,

--- a/src/resume/keyword-overrides.ts
+++ b/src/resume/keyword-overrides.ts
@@ -38,7 +38,14 @@ export interface KeywordEdit {
 }
 
 export type EditResult =
-  | { ok: true; keywords: MatchKeyword[]; term: string }
+  | {
+      ok: true;
+      keywords: MatchKeyword[];
+      /** The row's own spelling — the edit may have been addressed by an alias. */
+      term: string;
+      /** The edit deleted the row: only a "reset" on a term the user added does that. */
+      removed: boolean;
+    }
   | { ok: false; error: string };
 
 /** Context the two text-reading edits need; the matcher is the browser module (keyword-matcher.ts). */
@@ -110,7 +117,7 @@ export function editKeyword(keywords: MatchKeyword[], edit: KeywordEdit): EditRe
   if (!current) return { ok: false, error: `"${edit.term}" is not in this comparison.` };
 
   if (edit.op === 'reset' && current.override?.added) {
-    return { ok: true, keywords: keywords.filter((_, i) => i !== index), term: current.term };
+    return { ok: true, keywords: keywords.filter((_, i) => i !== index), term: current.term, removed: true };
   }
   const patch: KeywordOverride =
     edit.op === 'level'
@@ -123,7 +130,7 @@ export function editKeyword(keywords: MatchKeyword[], edit: KeywordEdit): EditRe
           : { requirement: undefined, excluded: false };
   const next = [...keywords];
   next[index] = withOverride(current, patch);
-  return { ok: true, keywords: next, term: current.term };
+  return { ok: true, keywords: next, term: current.term, removed: false };
 }
 
 /**
@@ -170,7 +177,7 @@ export function addKeyword(
     note: found ? 'added by you — already in this resume' : 'added by you — confirm whether you have it',
     ...(inPosting ? {} : { unanchored: true }),
   };
-  return { ok: true, keywords: [...keywords, added], term: added.term };
+  return { ok: true, keywords: [...keywords, added], term: added.term, removed: false };
 }
 
 export interface CarryReport {

--- a/src/resume/keyword-overrides.ts
+++ b/src/resume/keyword-overrides.ts
@@ -145,8 +145,12 @@ export function addKeyword(
   input: { term: string; requirement: RequirementLevel },
   ctx: KeywordEditContext,
 ): EditResult {
-  const term = input.term.trim().replace(/\s+/g, ' ').slice(0, MAX_TERM_CHARS);
+  const term = input.term.trim().replace(/\s+/g, ' ');
   if (term.length === 0) return { ok: false, error: 'Type the keyword first.' };
+  // Truncating would store a term that highlights nothing and reads as a bug.
+  if (term.length > MAX_TERM_CHARS) {
+    return { ok: false, error: `Keep the keyword under ${MAX_TERM_CHARS} characters — it has to match the posting word for word.` };
+  }
   const key = canonicalTerm(term);
   const clash = keywords.find((k) => names(k).includes(key));
   if (clash) {

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -13,6 +13,7 @@ import {
 } from './prompts';
 import { annotateElsewhere, applyFacts } from './facts';
 import { withTableAliases } from './keyword-aliases';
+import { carryOverrides, effectiveKeywords } from './keyword-overrides';
 import { anchorKeywords } from './keyword-anchor';
 import { loadKeywordMatcher } from './keyword-matcher';
 import { readMatchMode, type MatchMode } from './match-mode';
@@ -55,17 +56,20 @@ export async function matchResumeToJob(
     getLatestMatchForJob(job.id),
     loadKeywordMatcher(),
   ]);
+  // The user's own edits to the last frame for this posting: the levels they
+  // set go into the prompt, and carryOverrides puts every override back on the
+  // fresh reply below, so an override sticks to the posting (§5).
+  const storedKeywords = previousMatch ? readKeywords(previousMatch.keywords) : [];
   const context: MatchContext = {
     confirmedFacts: facts.filter((f) => f.status === 'confirmed').map((f) => ({ term: f.term, note: f.note })),
     deniedTerms: facts.filter((f) => f.status === 'denied').map((f) => f.term),
     otherResumeSkills: otherSkills,
     // The previous run's keyword frame keeps terms/levels stable across
-    // versions, so a better resume shows up as a better number.
-    previousKeywords: previousMatch
-      ? readKeywords(previousMatch.keywords)
-          .slice(0, PREVIOUS_KEYWORDS_MAX)
-          .map((k) => ({ term: k.term, priority: k.priority, requirement: k.requirement, primary: k.primary }))
-      : undefined,
+    // versions, so a better resume shows up as a better number. Terms the user
+    // ignored are left out of it — asking for them back would be noise.
+    previousKeywords: effectiveKeywords(storedKeywords)
+      .slice(0, PREVIOUS_KEYWORDS_MAX)
+      .map((k) => ({ term: k.term, priority: k.priority, requirement: k.requirement, primary: k.primary })),
   };
   const prompt = buildMatchPrompt(resume.text, job, mode, context);
   const ai = await getAiRuntime();
@@ -88,14 +92,22 @@ export async function matchResumeToJob(
       // table joins the model's spellings, every term is anchored to the
       // posting (or flagged), stored facts always win, and unclaimable terms
       // point at the resume that has them.
-      const anchor = anchorKeywords(
-        parsed.data.keywords.map(withTableAliases),
-        `${job.title}\n${job.description}`,
+      const posting = `${job.title}\n${job.description}`;
+      const anchor = anchorKeywords(parsed.data.keywords.map(withTableAliases), posting, matcher);
+      const carry = carryOverrides(anchor.keywords, storedKeywords, {
+        resumeText: resume.text,
+        posting,
         matcher,
-      );
-      const withFacts = applyFacts(anchor.keywords, facts).keywords;
+      });
+      const withFacts = applyFacts(carry.keywords, facts).keywords;
       const keywords = annotateElsewhere(withFacts, otherSkills);
-      const breakdown = scoreMatch(keywords, parsed.data.alignment, parsed.data.red_flags.length);
+      // The row stores what the user sees; the score reads what they decided:
+      // their levels, without the terms they ignored (§5).
+      const breakdown = scoreMatch(
+        effectiveKeywords(keywords),
+        parsed.data.alignment,
+        parsed.data.red_flags.length,
+      );
       const row = await createMatch({
         jobId: job.id,
         resumeId: resume.id,
@@ -121,6 +133,8 @@ export async function matchResumeToJob(
           keywords: keywords.length,
           anchored: anchor.anchored,
           unanchored: anchor.unanchored,
+          overrides: carry.carried,
+          readded: carry.readded,
           promptVersion: PROMPT_VERSION,
           chars: out.text.length,
           ms: Date.now() - started,

--- a/src/resume/prompts.ts
+++ b/src/resume/prompts.ts
@@ -119,6 +119,17 @@ export const MatchSchema = z.object({
         // Set by post-processing when the posting contains the term in no
         // recognisable spelling — the panes cannot highlight it (F2 guard).
         unanchored: z.boolean().optional(),
+        // The user's own say over this row (§5): a re-levelled requirement, a
+        // term ignored as noise, a term they typed themselves. Written only by
+        // keyword-overrides.ts — never by the model, whose copy of the field is
+        // stripped on the way in — and read back from older rows as absent.
+        override: z
+          .object({
+            requirement: z.enum(REQUIREMENT_LEVELS).optional(),
+            excluded: z.boolean().optional(),
+            added: z.boolean().optional(),
+          })
+          .optional(),
       }),
     )
     .default([])

--- a/src/web/flash.ts
+++ b/src/web/flash.ts
@@ -60,6 +60,14 @@ export function parseFlashCookie(cookieHeader: string | undefined): FlashMessage
   return null;
 }
 
+/**
+ * A redirect target from a form field, kept local — an absolute or
+ * protocol-relative URL would be an open redirect.
+ */
+export function safeBack(back: unknown, fallback: string): string {
+  return typeof back === 'string' && back.startsWith('/') && !back.startsWith('//') ? back : fallback;
+}
+
 export function clearFlashCookie(): string {
   return 'flash=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax';
 }

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -30,6 +30,9 @@ import {
   type MatchKeyword,
 } from '../../resume/prompts';
 import { readMatchMode } from '../../resume/match-mode';
+import type { CountedKeyword } from '../../resume/keyword-matcher';
+import { effectiveRequirement, isIgnored } from '../../resume/keyword-overrides';
+import { REQUIREMENT_LEVELS, type RequirementLevel } from '../../resume/score';
 import { readBreakdown, type ScoreBreakdown } from '../../resume/score';
 import { diffMatches } from '../../resume/diff';
 
@@ -42,6 +45,8 @@ export interface ResumeMatchCardProps {
   suggestedReason: 'linked' | 'overlap';
   matches: MatchWithResume[];
   selected: MatchWithResume | null;
+  /** The selected comparison's keywords, ordered and counted by the matcher. */
+  selectedKeywords: CountedKeyword[];
 }
 
 const PRIORITY_TONE: Record<MatchAction['priority'], Tone> = {
@@ -58,10 +63,14 @@ const STATUS_VIEW: Record<MatchKeyword['status'], { label: string; tone: Tone }>
   cannot_claim: { label: 'no evidence', tone: 'danger' },
 };
 
-/** Sort order for the needs-attention keyword rows: hardest requirement first. */
-const REQ_RANK: Record<string, number> = { must: 0, preferred: 1, nice: 2, context: 3 };
-
 const KEYWORD_COLUMNS = ['Keyword', 'Wants it', 'Status', 'Where', 'Note'];
+
+/** Where a keyword edit posts and where it comes back to (§5). */
+export interface KeywordEditTarget {
+  jobId: number;
+  matchId: number;
+  back: string;
+}
 
 const HARD_VIEW: Record<MatchHardRequirement['status'], { label: string; tone: Tone }> = {
   pass: { label: 'pass', tone: 'ok' },
@@ -78,6 +87,7 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
   suggestedReason,
   matches,
   selected,
+  selectedKeywords,
 }) => (
   <div id="resume-match">
     <Card>
@@ -134,6 +144,7 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
         <MatchReport
           match={selected}
           previous={previousFor(selected, matches)}
+          keywords={selectedKeywords}
           factsBack={`/jobs/${jobId}?match=${selected.id}#resume-match`}
         />
       )}
@@ -295,10 +306,11 @@ export const ConfirmFacts: FC<{ asks: MatchKeyword[]; matchId: number; back: str
 export const MatchReport: FC<{
   match: MatchWithResume;
   previous: MatchWithResume | null;
-  /** Where the ask_user confirm/deny forms return to. */
+  /** This match's keywords, ordered and counted by the matcher (§5). */
+  keywords: CountedKeyword[];
+  /** Where the ask_user confirm/deny and keyword-override forms return to. */
   factsBack: string;
-}> = ({ match, previous, factsBack }) => {
-  const keywords = readKeywords(match.keywords);
+}> = ({ match, previous, keywords, factsBack }) => {
   const bd = readBreakdown(match.breakdown);
   const scoreDelta = previous ? match.matchScore - previous.matchScore : null;
   return (
@@ -346,7 +358,10 @@ export const MatchReport: FC<{
           <RemovalsBlock removals={readRemovals(match.removals)} />
         </>
       )}
-      <KeywordTable keywords={keywords} />
+      <KeywordTable
+        keywords={keywords}
+        edit={{ jobId: match.jobId, matchId: match.id, back: factsBack }}
+      />
     </div>
   );
 };
@@ -539,24 +554,36 @@ export const RemovalsBlock: FC<{ removals: ReturnType<typeof readRemovals>; jump
     </div>
   );
 
-/** Keyword coverage: needs-attention rows first, matched rows behind a disclosure. */
-export const KeywordTable: FC<{ keywords: MatchKeyword[] }> = ({ keywords }) => {
+/**
+ * Keyword coverage: needs-attention rows first, matched rows behind a
+ * disclosure, and — when the user has ignored any — a third group they can
+ * bring back. Rows arrive ORDERED (hardest requirement first, ties broken by
+ * how often the posting repeats the term): only the matcher can count that,
+ * so the routes order through it and this component renders what it is given.
+ *
+ * With `edit`, every row carries the §5 controls: re-level, ignore, reset,
+ * and a form to add a term the model missed. Each is a plain POST that
+ * recomputes the score in code — no AI call.
+ */
+export const KeywordTable: FC<{ keywords: CountedKeyword[]; edit?: KeywordEditTarget }> = ({
+  keywords,
+  edit,
+}) => {
   if (keywords.length === 0) return null;
-  // Problems first: unmatched keywords sorted hardest-requirement-first; matched
-  // rows fold behind a disclosure so success noise never buries the gaps.
-  const attention = keywords
-    .filter((k) => k.status !== 'present')
-    .sort((a, b) => (REQ_RANK[a.requirement ?? ''] ?? 4) - (REQ_RANK[b.requirement ?? ''] ?? 4));
-  const matchedKeywords = keywords.filter((k) => k.status === 'present');
+  const ignored = keywords.filter(isIgnored);
+  const counted = keywords.filter((k) => !isIgnored(k));
+  const attention = counted.filter((k) => k.status !== 'present');
+  const matchedKeywords = counted.filter((k) => k.status === 'present');
   return (
     <div class="-mx-5 -mb-5 border-t border-line">
       <div class="px-5 py-3 text-[13px] font-medium text-ink-muted">
-        Keyword coverage — {matchedKeywords.length} of {keywords.length} matched
+        Keyword coverage — {matchedKeywords.length} of {counted.length} matched
+        {ignored.length > 0 ? ` · ${ignored.length} ignored` : ''}
       </div>
       {attention.length > 0 ? (
         <Table columns={KEYWORD_COLUMNS}>
           {attention.map((k) => (
-            <KeywordRow k={k} />
+            <KeywordRow k={k} edit={edit} />
           ))}
         </Table>
       ) : (
@@ -564,34 +591,54 @@ export const KeywordTable: FC<{ keywords: MatchKeyword[] }> = ({ keywords }) => 
       )}
       {matchedKeywords.length > 0 && (
         <details>
-          <summary class="cursor-pointer border-t border-line px-5 py-2.5 text-[13px] font-medium text-ink-muted transition-colors duration-150 hover:text-ink">
-            Matched — {matchedKeywords.length} keywords
-          </summary>
+          <summary class={KEYWORD_SUMMARY}>Matched — {matchedKeywords.length} keywords</summary>
           <Table columns={KEYWORD_COLUMNS}>
             {matchedKeywords.map((k) => (
-              <KeywordRow k={k} />
+              <KeywordRow k={k} edit={edit} />
             ))}
           </Table>
         </details>
       )}
+      {ignored.length > 0 && (
+        <details>
+          <summary class={KEYWORD_SUMMARY}>
+            Ignored — {ignored.length} keyword{ignored.length === 1 ? '' : 's'} out of the score
+          </summary>
+          <Table columns={KEYWORD_COLUMNS}>
+            {ignored.map((k) => (
+              <KeywordRow k={k} edit={edit} />
+            ))}
+          </Table>
+        </details>
+      )}
+      {edit && <AddKeywordForm edit={edit} />}
     </div>
   );
 };
+
+const KEYWORD_SUMMARY =
+  'cursor-pointer border-t border-line px-5 py-2.5 text-[13px] font-medium text-ink-muted transition-colors duration-150 hover:text-ink';
 
 function fmtDelta(n: number): string {
   return `${n > 0 ? '+' : ''}${n}`;
 }
 
-const KeywordRow: FC<{ k: MatchKeyword }> = ({ k }) => (
-  <Tr>
+const KeywordRow: FC<{ k: CountedKeyword; edit?: KeywordEditTarget }> = ({ k, edit }) => (
+  <Tr class={isIgnored(k) ? 'opacity-60' : ''}>
     <Td class="text-xs font-medium text-ink">
       <span class="inline-flex flex-wrap items-center gap-1.5">
         {k.term}
         {k.primary && <Badge tone="info">primary</Badge>}
+        {k.count > 1 && (
+          <span class="font-mono text-ink-faint" title={`the posting says it ${k.count} times`}>
+            ×{k.count}
+          </span>
+        )}
+        {k.override?.added && <Badge tone="violet">yours</Badge>}
       </span>
     </Td>
-    <Td class="text-xs text-ink-faint" title={`priority ${k.priority}`}>
-      {k.requirement}
+    <Td class="text-xs text-ink-faint">
+      {edit ? <LevelControls k={k} edit={edit} /> : effectiveRequirement(k)}
     </Td>
     <Td>
       <span class="inline-flex flex-wrap items-center gap-1">
@@ -607,6 +654,102 @@ const KeywordRow: FC<{ k: MatchKeyword }> = ({ k }) => (
     <Td class="text-xs text-ink-muted">{k.where ?? '—'}</Td>
     <Td class="max-w-md text-xs text-ink-muted">{k.note ?? '—'}</Td>
   </Tr>
+);
+
+/*
+ * One form per row: the select posts on change, and each button sets `op`
+ * before submitting (the same idiom as the Compare / Full analysis pair
+ * above), so the row never sends two conflicting values for one field.
+ */
+const LevelControls: FC<{ k: CountedKeyword; edit: KeywordEditTarget }> = ({ k, edit }) => {
+  const level = effectiveRequirement(k);
+  const overridden = k.override?.requirement !== undefined;
+  return (
+    <form
+      method="post"
+      action={`/jobs/${edit.jobId}/matches/${edit.matchId}/keywords`}
+      class="flex flex-wrap items-center gap-1.5"
+    >
+      <input type="hidden" name="term" value={k.term} />
+      <input type="hidden" name="back" value={edit.back} />
+      <input type="hidden" name="op" value="level" />
+      <Select
+        name="requirement"
+        class="!w-auto py-1 text-xs"
+        onchange="this.form.submit()"
+        aria-label={`How much the posting wants ${k.term}`}
+        title={overridden ? `you set this — the AI said ${k.requirement}` : 'how much the posting wants it'}
+      >
+        {REQUIREMENT_LEVELS.map((r) => (
+          <option value={r} selected={r === level}>
+            {r}
+          </option>
+        ))}
+      </Select>
+      {overridden && <Badge tone="violet">yours</Badge>}
+      <button
+        type="submit"
+        class={ROW_LINK}
+        onclick={`this.form.elements.op.value='${isIgnored(k) ? 'restore' : 'ignore'}'`}
+        title={
+          isIgnored(k)
+            ? 'Count this keyword again'
+            : 'Noise: drop it from the score and the highlights (you can bring it back)'
+        }
+      >
+        {isIgnored(k) ? 'restore' : 'ignore'}
+      </button>
+      {(overridden || k.override?.added) && (
+        <button
+          type="submit"
+          class={ROW_LINK}
+          onclick="this.form.elements.op.value='reset'"
+          title={k.override?.added ? 'Remove the keyword you added' : "Back to the AI's own verdict"}
+        >
+          {k.override?.added ? 'remove' : 'reset'}
+        </button>
+      )}
+    </form>
+  );
+};
+
+const ROW_LINK =
+  'cursor-pointer whitespace-nowrap text-xs text-ink-muted underline-offset-2 transition-colors duration-150 hover:text-ink hover:underline';
+
+/** A word the model missed. Status is read from the resume text, never guessed. */
+const AddKeywordForm: FC<{ edit: KeywordEditTarget }> = ({ edit }) => (
+  <form
+    method="post"
+    action={`/jobs/${edit.jobId}/matches/${edit.matchId}/keywords`}
+    class="flex flex-wrap items-end gap-2 border-t border-line px-5 py-3"
+  >
+    <input type="hidden" name="op" value="add" />
+    <input type="hidden" name="back" value={edit.back} />
+    <label class="block">
+      <span class="block text-[13px] font-medium text-ink">Add a keyword</span>
+      <Input
+        name="term"
+        required
+        maxlength={60}
+        placeholder="a word this posting wants"
+        class="mt-1.5 !w-56 py-1 text-xs"
+      />
+    </label>
+    <Select name="requirement" class="!w-auto py-1 text-xs" aria-label="How much the posting wants it">
+      {REQUIREMENT_LEVELS.map((r) => (
+        <option value={r} selected={r === 'preferred'}>
+          {r}
+        </option>
+      ))}
+    </Select>
+    <Button size="sm" variant="secondary">
+      Add
+    </Button>
+    <Hint class="basis-full">
+      It counts in the score straight away — matched if your resume already says it, otherwise a
+      confirm question. No AI call.
+    </Hint>
+  </form>
 );
 
 const MarkedList: FC<{ label: string; items: string[]; kind: 'check' | 'x'; tone: string }> = ({

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -358,9 +358,12 @@ export const MatchReport: FC<{
           <RemovalsBlock removals={readRemovals(match.removals)} />
         </>
       )}
+      {/* A comparison written before ADR 0012 has no breakdown to re-score
+          from, so it gets the table without the controls rather than buttons
+          that can only fail. */}
       <KeywordTable
         keywords={keywords}
-        edit={{ jobId: match.jobId, matchId: match.id, back: factsBack }}
+        edit={bd ? { jobId: match.jobId, matchId: match.id, back: factsBack } : undefined}
       />
     </div>
   );

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -645,7 +645,13 @@ const KeywordRow: FC<{ k: CountedKeyword; edit?: KeywordEditTarget }> = ({ k, ed
         <Badge tone={STATUS_VIEW[k.status].tone}>{STATUS_VIEW[k.status].label}</Badge>
         {k.elsewhere && <Badge tone="violet">in "{k.elsewhere}"</Badge>}
         {k.unanchored && (
-          <span title="The AI worded this keyword differently from the posting, so the description pane cannot highlight it.">
+          <span
+            title={
+              k.override?.added
+                ? 'You added this word and the posting does not contain it, so the description pane cannot highlight it.'
+                : 'The AI worded this keyword differently from the posting, so the description pane cannot highlight it.'
+            }
+          >
             <Badge>not in posting</Badge>
           </span>
         )}
@@ -678,7 +684,13 @@ const LevelControls: FC<{ k: CountedKeyword; edit: KeywordEditTarget }> = ({ k, 
         class="!w-auto py-1 text-xs"
         onchange="this.form.submit()"
         aria-label={`How much the posting wants ${k.term}`}
-        title={overridden ? `you set this — the AI said ${k.requirement}` : 'how much the posting wants it'}
+        title={
+          !overridden
+            ? 'how much the posting wants it'
+            : level === k.requirement
+              ? 'you set this level — it stays yours on every re-run'
+              : `you set this — the AI said ${k.requirement}`
+        }
       >
         {REQUIREMENT_LEVELS.map((r) => (
           <option value={r} selected={r === level}>

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -5,8 +5,9 @@ import { Badge, Button, Card, FitBadge, Flash, Hint, SUBMIT_ONCE } from '../ui';
 import type { FlashMessage } from '../flash';
 import { fitTone, formatRelative, type Tone } from '../format';
 import type { MatchWithResume } from '../../resume/store';
-import { withTableAliases } from '../../resume/keyword-aliases';
-import { readActions, readHardRequirements, readKeywords, readRemovals } from '../../resume/prompts';
+import type { CountedKeyword } from '../../resume/keyword-matcher';
+import { effectiveKeywords } from '../../resume/keyword-overrides';
+import { readActions, readHardRequirements, readRemovals } from '../../resume/prompts';
 import { readMatchMode } from '../../resume/match-mode';
 import { readBreakdown } from '../../resume/score';
 import {
@@ -42,6 +43,8 @@ export interface TargetPageProps {
   /** ephemeral = the hidden /target scratch resume: no versions, no saving. */
   resume: { id: number; name: string; version: number; ephemeral: boolean };
   match: MatchWithResume;
+  /** The match's keywords, ordered and counted against the posting (§5). */
+  keywords: CountedKeyword[];
   matches: MatchWithResume[];
   /** Most recent earlier run of the same resume — the "vs last time" delta. */
   previous: MatchWithResume | null;
@@ -98,18 +101,21 @@ export const TargetPage: FC<TargetPageProps> = ({
   job,
   resume,
   match,
+  keywords,
   matches,
   previous,
   resumeText,
   draftText,
   flash,
 }) => {
-  // Table spellings apply on read too, so matches stored before the table (or before an entry) highlight the same way.
-  const keywords = readKeywords(match.keywords).map(withTableAliases);
+  // The panes, the chips and the live score work from the effective list: the
+  // user's own levels, without the terms they ignored (§5). The table below
+  // still gets the full list, so an ignored row can be brought back.
+  const scored = effectiveKeywords(keywords);
   const actions = readActions(match.actions);
   const removals = readRemovals(match.removals);
   const hard = readHardRequirements(match.hardRequirements);
-  const asks = keywords.filter((k) => k.status === 'ask_user');
+  const asks = scored.filter((k) => k.status === 'ask_user');
   const highActions = actions.filter((a) => a.priority === 'high').length;
   // A quick check has no suggestions yet — the tab offers the second call instead (ADR 0029).
   const fast = readMatchMode(match.breakdown) === 'fast';
@@ -125,7 +131,7 @@ export const TargetPage: FC<TargetPageProps> = ({
     resumeText,
     draftText: draftText ?? null,
     jobText: job.description,
-    keywords,
+    keywords: scored,
     actions,
     removals,
     // Fixed score parts for the live estimate; null on pre-ADR-0012 matches.
@@ -406,7 +412,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                 </span>
               </div>
               <div id="score-detail" class="mt-0.5 text-xs text-ink-faint">
-                {keywords.length} keywords from the AI match
+                {scored.length} keywords from the AI match
               </div>
               <Hint class="mt-1">
                 {breakdown
@@ -523,7 +529,10 @@ export const TargetPage: FC<TargetPageProps> = ({
                 </>
               )}
               <MatchSignals match={match} />
-              <KeywordTable keywords={keywords} />
+              <KeywordTable
+                keywords={keywords}
+                edit={{ jobId: job.id, matchId: match.id, back: `/jobs/${job.id}/target?match=${match.id}` }}
+              />
             </div>
           </Card>
         </div>

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -469,6 +469,13 @@ export const TargetPage: FC<TargetPageProps> = ({
               <span><mark class="kw-missing rounded px-1">missing</mark></span>
               <span><mark class="kw-ask rounded px-1">confirm</mark></span>
               <span><mark class="kw-cannot rounded px-1">no evidence</mark></span>
+              {/* The intensity key: same colour, graded by how hard the posting asks. */}
+              <span class="inline-flex items-center gap-1">
+                weight
+                <mark class="kw-missing kw-w4 rounded px-1">must</mark>
+                <mark class="kw-missing kw-w2 rounded px-1">preferred</mark>
+                <mark class="kw-missing kw-w1 rounded px-1">nice</mark>
+              </span>
             </div>
           </div>
           <div
@@ -476,7 +483,9 @@ export const TargetPage: FC<TargetPageProps> = ({
             class="max-h-[70vh] overflow-auto whitespace-pre-wrap break-words font-sans text-sm leading-7 text-ink-muted"
           ></div>
           <Hint class="mt-2">
-            Highlights follow the AI's keyword list — benefits, perks and legal boilerplate are deliberately never keywords.
+            Highlights follow the AI's keyword list — benefits, perks and legal boilerplate are
+            deliberately never keywords. The stronger a mark, the harder the posting asks; hover one
+            to see how often it says the word. Re-level or ignore any of them in the keyword table.
           </Hint>
         </Card>
 
@@ -616,6 +625,16 @@ const TARGET_CSS = `
   .kw-missing { background: rgb(var(--warn) / 0.22); }
   .kw-ask { background: rgb(var(--violet) / 0.16); box-shadow: inset 0 0 0 1px rgb(var(--violet) / 0.4); }
   .kw-cannot { background: rgb(var(--ink-faint) / 0.2); text-decoration: line-through; }
+  /* Visual weight (target-plan.md §5). jobSpans tags every mark kw-w0 (context)
+     … kw-w4 (a primary-stack must), so a gap the posting insists on can never
+     look like a gap it merely mentions. The base rules above are the preferred
+     tier; only the problem marks are graded — a matched word is matched. */
+  .kw-missing.kw-w3 { background: rgb(var(--warn) / 0.34); box-shadow: inset 0 0 0 1px rgb(var(--warn) / 0.6); }
+  .kw-missing.kw-w4 { background: rgb(var(--warn) / 0.42); box-shadow: inset 0 0 0 1.5px rgb(var(--warn) / 0.85); font-weight: 600; }
+  .kw-missing.kw-w1, .kw-missing.kw-w0 { background: rgb(var(--warn) / 0.1); }
+  .kw-ask.kw-w3, .kw-ask.kw-w4 { background: rgb(var(--violet) / 0.24); box-shadow: inset 0 0 0 1.5px rgb(var(--violet) / 0.7); }
+  .kw-ask.kw-w1, .kw-ask.kw-w0 { background: rgb(var(--violet) / 0.1); box-shadow: none; }
+  .kw-cannot.kw-w1, .kw-cannot.kw-w0 { background: rgb(var(--ink-faint) / 0.12); text-decoration-color: rgb(var(--ink-faint) / 0.5); }
   .edit-remove { background: rgb(var(--danger) / 0.15); text-decoration: line-through; }
   .edit-change { background: rgb(var(--warn) / 0.1); box-shadow: inset 0 0 0 1px rgb(var(--warn) / 0.55); }
   /* Matched highlights are opt-in inside the panes; issue marks always show.

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -540,7 +540,11 @@ export const TargetPage: FC<TargetPageProps> = ({
               <MatchSignals match={match} />
               <KeywordTable
                 keywords={keywords}
-                edit={{ jobId: job.id, matchId: match.id, back: `/jobs/${job.id}/target?match=${match.id}` }}
+                edit={
+                  breakdown
+                    ? { jobId: job.id, matchId: match.id, back: `/jobs/${job.id}/target?match=${match.id}` }
+                    : undefined
+                }
               />
             </div>
           </Card>

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -5,13 +5,33 @@
  * elements, so importing it under node:test touches no DOM.
  */
 
-import { scoreKeywords, highlightHtml, jobSpans, resumeSpans, locateQuote } from './target.mjs';
+import {
+  scoreKeywords,
+  highlightHtml,
+  jobSpans,
+  resumeSpans,
+  locateQuote,
+  keywordRank,
+  orderKeywords,
+  wantsLabel,
+} from './target.mjs';
 import { computeScore, entriesFromLive } from './score.mjs';
 
 // Full literal class names — the Tailwind CDN JIT only generates what it can
 // see verbatim in the document, composed strings would come out unstyled.
 const TONE_TEXT = { ok: 'text-ok', info: 'text-info', warn: 'text-warn', danger: 'text-danger' };
 const TONE_BG = { ok: 'bg-ok', info: 'bg-info', warn: 'bg-warn', danger: 'bg-danger' };
+
+// A missing chip carries the same weight the pane marks do (target-plan.md §5):
+// a primary-stack must shouts, a nice-to-have whispers.
+const CHIP_BASE = 'chip inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ring-1 ring-inset';
+const CHIP_WEIGHT = {
+  4: 'bg-warn/25 text-warn ring-warn/60 font-semibold',
+  3: 'bg-warn/15 text-warn ring-warn/40',
+  2: 'bg-warn/10 text-warn ring-warn/25',
+  1: 'bg-warn/5 text-ink-muted ring-line',
+  0: 'bg-warn/5 text-ink-muted ring-line',
+};
 
 function tone(score) {
   return score >= 85 ? 'ok' : score >= 70 ? 'info' : score >= 50 ? 'warn' : 'danger';
@@ -88,12 +108,18 @@ export function init(data) {
     jd.innerHTML = highlightHtml(data.jobText, jobSpans(data.keywords, data.jobText, scored));
 
     chips.innerHTML = '';
-    for (const r of scored.rows.filter((r) => !r.found && !r.excluded).sort((a, b) => a.priority - b.priority)) {
+    // Hardest requirement first, then the words the posting keeps repeating.
+    for (const r of orderKeywords(scored.rows.filter((r) => !r.found && !r.excluded), data.jobText)) {
       const b = document.createElement('button');
       b.type = 'button';
-      b.className = 'chip inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ring-1 ring-inset bg-warn/10 text-warn ring-warn/25';
-      b.textContent = r.term + ' · P' + r.priority;
-      b.title = (r.where ? 'Add in: ' + r.where + '. ' : '') + (r.note || '');
+      b.className = CHIP_BASE + ' ' + (CHIP_WEIGHT[keywordRank(r)] ?? CHIP_WEIGHT[2]);
+      b.textContent = r.count > 1 ? r.term + ' ×' + r.count : r.term;
+      b.title = [
+        wantsLabel(r),
+        r.count > 1 ? '×' + r.count + ' in the posting' : null,
+        r.where ? 'add in: ' + r.where : null,
+        r.note,
+      ].filter(Boolean).join(' · ');
       b.addEventListener('click', () => jumpToSection(r.where));
       chips.appendChild(b);
     }

--- a/src/web/public/target.mjs
+++ b/src/web/public/target.mjs
@@ -15,9 +15,63 @@ import { SCORING } from './score.mjs';
 // Fallback for keyword rows that predate requirement levels (ADR 0012).
 const PRIORITY_WEIGHT = { 1: 3, 2: 2, 3: 1, 4: 1 };
 
+/**
+ * The requirement level in force. A row the user re-levelled by hand carries
+ * their choice in `override` (src/resume/keyword-overrides.ts); the panes and
+ * the live editor are handed lists with that already applied, the
+ * server-rendered keyword table is not — so read both here and neither caller
+ * has to care.
+ */
+function levelOf(k) {
+  return k.override?.requirement ?? k.requirement;
+}
+
 function keywordWeight(k) {
-  if (k.requirement) return SCORING.requirementWeight[k.requirement] ?? 0;
+  const level = levelOf(k);
+  if (level) return SCORING.requirementWeight[level] ?? 0;
   return PRIORITY_WEIGHT[k.priority] ?? 1;
+}
+
+/**
+ * How loudly the posting asks for a term: 4 a primary-stack must · 3 must ·
+ * 2 preferred · 1 nice · 0 context. One source for both the display order and
+ * the intensity of the mark, so a missing must-have can never look like a
+ * missing nice-to-have (target-plan.md §5).
+ */
+export function keywordRank(k) {
+  const weight = keywordWeight(k);
+  return k.primary === true && levelOf(k) === 'must' ? weight + 1 : weight;
+}
+
+/** Intensity class for a mark or a chip: kw-w0 (context) … kw-w4 (primary must). */
+export function weightClass(k) {
+  return 'kw-w' + keywordRank(k);
+}
+
+/** The requirement in words, for tooltips and chip titles. */
+function wantsLabel(k) {
+  const level = levelOf(k) ?? 'P' + k.priority;
+  return k.primary === true ? level + ' · primary stack' : level;
+}
+
+/**
+ * Display order for keyword lists: what the posting insists on hardest first,
+ * ties broken by how often the posting repeats the term — a word said four
+ * times outranks one said once at the same level. Every row comes back with
+ * that `count`, so callers can say "×4 in the posting" without searching
+ * again. Used by the panes, the missing chips and the server-rendered keyword
+ * table: one implementation, nothing to mirror.
+ */
+export function orderKeywords(keywords, jobText) {
+  return keywords
+    .map((k) => ({ ...k, count: findTerm(jobText, k.term, k.aliases ?? []).length }))
+    .sort(
+      (a, b) =>
+        keywordRank(b) - keywordRank(a) ||
+        b.count - a.count ||
+        (a.priority ?? 4) - (b.priority ?? 4) ||
+        a.term.localeCompare(b.term),
+    );
 }
 // A hit must not be glued to token characters: "C" is not "C++", "Java" is
 // not "JavaScript", "x.php" is a file. A trailing "." before a space or the
@@ -194,8 +248,12 @@ export function jobSpans(keywords, jobText, scored) {
       : found ? 'kw-found'
       : k.status === 'ask_user' ? 'kw-ask'
       : 'kw-missing';
-    for (const s of findTerm(jobText, k.term, k.aliases ?? [])) {
-      spans.push({ ...s, cls, title: `${k.term} · P${k.priority} · ${LABEL[cls]}` });
+    // Every occurrence is already in hand, so the frequency costs nothing.
+    const hits = findTerm(jobText, k.term, k.aliases ?? []);
+    const often = hits.length > 1 ? ` · ×${hits.length} in the posting` : '';
+    const title = `${k.term} · ${wantsLabel(k)} · ${LABEL[cls]}${often}`;
+    for (const s of hits) {
+      spans.push({ ...s, cls: `${cls} ${weightClass(k)}`, title });
     }
   }
   return spans;
@@ -204,9 +262,11 @@ export function jobSpans(keywords, jobText, scored) {
 /** Spans for the resume pane: present keywords, quoted removals, quoted actions. */
 export function resumeSpans(keywords, actions, removals, resumeText) {
   const spans = [];
+  // No weight class here: everything marked in the resume is a keyword the
+  // resume HAS, and the sort below keys off a single class per span.
   for (const k of keywords) {
     for (const s of findTerm(resumeText, k.term, k.aliases ?? [])) {
-      spans.push({ ...s, cls: 'kw-present', title: `${k.term} · P${k.priority}` });
+      spans.push({ ...s, cls: 'kw-present', title: `${k.term} · ${wantsLabel(k)}` });
     }
   }
   for (const r of removals) {

--- a/src/web/public/target.mjs
+++ b/src/web/public/target.mjs
@@ -48,8 +48,8 @@ export function weightClass(k) {
   return 'kw-w' + keywordRank(k);
 }
 
-/** The requirement in words, for tooltips and chip titles. */
-function wantsLabel(k) {
+/** The requirement in words — one vocabulary for the pane tooltips and the chips. */
+export function wantsLabel(k) {
   const level = levelOf(k) ?? 'P' + k.priority;
   return k.primary === true ? level + ' · primary stack' : level;
 }

--- a/src/web/routes/facts.ts
+++ b/src/web/routes/facts.ts
@@ -6,7 +6,7 @@ import { readPromptVersion } from '../../resume/match-reuse';
 import { readKeywords } from '../../resume/prompts';
 import { readBreakdown, scoreMatch } from '../../resume/score';
 import { deleteFact, getMatch, updateMatchScoring, upsertFact } from '../../resume/store';
-import { flashRedirect } from '../flash';
+import { flashRedirect, safeBack } from '../flash';
 
 /*
  * "ask_user" answers. Confirming or denying a term stores a CandidateFact and
@@ -22,18 +22,13 @@ const FactFormSchema = z.object({
   back: z.string().optional().default('/resumes'),
 });
 
-/** Local paths only — no open redirects. */
-function safeBack(back: string): string {
-  return back.startsWith('/') && !back.startsWith('//') ? back : '/resumes';
-}
-
 export const factsRoute = new Hono();
 
 factsRoute.post('/facts', async (c) => {
   const parsed = FactFormSchema.safeParse(await c.req.parseBody());
   if (!parsed.success) return c.text('Bad fact', 400);
   const f = parsed.data;
-  const back = safeBack(f.back);
+  const back = safeBack(f.back, '/resumes');
   const note = f.note.trim().slice(0, 300) || null;
   const fact = await upsertFact(f.term, f.decision, note);
 
@@ -68,7 +63,7 @@ factsRoute.post('/facts', async (c) => {
 factsRoute.post('/facts/delete', async (c) => {
   const form = await c.req.parseBody();
   const term = typeof form.term === 'string' ? form.term : '';
-  const back = safeBack(typeof form.back === 'string' ? form.back : '/resumes');
+  const back = safeBack(form.back, '/resumes');
   if (term.trim().length === 0) return c.text('Bad fact', 400);
   await deleteFact(term);
   return flashRedirect(back, 'ok', `Forgot "${term.trim().toLowerCase()}".`);

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -51,8 +51,11 @@ import {
   COVER_TONES,
   coverGateSources,
   readCoverAngles,
+  readKeywords,
   type CoverTone,
 } from '../../resume/prompts';
+import { withTableAliases } from '../../resume/keyword-aliases';
+import { loadKeywordMatcher, type CountedKeyword } from '../../resume/keyword-matcher';
 import { factCheck } from '../../resume/fact-check';
 import { buildLetterDocx, DOCX_MIME } from '../../resume/docx-write';
 import { buildLetterPdf } from '../../resume/pdf-write';
@@ -208,6 +211,21 @@ jobsRoute.post('/jobs/new', async (c) => {
   );
 });
 
+/**
+ * One comparison's keywords as both pages want them: alias-table spellings
+ * applied on read (so a match stored before an entry highlights the same way)
+ * and ordered by the matcher — hardest requirement first, ties broken by how
+ * often the posting repeats the term, each row carrying that count (§5).
+ */
+async function orderedKeywords(
+  match: { keywords: unknown } | null,
+  posting: string,
+): Promise<CountedKeyword[]> {
+  if (!match) return [];
+  const matcher = await loadKeywordMatcher();
+  return matcher.orderKeywords(readKeywords(match.keywords).map(withTableAliases), posting);
+}
+
 jobsRoute.get('/jobs/:id', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
@@ -262,6 +280,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
   const appliedPick = preselectAppliedResume(resumes, selected?.resumeId ?? null, suggested);
 
   const flashCookie = parseFlashCookie(c.req.header('cookie'));
+  const selectedKeywords = await orderedKeywords(selected, job.description);
   return c.html(
     <JobDetailPage
       job={job}
@@ -288,6 +307,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
         suggestedReason,
         matches,
         selected,
+        selectedKeywords,
       }}
       coverLetters={{
         jobId: id,
@@ -668,6 +688,7 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
       job={{ id: job.id, title: job.title, companyName: job.company.name, location: job.location, description: job.description }}
       resume={{ id: resume.id, name: resume.name, version: resume.version, ephemeral: resume.hidden }}
       match={match}
+      keywords={await orderedKeywords(match, job.description)}
       matches={matches}
       previous={previousFor(match, matches)}
       resumeText={match.resumeText || resume.text}

--- a/src/web/routes/keywords.ts
+++ b/src/web/routes/keywords.ts
@@ -31,7 +31,8 @@ const KeywordFormSchema = z.object({
 });
 
 /** What the flash says happened, before the score half of the sentence. */
-function describe(op: string, term: string, requirement: string | undefined): string {
+function describe(op: string, result: { term: string; removed: boolean }, requirement: string | undefined): string {
+  const term = result.term;
   switch (op) {
     case 'add':
       return `Added "${term}" as ${requirement}`;
@@ -42,7 +43,7 @@ function describe(op: string, term: string, requirement: string | undefined): st
     case 'restore':
       return `"${term}" counts again`;
     default:
-      return `"${term}" back to the AI's own verdict`;
+      return result.removed ? `Removed "${term}"` : `"${term}" back to the AI's own verdict`;
   }
 }
 
@@ -95,5 +96,5 @@ keywordsRoute.post('/jobs/:id/matches/:matchId/keywords', async (c) => {
   });
   const score =
     next.score === match.matchScore ? `score stays ${next.score}` : `score ${match.matchScore} → ${next.score}`;
-  return flashRedirect(back, 'ok', `${describe(form.op, result.term, form.requirement)} — ${score}, no AI call.`);
+  return flashRedirect(back, 'ok', `${describe(form.op, result, form.requirement)} — ${score}, no AI call.`);
 });

--- a/src/web/routes/keywords.ts
+++ b/src/web/routes/keywords.ts
@@ -31,7 +31,11 @@ const KeywordFormSchema = z.object({
 });
 
 /** What the flash says happened, before the score half of the sentence. */
-function describe(op: string, result: { term: string; removed: boolean }, requirement: string | undefined): string {
+function describe(
+  op: z.infer<typeof KeywordFormSchema>['op'],
+  result: { term: string; removed: boolean },
+  requirement: string | undefined,
+): string {
   const term = result.term;
   switch (op) {
     case 'add':

--- a/src/web/routes/keywords.ts
+++ b/src/web/routes/keywords.ts
@@ -1,0 +1,99 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { prisma } from '../../db';
+import { loadKeywordMatcher } from '../../resume/keyword-matcher';
+import {
+  addKeyword,
+  editKeyword,
+  effectiveKeywords,
+  type EditResult,
+} from '../../resume/keyword-overrides';
+import { readMatchMode } from '../../resume/match-mode';
+import { readPromptVersion } from '../../resume/match-reuse';
+import { readKeywords } from '../../resume/prompts';
+import { readBreakdown, REQUIREMENT_LEVELS, scoreMatch } from '../../resume/score';
+import { getMatch, updateMatchScoring } from '../../resume/store';
+import { flashRedirect, safeBack } from '../flash';
+
+/*
+ * Per-keyword overrides (target-plan.md §5). Re-levelling, ignoring and adding
+ * a term are the user's judgment, not the model's: the edit lands in the
+ * comparison's own `keywords` JSON and the score is recomputed right here by
+ * score.ts — the same free, instant path a confirmed ask_user fact takes
+ * (routes/facts.ts). No AI call is made or needed.
+ */
+
+const KeywordFormSchema = z.object({
+  op: z.enum(['level', 'ignore', 'restore', 'reset', 'add']),
+  term: z.string().trim().min(1).max(100),
+  requirement: z.enum(REQUIREMENT_LEVELS).optional(),
+  back: z.string().optional(),
+});
+
+/** What the flash says happened, before the score half of the sentence. */
+function describe(op: string, term: string, requirement: string | undefined): string {
+  switch (op) {
+    case 'add':
+      return `Added "${term}" as ${requirement}`;
+    case 'level':
+      return `"${term}" is now ${requirement}`;
+    case 'ignore':
+      return `Ignoring "${term}"`;
+    case 'restore':
+      return `"${term}" counts again`;
+    default:
+      return `"${term}" back to the AI's own verdict`;
+  }
+}
+
+export const keywordsRoute = new Hono();
+
+keywordsRoute.post('/jobs/:id/matches/:matchId/keywords', async (c) => {
+  const id = Number(c.req.param('id'));
+  const matchId = Number(c.req.param('matchId'));
+  if (!Number.isFinite(id) || !Number.isFinite(matchId)) return c.text('Bad id', 400);
+  const parsed = KeywordFormSchema.safeParse(await c.req.parseBody());
+  if (!parsed.success) return c.text('Bad keyword edit', 400);
+  const form = parsed.data;
+  const back = safeBack(form.back, `/jobs/${id}?match=${matchId}#resume-match`);
+
+  const match = await getMatch(matchId);
+  if (!match || match.jobId !== id) return c.text('Not found', 404);
+  const breakdown = readBreakdown(match.breakdown);
+  if (!breakdown) {
+    return flashRedirect(back, 'warn', 'This comparison predates the deterministic score — run Compare again to edit its keywords.');
+  }
+
+  const keywords = readKeywords(match.keywords);
+  let result: EditResult;
+  if (form.op === 'add') {
+    const [job, matcher] = await Promise.all([
+      prisma.job.findUnique({ where: { id }, select: { title: true, description: true } }),
+      loadKeywordMatcher(),
+    ]);
+    if (!job) return c.text('Not found', 404);
+    const requirement = form.requirement ?? 'preferred';
+    result = addKeyword(
+      keywords,
+      { term: form.term, requirement },
+      // The same posting text the anchor pass reads, so "not in posting" means
+      // the same thing whoever added the term.
+      { resumeText: match.resumeText, posting: `${job.title}\n${job.description}`, matcher },
+    );
+  } else {
+    if (form.op === 'level' && !form.requirement) return c.text('Bad keyword edit', 400);
+    result = editKeyword(keywords, { op: form.op, term: form.term, requirement: form.requirement });
+  }
+  if (!result.ok) return flashRedirect(back, 'err', result.error);
+
+  const next = scoreMatch(effectiveKeywords(result.keywords), breakdown.alignment, match.redFlags.length);
+  await updateMatchScoring(match.id, {
+    keywords: result.keywords,
+    breakdown: next,
+    promptVersion: readPromptVersion(match.breakdown),
+    mode: readMatchMode(match.breakdown),
+  });
+  const score =
+    next.score === match.matchScore ? `score stays ${next.score}` : `score ${match.matchScore} → ${next.score}`;
+  return flashRedirect(back, 'ok', `${describe(form.op, result.term, form.requirement)} — ${score}, no AI call.`);
+});

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -17,6 +17,7 @@ import { resumesRoute } from './routes/resumes';
 import { targetRoute } from './routes/target';
 import { letterRoute } from './routes/letter';
 import { factsRoute } from './routes/facts';
+import { keywordsRoute } from './routes/keywords';
 import { healthRoute } from './routes/health';
 import { welcomeRoute } from './routes/welcome';
 
@@ -83,6 +84,7 @@ app.route('/', resumesRoute);
 app.route('/', targetRoute);
 app.route('/', letterRoute);
 app.route('/', factsRoute);
+app.route('/', keywordsRoute);
 app.route('/', companiesRoute);
 app.route('/', discoveryRoute);
 app.route('/', runsRoute);

--- a/src/web/target.test.ts
+++ b/src/web/target.test.ts
@@ -16,13 +16,19 @@ const matcher = import('./public/target.mjs') as Promise<{
     keywords: { term: string; priority: number; requirement?: string; status: string; aliases?: string[] }[],
     jobText: string,
     scored: { rows: { term: string; found: boolean }[] },
-  ) => { start: number; end: number; cls: string }[];
+  ) => { start: number; end: number; cls: string; title: string }[];
   resumeSpans: (
     keywords: { term: string; priority: number; status: string; aliases?: string[] }[],
     actions: { quote: string | null; what: string }[],
     removals: { quote: string | null; what: string }[],
     text: string,
   ) => { start: number; end: number; cls: string }[];
+  keywordRank: (k: { requirement?: string; priority?: number; primary?: boolean }) => number;
+  weightClass: (k: { requirement?: string; priority?: number; primary?: boolean }) => string;
+  orderKeywords: <T extends { term: string; aliases?: string[] }>(
+    keywords: T[],
+    jobText: string,
+  ) => (T & { count: number })[];
 }>;
 
 const RESUME = 'Senior PHP/Laravel engineer. Node.js, C++, CI/CD and PostgreSQL. Built .NET tools.';
@@ -84,8 +90,9 @@ test('jobSpans classes: found, missing, ask_user and cannot_claim', async () => 
     { term: 'Terraform', priority: 2, requirement: 'preferred', status: 'ask_user' },
   ];
   const scored = scoreKeywords(keywords, RESUME);
+  // The status class comes first, the §5 weight class second.
   const byCls = jobSpans(keywords, jobText, scored).map((s) => s.cls);
-  assert.deepEqual(byCls, ['kw-found', 'kw-cannot', 'kw-missing', 'kw-ask']);
+  assert.deepEqual(byCls, ['kw-found kw-w3', 'kw-cannot kw-w3', 'kw-missing kw-w2', 'kw-ask kw-w2']);
 });
 
 test('locateQuote finds exact text, then tolerates punctuation and spacing drift', async () => {
@@ -196,4 +203,80 @@ test('findTerm tolerates plurals and separators and keeps the whole-token guards
 test('findTerm counts a span once when the term and an alias both spell it', async () => {
   const { findTerm } = await matcher;
   assert.deepEqual(findTerm('frontend work', 'front end', ['frontend']), [{ start: 0, end: 8 }]);
+});
+
+/* ---------- §5: visual weight and the frequency tiebreaker ---------- */
+
+const RANKS: [Record<string, unknown>, number][] = [
+  [{ requirement: 'must', primary: true }, 4],
+  [{ requirement: 'must', primary: false }, 3],
+  [{ requirement: 'preferred', primary: true }, 2], // primary only counts on a must (score.ts v3)
+  [{ requirement: 'preferred' }, 2],
+  [{ requirement: 'nice' }, 1],
+  [{ requirement: 'context' }, 0],
+  [{ priority: 1 }, 3], // pre-ADR-0012 rows fall back to the priority weights
+  [{ priority: 4 }, 1],
+];
+
+test('keywordRank grades how hard the posting asks, and the class follows it', async () => {
+  const { keywordRank, weightClass } = await matcher;
+  for (const [k, rank] of RANKS) {
+    assert.equal(keywordRank(k), rank, JSON.stringify(k));
+    assert.equal(weightClass(k), `kw-w${rank}`);
+  }
+});
+
+const POSTING = 'Kafka, Kafka, Kafka and Kafka. Also Docker, Docker and Terraform, plus Helm.';
+
+test('orderKeywords sorts by weight first and by posting frequency within a level', async () => {
+  const { orderKeywords } = await matcher;
+  const rows = orderKeywords(
+    [
+      { term: 'Helm', priority: 3, requirement: 'nice', primary: false, aliases: [] },
+      { term: 'Docker', priority: 2, requirement: 'must', primary: false, aliases: [] },
+      { term: 'Terraform', priority: 2, requirement: 'must', primary: false, aliases: [] },
+      { term: 'Kafka', priority: 1, requirement: 'must', primary: true, aliases: [] },
+    ],
+    POSTING,
+  );
+  assert.deepEqual(
+    rows.map((r) => [r.term, r.count]),
+    [
+      ['Kafka', 4], // primary must outranks every plain must
+      ['Docker', 2], // same level as Terraform, said twice as often
+      ['Terraform', 1],
+      ['Helm', 1],
+    ],
+  );
+});
+
+test('orderKeywords breaks a full tie by priority, then alphabetically — never by input order', async () => {
+  const { orderKeywords } = await matcher;
+  const same = (term: string, priority: number) => ({ term, priority, requirement: 'nice', primary: false, aliases: [] });
+  const rows = orderKeywords([same('Zulu', 3), same('Alpha', 3), same('Bravo', 2)], 'nothing here');
+  assert.deepEqual(rows.map((r) => r.term), ['Bravo', 'Alpha', 'Zulu']);
+});
+
+test('orderKeywords counts aliases and plurals as the same term', async () => {
+  const { orderKeywords } = await matcher;
+  const [row] = orderKeywords(
+    [{ term: 'Kubernetes', priority: 1, requirement: 'must', primary: false, aliases: ['k8s'] }],
+    'We run Kubernetes; the k8s clusters are ours.',
+  );
+  assert.equal(row?.count, 2);
+});
+
+test('jobSpans carries the weight class and says how often the posting repeats a term', async () => {
+  const { jobSpans, scoreKeywords } = await matcher;
+  const keywords = [
+    { term: 'Kafka', priority: 1, requirement: 'must', primary: true, status: 'add', aliases: [] },
+    { term: 'Helm', priority: 3, requirement: 'nice', primary: false, status: 'add', aliases: [] },
+  ];
+  const spans = jobSpans(keywords, POSTING, scoreKeywords(keywords, 'a resume with neither'));
+  const kafka = spans.filter((s) => s.cls.startsWith('kw-missing kw-w4'));
+  const helm = spans.filter((s) => s.cls === 'kw-missing kw-w1');
+  assert.equal(kafka.length, 4, 'every occurrence is marked at the primary-must intensity');
+  assert.equal(helm.length, 1);
+  assert.equal(kafka[0]?.title, 'Kafka · must · primary stack · missing · ×4 in the posting');
+  assert.equal(helm[0]?.title, 'Helm · nice · missing', 'a single mention says nothing extra');
 });


### PR DESCRIPTION
Block 5 of §13 ([docs/target-plan.md](docs/target-plan.md) §5): the keyword
list stops being the model's alone. Three edits per row — **re-level** what the
posting demands, **ignore** a term as noise, **add** a word the model missed —
plus visual weight in the panes and posting frequency as the tiebreaker.

Everything here is arithmetic over the stored analysis. **No AI call, no schema
change, no `PROMPT_VERSION` bump, and `score.ts` is untouched** — an override is
a different *input* to the same formula, so the `score.mjs` parity test stayed
green with nothing to mirror.

## What it does

- **The write path** is `POST /jobs/:id/matches/:matchId/keywords` →
  `scoreMatch` → `updateMatchScoring`, the same free, instant path a confirmed
  `ask_user` fact takes. The flash says so: *"system scalability" is now nice —
  score 66 → 67, no AI call.*
- **The override rides beside the model's verdict** in the comparison's own
  `keywords` JSON (`override: { requirement?, excluded?, added? }`), so nothing
  is overwritten, the table can show both, and *reset* always has somewhere to
  go back to. `effectiveKeywords()` — the user's levels minus the rows they
  ignored — is what the score, the panes and the live editor read.
- **An added term's status is read, never guessed**: written in the resume →
  `present`; not written → a confirm question the existing ask_user flow
  answers. One the posting does not contain is flagged *not in posting*, the
  same badge a model paraphrase gets, with copy that fits who added it.
- **Overrides stick to the posting.** They go into the next run's keyword frame
  and are re-applied to the fresh reply afterwards, including a hand-added term
  the model did not repeat — whose status is re-read against the current resume
  text. A carried level is kept even when the model comes to agree: the point
  of an override is that the level stops depending on the next reply.
- **`override` is stripped from every model reply on the way in.** The field is
  the user's; a posting must not be able to talk the model into dropping a
  must-have from the score (ADR 0022 covers the prompt, this covers the reply).
- **Visual weight**: marks and chips are graded `kw-w0` (context) … `kw-w4` (a
  primary-stack must) from one shared `keywordRank()`, with the legend showing
  the tiers. **Frequency**: equal-weight terms are ordered by how often the
  posting repeats them, shown as *×4* in the table and *×4 in the posting* in
  every tooltip — it costs nothing, the panes already had every occurrence.
- Weight, order and frequency live in `src/web/public/target.mjs`, the module
  the panes, the chips **and** the server-rendered table share — one
  implementation, nothing to mirror.

## Verification

- `npm run lint:types`, `npm test` (931 tests, +17), `npx prisma format --check`
  — all green. New pure-module tests: `keyword-overrides.test.ts` (17) and the
  ordering/weight table in `target.test.ts`.
- **Live on job #1393, match #59** (Docker, the real dashboard): must → nice
  66 → 67, ignoring a `cannot_claim` nice 67 → 68, adding a term the resume
  already had 68 → 68, adding one it lacked 68 → 67, five resets back to
  exactly **66** — the score it started with. **2–15 ms per edit and not one
  `resume:` line in the web log**, i.e. no AI call anywhere on the path.
  The select's auto-submit and the buttons' `op` setter were exercised from
  the browser, not only by curl.
- **Carrying**: a forced re-run of the quick check on the same posting logged
  `overrides: 3, readded: 1` in 50 s — the re-levelled and ignored rows came
  back on the fresh reply, and the hand-added term the model did not repeat was
  put back with its status re-read. That verification row was deleted
  afterwards, so job #1393 holds exactly the matches it held before (55–59, no
  overrides left behind).
- Dashboard matrix: `docker compose build web`, screenshots of the keyword
  table and both panes at 1200 / 768 / 375, **0 console errors**; the page never
  scrolls horizontally (the table scrolls inside its own container, as before).

## Follow-ups (P2/P3 from the pre-merge review, not fixed here)

1. **Check-then-act on the override write path.** `getMatch` → compute →
   `updateMatchScoring` is a read-modify-write of the `keywords` JSON: two tabs,
   or a fact confirmation landing between the read and the write, can lose one
   edit. Same class as #70 / #72 and as the suggestions route from #82; worth
   one fix for all of them (re-read inside a transaction).
2. **The auto-submitting level select** fires on arrow-key navigation in some
   browsers, so a keyboard user can submit a level they were only passing
   through. It is the house pattern (the `/settings` model pickers save on
   change) — revisit for all of them together if it annoys.
3. **The landing demo** (`site/public/demo/`) vendors the matcher byte-for-byte,
   so it picked up the new exports, but keeps its own flat CSS and
   priority-ordered chips — it no longer shows what the product shows.

## Release notes draft — v1.17.0

**Your say over every keyword.** Re-level what the posting demands, ignore a
term as noise, or add a word the AI missed — the score updates on the spot,
with no AI call, and the change sticks to that posting on every re-run. A term
you add reads its status from your resume instead of guessing. In the panes a
missing must-have no longer looks like a missing nice-to-have: marks and chips
are graded by how hard the posting asks, and equal ones are ordered by how
often it repeats them (*×4 in the posting*).
