### PR TITLE
Rebuild keywords: a way out of a frozen keyword frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.18.0] — 2026-09-02
+
+### Added
+- **Rebuild keywords** ([docs/target-plan.md](docs/target-plan.md) §4 F7,
+  TASKS §13). Every comparison of the same posting has been reusing the first
+  run's keyword list on purpose, so scores stay comparable between resume
+  versions — but a word the model missed on run 1 stayed missed on every run
+  after it. The keyword table now carries a way out: one run with the stored
+  list withheld, so the model reads the terms out of the posting again.
+  Measured on a real posting: the carried list had been repeating the same 26
+  terms through five analyses; the rebuild found 30, including **BullMQ** and
+  **GCP PubSub** — both named in the job description, neither ever listed.
+- **A prompt bump no longer inherits the old prompt's keywords.** When the
+  analysis prompt changes, the stored list was written under rules the new one
+  does not follow, so it is not offered to the model at all.
+- **A rebuilt analysis says the score is not comparable** instead of showing a
+  delta against the previous one: the two count different terms, and a −3 that
+  means "different list" reads exactly like a −3 that means "worse resume".
+
+### Changed
+- A rebuild skips the reuse memo. Without that it would answer with the very
+  analysis whose keyword list the user asked to replace.
+- **Your keyword edits survive a rebuild.** Re-levelled, ignored and
+  hand-added terms are re-applied to whatever the fresh run returns — a
+  rebuild resets the model's guess, never your decision.
+- `resume: matched` logs which frame the run used (`carried`, `first-run`,
+  `rebuild`, `prompt-bump`) next to the keyword counts.
+
+### Closed without building
+- `match-split-frame` (a cached per-job keyword frame + a statuses-only call),
+  the one block of the compare-speed plan left open. The gate was "only if the
+  measurements demand it": the quick check now runs at a p50 of 15 s on the
+  bench fixtures and 40-42 s on one of the longest postings we store, against
+  a 30-40 s target — so the block is closed by the numbers rather than built.
+  Details in TASKS §13.
+
 ## [1.17.0] — 2026-09-02
 
 ### Added
@@ -1112,6 +1148,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.18.0]: https://github.com/applypack/applypack/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/applypack/applypack/compare/v1.16.0...v1.17.0
 [1.16.0]: https://github.com/applypack/applypack/compare/v1.15.0...v1.16.0
 [1.15.0]: https://github.com/applypack/applypack/compare/v1.14.0...v1.15.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@
   (ADR 0012), `facts.ts`, `diff.ts`, `parse-warnings.ts`, `match-mode.ts`,
   `match-reuse.ts`, `bench-report.ts`,
   `profile-draft.ts` (ADR 0015), `fact-check.ts` (ADR 0020),
-  `keyword-overrides.ts` are pure (tested);
+  `keyword-overrides.ts`, `keyword-frame.ts` are pure (tested);
   `scan.ts` / `match.ts` / `suggestions.ts` / `cover-letter.ts` call the AI
   provider (the letter is gated by `fact-check.ts` and generates from stored
   inputs only — ADR 0021); `store.ts` is the only file that touches Prisma.
@@ -197,6 +197,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | What counts as primary stack / sibling-tech rules (prompt side) | `src/resume/prompts.ts:MATCH_SYSTEM` steps 3-4 — guard-tested in `prompts.test.ts` |
 | ask_user confirmations (CandidateFact rows, instant re-score) | `src/resume/facts.ts` (pure) + `src/web/routes/facts.ts` (POST /facts), managed on `/resumes` |
 | Per-keyword overrides (re-level / ignore / add your own term) | `src/resume/keyword-overrides.ts` (pure): `effectiveKeywords` feeds the score, `carryOverrides` re-applies them to the next reply; route `src/web/routes/keywords.ts` |
+| Whether a run inherits the posting's keyword frame (rebuild, prompt bump) | `src/resume/keyword-frame.ts:planKeywordFrame` (pure, issue #79) — the reason is stored in the `breakdown` JSON and read back by `freshFrame` |
 | Keyword display order + mark intensity (weight, then posting frequency) | `src/web/public/target.mjs:keywordRank` / `orderKeywords` — one implementation for the panes, the chips and the server-rendered table |
 | Anti-hallucination gate for generated prose (pass/warn/block) | `src/resume/fact-check.ts:factCheck` (pure, ADR 0020) — sources arrive as arguments, `store.ts` loads them |
 | Cover letter generation (gated, stored-inputs-only) | `src/resume/cover-letter.ts` + `COVER_SYSTEM` in `prompts.ts` (ADR 0021); card `src/web/pages/cover-letter-card.tsx` |
@@ -253,6 +254,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | Compare a resume with a posting | `/jobs/:id` → "Resume match" card — **Compare** = quick check (keywords, gates, score), **Full analysis** = also the edit suggestions (ADR 0029) |
 | Get the edit suggestions for a quick check | the comparison → "Get suggestions" (second call, reuses the stored verdicts, score unchanged) |
 | Re-level, ignore or add a keyword by hand | the keyword table on `/jobs/:id` or `/jobs/:id/target` → the "Wants it" select, `ignore` / `reset`, and "Add a keyword" (instant re-score, no AI call; the edit sticks to the posting across re-runs) |
+| Throw away a keyword list the model got wrong | the keyword table → "Rebuild keywords" (one run with the stored frame withheld; your own keyword edits survive it, the new score is not comparable with the old) |
 | Paste a posting the fetchers don't see | `/jobs` → "+ Paste a job" (`/jobs/new`) |
 | Compare a pasted posting with any resume in one step | menu → Compare (`/target`): paste posting, pick / upload / paste resume, Compare |
 | Check whether a posting is real | `/jobs/:id` → "Is this job real?" → Verify (web search, 2-4 min) |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -810,9 +810,10 @@ icon; progress visible step-by-step via the target-run registry pattern.
 
 ## 13. /target compare speed (30-40 s) + keyword-matcher accuracy (analysis 2026-08-31)
 
-Full plan: [docs/target-plan.md](./target-plan.md). **Blocks 1–5 shipped
-2026-09-02 (measured numbers in the plan's §2.3, §3.4, §4 and §5); block 6
-opens only if the numbers demand it.** §12's
+Full plan: [docs/target-plan.md](./target-plan.md). **Section closed
+2026-09-02: blocks 1–5 plus `keyword-frame-rebuild` shipped (measured numbers
+in the plan's §2.3, §3.4, §4 and §5), block 6 closed by the numbers rather
+than built.** §12's
 async-upload item overlaps the `/resumes`
 sync-scan finding, planned there, referenced here.
 
@@ -900,5 +901,32 @@ Sonnet bench for the resume role — not "make Opus stream faster".
       re-run logged `overrides: 3, readded: 1`, so the edits survived into
       the fresh reply. An added term's status is read from the resume, and
       the `override` field is stripped from every model reply on the way in.
-- [ ] (only if still short of target) `match-split-frame` — per-job cached
-      keyword frame + statuses-only judge call (**ADR**)
+- [x] `keyword-frame-rebuild` — "Rebuild keywords" runs the analysis once
+      without `previousKeywords`, and a frame written under another
+      `PROMPT_VERSION` is never inherited (§4 F7, issue #79) — done
+      2026-09-02, branch `keyword-frame-rebuild` (PR #84). The decision is a
+      pure function of (stored prompt version, request flag) in
+      `keyword-frame.ts`; its reason rides in the `breakdown` JSON, so a
+      rebuilt row replaces the version delta with *"not comparable"* instead
+      of inviting a comparison between two different term lists. A rebuild
+      bypasses the reuse memo (it would otherwise hand back the very frame it
+      was asked to replace) and keeps every user override — `carryOverrides`
+      reads the full stored row, not the withheld frame. Measured live on job
+      #1393 (quick check, CLI engine): carried **42.2 s / 26 terms**, the same
+      list the frame had carried through five analyses since prompt v5;
+      rebuilt **41.8 s / 30 terms** — 23 shared, 3 dropped, **7 new (BullMQ,
+      GCP PubSub, AI tools, observability tools, performance monitoring,
+      CI/CD, Microservices)**, every one of them literally in the posting,
+      `unanchored` still 0. Score 67 → 64, which is what the card now says
+      out loud. The must → nice override set before the rebuild survived it.
+- [x] `match-split-frame` — per-job cached keyword frame + statuses-only judge
+      call (**ADR**). **Not built: closed 2026-09-02 by the numbers, not by
+      taste.** The gate was "only if still short of target" (30-40 s). After
+      block 4 the quick check is **p50 15 s** on the gold fixtures and
+      **40 / 42.2 / 41.8 s** on job #1393, one of the longest descriptions we
+      store — inside the band on short postings, ~2 s over on a long one. The
+      split would buy those seconds with a second prompt variant, an ADR and a
+      per-job cache to invalidate, while block 3 already answers the
+      as-you-type case with no call at all (0-15 ms) and F7 shows that a
+      frozen frame is a liability, not an asset. Reopen only if a measured
+      compare goes back over ~60 s.

--- a/docs/target-plan.md
+++ b/docs/target-plan.md
@@ -314,6 +314,21 @@ frequent first:
   stays missed on every later run. *Fix:* a "Rebuild keywords" action that
   skips `previousKeywords` once, and an automatic skip when the stored
   frame's `PROMPT_VERSION` is older than current.
+  **Shipped 2026-09-02** (issue #79, PR #84): the decision is a pure function
+  (`keyword-frame.ts:planKeywordFrame`) of the stored frame's prompt version
+  and one request flag, and its reason is stored in the `breakdown` JSON so a
+  rebuilt row can say why its score stands alone. Measured live on job #1393
+  (5 k-char posting, resume 5, quick check on the CLI engine): the carried run
+  cost **42.2 s and listed the same 26 terms the frame has carried since
+  prompt v5** (5 analyses deep — matches #55…#59), the rebuild cost **41.8 s
+  and listed 30**: 23 shared, 3 dropped, **7 new — BullMQ, GCP PubSub, AI
+  tools, observability tools, performance monitoring, CI/CD, Microservices**.
+  All seven are literally in the posting, so five consecutive runs had been
+  reproducing a list that was missing two named technologies the job asks for;
+  `unanchored` stayed 0, so nothing new was invented either. Score 67 → 64 —
+  which is the point of the "not comparable" line on the card, not a
+  regression. A rebuild costs exactly one normal call: it is the same request
+  minus one prompt block.
 - **F8 (optional safety net) — deterministic lexicon sweep.** A pure module
   with a few hundred known tech terms scans the posting for anything absent
   from the AI list and shows them as neutral **unrated** marks (never
@@ -340,7 +355,8 @@ lead" or "startup / fast-paced environment" that no matcher can place. On the
 current prompt no stored row misses the posting, so F2 acts as the safety net
 and the metric (`anchored` / `unanchored` on the `resume: matched` line), not
 as a repair of today's output. F1 moved to `match-fast-mode` (block 4) — it is
-a prompt change; F7 is issue #79; F8 stays open (§8).
+a prompt change; F7 shipped as `keyword-frame-rebuild` (above); F8 stays open
+(§8).
 
 ## 5. Keyword priorities — present vs missing
 
@@ -450,7 +466,26 @@ Sources: [jobscan.co](https://www.jobscan.co/blog/top-resume-keywords-boost-resu
    no ADR and no schema change; `PROMPT_VERSION` untouched — this is
    post-processing. `score.ts` untouched too, so the score.mjs parity test
    stayed green without a mirrored edit.
-6. (only if measurements demand) `match-split-frame` — §3.3 item 8 + ADR.
+6. ~~(only if measurements demand) `match-split-frame` — §3.3 item 8 + ADR.~~
+   **Not needed — closed 2026-09-02 by the numbers.** The condition was
+   "only if measurements demand"; the owner's band is 30-40 s. Where the quick
+   check lands after block 4: **p50 15 s** on the gold fixtures (24 s full,
+   77 s vs 116 s for the suite) and **40 s / 42.2 s / 41.8 s** on job #1393,
+   whose 5 k-char description is at the long end of what we store. So the band
+   is met on short postings and missed by ~2 s on a long one. Splitting the
+   frame would buy the difference by caching the term list per job and asking
+   the model for statuses only — the same saving the fast prompt already
+   made (**2591 vs 4373 reply characters**), for a second prompt variant, an
+   ADR, and a cached frame to invalidate on every posting edit. Against that:
+   block 3 already answers the as-you-type case with **no call at all**
+   (0-15 ms), and F7 above exists precisely because a frozen frame goes stale
+   — a cache would freeze it harder. Reopen only if a measured compare goes
+   back over ~60 s.
+7. `keyword-frame-rebuild` — §4 F7 (issue #79): "Rebuild keywords" runs once
+   without `previousKeywords`, and a frame written by another `PROMPT_VERSION`
+   is never inherited. Pure decision module, no schema change, no prompt
+   change, `PROMPT_VERSION` untouched. **Shipped 2026-09-02** (PR #84, numbers
+   in §4 F7).
 
 ## 8. Open questions for the owner
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/resume/keyword-frame.test.ts
+++ b/src/resume/keyword-frame.test.ts
@@ -1,104 +1,68 @@
-import { test } from "node:test";
-import assert from "node:assert/strict";
-import {
-  freshFrame,
-  freshFrameNotice,
-  planKeywordFrame,
-  readFrameReason,
-  type StoredFrame,
-} from "./keyword-frame";
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { freshFrame, freshFrameNotice, planKeywordFrame, readFrameReason, type StoredFrame } from './keyword-frame';
 
 const stored: StoredFrame = { terms: 24, promptVersion: 6 };
 
-test("a frame from the current prompt is carried", () => {
-  assert.deepEqual(planKeywordFrame(stored, 6, false), {
-    carry: true,
-    reason: "carried",
-  });
+test('a frame from the current prompt is carried', () => {
+  assert.deepEqual(planKeywordFrame(stored, 6, false), { carry: true, reason: 'carried' });
 });
 
-test("rebuild drops the frame the user asked to drop", () => {
-  assert.deepEqual(planKeywordFrame(stored, 6, true), {
+test('rebuild drops the frame the user asked to drop', () => {
+  assert.deepEqual(planKeywordFrame(stored, 6, true), { carry: false, reason: 'rebuild' });
+});
+
+test('a prompt bump never inherits the previous prompt frame', () => {
+  assert.deepEqual(planKeywordFrame({ ...stored, promptVersion: 5 }, 6, false), {
     carry: false,
-    reason: "rebuild",
+    reason: 'prompt-bump',
   });
-});
-
-test("a prompt bump never inherits the previous prompt frame", () => {
-  assert.deepEqual(
-    planKeywordFrame({ ...stored, promptVersion: 5 }, 6, false),
-    {
-      carry: false,
-      reason: "prompt-bump",
-    },
-  );
   assert.deepEqual(
     planKeywordFrame({ ...stored, promptVersion: null }, 6, false),
-    { carry: false, reason: "prompt-bump" },
-    "a row from before the marker cannot say which rules it followed",
+    { carry: false, reason: 'prompt-bump' },
+    'a row from before the marker cannot say which rules it followed',
   );
   assert.deepEqual(
     planKeywordFrame({ ...stored, promptVersion: 7 }, 6, false),
-    { carry: false, reason: "prompt-bump" },
-    "a downgrade is just as foreign a frame",
+    { carry: false, reason: 'prompt-bump' },
+    'a downgrade is just as foreign a frame',
   );
 });
 
-test("nothing stored is a first run, whatever was asked", () => {
-  assert.deepEqual(planKeywordFrame(null, 6, false), {
-    carry: false,
-    reason: "first-run",
-  });
-  assert.deepEqual(planKeywordFrame(null, 6, true), {
-    carry: false,
-    reason: "first-run",
-  });
+test('nothing stored is a first run, whatever was asked', () => {
+  assert.deepEqual(planKeywordFrame(null, 6, false), { carry: false, reason: 'first-run' });
+  assert.deepEqual(planKeywordFrame(null, 6, true), { carry: false, reason: 'first-run' });
   assert.deepEqual(
     planKeywordFrame({ terms: 0, promptVersion: 6 }, 6, false),
-    { carry: false, reason: "first-run" },
-    "an empty list is nothing to inherit",
+    { carry: false, reason: 'first-run' },
+    'an empty list is nothing to inherit',
   );
 });
 
-test("rebuild wins over a stale version — one reason, the one the user chose", () => {
-  assert.deepEqual(planKeywordFrame({ terms: 24, promptVersion: 5 }, 6, true), {
-    carry: false,
-    reason: "rebuild",
-  });
+test('rebuild wins over a stale version — one reason, the one the user chose', () => {
+  assert.deepEqual(planKeywordFrame({ terms: 24, promptVersion: 5 }, 6, true), { carry: false, reason: 'rebuild' });
 });
 
-test("readFrameReason reads the marker and nothing else", () => {
-  assert.equal(readFrameReason({ score: 71, frame: "rebuild" }), "rebuild");
-  assert.equal(readFrameReason({ score: 71 }), null, "pre-marker rows");
-  assert.equal(readFrameReason({ frame: "REBUILD" }), null);
+test('readFrameReason reads the marker and nothing else', () => {
+  assert.equal(readFrameReason({ score: 71, frame: 'rebuild' }), 'rebuild');
+  assert.equal(readFrameReason({ score: 71 }), null, 'pre-marker rows');
+  assert.equal(readFrameReason({ frame: 'REBUILD' }), null);
   assert.equal(readFrameReason({ frame: true }), null);
   assert.equal(readFrameReason(null), null);
 });
 
-test("only a re-extracted frame makes a score incomparable", () => {
-  assert.equal(freshFrame({ frame: "rebuild" }), "rebuild");
-  assert.equal(freshFrame({ frame: "prompt-bump" }), "prompt-bump");
-  assert.equal(
-    freshFrame({ frame: "carried" }),
-    null,
-    "a carried frame is what makes it fair",
-  );
-  assert.equal(
-    freshFrame({ frame: "first-run" }),
-    null,
-    "nothing to be compared with",
-  );
-  assert.equal(
-    freshFrame({}),
-    null,
-    "rows written before the marker read as comparable",
-  );
+test('only a re-extracted frame makes a score incomparable', () => {
+  assert.equal(freshFrame({ frame: 'rebuild' }), 'rebuild');
+  assert.equal(freshFrame({ frame: 'prompt-bump' }), 'prompt-bump');
+  assert.equal(freshFrame({ frame: 'carried' }), null, 'a carried frame is what makes it fair');
+  assert.equal(freshFrame({ frame: 'first-run' }), null, 'nothing to be compared with');
+  assert.equal(freshFrame({}), null, 'rows written before the marker read as comparable');
 });
 
-test("the notice says the terms differ, never that the score got worse", () => {
-  const rebuilt = freshFrameNotice("rebuild");
+test('the notice says the terms differ, never that the score got worse', () => {
+  const rebuilt = freshFrameNotice('rebuild');
   assert.match(rebuilt, /rebuilt from the posting/);
   assert.match(rebuilt, /different set of terms/);
   assert.doesNotMatch(rebuilt, /lower|worse|dropped/);
-  assert.match(freshFrameNotice("prompt-bump"), /prompt changed/);
+  assert.match(freshFrameNotice('prompt-bump'), /prompt changed/);
 });

--- a/src/resume/keyword-frame.test.ts
+++ b/src/resume/keyword-frame.test.ts
@@ -1,0 +1,104 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  freshFrame,
+  freshFrameNotice,
+  planKeywordFrame,
+  readFrameReason,
+  type StoredFrame,
+} from "./keyword-frame";
+
+const stored: StoredFrame = { terms: 24, promptVersion: 6 };
+
+test("a frame from the current prompt is carried", () => {
+  assert.deepEqual(planKeywordFrame(stored, 6, false), {
+    carry: true,
+    reason: "carried",
+  });
+});
+
+test("rebuild drops the frame the user asked to drop", () => {
+  assert.deepEqual(planKeywordFrame(stored, 6, true), {
+    carry: false,
+    reason: "rebuild",
+  });
+});
+
+test("a prompt bump never inherits the previous prompt frame", () => {
+  assert.deepEqual(
+    planKeywordFrame({ ...stored, promptVersion: 5 }, 6, false),
+    {
+      carry: false,
+      reason: "prompt-bump",
+    },
+  );
+  assert.deepEqual(
+    planKeywordFrame({ ...stored, promptVersion: null }, 6, false),
+    { carry: false, reason: "prompt-bump" },
+    "a row from before the marker cannot say which rules it followed",
+  );
+  assert.deepEqual(
+    planKeywordFrame({ ...stored, promptVersion: 7 }, 6, false),
+    { carry: false, reason: "prompt-bump" },
+    "a downgrade is just as foreign a frame",
+  );
+});
+
+test("nothing stored is a first run, whatever was asked", () => {
+  assert.deepEqual(planKeywordFrame(null, 6, false), {
+    carry: false,
+    reason: "first-run",
+  });
+  assert.deepEqual(planKeywordFrame(null, 6, true), {
+    carry: false,
+    reason: "first-run",
+  });
+  assert.deepEqual(
+    planKeywordFrame({ terms: 0, promptVersion: 6 }, 6, false),
+    { carry: false, reason: "first-run" },
+    "an empty list is nothing to inherit",
+  );
+});
+
+test("rebuild wins over a stale version — one reason, the one the user chose", () => {
+  assert.deepEqual(planKeywordFrame({ terms: 24, promptVersion: 5 }, 6, true), {
+    carry: false,
+    reason: "rebuild",
+  });
+});
+
+test("readFrameReason reads the marker and nothing else", () => {
+  assert.equal(readFrameReason({ score: 71, frame: "rebuild" }), "rebuild");
+  assert.equal(readFrameReason({ score: 71 }), null, "pre-marker rows");
+  assert.equal(readFrameReason({ frame: "REBUILD" }), null);
+  assert.equal(readFrameReason({ frame: true }), null);
+  assert.equal(readFrameReason(null), null);
+});
+
+test("only a re-extracted frame makes a score incomparable", () => {
+  assert.equal(freshFrame({ frame: "rebuild" }), "rebuild");
+  assert.equal(freshFrame({ frame: "prompt-bump" }), "prompt-bump");
+  assert.equal(
+    freshFrame({ frame: "carried" }),
+    null,
+    "a carried frame is what makes it fair",
+  );
+  assert.equal(
+    freshFrame({ frame: "first-run" }),
+    null,
+    "nothing to be compared with",
+  );
+  assert.equal(
+    freshFrame({}),
+    null,
+    "rows written before the marker read as comparable",
+  );
+});
+
+test("the notice says the terms differ, never that the score got worse", () => {
+  const rebuilt = freshFrameNotice("rebuild");
+  assert.match(rebuilt, /rebuilt from the posting/);
+  assert.match(rebuilt, /different set of terms/);
+  assert.doesNotMatch(rebuilt, /lower|worse|dropped/);
+  assert.match(freshFrameNotice("prompt-bump"), /prompt changed/);
+});

--- a/src/resume/keyword-frame.ts
+++ b/src/resume/keyword-frame.ts
@@ -1,0 +1,89 @@
+/*
+ * Which keyword frame a comparison runs with (docs/target-plan.md §4 F7,
+ * issue #79). CONSISTENCY ACROSS RUNS freezes the term list per posting so a
+ * better resume shows up as a better number — the flip side is that a term the
+ * model missed on run 1 stays missed on every run after it. Two ways out of a
+ * bad frame, both decided here and nowhere else:
+ *
+ * - "Rebuild keywords" — the user says this frame is wrong: run once without
+ *   it and let the model read the posting again.
+ * - A prompt bump — a frame extracted under rules the current prompt no
+ *   longer follows is never inherited, or the bump would keep re-deriving the
+ *   old prompt's list.
+ *
+ * Only the MODEL's frame is dropped. The user's overrides — re-levelled,
+ * ignored and hand-added terms — are re-applied by carryOverrides from the
+ * full stored list rather than from the frame, so they survive both cases: a
+ * rebuild resets the machine's guess, never the person's decision.
+ *
+ * Pure — tested in keyword-frame.test.ts. The reason is stored in the
+ * breakdown JSON (no schema change, the same trick as the mode marker of
+ * ADR 0029) so the card can say why a score stands on its own.
+ */
+
+export const FRAME_REASONS = [
+  "carried",
+  "first-run",
+  "rebuild",
+  "prompt-bump",
+] as const;
+export type FrameReason = (typeof FRAME_REASONS)[number];
+
+/** The latest stored analysis of this posting, as the frame decision reads it. */
+export interface StoredFrame {
+  /** How many keywords it holds — an empty list is nothing to inherit. */
+  terms: number;
+  /** The prompt that wrote them; null on rows older than the marker. */
+  promptVersion: number | null;
+}
+
+export interface FramePlan {
+  /** Whether PREVIOUS KEYWORDS goes into the prompt at all. */
+  carry: boolean;
+  reason: FrameReason;
+}
+
+export function planKeywordFrame(
+  stored: StoredFrame | null,
+  promptVersion: number,
+  rebuild: boolean,
+): FramePlan {
+  if (stored === null || stored.terms === 0)
+    return { carry: false, reason: "first-run" };
+  if (rebuild) return { carry: false, reason: "rebuild" };
+  // Any other version, not just an older one: a downgrade inherits a frame
+  // written by rules this prompt does not have either, and a pre-marker row
+  // (null) cannot say which rules it followed at all.
+  if (stored.promptVersion !== promptVersion)
+    return { carry: false, reason: "prompt-bump" };
+  return { carry: true, reason: "carried" };
+}
+
+/** The stored marker; null on rows written before it existed. */
+export function readFrameReason(breakdown: unknown): FrameReason | null {
+  if (typeof breakdown !== "object" || breakdown === null) return null;
+  const v = (breakdown as { frame?: unknown }).frame;
+  return FRAME_REASONS.includes(v as FrameReason) ? (v as FrameReason) : null;
+}
+
+/**
+ * Why this row's score cannot be read against the one before it: its terms were
+ * extracted afresh, so the two numbers count different things. A first run has
+ * nothing to be compared with, and a carried frame is what makes the comparison
+ * fair in the first place — neither says anything here.
+ */
+export function freshFrame(
+  breakdown: unknown,
+): "rebuild" | "prompt-bump" | null {
+  const reason = readFrameReason(breakdown);
+  return reason === "rebuild" || reason === "prompt-bump" ? reason : null;
+}
+
+/** What the card says in place of the version delta. */
+export function freshFrameNotice(reason: "rebuild" | "prompt-bump"): string {
+  const why =
+    reason === "rebuild"
+      ? "Keywords were rebuilt from the posting for this run"
+      : "The analysis prompt changed, so the earlier keywords were not reused";
+  return `${why}, so this analysis counts a different set of terms. Read the score on its own — the earlier ones judged another list.`;
+}

--- a/src/resume/keyword-frame.ts
+++ b/src/resume/keyword-frame.ts
@@ -21,12 +21,7 @@
  * ADR 0029) so the card can say why a score stands on its own.
  */
 
-export const FRAME_REASONS = [
-  "carried",
-  "first-run",
-  "rebuild",
-  "prompt-bump",
-] as const;
+export const FRAME_REASONS = ['carried', 'first-run', 'rebuild', 'prompt-bump'] as const;
 export type FrameReason = (typeof FRAME_REASONS)[number];
 
 /** The latest stored analysis of this posting, as the frame decision reads it. */
@@ -43,25 +38,19 @@ export interface FramePlan {
   reason: FrameReason;
 }
 
-export function planKeywordFrame(
-  stored: StoredFrame | null,
-  promptVersion: number,
-  rebuild: boolean,
-): FramePlan {
-  if (stored === null || stored.terms === 0)
-    return { carry: false, reason: "first-run" };
-  if (rebuild) return { carry: false, reason: "rebuild" };
+export function planKeywordFrame(stored: StoredFrame | null, promptVersion: number, rebuild: boolean): FramePlan {
+  if (stored === null || stored.terms === 0) return { carry: false, reason: 'first-run' };
+  if (rebuild) return { carry: false, reason: 'rebuild' };
   // Any other version, not just an older one: a downgrade inherits a frame
   // written by rules this prompt does not have either, and a pre-marker row
   // (null) cannot say which rules it followed at all.
-  if (stored.promptVersion !== promptVersion)
-    return { carry: false, reason: "prompt-bump" };
-  return { carry: true, reason: "carried" };
+  if (stored.promptVersion !== promptVersion) return { carry: false, reason: 'prompt-bump' };
+  return { carry: true, reason: 'carried' };
 }
 
 /** The stored marker; null on rows written before it existed. */
 export function readFrameReason(breakdown: unknown): FrameReason | null {
-  if (typeof breakdown !== "object" || breakdown === null) return null;
+  if (typeof breakdown !== 'object' || breakdown === null) return null;
   const v = (breakdown as { frame?: unknown }).frame;
   return FRAME_REASONS.includes(v as FrameReason) ? (v as FrameReason) : null;
 }
@@ -72,18 +61,16 @@ export function readFrameReason(breakdown: unknown): FrameReason | null {
  * nothing to be compared with, and a carried frame is what makes the comparison
  * fair in the first place — neither says anything here.
  */
-export function freshFrame(
-  breakdown: unknown,
-): "rebuild" | "prompt-bump" | null {
+export function freshFrame(breakdown: unknown): 'rebuild' | 'prompt-bump' | null {
   const reason = readFrameReason(breakdown);
-  return reason === "rebuild" || reason === "prompt-bump" ? reason : null;
+  return reason === 'rebuild' || reason === 'prompt-bump' ? reason : null;
 }
 
 /** What the card says in place of the version delta. */
-export function freshFrameNotice(reason: "rebuild" | "prompt-bump"): string {
+export function freshFrameNotice(reason: 'rebuild' | 'prompt-bump'): string {
   const why =
-    reason === "rebuild"
-      ? "Keywords were rebuilt from the posting for this run"
-      : "The analysis prompt changed, so the earlier keywords were not reused";
+    reason === 'rebuild'
+      ? 'Keywords were rebuilt from the posting for this run'
+      : 'The analysis prompt changed, so the earlier keywords were not reused';
   return `${why}, so this analysis counts a different set of terms. Read the score on its own — the earlier ones judged another list.`;
 }

--- a/src/resume/keyword-overrides.test.ts
+++ b/src/resume/keyword-overrides.test.ts
@@ -1,5 +1,5 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test } from "node:test";
+import assert from "node:assert/strict";
 import {
   addKeyword,
   carryOverrides,
@@ -7,10 +7,10 @@ import {
   effectiveKeywords,
   effectiveRequirement,
   isIgnored,
-} from './keyword-overrides';
-import type { MatchKeyword } from './prompts';
-import { scoreMatch } from './score';
-import { loadKeywordMatcher } from './keyword-matcher';
+} from "./keyword-overrides";
+import type { MatchKeyword } from "./prompts";
+import { scoreMatch } from "./score";
+import { loadKeywordMatcher } from "./keyword-matcher";
 
 /*
  * §5 overrides: the user re-levels, ignores and adds keywords, and the score
@@ -18,8 +18,10 @@ import { loadKeywordMatcher } from './keyword-matcher';
  * module the panes use, loaded here the same way the server loads it.
  */
 
-const RESUME = 'Senior PHP engineer. Laravel, PostgreSQL, Docker and CI/CD pipelines.';
-const POSTING = 'We need Laravel, Kafka and a lot of Docker. Free snacks and a ping-pong table.';
+const RESUME =
+  "Senior PHP engineer. Laravel, PostgreSQL, Docker and CI/CD pipelines.";
+const POSTING =
+  "We need Laravel, Kafka and a lot of Docker. Free snacks and a ping-pong table.";
 
 /** The matcher is the browser module the panes use — loaded as the server loads it. */
 async function context(resumeText = RESUME) {
@@ -29,9 +31,9 @@ async function context(resumeText = RESUME) {
 function kw(over: Partial<MatchKeyword> & { term: string }): MatchKeyword {
   return {
     priority: 2,
-    requirement: 'preferred',
+    requirement: "preferred",
     primary: false,
-    status: 'present',
+    status: "present",
     aliases: [],
     where: null,
     note: null,
@@ -41,172 +43,377 @@ function kw(over: Partial<MatchKeyword> & { term: string }): MatchKeyword {
 }
 
 const LIST: MatchKeyword[] = [
-  kw({ term: 'Laravel', requirement: 'must', primary: true, priority: 1 }),
-  kw({ term: 'ping-pong table', requirement: 'nice', priority: 4, status: 'cannot_claim' }),
+  kw({ term: "Laravel", requirement: "must", primary: true, priority: 1 }),
+  kw({
+    term: "ping-pong table",
+    requirement: "nice",
+    priority: 4,
+    status: "cannot_claim",
+  }),
 ];
 
-test('re-levelling stores the user level beside the model verdict, and back again resets it', () => {
-  const up = editKeyword(LIST, { op: 'level', term: 'ping-pong table', requirement: 'must' });
+test("re-levelling stores the user level beside the model verdict, and back again resets it", () => {
+  const up = editKeyword(LIST, {
+    op: "level",
+    term: "ping-pong table",
+    requirement: "must",
+  });
   assert.ok(up.ok);
   const row = up.keywords[1]!;
-  assert.equal(row.requirement, 'nice', "the model's own verdict is never overwritten");
-  assert.equal(effectiveRequirement(row), 'must');
+  assert.equal(
+    row.requirement,
+    "nice",
+    "the model's own verdict is never overwritten",
+  );
+  assert.equal(effectiveRequirement(row), "must");
 
-  const back = editKeyword(up.keywords, { op: 'level', term: 'ping-pong table', requirement: 'nice' });
+  const back = editKeyword(up.keywords, {
+    op: "level",
+    term: "ping-pong table",
+    requirement: "nice",
+  });
   assert.ok(back.ok);
-  assert.equal(back.keywords[1]?.override, undefined, 'the model level again means no override at all');
+  assert.equal(
+    back.keywords[1]?.override,
+    undefined,
+    "the model level again means no override at all",
+  );
 });
 
-test('an alias addresses the same row as the term', () => {
-  const list = [kw({ term: 'PostgreSQL', aliases: ['postgres'] })];
-  const r = editKeyword(list, { op: 'ignore', term: 'POSTGRES' });
+test("an alias addresses the same row as the term", () => {
+  const list = [kw({ term: "PostgreSQL", aliases: ["postgres"] })];
+  const r = editKeyword(list, { op: "ignore", term: "POSTGRES" });
   assert.ok(r.ok);
-  assert.equal(r.term, 'PostgreSQL');
+  assert.equal(r.term, "PostgreSQL");
   assert.ok(isIgnored(r.keywords[0]!));
 });
 
-test('an unknown term is refused rather than silently added', () => {
-  const r = editKeyword(LIST, { op: 'ignore', term: 'Kafka' });
+test("an unknown term is refused rather than silently added", () => {
+  const r = editKeyword(LIST, { op: "ignore", term: "Kafka" });
   assert.equal(r.ok, false);
 });
 
-test('ignore drops the row from the effective list; restore brings it back', () => {
-  const off = editKeyword(LIST, { op: 'ignore', term: 'ping-pong table' });
+test("ignore drops the row from the effective list; restore brings it back", () => {
+  const off = editKeyword(LIST, { op: "ignore", term: "ping-pong table" });
   assert.ok(off.ok);
   assert.equal(effectiveKeywords(off.keywords).length, 1);
-  assert.equal(off.keywords.length, 2, 'the row stays stored so the user can undo it');
+  assert.equal(
+    off.keywords.length,
+    2,
+    "the row stays stored so the user can undo it",
+  );
 
-  const on = editKeyword(off.keywords, { op: 'restore', term: 'ping-pong table' });
+  const on = editKeyword(off.keywords, {
+    op: "restore",
+    term: "ping-pong table",
+  });
   assert.ok(on.ok);
   assert.equal(effectiveKeywords(on.keywords).length, 2);
 });
 
-test('ignoring a keyword raises the score without touching the formula', () => {
-  const alignment = { title: 'strong', summary: 'strong', recent_role: 'strong' } as const;
+test("ignoring a keyword raises the score without touching the formula", () => {
+  const alignment = {
+    title: "strong",
+    summary: "strong",
+    recent_role: "strong",
+  } as const;
   const list = [
-    kw({ term: 'Laravel', requirement: 'must', primary: true, status: 'present' }),
-    kw({ term: 'ping-pong table', requirement: 'must', status: 'cannot_claim' }),
+    kw({
+      term: "Laravel",
+      requirement: "must",
+      primary: true,
+      status: "present",
+    }),
+    kw({
+      term: "ping-pong table",
+      requirement: "must",
+      status: "cannot_claim",
+    }),
   ];
   const before = scoreMatch(effectiveKeywords(list), alignment, 0);
   const after = scoreMatch(
-    effectiveKeywords((editKeyword(list, { op: 'ignore', term: 'ping-pong table' }) as { keywords: MatchKeyword[] }).keywords),
+    effectiveKeywords(
+      (
+        editKeyword(list, { op: "ignore", term: "ping-pong table" }) as {
+          keywords: MatchKeyword[];
+        }
+      ).keywords,
+    ),
     alignment,
     0,
   );
   assert.ok(after.score > before.score, `${before.score} → ${after.score}`);
 });
 
-test('reset clears an override on a model row and deletes a row the user added', async () => {
-  const added = addKeyword(LIST, { term: 'Kafka', requirement: 'must' }, await context());
+test("reset clears an override on a model row and deletes a row the user added", async () => {
+  const added = addKeyword(
+    LIST,
+    { term: "Kafka", requirement: "must" },
+    await context(),
+  );
   assert.ok(added.ok);
-  const levelled = editKeyword(added.keywords, { op: 'level', term: 'Laravel', requirement: 'nice' });
+  const levelled = editKeyword(added.keywords, {
+    op: "level",
+    term: "Laravel",
+    requirement: "nice",
+  });
   assert.ok(levelled.ok);
 
-  const clean = editKeyword(levelled.keywords, { op: 'reset', term: 'Laravel' });
+  const clean = editKeyword(levelled.keywords, {
+    op: "reset",
+    term: "Laravel",
+  });
   assert.ok(clean.ok);
   assert.equal(clean.keywords[0]?.override, undefined);
-  assert.equal(effectiveRequirement(clean.keywords[0]!), 'must');
+  assert.equal(effectiveRequirement(clean.keywords[0]!), "must");
 
-  const gone = editKeyword(clean.keywords, { op: 'reset', term: 'Kafka' });
+  const gone = editKeyword(clean.keywords, { op: "reset", term: "Kafka" });
   assert.ok(gone.ok);
   assert.equal(gone.keywords.length, LIST.length);
-  assert.equal(gone.removed, true, 'the row is gone, not reverted — the flash has to say so');
+  assert.equal(
+    gone.removed,
+    true,
+    "the row is gone, not reverted — the flash has to say so",
+  );
 });
 
-test('an added term reads its status from the resume, never from a guess', async () => {
-  const known = addKeyword(LIST, { term: 'Docker', requirement: 'must' }, await context());
+test("an added term reads its status from the resume, never from a guess", async () => {
+  const known = addKeyword(
+    LIST,
+    { term: "Docker", requirement: "must" },
+    await context(),
+  );
   assert.ok(known.ok);
   const docker = known.keywords.at(-1)!;
-  assert.equal(docker.status, 'present', 'written in the resume');
+  assert.equal(docker.status, "present", "written in the resume");
   assert.equal(docker.override?.added, true);
-  assert.equal(docker.unanchored, undefined, 'the posting says Docker too');
+  assert.equal(docker.unanchored, undefined, "the posting says Docker too");
 
-  const missing = addKeyword(LIST, { term: 'Kafka', requirement: 'must' }, await context());
+  const missing = addKeyword(
+    LIST,
+    { term: "Kafka", requirement: "must" },
+    await context(),
+  );
   assert.ok(missing.ok);
-  assert.equal(missing.keywords.at(-1)?.status, 'ask_user', 'not in the resume — a question, not a claim');
+  assert.equal(
+    missing.keywords.at(-1)?.status,
+    "ask_user",
+    "not in the resume — a question, not a claim",
+  );
 });
 
-test('an added term the posting never mentions is flagged unanchored', async () => {
-  const r = addKeyword(LIST, { term: 'Kubernetes', requirement: 'nice' }, await context());
+test("an added term the posting never mentions is flagged unanchored", async () => {
+  const r = addKeyword(
+    LIST,
+    { term: "Kubernetes", requirement: "nice" },
+    await context(),
+  );
   assert.ok(r.ok);
   assert.equal(r.keywords.at(-1)?.unanchored, true);
 });
 
-test('an added term picks up the alias table, so k8s finds Kubernetes', async () => {
-  const r = addKeyword([], { term: 'k8s', requirement: 'nice' }, await context('Ran Kubernetes in prod.'));
+test("an added term picks up the alias table, so k8s finds Kubernetes", async () => {
+  const r = addKeyword(
+    [],
+    { term: "k8s", requirement: "nice" },
+    await context("Ran Kubernetes in prod."),
+  );
   assert.ok(r.ok);
-  assert.equal(r.keywords[0]?.status, 'present');
+  assert.equal(r.keywords[0]?.status, "present");
 });
 
-test('a duplicate is refused, and an ignored duplicate says so', async () => {
-  const dup = addKeyword(LIST, { term: 'laravel', requirement: 'must' }, await context());
+test("a duplicate is refused, and an ignored duplicate says so", async () => {
+  const dup = addKeyword(
+    LIST,
+    { term: "laravel", requirement: "must" },
+    await context(),
+  );
   assert.equal(dup.ok, false);
-  const off = editKeyword(LIST, { op: 'ignore', term: 'Laravel' });
+  const off = editKeyword(LIST, { op: "ignore", term: "Laravel" });
   assert.ok(off.ok);
-  const again = addKeyword(off.keywords, { term: 'Laravel', requirement: 'must' }, await context());
+  const again = addKeyword(
+    off.keywords,
+    { term: "Laravel", requirement: "must" },
+    await context(),
+  );
   assert.equal(again.ok, false);
   assert.match((again as { error: string }).error, /restore/);
 });
 
-test('an empty term is refused, and so is one too long to match anything', async () => {
+test("an empty term is refused, and so is one too long to match anything", async () => {
   const ctx = await context();
-  assert.equal(addKeyword(LIST, { term: '   ', requirement: 'must' }, ctx).ok, false);
-  const long = addKeyword(LIST, { term: 'x'.repeat(61), requirement: 'must' }, ctx);
-  assert.equal(long.ok, false, 'refused, not silently truncated to something that highlights nowhere');
+  assert.equal(
+    addKeyword(LIST, { term: "   ", requirement: "must" }, ctx).ok,
+    false,
+  );
+  const long = addKeyword(
+    LIST,
+    { term: "x".repeat(61), requirement: "must" },
+    ctx,
+  );
+  assert.equal(
+    long.ok,
+    false,
+    "refused, not silently truncated to something that highlights nowhere",
+  );
 });
 
 /* ---------- carrying overrides into the next run ---------- */
 
-test('the next run gets the stored levels and exclusions back', async () => {
+test("the next run gets the stored levels and exclusions back", async () => {
   const previous: MatchKeyword[] = [
-    kw({ term: 'Laravel', requirement: 'must', override: { requirement: 'nice' } }),
-    kw({ term: 'ping-pong table', requirement: 'nice', override: { excluded: true } }),
-    kw({ term: 'Docker', requirement: 'preferred' }),
+    kw({
+      term: "Laravel",
+      requirement: "must",
+      override: { requirement: "nice" },
+    }),
+    kw({
+      term: "ping-pong table",
+      requirement: "nice",
+      override: { excluded: true },
+    }),
+    kw({ term: "Docker", requirement: "preferred" }),
   ];
   const fresh: MatchKeyword[] = [
-    kw({ term: 'Laravel', requirement: 'must' }),
-    kw({ term: 'ping-pong table', requirement: 'preferred' }),
-    kw({ term: 'Docker', requirement: 'must' }),
+    kw({ term: "Laravel", requirement: "must" }),
+    kw({ term: "ping-pong table", requirement: "preferred" }),
+    kw({ term: "Docker", requirement: "must" }),
   ];
   const r = carryOverrides(fresh, previous, await context());
   assert.equal(r.carried, 2);
   assert.equal(r.readded, 0);
-  assert.equal(effectiveRequirement(r.keywords[0]!), 'nice');
+  assert.equal(effectiveRequirement(r.keywords[0]!), "nice");
   assert.ok(isIgnored(r.keywords[1]!));
-  assert.equal(r.keywords[2]?.override, undefined, 'a row the user never touched carries nothing');
+  assert.equal(
+    r.keywords[2]?.override,
+    undefined,
+    "a row the user never touched carries nothing",
+  );
 });
 
-test('a hand-added term the model did not repeat comes back, re-read against the new resume', async () => {
-  const previous = (addKeyword([], { term: 'Kafka', requirement: 'must' }, await context()) as { keywords: MatchKeyword[] }).keywords;
-  assert.equal(previous[0]?.status, 'ask_user');
-  const r = carryOverrides([kw({ term: 'Laravel' })], previous, await context(`${RESUME} Also ran Kafka.`));
+test("a hand-added term the model did not repeat comes back, re-read against the new resume", async () => {
+  const previous = (
+    addKeyword([], { term: "Kafka", requirement: "must" }, await context()) as {
+      keywords: MatchKeyword[];
+    }
+  ).keywords;
+  assert.equal(previous[0]?.status, "ask_user");
+  const r = carryOverrides(
+    [kw({ term: "Laravel" })],
+    previous,
+    await context(`${RESUME} Also ran Kafka.`),
+  );
   assert.equal(r.readded, 1);
-  assert.equal(r.keywords.at(-1)?.term, 'Kafka');
-  assert.equal(r.keywords.at(-1)?.status, 'present', 'written in since the last run');
+  assert.equal(r.keywords.at(-1)?.term, "Kafka");
+  assert.equal(
+    r.keywords.at(-1)?.status,
+    "present",
+    "written in since the last run",
+  );
   assert.equal(r.keywords.at(-1)?.override?.added, true);
 });
 
-test('when the model finally lists a hand-added term, the row is its own but the level stays the user\'s', async () => {
-  const previous = (addKeyword([], { term: 'Kafka', requirement: 'must' }, await context()) as { keywords: MatchKeyword[] }).keywords;
-  const r = carryOverrides([kw({ term: 'Kafka', requirement: 'nice', status: 'cannot_claim' })], previous, await context());
-  assert.equal(r.readded, 0, 'no duplicate row');
+test("when the model finally lists a hand-added term, the row is its own but the level stays the user's", async () => {
+  const previous = (
+    addKeyword([], { term: "Kafka", requirement: "must" }, await context()) as {
+      keywords: MatchKeyword[];
+    }
+  ).keywords;
+  const r = carryOverrides(
+    [kw({ term: "Kafka", requirement: "nice", status: "cannot_claim" })],
+    previous,
+    await context(),
+  );
+  assert.equal(r.readded, 0, "no duplicate row");
   assert.equal(r.keywords.length, 1);
-  assert.equal(r.keywords[0]?.status, 'cannot_claim', "the model's fresh verdict wins");
-  assert.equal(effectiveRequirement(r.keywords[0]!), 'must', 'the level the user picked is still theirs');
+  assert.equal(
+    r.keywords[0]?.status,
+    "cannot_claim",
+    "the model's fresh verdict wins",
+  );
+  assert.equal(
+    effectiveRequirement(r.keywords[0]!),
+    "must",
+    "the level the user picked is still theirs",
+  );
   assert.equal(r.keywords[0]?.override?.added, undefined);
 });
 
-test('an override the model now agrees with is still kept — that is what makes it stick', async () => {
-  const previous = [kw({ term: 'Laravel', requirement: 'must', override: { requirement: 'nice' } })];
+test("an override the model now agrees with is still kept — that is what makes it stick", async () => {
+  const previous = [
+    kw({
+      term: "Laravel",
+      requirement: "must",
+      override: { requirement: "nice" },
+    }),
+  ];
   // The frame told the model "nice", so it says nice this time. Dropping the
   // override here would leave the level at the mercy of the next reply.
-  const r = carryOverrides([kw({ term: 'Laravel', requirement: 'nice' })], previous, await context());
-  assert.equal(r.keywords[0]?.override?.requirement, 'nice');
+  const r = carryOverrides(
+    [kw({ term: "Laravel", requirement: "nice" })],
+    previous,
+    await context(),
+  );
+  assert.equal(r.keywords[0]?.override?.requirement, "nice");
 });
 
-test('an override in the reply is stripped — only the user writes that field', async () => {
-  const fresh = [kw({ term: 'Laravel', requirement: 'must', override: { excluded: true } })];
+test("an override in the reply is stripped — only the user writes that field", async () => {
+  const fresh = [
+    kw({ term: "Laravel", requirement: "must", override: { excluded: true } }),
+  ];
   const r = carryOverrides(fresh, [], await context());
   assert.equal(r.keywords[0]?.override, undefined);
-  assert.equal(effectiveKeywords(r.keywords).length, 1, 'a prompt-injected exclusion cannot drop a must-have');
+  assert.equal(
+    effectiveKeywords(r.keywords).length,
+    1,
+    "a prompt-injected exclusion cannot drop a must-have",
+  );
+});
+
+test("a rebuilt frame keeps every override — the machine guess resets, the human decision does not", async () => {
+  // What "Rebuild keywords" produces (keyword-frame.ts): the model never saw
+  // the old list, so the reply shares neither its order, its levels nor all of
+  // its terms. carryOverrides reads the FULL stored row, not the frame that
+  // was withheld, so all three edits still land.
+  const ctx = await context();
+  const previous = [
+    kw({
+      term: "Laravel",
+      requirement: "must",
+      override: { requirement: "nice" },
+    }),
+    kw({
+      term: "ping-pong",
+      requirement: "nice",
+      override: { excluded: true },
+    }),
+    ...(
+      addKeyword([], { term: "Kafka", requirement: "must" }, ctx) as {
+        keywords: MatchKeyword[];
+      }
+    ).keywords,
+  ];
+  const rebuilt = [
+    kw({ term: "Docker", requirement: "must" }),
+    kw({ term: "ping-pong", requirement: "context" }),
+    kw({ term: "Laravel", requirement: "must" }),
+  ];
+  const r = carryOverrides(rebuilt, previous, ctx);
+  assert.equal(r.carried, 2);
+  assert.equal(
+    r.readded,
+    1,
+    "the term the user added is not the model's to forget",
+  );
+  assert.equal(
+    effectiveRequirement(r.keywords.find((k) => k.term === "Laravel")!),
+    "nice",
+  );
+  assert.ok(isIgnored(r.keywords.find((k) => k.term === "ping-pong")!));
+  assert.equal(r.keywords.at(-1)?.term, "Kafka");
+  assert.equal(
+    r.keywords.find((k) => k.term === "Docker")?.override,
+    undefined,
+    "a term only the rebuild found arrives clean",
+  );
 });

--- a/src/resume/keyword-overrides.test.ts
+++ b/src/resume/keyword-overrides.test.ts
@@ -1,5 +1,5 @@
-import { test } from "node:test";
-import assert from "node:assert/strict";
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import {
   addKeyword,
   carryOverrides,
@@ -7,10 +7,10 @@ import {
   effectiveKeywords,
   effectiveRequirement,
   isIgnored,
-} from "./keyword-overrides";
-import type { MatchKeyword } from "./prompts";
-import { scoreMatch } from "./score";
-import { loadKeywordMatcher } from "./keyword-matcher";
+} from './keyword-overrides';
+import type { MatchKeyword } from './prompts';
+import { scoreMatch } from './score';
+import { loadKeywordMatcher } from './keyword-matcher';
 
 /*
  * §5 overrides: the user re-levels, ignores and adds keywords, and the score
@@ -18,10 +18,8 @@ import { loadKeywordMatcher } from "./keyword-matcher";
  * module the panes use, loaded here the same way the server loads it.
  */
 
-const RESUME =
-  "Senior PHP engineer. Laravel, PostgreSQL, Docker and CI/CD pipelines.";
-const POSTING =
-  "We need Laravel, Kafka and a lot of Docker. Free snacks and a ping-pong table.";
+const RESUME = 'Senior PHP engineer. Laravel, PostgreSQL, Docker and CI/CD pipelines.';
+const POSTING = 'We need Laravel, Kafka and a lot of Docker. Free snacks and a ping-pong table.';
 
 /** The matcher is the browser module the panes use — loaded as the server loads it. */
 async function context(resumeText = RESUME) {
@@ -31,9 +29,9 @@ async function context(resumeText = RESUME) {
 function kw(over: Partial<MatchKeyword> & { term: string }): MatchKeyword {
   return {
     priority: 2,
-    requirement: "preferred",
+    requirement: 'preferred',
     primary: false,
-    status: "present",
+    status: 'present',
     aliases: [],
     where: null,
     note: null,
@@ -43,377 +41,201 @@ function kw(over: Partial<MatchKeyword> & { term: string }): MatchKeyword {
 }
 
 const LIST: MatchKeyword[] = [
-  kw({ term: "Laravel", requirement: "must", primary: true, priority: 1 }),
-  kw({
-    term: "ping-pong table",
-    requirement: "nice",
-    priority: 4,
-    status: "cannot_claim",
-  }),
+  kw({ term: 'Laravel', requirement: 'must', primary: true, priority: 1 }),
+  kw({ term: 'ping-pong table', requirement: 'nice', priority: 4, status: 'cannot_claim' }),
 ];
 
-test("re-levelling stores the user level beside the model verdict, and back again resets it", () => {
-  const up = editKeyword(LIST, {
-    op: "level",
-    term: "ping-pong table",
-    requirement: "must",
-  });
+test('re-levelling stores the user level beside the model verdict, and back again resets it', () => {
+  const up = editKeyword(LIST, { op: 'level', term: 'ping-pong table', requirement: 'must' });
   assert.ok(up.ok);
   const row = up.keywords[1]!;
-  assert.equal(
-    row.requirement,
-    "nice",
-    "the model's own verdict is never overwritten",
-  );
-  assert.equal(effectiveRequirement(row), "must");
+  assert.equal(row.requirement, 'nice', "the model's own verdict is never overwritten");
+  assert.equal(effectiveRequirement(row), 'must');
 
-  const back = editKeyword(up.keywords, {
-    op: "level",
-    term: "ping-pong table",
-    requirement: "nice",
-  });
+  const back = editKeyword(up.keywords, { op: 'level', term: 'ping-pong table', requirement: 'nice' });
   assert.ok(back.ok);
-  assert.equal(
-    back.keywords[1]?.override,
-    undefined,
-    "the model level again means no override at all",
-  );
+  assert.equal(back.keywords[1]?.override, undefined, 'the model level again means no override at all');
 });
 
-test("an alias addresses the same row as the term", () => {
-  const list = [kw({ term: "PostgreSQL", aliases: ["postgres"] })];
-  const r = editKeyword(list, { op: "ignore", term: "POSTGRES" });
+test('an alias addresses the same row as the term', () => {
+  const list = [kw({ term: 'PostgreSQL', aliases: ['postgres'] })];
+  const r = editKeyword(list, { op: 'ignore', term: 'POSTGRES' });
   assert.ok(r.ok);
-  assert.equal(r.term, "PostgreSQL");
+  assert.equal(r.term, 'PostgreSQL');
   assert.ok(isIgnored(r.keywords[0]!));
 });
 
-test("an unknown term is refused rather than silently added", () => {
-  const r = editKeyword(LIST, { op: "ignore", term: "Kafka" });
+test('an unknown term is refused rather than silently added', () => {
+  const r = editKeyword(LIST, { op: 'ignore', term: 'Kafka' });
   assert.equal(r.ok, false);
 });
 
-test("ignore drops the row from the effective list; restore brings it back", () => {
-  const off = editKeyword(LIST, { op: "ignore", term: "ping-pong table" });
+test('ignore drops the row from the effective list; restore brings it back', () => {
+  const off = editKeyword(LIST, { op: 'ignore', term: 'ping-pong table' });
   assert.ok(off.ok);
   assert.equal(effectiveKeywords(off.keywords).length, 1);
-  assert.equal(
-    off.keywords.length,
-    2,
-    "the row stays stored so the user can undo it",
-  );
+  assert.equal(off.keywords.length, 2, 'the row stays stored so the user can undo it');
 
-  const on = editKeyword(off.keywords, {
-    op: "restore",
-    term: "ping-pong table",
-  });
+  const on = editKeyword(off.keywords, { op: 'restore', term: 'ping-pong table' });
   assert.ok(on.ok);
   assert.equal(effectiveKeywords(on.keywords).length, 2);
 });
 
-test("ignoring a keyword raises the score without touching the formula", () => {
-  const alignment = {
-    title: "strong",
-    summary: "strong",
-    recent_role: "strong",
-  } as const;
+test('ignoring a keyword raises the score without touching the formula', () => {
+  const alignment = { title: 'strong', summary: 'strong', recent_role: 'strong' } as const;
   const list = [
-    kw({
-      term: "Laravel",
-      requirement: "must",
-      primary: true,
-      status: "present",
-    }),
-    kw({
-      term: "ping-pong table",
-      requirement: "must",
-      status: "cannot_claim",
-    }),
+    kw({ term: 'Laravel', requirement: 'must', primary: true, status: 'present' }),
+    kw({ term: 'ping-pong table', requirement: 'must', status: 'cannot_claim' }),
   ];
   const before = scoreMatch(effectiveKeywords(list), alignment, 0);
   const after = scoreMatch(
-    effectiveKeywords(
-      (
-        editKeyword(list, { op: "ignore", term: "ping-pong table" }) as {
-          keywords: MatchKeyword[];
-        }
-      ).keywords,
-    ),
+    effectiveKeywords((editKeyword(list, { op: 'ignore', term: 'ping-pong table' }) as { keywords: MatchKeyword[] }).keywords),
     alignment,
     0,
   );
   assert.ok(after.score > before.score, `${before.score} → ${after.score}`);
 });
 
-test("reset clears an override on a model row and deletes a row the user added", async () => {
-  const added = addKeyword(
-    LIST,
-    { term: "Kafka", requirement: "must" },
-    await context(),
-  );
+test('reset clears an override on a model row and deletes a row the user added', async () => {
+  const added = addKeyword(LIST, { term: 'Kafka', requirement: 'must' }, await context());
   assert.ok(added.ok);
-  const levelled = editKeyword(added.keywords, {
-    op: "level",
-    term: "Laravel",
-    requirement: "nice",
-  });
+  const levelled = editKeyword(added.keywords, { op: 'level', term: 'Laravel', requirement: 'nice' });
   assert.ok(levelled.ok);
 
-  const clean = editKeyword(levelled.keywords, {
-    op: "reset",
-    term: "Laravel",
-  });
+  const clean = editKeyword(levelled.keywords, { op: 'reset', term: 'Laravel' });
   assert.ok(clean.ok);
   assert.equal(clean.keywords[0]?.override, undefined);
-  assert.equal(effectiveRequirement(clean.keywords[0]!), "must");
+  assert.equal(effectiveRequirement(clean.keywords[0]!), 'must');
 
-  const gone = editKeyword(clean.keywords, { op: "reset", term: "Kafka" });
+  const gone = editKeyword(clean.keywords, { op: 'reset', term: 'Kafka' });
   assert.ok(gone.ok);
   assert.equal(gone.keywords.length, LIST.length);
-  assert.equal(
-    gone.removed,
-    true,
-    "the row is gone, not reverted — the flash has to say so",
-  );
+  assert.equal(gone.removed, true, 'the row is gone, not reverted — the flash has to say so');
 });
 
-test("an added term reads its status from the resume, never from a guess", async () => {
-  const known = addKeyword(
-    LIST,
-    { term: "Docker", requirement: "must" },
-    await context(),
-  );
+test('an added term reads its status from the resume, never from a guess', async () => {
+  const known = addKeyword(LIST, { term: 'Docker', requirement: 'must' }, await context());
   assert.ok(known.ok);
   const docker = known.keywords.at(-1)!;
-  assert.equal(docker.status, "present", "written in the resume");
+  assert.equal(docker.status, 'present', 'written in the resume');
   assert.equal(docker.override?.added, true);
-  assert.equal(docker.unanchored, undefined, "the posting says Docker too");
+  assert.equal(docker.unanchored, undefined, 'the posting says Docker too');
 
-  const missing = addKeyword(
-    LIST,
-    { term: "Kafka", requirement: "must" },
-    await context(),
-  );
+  const missing = addKeyword(LIST, { term: 'Kafka', requirement: 'must' }, await context());
   assert.ok(missing.ok);
-  assert.equal(
-    missing.keywords.at(-1)?.status,
-    "ask_user",
-    "not in the resume — a question, not a claim",
-  );
+  assert.equal(missing.keywords.at(-1)?.status, 'ask_user', 'not in the resume — a question, not a claim');
 });
 
-test("an added term the posting never mentions is flagged unanchored", async () => {
-  const r = addKeyword(
-    LIST,
-    { term: "Kubernetes", requirement: "nice" },
-    await context(),
-  );
+test('an added term the posting never mentions is flagged unanchored', async () => {
+  const r = addKeyword(LIST, { term: 'Kubernetes', requirement: 'nice' }, await context());
   assert.ok(r.ok);
   assert.equal(r.keywords.at(-1)?.unanchored, true);
 });
 
-test("an added term picks up the alias table, so k8s finds Kubernetes", async () => {
-  const r = addKeyword(
-    [],
-    { term: "k8s", requirement: "nice" },
-    await context("Ran Kubernetes in prod."),
-  );
+test('an added term picks up the alias table, so k8s finds Kubernetes', async () => {
+  const r = addKeyword([], { term: 'k8s', requirement: 'nice' }, await context('Ran Kubernetes in prod.'));
   assert.ok(r.ok);
-  assert.equal(r.keywords[0]?.status, "present");
+  assert.equal(r.keywords[0]?.status, 'present');
 });
 
-test("a duplicate is refused, and an ignored duplicate says so", async () => {
-  const dup = addKeyword(
-    LIST,
-    { term: "laravel", requirement: "must" },
-    await context(),
-  );
+test('a duplicate is refused, and an ignored duplicate says so', async () => {
+  const dup = addKeyword(LIST, { term: 'laravel', requirement: 'must' }, await context());
   assert.equal(dup.ok, false);
-  const off = editKeyword(LIST, { op: "ignore", term: "Laravel" });
+  const off = editKeyword(LIST, { op: 'ignore', term: 'Laravel' });
   assert.ok(off.ok);
-  const again = addKeyword(
-    off.keywords,
-    { term: "Laravel", requirement: "must" },
-    await context(),
-  );
+  const again = addKeyword(off.keywords, { term: 'Laravel', requirement: 'must' }, await context());
   assert.equal(again.ok, false);
   assert.match((again as { error: string }).error, /restore/);
 });
 
-test("an empty term is refused, and so is one too long to match anything", async () => {
+test('an empty term is refused, and so is one too long to match anything', async () => {
   const ctx = await context();
-  assert.equal(
-    addKeyword(LIST, { term: "   ", requirement: "must" }, ctx).ok,
-    false,
-  );
-  const long = addKeyword(
-    LIST,
-    { term: "x".repeat(61), requirement: "must" },
-    ctx,
-  );
-  assert.equal(
-    long.ok,
-    false,
-    "refused, not silently truncated to something that highlights nowhere",
-  );
+  assert.equal(addKeyword(LIST, { term: '   ', requirement: 'must' }, ctx).ok, false);
+  const long = addKeyword(LIST, { term: 'x'.repeat(61), requirement: 'must' }, ctx);
+  assert.equal(long.ok, false, 'refused, not silently truncated to something that highlights nowhere');
 });
 
 /* ---------- carrying overrides into the next run ---------- */
 
-test("the next run gets the stored levels and exclusions back", async () => {
+test('the next run gets the stored levels and exclusions back', async () => {
   const previous: MatchKeyword[] = [
-    kw({
-      term: "Laravel",
-      requirement: "must",
-      override: { requirement: "nice" },
-    }),
-    kw({
-      term: "ping-pong table",
-      requirement: "nice",
-      override: { excluded: true },
-    }),
-    kw({ term: "Docker", requirement: "preferred" }),
+    kw({ term: 'Laravel', requirement: 'must', override: { requirement: 'nice' } }),
+    kw({ term: 'ping-pong table', requirement: 'nice', override: { excluded: true } }),
+    kw({ term: 'Docker', requirement: 'preferred' }),
   ];
   const fresh: MatchKeyword[] = [
-    kw({ term: "Laravel", requirement: "must" }),
-    kw({ term: "ping-pong table", requirement: "preferred" }),
-    kw({ term: "Docker", requirement: "must" }),
+    kw({ term: 'Laravel', requirement: 'must' }),
+    kw({ term: 'ping-pong table', requirement: 'preferred' }),
+    kw({ term: 'Docker', requirement: 'must' }),
   ];
   const r = carryOverrides(fresh, previous, await context());
   assert.equal(r.carried, 2);
   assert.equal(r.readded, 0);
-  assert.equal(effectiveRequirement(r.keywords[0]!), "nice");
+  assert.equal(effectiveRequirement(r.keywords[0]!), 'nice');
   assert.ok(isIgnored(r.keywords[1]!));
-  assert.equal(
-    r.keywords[2]?.override,
-    undefined,
-    "a row the user never touched carries nothing",
-  );
+  assert.equal(r.keywords[2]?.override, undefined, 'a row the user never touched carries nothing');
 });
 
-test("a hand-added term the model did not repeat comes back, re-read against the new resume", async () => {
-  const previous = (
-    addKeyword([], { term: "Kafka", requirement: "must" }, await context()) as {
-      keywords: MatchKeyword[];
-    }
-  ).keywords;
-  assert.equal(previous[0]?.status, "ask_user");
-  const r = carryOverrides(
-    [kw({ term: "Laravel" })],
-    previous,
-    await context(`${RESUME} Also ran Kafka.`),
-  );
+test('a hand-added term the model did not repeat comes back, re-read against the new resume', async () => {
+  const previous = (addKeyword([], { term: 'Kafka', requirement: 'must' }, await context()) as { keywords: MatchKeyword[] }).keywords;
+  assert.equal(previous[0]?.status, 'ask_user');
+  const r = carryOverrides([kw({ term: 'Laravel' })], previous, await context(`${RESUME} Also ran Kafka.`));
   assert.equal(r.readded, 1);
-  assert.equal(r.keywords.at(-1)?.term, "Kafka");
-  assert.equal(
-    r.keywords.at(-1)?.status,
-    "present",
-    "written in since the last run",
-  );
+  assert.equal(r.keywords.at(-1)?.term, 'Kafka');
+  assert.equal(r.keywords.at(-1)?.status, 'present', 'written in since the last run');
   assert.equal(r.keywords.at(-1)?.override?.added, true);
 });
 
-test("when the model finally lists a hand-added term, the row is its own but the level stays the user's", async () => {
-  const previous = (
-    addKeyword([], { term: "Kafka", requirement: "must" }, await context()) as {
-      keywords: MatchKeyword[];
-    }
-  ).keywords;
-  const r = carryOverrides(
-    [kw({ term: "Kafka", requirement: "nice", status: "cannot_claim" })],
-    previous,
-    await context(),
-  );
-  assert.equal(r.readded, 0, "no duplicate row");
+test('when the model finally lists a hand-added term, the row is its own but the level stays the user\'s', async () => {
+  const previous = (addKeyword([], { term: 'Kafka', requirement: 'must' }, await context()) as { keywords: MatchKeyword[] }).keywords;
+  const r = carryOverrides([kw({ term: 'Kafka', requirement: 'nice', status: 'cannot_claim' })], previous, await context());
+  assert.equal(r.readded, 0, 'no duplicate row');
   assert.equal(r.keywords.length, 1);
-  assert.equal(
-    r.keywords[0]?.status,
-    "cannot_claim",
-    "the model's fresh verdict wins",
-  );
-  assert.equal(
-    effectiveRequirement(r.keywords[0]!),
-    "must",
-    "the level the user picked is still theirs",
-  );
+  assert.equal(r.keywords[0]?.status, 'cannot_claim', "the model's fresh verdict wins");
+  assert.equal(effectiveRequirement(r.keywords[0]!), 'must', 'the level the user picked is still theirs');
   assert.equal(r.keywords[0]?.override?.added, undefined);
 });
 
-test("an override the model now agrees with is still kept — that is what makes it stick", async () => {
-  const previous = [
-    kw({
-      term: "Laravel",
-      requirement: "must",
-      override: { requirement: "nice" },
-    }),
-  ];
+test('an override the model now agrees with is still kept — that is what makes it stick', async () => {
+  const previous = [kw({ term: 'Laravel', requirement: 'must', override: { requirement: 'nice' } })];
   // The frame told the model "nice", so it says nice this time. Dropping the
   // override here would leave the level at the mercy of the next reply.
-  const r = carryOverrides(
-    [kw({ term: "Laravel", requirement: "nice" })],
-    previous,
-    await context(),
-  );
-  assert.equal(r.keywords[0]?.override?.requirement, "nice");
+  const r = carryOverrides([kw({ term: 'Laravel', requirement: 'nice' })], previous, await context());
+  assert.equal(r.keywords[0]?.override?.requirement, 'nice');
 });
 
-test("an override in the reply is stripped — only the user writes that field", async () => {
-  const fresh = [
-    kw({ term: "Laravel", requirement: "must", override: { excluded: true } }),
-  ];
+test('an override in the reply is stripped — only the user writes that field', async () => {
+  const fresh = [kw({ term: 'Laravel', requirement: 'must', override: { excluded: true } })];
   const r = carryOverrides(fresh, [], await context());
   assert.equal(r.keywords[0]?.override, undefined);
-  assert.equal(
-    effectiveKeywords(r.keywords).length,
-    1,
-    "a prompt-injected exclusion cannot drop a must-have",
-  );
+  assert.equal(effectiveKeywords(r.keywords).length, 1, 'a prompt-injected exclusion cannot drop a must-have');
 });
 
-test("a rebuilt frame keeps every override — the machine guess resets, the human decision does not", async () => {
+test('a rebuilt frame keeps every override — the machine guess resets, the human decision does not', async () => {
   // What "Rebuild keywords" produces (keyword-frame.ts): the model never saw
   // the old list, so the reply shares neither its order, its levels nor all of
   // its terms. carryOverrides reads the FULL stored row, not the frame that
   // was withheld, so all three edits still land.
   const ctx = await context();
   const previous = [
-    kw({
-      term: "Laravel",
-      requirement: "must",
-      override: { requirement: "nice" },
-    }),
-    kw({
-      term: "ping-pong",
-      requirement: "nice",
-      override: { excluded: true },
-    }),
-    ...(
-      addKeyword([], { term: "Kafka", requirement: "must" }, ctx) as {
-        keywords: MatchKeyword[];
-      }
-    ).keywords,
+    kw({ term: 'Laravel', requirement: 'must', override: { requirement: 'nice' } }),
+    kw({ term: 'ping-pong', requirement: 'nice', override: { excluded: true } }),
+    ...(addKeyword([], { term: 'Kafka', requirement: 'must' }, ctx) as { keywords: MatchKeyword[] }).keywords,
   ];
   const rebuilt = [
-    kw({ term: "Docker", requirement: "must" }),
-    kw({ term: "ping-pong", requirement: "context" }),
-    kw({ term: "Laravel", requirement: "must" }),
+    kw({ term: 'Docker', requirement: 'must' }),
+    kw({ term: 'ping-pong', requirement: 'context' }),
+    kw({ term: 'Laravel', requirement: 'must' }),
   ];
   const r = carryOverrides(rebuilt, previous, ctx);
   assert.equal(r.carried, 2);
+  assert.equal(r.readded, 1, "the term the user added is not the model's to forget");
+  assert.equal(effectiveRequirement(r.keywords.find((k) => k.term === 'Laravel')!), 'nice');
+  assert.ok(isIgnored(r.keywords.find((k) => k.term === 'ping-pong')!));
+  assert.equal(r.keywords.at(-1)?.term, 'Kafka');
   assert.equal(
-    r.readded,
-    1,
-    "the term the user added is not the model's to forget",
-  );
-  assert.equal(
-    effectiveRequirement(r.keywords.find((k) => k.term === "Laravel")!),
-    "nice",
-  );
-  assert.ok(isIgnored(r.keywords.find((k) => k.term === "ping-pong")!));
-  assert.equal(r.keywords.at(-1)?.term, "Kafka");
-  assert.equal(
-    r.keywords.find((k) => k.term === "Docker")?.override,
+    r.keywords.find((k) => k.term === 'Docker')?.override,
     undefined,
-    "a term only the rebuild found arrives clean",
+    'a term only the rebuild found arrives clean',
   );
 });

--- a/src/resume/match-mode.test.ts
+++ b/src/resume/match-mode.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFrameReason } from './keyword-frame';
 import { parseMatchMode, readMatchMode, storedBreakdown, withSuggestionsMode } from './match-mode';
 import { scoreMatch } from './score';
 
@@ -19,13 +20,15 @@ test('readMatchMode: the marker, and "full" for rows written before it', () => {
   assert.equal(readMatchMode(null), 'full');
 });
 
-test('storedBreakdown carries the score parts and both markers', () => {
+test('storedBreakdown carries the score parts and all three markers', () => {
   const bd = scoreMatch([], null, 0);
-  const stored = storedBreakdown(bd, { promptVersion: 6, mode: 'fast' });
+  const stored = storedBreakdown(bd, { promptVersion: 6, mode: 'fast', frame: 'rebuild' });
   assert.equal(stored.score, bd.score);
   assert.equal(stored.promptVersion, 6);
   assert.equal(stored.mode, 'fast');
+  assert.equal(stored.frame, 'rebuild');
   assert.equal(readMatchMode(stored), 'fast');
+  assert.equal(readFrameReason(stored), 'rebuild');
 });
 
 test('withSuggestionsMode flips a stored JSON to full and keeps everything else', () => {

--- a/src/resume/match-mode.ts
+++ b/src/resume/match-mode.ts
@@ -1,3 +1,4 @@
+import type { FrameReason } from './keyword-frame';
 import type { ScoreBreakdown } from './score';
 
 /*
@@ -23,12 +24,17 @@ export function readMatchMode(breakdown: unknown): MatchMode {
   return (breakdown as { mode?: unknown }).mode === 'fast' ? 'fast' : 'full';
 }
 
-/** What store.ts writes into the JSON column: the score parts plus both markers. */
+/**
+ * What store.ts writes into the JSON column: the score parts plus the three
+ * markers. Every field is required, so the compiler names any write that would
+ * drop one — a re-score that forgets `frame` would silently make an
+ * incomparable score look comparable again.
+ */
 export function storedBreakdown(
   bd: ScoreBreakdown,
-  meta: { promptVersion: number | null; mode: MatchMode },
+  meta: { promptVersion: number | null; mode: MatchMode; frame: FrameReason | null },
 ): Record<string, unknown> {
-  return { ...bd, promptVersion: meta.promptVersion, mode: meta.mode };
+  return { ...bd, promptVersion: meta.promptVersion, mode: meta.mode, frame: meta.frame };
 }
 
 /** The same JSON after suggestions were added — the row is now a full analysis. */

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -15,6 +15,7 @@ import { annotateElsewhere, applyFacts } from './facts';
 import { withTableAliases } from './keyword-aliases';
 import { carryOverrides, effectiveKeywords } from './keyword-overrides';
 import { anchorKeywords } from './keyword-anchor';
+import { planKeywordFrame } from './keyword-frame';
 import { loadKeywordMatcher } from './keyword-matcher';
 import { readMatchMode, type MatchMode } from './match-mode';
 import { readPromptVersion, reuseDecision } from './match-reuse';
@@ -43,11 +44,13 @@ const PARSE_ATTEMPTS = 2;
  *
  * `mode` picks the prompt variant (ADR 0029): the quick check (default)
  * returns the score-complete subset, "full" also writes the suggestions.
+ * `rebuild` throws away the keyword frame this posting has been carrying and
+ * lets the model read the terms out of the description again (issue #79).
  */
 export async function matchResumeToJob(
   resume: { id: number; text: string; version: number },
   job: MatchJobInput & { id: number },
-  opts: { draft?: boolean; mode?: MatchMode } = {},
+  opts: { draft?: boolean; mode?: MatchMode; rebuild?: boolean } = {},
 ): Promise<ResumeMatch | null> {
   const mode = opts.mode ?? 'fast';
   const [facts, otherSkills, previousMatch, matcher] = await Promise.all([
@@ -58,8 +61,16 @@ export async function matchResumeToJob(
   ]);
   // The user's own edits to the last frame for this posting: the levels they
   // set go into the prompt, and carryOverrides puts every override back on the
-  // fresh reply below, so an override sticks to the posting (§5).
+  // fresh reply below, so an override sticks to the posting (§5) — including
+  // when the frame itself is dropped.
   const storedKeywords = previousMatch ? readKeywords(previousMatch.keywords) : [];
+  const frame = planKeywordFrame(
+    previousMatch
+      ? { terms: storedKeywords.length, promptVersion: readPromptVersion(previousMatch.breakdown) }
+      : null,
+    PROMPT_VERSION,
+    opts.rebuild ?? false,
+  );
   const context: MatchContext = {
     confirmedFacts: facts.filter((f) => f.status === 'confirmed').map((f) => ({ term: f.term, note: f.note })),
     deniedTerms: facts.filter((f) => f.status === 'denied').map((f) => f.term),
@@ -67,9 +78,11 @@ export async function matchResumeToJob(
     // The previous run's keyword frame keeps terms/levels stable across
     // versions, so a better resume shows up as a better number. Terms the user
     // ignored are left out of it — asking for them back would be noise.
-    previousKeywords: effectiveKeywords(storedKeywords)
-      .slice(0, PREVIOUS_KEYWORDS_MAX)
-      .map((k) => ({ term: k.term, priority: k.priority, requirement: k.requirement, primary: k.primary })),
+    previousKeywords: frame.carry
+      ? effectiveKeywords(storedKeywords)
+          .slice(0, PREVIOUS_KEYWORDS_MAX)
+          .map((k) => ({ term: k.term, priority: k.priority, requirement: k.requirement, primary: k.primary }))
+      : undefined,
   };
   const prompt = buildMatchPrompt(resume.text, job, mode, context);
   const ai = await getAiRuntime();
@@ -119,6 +132,7 @@ export async function matchResumeToJob(
         breakdown,
         promptVersion: PROMPT_VERSION,
         mode,
+        frame: frame.reason,
       });
       logger.info(
         {
@@ -135,6 +149,7 @@ export async function matchResumeToJob(
           unanchored: anchor.unanchored,
           overrides: carry.carried,
           readded: carry.readded,
+          frame: frame.reason,
           promptVersion: PROMPT_VERSION,
           chars: out.text.length,
           ms: Date.now() - started,

--- a/src/resume/store.ts
+++ b/src/resume/store.ts
@@ -1,6 +1,7 @@
 import type { CandidateFact, CoverLetter, Prisma, Resume, ResumeMatch } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../logger';
+import type { FrameReason } from './keyword-frame';
 import { storedBreakdown, withSuggestionsMode, type MatchMode } from './match-mode';
 import type { MatchKeyword, MatchSuggestions, ResumeMatchResult, ResumeScan } from './prompts';
 import type { ScoreBreakdown } from './score';
@@ -225,9 +226,10 @@ export async function createMatch(input: {
   result: ResumeMatchResult;
   /** Computed by score.ts — the model never sets the number (ADR 0012). */
   breakdown: ScoreBreakdown;
-  /** Both ride inside the breakdown JSON — the memo key (match-reuse.ts) and the row's shape (ADR 0029). */
+  /** All three ride inside the breakdown JSON — the memo key (match-reuse.ts), the row's shape (ADR 0029) and where its keyword frame came from (keyword-frame.ts). */
   promptVersion: number;
   mode: MatchMode;
+  frame: FrameReason;
 }): Promise<ResumeMatch> {
   const r = input.result;
   return prisma.resumeMatch.create({
@@ -264,7 +266,14 @@ export async function getLatestMatchForJob(jobId: number): Promise<ResumeMatch |
 /** A fact flip recomputes the stored score deterministically — no AI call. */
 export async function updateMatchScoring(
   id: number,
-  input: { keywords: MatchKeyword[]; breakdown: ScoreBreakdown; promptVersion: number | null; mode: MatchMode },
+  input: {
+    keywords: MatchKeyword[];
+    breakdown: ScoreBreakdown;
+    /** The row's own markers, read off it and written back — a re-score changes the number, never what the row is. */
+    promptVersion: number | null;
+    mode: MatchMode;
+    frame: FrameReason | null;
+  },
 ): Promise<ResumeMatch> {
   return prisma.resumeMatch.update({
     where: { id },

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -84,7 +84,6 @@ export interface RebuildTarget {
   mode: MatchMode;
   /** The analysed text when it was an unsaved draft: re-judged as is, so the frame is the only thing that changes. */
   draftText?: string;
-  next?: 'target';
   formId?: string;
 }
 
@@ -662,8 +661,9 @@ export const KeywordTable: FC<{
  * own keyword edits are re-applied to whatever comes back — a rebuild resets
  * the model's guess, not their decisions.
  */
-const REBUILD_TITLE =
-  'Runs the analysis once without the stored keyword list, so the model reads the terms out of the posting again (~½ min). Your own keyword edits are kept; the new score counts a different set of terms.';
+function rebuildTitle(mode: MatchMode): string {
+  return `Runs this ${mode === 'fast' ? 'check (~½ min on Opus)' : 'full analysis (~2 min on Opus)'} once without the stored keyword list, so the model reads the terms out of the posting again. Your own keyword edits are kept; the new score counts a different set of terms.`;
+}
 
 const RebuildKeywords: FC<{ target: RebuildTarget }> = ({ target }) =>
   target.formId ? (
@@ -671,7 +671,7 @@ const RebuildKeywords: FC<{ target: RebuildTarget }> = ({ target }) =>
       type="submit"
       form={target.formId}
       class={`${ROW_LINK} ml-auto`}
-      title={REBUILD_TITLE}
+      title={rebuildTitle(target.mode)}
       onclick={`this.form.elements.rebuild.value='1';this.form.elements.mode.value='${target.mode}'`}
     >
       Rebuild keywords
@@ -681,11 +681,10 @@ const RebuildKeywords: FC<{ target: RebuildTarget }> = ({ target }) =>
       <input type="hidden" name="resumeId" value={String(target.resumeId)} />
       <input type="hidden" name="mode" value={target.mode} />
       <input type="hidden" name="rebuild" value="1" />
-      {target.next && <input type="hidden" name="next" value={target.next} />}
       {/* A draft row was judged on text no version holds — send it back, or the
           rebuild would quietly score the stored resume instead. */}
       {target.draftText !== undefined && <input type="hidden" name="draftText" value={target.draftText} />}
-      <button type="submit" class={ROW_LINK} title={REBUILD_TITLE}>
+      <button type="submit" class={ROW_LINK} title={rebuildTitle(target.mode)}>
         Rebuild keywords
       </button>
     </form>

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -29,7 +29,8 @@ import {
   type MatchHardRequirement,
   type MatchKeyword,
 } from '../../resume/prompts';
-import { readMatchMode } from '../../resume/match-mode';
+import { freshFrame, freshFrameNotice } from '../../resume/keyword-frame';
+import { readMatchMode, type MatchMode } from '../../resume/match-mode';
 import type { CountedKeyword } from '../../resume/keyword-matcher';
 import { effectiveRequirement, isIgnored } from '../../resume/keyword-overrides';
 import { REQUIREMENT_LEVELS, type RequirementLevel } from '../../resume/score';
@@ -70,6 +71,21 @@ export interface KeywordEditTarget {
   jobId: number;
   matchId: number;
   back: string;
+}
+
+/**
+ * What "Rebuild keywords" needs to re-run this comparison (issue #79). The
+ * targeted view passes `formId` so its own form — the one carrying the live
+ * editor text — is submitted instead of ours.
+ */
+export interface RebuildTarget {
+  jobId: number;
+  resumeId: number;
+  mode: MatchMode;
+  /** The analysed text when it was an unsaved draft: re-judged as is, so the frame is the only thing that changes. */
+  draftText?: string;
+  next?: 'target';
+  formId?: string;
 }
 
 const HARD_VIEW: Record<MatchHardRequirement['status'], { label: string; tone: Tone }> = {
@@ -312,7 +328,9 @@ export const MatchReport: FC<{
   factsBack: string;
 }> = ({ match, previous, keywords, factsBack }) => {
   const bd = readBreakdown(match.breakdown);
-  const scoreDelta = previous ? match.matchScore - previous.matchScore : null;
+  // A re-extracted frame counts different terms, so the older number is not a
+  // baseline for this one (keyword-frame.ts). DeltaBox says so in words.
+  const scoreDelta = previous && !freshFrame(match.breakdown) ? match.matchScore - previous.matchScore : null;
   return (
     <div class="mt-5 space-y-5 border-t border-line pt-4">
       <div class="flex flex-wrap items-center gap-3">
@@ -364,6 +382,12 @@ export const MatchReport: FC<{
       <KeywordTable
         keywords={keywords}
         edit={bd ? { jobId: match.jobId, matchId: match.id, back: factsBack } : undefined}
+        rebuild={{
+          jobId: match.jobId,
+          resumeId: match.resumeId,
+          mode: readMatchMode(match.breakdown),
+          ...(match.draft ? { draftText: match.resumeText } : {}),
+        }}
       />
     </div>
   );
@@ -399,6 +423,15 @@ export const DeltaBox: FC<{ match: MatchWithResume; previous: MatchWithResume | 
   previous,
 }) => {
   if (!previous) return null;
+  const fresh = freshFrame(match.breakdown);
+  if (fresh) {
+    return (
+      <div class="rounded-md border border-line bg-surface-overlay/50 px-3 py-2 text-xs leading-5 text-ink-muted">
+        <span class="font-medium text-ink">Not comparable with v{previous.resumeVersion}: </span>
+        {freshFrameNotice(fresh)}
+      </div>
+    );
+  }
   const delta = diffMatches(
     { keywords: readKeywords(previous.keywords), breakdown: readBreakdown(previous.breakdown) },
     { keywords: readKeywords(match.keywords), breakdown: readBreakdown(match.breakdown) },
@@ -568,10 +601,11 @@ export const RemovalsBlock: FC<{ removals: ReturnType<typeof readRemovals>; jump
  * and a form to add a term the model missed. Each is a plain POST that
  * recomputes the score in code — no AI call.
  */
-export const KeywordTable: FC<{ keywords: CountedKeyword[]; edit?: KeywordEditTarget }> = ({
-  keywords,
-  edit,
-}) => {
+export const KeywordTable: FC<{
+  keywords: CountedKeyword[];
+  edit?: KeywordEditTarget;
+  rebuild?: RebuildTarget;
+}> = ({ keywords, edit, rebuild }) => {
   if (keywords.length === 0) return null;
   const ignored = keywords.filter(isIgnored);
   const counted = keywords.filter((k) => !isIgnored(k));
@@ -579,9 +613,12 @@ export const KeywordTable: FC<{ keywords: CountedKeyword[]; edit?: KeywordEditTa
   const matchedKeywords = counted.filter((k) => k.status === 'present');
   return (
     <div class="-mx-5 -mb-5 border-t border-line">
-      <div class="px-5 py-3 text-[13px] font-medium text-ink-muted">
-        Keyword coverage — {matchedKeywords.length} of {counted.length} matched
-        {ignored.length > 0 ? ` · ${ignored.length} ignored` : ''}
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 px-5 py-3 text-[13px] font-medium text-ink-muted">
+        <span>
+          Keyword coverage — {matchedKeywords.length} of {counted.length} matched
+          {ignored.length > 0 ? ` · ${ignored.length} ignored` : ''}
+        </span>
+        {rebuild && <RebuildKeywords target={rebuild} />}
       </div>
       {attention.length > 0 ? (
         <Table columns={KEYWORD_COLUMNS}>
@@ -618,6 +655,41 @@ export const KeywordTable: FC<{ keywords: CountedKeyword[]; edit?: KeywordEditTa
     </div>
   );
 };
+
+/**
+ * The way out of a keyword frame that got it wrong (issue #79): one run with
+ * the stored list withheld, so the model reads the posting again. The user's
+ * own keyword edits are re-applied to whatever comes back — a rebuild resets
+ * the model's guess, not their decisions.
+ */
+const REBUILD_TITLE =
+  'Runs the analysis once without the stored keyword list, so the model reads the terms out of the posting again (~½ min). Your own keyword edits are kept; the new score counts a different set of terms.';
+
+const RebuildKeywords: FC<{ target: RebuildTarget }> = ({ target }) =>
+  target.formId ? (
+    <button
+      type="submit"
+      form={target.formId}
+      class={`${ROW_LINK} ml-auto`}
+      title={REBUILD_TITLE}
+      onclick={`this.form.elements.rebuild.value='1';this.form.elements.mode.value='${target.mode}'`}
+    >
+      Rebuild keywords
+    </button>
+  ) : (
+    <form method="post" action={`/jobs/${target.jobId}/match`} class="ml-auto" onsubmit={SUBMIT_ONCE}>
+      <input type="hidden" name="resumeId" value={String(target.resumeId)} />
+      <input type="hidden" name="mode" value={target.mode} />
+      <input type="hidden" name="rebuild" value="1" />
+      {target.next && <input type="hidden" name="next" value={target.next} />}
+      {/* A draft row was judged on text no version holds — send it back, or the
+          rebuild would quietly score the stored resume instead. */}
+      {target.draftText !== undefined && <input type="hidden" name="draftText" value={target.draftText} />}
+      <button type="submit" class={ROW_LINK} title={REBUILD_TITLE}>
+        Rebuild keywords
+      </button>
+    </form>
+  );
 
 const KEYWORD_SUMMARY =
   'cursor-pointer border-t border-line px-5 py-2.5 text-[13px] font-medium text-ink-muted transition-colors duration-150 hover:text-ink';

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -359,8 +359,9 @@ export const TargetPage: FC<TargetPageProps> = ({
                   <input type="hidden" name="resumeId" value={resume.id} />
                   <input type="hidden" name="draftText" id="reanalyze-text" value="" />
                   <input type="hidden" name="next" value="target" />
-                  {/* Set by the full-analysis button's click — a disabled submitter is left out of the form data. */}
+                  {/* Set by the full-analysis and Rebuild buttons' clicks — a disabled submitter is left out of the form data. */}
                   <input type="hidden" name="mode" value="fast" />
+                  <input type="hidden" name="rebuild" value="" />
                   <Button variant="violet" class="w-full" title="Re-scores the text in the editor: keywords, gates and the number (~½ min on Opus)">
                     Re-check with AI
                   </Button>
@@ -545,6 +546,9 @@ export const TargetPage: FC<TargetPageProps> = ({
                     ? { jobId: job.id, matchId: match.id, back: `/jobs/${job.id}/target?match=${match.id}` }
                     : undefined
                 }
+                // Through the editor's own form, so a rebuild judges the text on
+                // screen — the same call Re-check makes, minus the stored frame.
+                rebuild={{ jobId: job.id, resumeId: resume.id, mode: fast ? 'fast' : 'full', formId: 'reanalyze-form' }}
               />
             </div>
           </Card>

--- a/src/web/routes/facts.ts
+++ b/src/web/routes/facts.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { applyFacts } from '../../resume/facts';
+import { readFrameReason } from '../../resume/keyword-frame';
 import { readMatchMode } from '../../resume/match-mode';
 import { readPromptVersion } from '../../resume/match-reuse';
 import { readKeywords } from '../../resume/prompts';
@@ -45,6 +46,7 @@ factsRoute.post('/facts', async (c) => {
           breakdown: newBd,
           promptVersion: readPromptVersion(match.breakdown),
           mode: readMatchMode(match.breakdown),
+          frame: readFrameReason(match.breakdown),
         });
         return flashRedirect(
           back,

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -468,14 +468,19 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
   const text = draft ? draftText : resume.text;
   // The quick check unless the form asked for the full report (ADR 0029).
   const mode = parseMatchMode(form.mode);
+  // "Rebuild keywords": read the terms out of the posting again instead of
+  // inheriting the frame this posting has been carrying (issue #79).
+  const rebuild = form.rebuild === '1';
   const toTarget = form.next === 'target';
   const resultUrl = (matchId: number) =>
     toTarget ? `/jobs/${id}/target?match=${matchId}` : `/jobs/${id}?match=${matchId}#resume-match`;
 
   // The same text was already judged: show that analysis instead of paying
-  // for it again — unless "Re-run anyway" asked for a fresh call. A full
-  // report asked of a stored quick check needs only the suggestions call.
-  if (form.force !== '1') {
+  // for it again — unless "Re-run anyway" or a rebuild asked for a fresh call.
+  // A rebuild that hit the memo would silently hand back the very frame it was
+  // asked to replace. A full report asked of a stored quick check needs only
+  // the suggestions call.
+  if (form.force !== '1' && !rebuild) {
     const reused = await findReusableMatch(job.id, resume.id, text, mode);
     if (reused?.decision === 'reuse') {
       return flashRedirect(resultUrl(reused.row.id), 'warn', reuseNotice(formatRelative(reused.row.createdAt)), {
@@ -492,7 +497,7 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
   startRun(run.id, async () => {
     // Ephemeral (scratch) compares keep only the current analysis.
     if (resume.hidden) await deleteMatchesForResume(resume.id);
-    const row = await matchResumeToJob({ id: resume.id, version: resume.version, text }, jobInput, { draft, mode });
+    const row = await matchResumeToJob({ id: resume.id, version: resume.version, text }, jobInput, { draft, mode, rebuild });
     if (!row) {
       updateRun(run.id, { stage: 'error', error: 'Comparison failed — see the web logs.' });
       return;
@@ -500,7 +505,9 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
     updateRun(run.id, {
       stage: 'done',
       resultUrl: resultUrl(row.id),
-      flash: `${draft ? 'Draft' : `"${resume.name}"`} ${mode === 'fast' ? 'checked' : 'compared'} — AI match ${row.matchScore}/100.`,
+      flash: rebuild
+        ? `Keywords rebuilt from the posting — AI match ${row.matchScore}/100, counted over a fresh set of terms.`
+        : `${draft ? 'Draft' : `"${resume.name}"`} ${mode === 'fast' ? 'checked' : 'compared'} — AI match ${row.matchScore}/100.`,
     });
   });
   return c.redirect(`/target/runs/${run.id}`, 303);

--- a/src/web/routes/keywords.ts
+++ b/src/web/routes/keywords.ts
@@ -8,6 +8,7 @@ import {
   effectiveKeywords,
   type EditResult,
 } from '../../resume/keyword-overrides';
+import { readFrameReason } from '../../resume/keyword-frame';
 import { readMatchMode } from '../../resume/match-mode';
 import { readPromptVersion } from '../../resume/match-reuse';
 import { readKeywords } from '../../resume/prompts';
@@ -97,6 +98,7 @@ keywordsRoute.post('/jobs/:id/matches/:matchId/keywords', async (c) => {
     breakdown: next,
     promptVersion: readPromptVersion(match.breakdown),
     mode: readMatchMode(match.breakdown),
+    frame: readFrameReason(match.breakdown),
   });
   const score =
     next.score === match.matchScore ? `score stays ${next.score}` : `score ${match.matchScore} → ${next.score}`;


### PR DESCRIPTION
Closes #79 — the last item of [target-plan.md](docs/target-plan.md) §4 (F7),
and closes TASKS §13 by settling block 6 with numbers instead of code.

## The problem

`CONSISTENCY ACROSS RUNS` + `previousKeywords` freeze the keyword list per
posting on purpose: that is what makes two resume versions comparable. The
flip side is that a term the model missed on run 1 stayed missed on every run
after it, and nothing could replace it.

Live proof from job #1393: five stored analyses (#55…#59, since prompt v5)
reproduced the same 26 terms. The posting names **BullMQ** and **GCP PubSub**
in its requirements. Neither has ever appeared in the keyword table.

## What this adds

- **Rebuild keywords** in the keyword-table header (job page and targeted
  view): one run with the stored frame withheld, so the model reads the terms
  out of the posting again. On the targeted view it submits the editor's own
  form, so the text on screen is what gets judged.
- **A prompt bump never inherits the previous prompt's frame** — a list
  written under rules the current prompt no longer follows is not offered to
  the model at all.
- **A rebuilt row says its score is not comparable** instead of showing a
  delta: the two runs count different terms, and a −3 that means "different
  list" reads exactly like a −3 that means "worse resume".
- A rebuild **bypasses the reuse memo**. Without that it would answer with the
  very analysis whose list the user asked to replace.
- **User overrides survive a rebuild.** `carryOverrides` reads the full stored
  row, not the withheld frame — the machine's guess resets, the person's
  decision does not.

## Shape

- `src/resume/keyword-frame.ts` (new, pure, 8 unit tests): `planKeywordFrame`
  is the whole decision — `(stored frame, current PROMPT_VERSION, rebuild
  flag) → carry | first-run | rebuild | prompt-bump`. No AI, no I/O.
- **No schema change, no ADR, no prompt change, `PROMPT_VERSION` untouched.**
  The chosen reason rides in the `breakdown` JSON beside the mode marker of
  ADR 0029; `storedBreakdown`'s meta made every field required, so the
  compiler names any write that would drop one.
- `score.ts` / `score.mjs` untouched — the formula did not move, so the parity
  test stayed green without a mirrored edit.

## Verification

`npm run lint:types` ✅ · `npm test` 940/940 ✅ · `npx prisma format --check` ✅

Live cycle on job #1393 (resume 5, quick check, `claude_code` engine), rows
deleted afterwards so the owner's data is exactly as it was:

| | carried run | rebuild run |
| --- | --- | --- |
| `frame` | `carried` | `rebuild` |
| keywords | 26 | **30** |
| time | 42.2 s | 41.8 s |
| `unanchored` | 0 | 0 |
| score | 67 | 64 |

The two frames share 23 terms; 3 dropped, **7 new — BullMQ, GCP PubSub, AI
tools, observability tools, performance monitoring, CI/CD, Microservices** —
and every one of them is literally in the description (`unanchored` stayed 0,
so nothing was invented). A `must → nice` override set before the rebuild
survived it. A rebuild costs one ordinary call: it is the same request minus a
prompt block.

Dashboard: `docker compose build web`, `/jobs/1393` and `/jobs/1393/target`
at 1200 / 768 / 375 px, **0 console errors**. The prompt-bump branch is
unit-tested; at runtime it takes the same `carry: false` path the live rebuild
exercised.

## Release notes draft (v1.18.0)

> **Rebuild keywords.** Every comparison of the same posting reuses the first
> run's keyword list, so scores stay comparable between resume versions — but
> a word the model missed on run 1 stayed missed forever. The keyword table
> now has a way out: one run with the stored list withheld. On a real posting
> the carried list had been repeating the same 26 terms through five
> analyses; the rebuild found 30, including BullMQ and GCP PubSub — both named
> in the job description, neither ever listed. Your own keyword edits survive
> it, and the rebuilt analysis says its score is not comparable with the
> earlier ones rather than pretending the difference is progress.
>
> Also: a prompt change no longer inherits the old prompt's keyword list, and
> `match-split-frame` — the last open block of the compare-speed plan — is
> closed by measurement (quick check p50 15 s on the bench, 40–42 s on one of
> the longest postings we store, against a 30–40 s target) rather than built.

## Follow-ups (not in this PR)

- **One override can land on several rows of a rebuilt frame.**
  `carryOverrides` matches by term *and* aliases, so the single `Grafana →
  nice` edit came back on `Grafana`, `observability tools` and `performance
  monitoring` (`overrides: 3` in the log) after the model split that concept
  into three rows. Defensible — the override follows the concept, not the
  spelling — but one decision multiplying into three score changes deserves
  its own look. New issue.
- The check-then-act class on the re-score routes (#70, #72, #76 and the
  PR #82/#83 follow-ups) is untouched here; `updateMatchScoring` now carries a
  third marker through the same read-modify-write it always had.
