### PR TITLE
fix: add CSRF protection to dashboard

### DIFF
--- a/docs/adr/0027-ai-keys-in-the-database.md
+++ b/docs/adr/0027-ai-keys-in-the-database.md
@@ -76,13 +76,10 @@ dashboard binds to `127.0.0.1` by default (config.ts `WEB_HOST`), Postgres
 is not published beyond the compose network, and the dashboard is
 single-user. What does not bound it: nothing else. A user who wants the key
 off the disk keeps using `.env` — that path is not deprecated.
-❌ The save route has no CSRF protection, because no route in this dashboard
-does. A page open in the same browser can POST a key of its own choosing to
-`127.0.0.1:4747` — it cannot read the stored one, but it can point the user's
-AI calls at an account it controls. That is the same class of exposure as
-every other unauthenticated POST here (delete a Telegram target, change the
-profile); this ADR does not fix it, it records that adding credentials to the
-surface makes fixing it worth scheduling.
+✅ **CSRF protection implemented (Issue #69).** All mutating routes (including
+the key-save route) are protected against cross-site POSTs via `Sec-Fetch-Site`
+and `Origin` header validation in `src/web/csrf.ts`. Cross-site requests from
+other origins or different local ports are rejected with 403 Forbidden.
 ❌ Encryption at rest was rejected, not overlooked: the decryption key would
 have to live in `.env`, which moves the secret rather than removing it, and
 reintroduces the file edit this ADR exists to delete. An OS keychain does

--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -1,0 +1,203 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import { csrfProtection } from './csrf';
+
+function createTestApp(): Hono {
+  const app = new Hono();
+  app.use('*', csrfProtection());
+  app.get('/test', (c) => c.text('get-ok'));
+  app.post('/test', (c) => c.text('post-ok'));
+  app.put('/test', (c) => c.text('put-ok'));
+  app.delete('/test', (c) => c.text('delete-ok'));
+  return app;
+}
+
+describe('csrfProtection', () => {
+  const app = createTestApp();
+
+  it('allows safe methods (GET, HEAD, OPTIONS) without restriction', async () => {
+    const getRes = await app.request('/test', {
+      method: 'GET',
+      headers: {
+        'sec-fetch-site': 'cross-site',
+        origin: 'http://evil.com',
+      },
+    });
+    assert.equal(getRes.status, 200);
+    assert.equal(await getRes.text(), 'get-ok');
+
+    const headRes = await app.request('/test', {
+      method: 'HEAD',
+      headers: {
+        'sec-fetch-site': 'cross-site',
+        origin: 'http://evil.com',
+      },
+    });
+    assert.equal(headRes.status, 200);
+  });
+
+  it('rejects cross-site Sec-Fetch-Site with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        'sec-fetch-site': 'cross-site',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Cross-site request rejected/);
+  });
+
+  it('allows same-origin Sec-Fetch-Site', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        'sec-fetch-site': 'same-origin',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('allows Sec-Fetch-Site none', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        'sec-fetch-site': 'none',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('rejects malicious Origin with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        origin: 'http://evil.com',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Invalid request origin/);
+  });
+
+  it('allows valid same-origin Origin', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        origin: 'http://127.0.0.1:4747',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('rejects cross-port localhost Origin with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: 'localhost:4747',
+        origin: 'http://localhost:3000',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Invalid request origin/);
+  });
+
+  it('rejects malformed Origin header with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        origin: 'not-a-valid-url',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Malformed Origin header/);
+  });
+
+  it('supports reverse proxy via X-Forwarded-Host', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        'x-forwarded-host': 'dashboard.example.com',
+        origin: 'https://dashboard.example.com',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('rejects malicious Referer fallback with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        referer: 'http://evil.com/attacker-form',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Invalid request referer/);
+  });
+
+  it('allows valid same-origin Referer fallback', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        referer: 'http://127.0.0.1:4747/jobs/123',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('rejects malformed Referer header with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        referer: ':::invalid-url',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Malformed Referer header/);
+  });
+
+  it('allows non-browser clients with no browser security headers', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('protects PUT and DELETE methods as well', async () => {
+    const putRes = await app.request('/test', {
+      method: 'PUT',
+      headers: {
+        host: '127.0.0.1:4747',
+        'sec-fetch-site': 'cross-site',
+      },
+    });
+    assert.equal(putRes.status, 403);
+
+    const deleteRes = await app.request('/test', {
+      method: 'DELETE',
+      headers: {
+        host: '127.0.0.1:4747',
+        origin: 'http://evil.com',
+      },
+    });
+    assert.equal(deleteRes.status, 403);
+  });
+});

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -1,0 +1,95 @@
+import type { Context, MiddlewareHandler } from 'hono';
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export interface CsrfOptions {
+  logger?: { warn: (obj: Record<string, unknown>, msg: string) => void };
+}
+
+/**
+ * Validates that mutating requests originate from the same host/port.
+ * Blocks cross-site attacks via Sec-Fetch-Site, Origin, and Referer header checks.
+ */
+export function csrfProtection(options: CsrfOptions = {}): MiddlewareHandler {
+  let log = options.logger;
+
+  return async (c: Context, next) => {
+    if (SAFE_METHODS.has(c.req.method)) {
+      return next();
+    }
+
+    if (!log) {
+      try {
+        log = (await import('../logger')).logger;
+      } catch {
+        // In environments without DB configuration (e.g. isolated unit tests), skip logger
+      }
+    }
+
+    const secFetchSite = c.req.header('sec-fetch-site');
+
+    // 1. Explicit cross-site Fetch Metadata header check.
+    if (secFetchSite === 'cross-site') {
+      log?.warn(
+        { path: c.req.path, method: c.req.method, secFetchSite },
+        'csrf: blocked cross-site request via Sec-Fetch-Site',
+      );
+      return c.text('Forbidden: Cross-site request rejected', 403);
+    }
+
+    const rawForwarded = c.req.header('x-forwarded-host');
+    const host = (rawForwarded ? rawForwarded.split(',')[0]?.trim() : null) || c.req.header('host') || '';
+
+    // 2. Origin header check when present.
+    const origin = c.req.header('origin');
+    if (origin) {
+      try {
+        const originUrl = new URL(origin);
+        if (!host || originUrl.host.toLowerCase() !== host.toLowerCase()) {
+          log?.warn(
+            { path: c.req.path, method: c.req.method },
+            'csrf: blocked request due to origin/host mismatch',
+          );
+          return c.text('Forbidden: Invalid request origin', 403);
+        }
+      } catch {
+        log?.warn(
+          { path: c.req.path, method: c.req.method },
+          'csrf: blocked malformed origin',
+        );
+        return c.text('Forbidden: Malformed Origin header', 403);
+      }
+      return next();
+    }
+
+    // 3. Sec-Fetch-Site same-origin or none (direct user action) passes.
+    if (secFetchSite === 'same-origin' || secFetchSite === 'none') {
+      return next();
+    }
+
+    // 4. Referer fallback check if present.
+    const referer = c.req.header('referer');
+    if (referer) {
+      try {
+        const refererUrl = new URL(referer);
+        if (!host || refererUrl.host.toLowerCase() !== host.toLowerCase()) {
+          log?.warn(
+            { path: c.req.path, method: c.req.method },
+            'csrf: blocked request due to referer/host mismatch',
+          );
+          return c.text('Forbidden: Invalid request referer', 403);
+        }
+      } catch {
+        log?.warn(
+          { path: c.req.path, method: c.req.method },
+          'csrf: blocked malformed referer',
+        );
+        return c.text('Forbidden: Malformed Referer header', 403);
+      }
+      return next();
+    }
+
+    // 5. Non-browser HTTP clients (curl, automated tests) without browser headers.
+    return next();
+  };
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -20,6 +20,7 @@ import { factsRoute } from './routes/facts';
 import { keywordsRoute } from './routes/keywords';
 import { healthRoute } from './routes/health';
 import { welcomeRoute } from './routes/welcome';
+import { csrfProtection } from './csrf';
 
 const app = new Hono();
 
@@ -39,6 +40,8 @@ app.use(
     referrerPolicy: 'no-referrer',
   }),
 );
+
+app.use('*', csrfProtection());
 
 if (config.WEB_BASIC_AUTH) {
   const [username, ...rest] = config.WEB_BASIC_AUTH.split(':');


### PR DESCRIPTION
## Summary

Fixes #69.

Added CSRF protection to the dashboard so a page from another origin can't submit state-changing requests to the local dashboard.

### What changed

- Added a global CSRF middleware for mutating requests.
- Checks `Sec-Fetch-Site`, `Origin`, and `Referer`.
- Checks the host and port, including localhost requests.
- Added support for `X-Forwarded-Host` when running behind a proxy.
- GET/HEAD/OPTIONS requests are left untouched.
- No changes were needed to the existing dashboard forms.
- Added tests covering the main CSRF cases.
- Updated the related ADR.

### Tests

- `npm run lint:types` — passed
- `npx tsx --test src/web/*.test.ts` — 119/119 passed
- `git diff --check` — passed
