### PR TITLE
pre-public hardening: the read-modify-write races and cross-origin writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ All notable changes to this project are documented here. The format follows
   the target site. Every state-changing request is now checked against the
   headers a browser attaches itself (`Origin`, `Sec-Fetch-Site`). No tokens, no
   session store, and `curl` still works: a request with no browser origin
-  headers at all is not the attack this stops.
+  headers at all is not the attack this stops. `Sec-Fetch-Site` decides
+  whenever the browser sends it — a dashboard rendered in a sandboxed frame
+  posts to itself with an opaque `Origin` *and* `Sec-Fetch-Site: same-origin`
+  (measured, not assumed), and no cross-site page can produce that pair.
 
 ## [1.19.0] — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.20.0] — 2026-09-02
+
+### Fixed
+- **Two tabs no longer lose an AI key** (#72). Saving a key read the whole
+  `aiKeys` map, merged one engine in and wrote the map back, so two saves in
+  flight kept only the later snapshot — the other engine's key was gone. The
+  merge is now a single `jsonb_set` statement: the database merges, and there
+  is no window to lose. Measured on a scratch database: two saves in flight,
+  before → one key stored, after → both.
+- **The eight-search ceiling is no longer advisory** (#70). Counting the
+  running searches and then flipping the row is check-then-act: two
+  activations both read seven, both passed, nine searches ran. The count and
+  the write now happen under one row lock. Measured: seven running, two
+  activations in flight, before → 9 running, after → 8.
+- **A second submit joins the run in flight instead of starting a second one**
+  (#76). `SUBMIT_ONCE` disables buttons in the browser, which cannot help a
+  second tab, a re-POSTed reload or a client with scripting off. Every POST
+  that starts an AI run — compare, full analysis, suggestions, cover letter,
+  scan, strength review, the wizard's steps, `/target` and `/letter` — now
+  names the work it is doing, and a request for work already running is
+  redirected to it. Repeating a *finished* run still starts a fresh one.
+- **A confirmed fact no longer drops your keyword overrides out of the score.**
+  The `/facts` re-score skipped `effectiveKeywords`, so answering a question on
+  a comparison you had re-levelled recomputed the number as if you never had.
+  Both re-score paths now share one locked function.
+
+### Security
+- **Cross-origin writes are refused** (#69). A page open in the same browser
+  could POST to the dashboard on `localhost:4747` — change a setting, delete a
+  resume, overwrite an AI key — because a form POST needs no permission from
+  the target site. Every state-changing request is now checked against the
+  headers a browser attaches itself (`Origin`, `Sec-Fetch-Site`). No tokens, no
+  session store, and `curl` still works: a request with no browser origin
+  headers at all is not the attack this stops.
+
 ## [1.19.0] — 2026-09-02
 
 ### Added
@@ -1181,6 +1216,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.20.0]: https://github.com/applypack/applypack/compare/v1.19.0...v1.20.0
 [1.19.0]: https://github.com/applypack/applypack/compare/v1.18.0...v1.19.0
 [1.18.0]: https://github.com/applypack/applypack/compare/v1.17.0...v1.18.0
 [1.17.0]: https://github.com/applypack/applypack/compare/v1.16.0...v1.17.0

--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ authentication unless you set `WEB_BASIC_AUTH`, so bind it wider only
 together with that. (Under Docker, compose sets `0.0.0.0` for the
 container and publishes the port on loopback only.)
 
+Writes are refused when they come from another origin: a POST whose
+`Origin` is not this dashboard, or whose `Sec-Fetch-Site` says
+`cross-site`, gets a 403. That is what stops a page open in the same
+browser from posting to your `localhost:4747`. A request with no browser
+origin headers at all — `curl`, a script — is not that attack and passes.
+If you put the dashboard behind a reverse proxy, pass the browser's host
+through (`proxy_set_header Host $host` in nginx); a proxy that rewrites
+`Host` to `localhost` makes every form look cross-origin.
+
 CLI engines (claude / gemini / codex) are simpler locally: install them
 globally, log in once in your terminal, and the probe on the AI tab turns
 green. Details per engine in [docs/ai-engines.md](./docs/ai-engines.md).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -948,3 +948,55 @@ Sonnet bench for the resume role — not "make Opus stream faster".
       as-you-type case with no call at all (0-15 ms) and F7 shows that a
       frozen frame is a liability, not an asset. Reopen only if a measured
       compare goes back over ~60 s.
+
+## 14. Pre-public hardening (2026-09-02)
+
+Not a feature: the class of bug a stranger meets first. Ordered by damage,
+not by issue number — #72 loses a pasted AI key, which is worth fixing
+before anyone else installs this.
+
+- [x] `pre-public-hardening` A+B — the read-modify-write races and the
+      cross-origin write guard, branch `pre-public-hardening`.
+      **Measured on a throwaway database** (`race_test`, all 47 migrations
+      applied from empty), each race run twice: once through the old code
+      path re-created inline, once through the shipped function.
+      - **#72** two tabs save a key for two engines: before → `[gemini_cli]`
+        (one key lost), after → `[gemini_cli, openai_api]`. The merge moved
+        into one `jsonb_set` statement; a transaction would not have helped,
+        because at Read Committed the read inside it still returns the
+        version current when it started.
+      - **#70** seven searches running, two activations in flight: before →
+        **2 accepted, 9 running**; after → **1 accepted, 8 running**. The
+        count and the write now share one lock on the singleton settings
+        row — locking the rows counted cannot see a row that became active
+        during the wait.
+      - **#76** three POSTs to `POST /resumes/8/review`, two of them
+        concurrent: **one run** (`abbe4376…`), two `run: joined a run
+        already in flight` lines, one review row. Every POST that starts an
+        AI run now names its work; a repeat after the answer still starts a
+        fresh run. The wizard's bespoke `scoreRunId` singleton was deleted
+        in favour of it.
+      - **PR #83's follow-up** — the keyword override and the `ask_user`
+        answer shared a read-modify-write of the same JSON. Two edits in
+        flight: before → one survived (`[postgres]`), after → both
+        (`[node.js, postgres]`). One locked function now serves both, which
+        also fixed a real bug: `/facts` re-scored without
+        `effectiveKeywords`, so answering a question on a comparison you had
+        re-levelled silently recomputed the number as if you never had.
+        Repeated live on job #1393 / match #59: two simultaneous edits →
+        3 overrides stored, five resets → back to **66** with 0 overrides,
+        the state PR #83 left behind.
+      - **#69** cross-origin POST → **403** from the middleware
+        (`Cross-origin request refused.` + a `web: cross-origin write
+        refused` log line); same-origin POST and header-less `curl` reach
+        their routes unchanged; GET is never checked. 11 unit tests on the
+        pure `sameOriginPost`.
+      - Five follow-ups that had only ever lived in PR bodies became issues
+        #88-#92; three of the same class were fixed here instead.
+- [ ] `pre-public-hardening` C — #73 (a stale `resumeId` in the profile
+      form raises a raw FK error), #74 + #75 (`appliedResumeText` is written
+      and never read; the board's drag and the application form leave the
+      applied-resume columns NULL).
+- [ ] `pre-public-check` — the six-point audit before strangers arrive:
+      clean install from an empty database, migrations, secrets, exposure,
+      README against the live UI, delete blast radius + a backup recipe.

--- a/docs/adr/0027-ai-keys-in-the-database.md
+++ b/docs/adr/0027-ai-keys-in-the-database.md
@@ -76,13 +76,10 @@ dashboard binds to `127.0.0.1` by default (config.ts `WEB_HOST`), Postgres
 is not published beyond the compose network, and the dashboard is
 single-user. What does not bound it: nothing else. A user who wants the key
 off the disk keeps using `.env` — that path is not deprecated.
-❌ The save route has no CSRF protection, because no route in this dashboard
-does. A page open in the same browser can POST a key of its own choosing to
-`127.0.0.1:4747` — it cannot read the stored one, but it can point the user's
-AI calls at an account it controls. That is the same class of exposure as
-every other unauthenticated POST here (delete a Telegram target, change the
-profile); this ADR does not fix it, it records that adding credentials to the
-surface makes fixing it worth scheduling.
+✅ **CSRF protection implemented (Issue #69).** All mutating routes (including
+the key-save route) are protected against cross-site POSTs via `Sec-Fetch-Site`
+and `Origin` header validation in `src/web/csrf.ts`. Cross-site requests from
+other origins or different local ports are rejected with 403 Forbidden.
 ❌ Encryption at rest was rejected, not overlooked: the decryption key would
 have to live in `.env`, which moves the secret rather than removing it, and
 reintroduces the file edit this ADR exists to delete. An OS keychain does

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/ai-keys.test.ts
+++ b/src/ai-keys.test.ts
@@ -7,7 +7,6 @@ import {
   parseAiKeys,
   providerTakesKey,
   resolveAiKey,
-  withAiKey,
 } from './ai-keys';
 
 describe('providerTakesKey', () => {
@@ -44,27 +43,6 @@ describe('parseAiKeys', () => {
     assert.deepEqual(keys, {});
     const atLimit = parseAiKeys({ openai_api: 'k'.repeat(MAX_AI_KEY_LENGTH) });
     assert.equal(atLimit.openai_api?.length, MAX_AI_KEY_LENGTH);
-  });
-});
-
-describe('withAiKey', () => {
-  it('adds, replaces and clears without touching the other engines', () => {
-    const one = withAiKey({}, 'openai_api', ' sk-openai ');
-    assert.deepEqual(one, { openai_api: 'sk-openai' });
-    const two = withAiKey(one, 'gemini_cli', 'gm');
-    assert.deepEqual(two, { openai_api: 'sk-openai', gemini_cli: 'gm' });
-    assert.deepEqual(withAiKey(two, 'openai_api', '   '), { gemini_cli: 'gm' });
-  });
-
-  it('keeps a long key intact — the routes reject one before it gets here', () => {
-    const long = 'k'.repeat(MAX_AI_KEY_LENGTH + 10);
-    assert.equal(withAiKey({}, 'openai_api', long).openai_api, long);
-  });
-
-  it('does not mutate the input', () => {
-    const before = { openai_api: 'a' };
-    withAiKey(before, 'openai_api', '');
-    assert.deepEqual(before, { openai_api: 'a' });
   });
 });
 

--- a/src/ai-keys.ts
+++ b/src/ai-keys.ts
@@ -4,7 +4,8 @@ import type { AiProviderId } from './ai-engine';
 /*
  * Per-engine credentials (ADR 0027): the key an engine needs, stored in
  * AppSettings.aiKeys so a non-technical user can paste it into the dashboard
- * instead of editing .env. Pure — parsing, merging and env resolution only;
+ * instead of editing .env. Pure — parsing and env resolution only; storing a
+ * key merges in SQL (settings.ts), so no in-memory merge can lose one;
  * the row itself is read and written through settings.ts. No I/O, no logging:
  * a secret must never leave this module by any path but its return value.
  */
@@ -55,15 +56,6 @@ export function parseAiKeys(raw: unknown): AiKeys {
     if (providerTakesKey(id as AiProviderId)) keys[id as AiKeyProviderId] = key;
   }
   return keys;
-}
-
-/** Stores a pasted key, or removes it when the value is blank. */
-export function withAiKey(keys: AiKeys, id: AiKeyProviderId, value: string): AiKeys {
-  const next = { ...keys };
-  const key = value.trim();
-  if (key.length === 0) delete next[id];
-  else next[id] = key;
-  return next;
 }
 
 /**

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -2,9 +2,8 @@ import type { Profile } from '@prisma/client';
 import { prisma } from './db';
 import { logger } from './logger';
 import { MAX_ACTIVE_PROFILES } from './profile-guards';
+import { ensureSettingsRow, SETTINGS_ID } from './settings';
 import type { PriorityRule } from './priority-rules';
-
-const SETTINGS_ID = 1;
 
 export interface ProfileInput {
   name: string;
@@ -87,23 +86,35 @@ export async function listActiveProfiles(): Promise<Profile[]> {
  * a dashboard that quietly stops working.
  */
 export async function setProfileActive(id: number, active: boolean): Promise<void> {
-  const profile = await prisma.profile.findUnique({ where: { id } });
-  if (!profile) throw new Error(`Profile ${id} not found`);
-  if (active) {
-    const running = await prisma.profile.count({ where: { active: true, id: { not: id } } });
-    if (running >= MAX_ACTIVE_PROFILES) {
-      throw new Error(
-        `At most ${MAX_ACTIVE_PROFILES} searches can run at once. Switch one off first.`,
-      );
+  // The whole decision runs under one lock (issue #70). Counting the running
+  // searches and then flipping the row in a second statement is check-then-act:
+  // two tabs both read 7, both pass, and 9 searches run. A transaction alone
+  // does not fix it — at Read Committed each transaction's count reads its own
+  // snapshot — and locking the rows we counted cannot see a row that became
+  // active while we waited. So both writers queue on the one row that stands
+  // for global state, and the loser re-counts after the winner has committed.
+  await ensureSettingsRow();
+  const name = await prisma.$transaction(async (tx) => {
+    await tx.$queryRaw`SELECT id FROM app_settings WHERE id = ${SETTINGS_ID} FOR UPDATE`;
+    const profile = await tx.profile.findUnique({ where: { id } });
+    if (!profile) throw new Error(`Profile ${id} not found`);
+    if (active) {
+      const running = await tx.profile.count({ where: { active: true, id: { not: id } } });
+      if (running >= MAX_ACTIVE_PROFILES) {
+        throw new Error(
+          `At most ${MAX_ACTIVE_PROFILES} searches can run at once. Switch one off first.`,
+        );
+      }
+    } else {
+      const settings = await tx.appSettings.findUnique({ where: { id: SETTINGS_ID } });
+      if (settings?.activeProfileId === id) {
+        throw new Error('The primary search cannot be switched off. Make another one primary first.');
+      }
     }
-  } else {
-    const settings = await prisma.appSettings.findUnique({ where: { id: SETTINGS_ID } });
-    if (settings?.activeProfileId === id) {
-      throw new Error('The primary search cannot be switched off. Make another one primary first.');
-    }
-  }
-  await prisma.profile.update({ where: { id }, data: { active } });
-  logger.info({ profileId: id, name: profile.name, active }, 'profiles: active toggled');
+    await tx.profile.update({ where: { id }, data: { active } });
+    return profile.name;
+  });
+  logger.info({ profileId: id, name, active }, 'profiles: active toggled');
 }
 
 export async function getActiveProfile(): Promise<Profile | null> {

--- a/src/resume/store.ts
+++ b/src/resume/store.ts
@@ -1,11 +1,13 @@
 import type { CandidateFact, CoverLetter, Prisma, Resume, ResumeMatch, ResumeReview } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../logger';
-import type { FrameReason } from './keyword-frame';
-import { storedBreakdown, withSuggestionsMode, type MatchMode } from './match-mode';
+import { readFrameReason, type FrameReason } from './keyword-frame';
+import { effectiveKeywords } from './keyword-overrides';
+import { readMatchMode, storedBreakdown, withSuggestionsMode, type MatchMode } from './match-mode';
+import { readPromptVersion } from './match-reuse';
 import type { MatchKeyword, MatchSuggestions, ResumeMatchResult, ResumeReviewResult, ResumeScan } from './prompts';
 import { storedReviewBreakdown, type ReviewBreakdown } from './review-score';
-import type { ScoreBreakdown } from './score';
+import { readBreakdown, scoreMatch, type ScoreBreakdown } from './score';
 
 /** Resume without the uploaded bytes — what every page and prompt works with. */
 export type ResumeSummary = Omit<Resume, 'original'>;
@@ -315,25 +317,69 @@ export async function getLatestMatchForJob(jobId: number): Promise<ResumeMatch |
   return prisma.resumeMatch.findFirst({ where: { jobId }, orderBy: { createdAt: 'desc' } });
 }
 
-/** A fact flip recomputes the stored score deterministically — no AI call. */
-export async function updateMatchScoring(
+export interface KeywordRescore<T> {
+  /** The list to store, or null to leave the row exactly as it is. */
+  keywords: MatchKeyword[] | null;
+  /** Handed back to the caller — the pure edit's own result, for the flash. */
+  detail: T;
+}
+
+export interface RescoreOutcome<T> {
+  detail: T;
+  /** The stored score before and after the edit; equal when nothing was written. */
+  before: number;
+  after: number;
+  /** False when the row predates the deterministic score (ADR 0012) — nothing was written. */
+  scored: boolean;
+}
+
+/**
+ * Read → pure edit → write of one comparison's keyword list, under a row lock.
+ *
+ * Two routes share this shape: a keyword override and an answered `ask_user`
+ * question. Both used to read the row, compute outside, and write the whole
+ * JSON back — check-then-act, so two edits in flight, or a confirmation
+ * landing during an override, kept only the last one (PR #83's follow-up).
+ * Postgres runs at Read Committed, so a plain transaction here would change
+ * nothing: the read inside it still returns the version current when it
+ * started. `SELECT … FOR UPDATE` first is what serialises them; the edit is
+ * pure and instant, so the lock is held for a millisecond.
+ *
+ * Scoring lives here too, deliberately: `effectiveKeywords` — the user's
+ * levels minus the rows they ignored — has to be applied before `scoreMatch`
+ * or an override silently disappears from the number, which is what the facts
+ * route did.
+ */
+export async function rescoreMatchKeywords<T>(
   id: number,
-  input: {
-    keywords: MatchKeyword[];
-    breakdown: ScoreBreakdown;
-    /** The row's own markers, read off it and written back — a re-score changes the number, never what the row is. */
-    promptVersion: number | null;
-    mode: MatchMode;
-    frame: FrameReason | null;
-  },
-): Promise<ResumeMatch> {
-  return prisma.resumeMatch.update({
-    where: { id },
-    data: {
-      keywords: input.keywords as Prisma.InputJsonValue,
-      breakdown: storedBreakdown(input.breakdown, input) as Prisma.InputJsonValue,
-      matchScore: input.breakdown.score,
-    },
+  edit: (match: ResumeMatch) => KeywordRescore<T>,
+): Promise<RescoreOutcome<T> | null> {
+  return prisma.$transaction(async (tx) => {
+    const locked = await tx.$queryRaw<{ id: number }[]>`SELECT id FROM resume_match WHERE id = ${id} FOR UPDATE`;
+    if (locked.length === 0) return null;
+    const match = await tx.resumeMatch.findUniqueOrThrow({ where: { id } });
+    const { keywords, detail } = edit(match);
+    const breakdown = readBreakdown(match.breakdown);
+    const before = match.matchScore;
+    if (keywords === null || !breakdown) {
+      return { detail, before, after: before, scored: breakdown !== null };
+    }
+    const next = scoreMatch(effectiveKeywords(keywords), breakdown.alignment, match.redFlags.length);
+    await tx.resumeMatch.update({
+      where: { id },
+      data: {
+        keywords: keywords as Prisma.InputJsonValue,
+        breakdown: storedBreakdown(next, {
+          // Read off the locked row, not off the caller's older copy: a
+          // re-score changes the number, never what the row is.
+          promptVersion: readPromptVersion(match.breakdown),
+          mode: readMatchMode(match.breakdown),
+          frame: readFrameReason(match.breakdown),
+        }) as Prisma.InputJsonValue,
+        matchScore: next.score,
+      },
+    });
+    return { detail, before, after: next.score, scored: true };
   });
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,7 @@ import type { Prisma, TelegramTarget } from '@prisma/client';
 import { prisma } from './db';
 import { logger } from './logger';
 import type { AiEngineConfig } from './ai-engine';
-import { parseAiKeys, withAiKey, type AiKeyProviderId, type AiKeys } from './ai-keys';
+import { parseAiKeys, type AiKeyProviderId, type AiKeys } from './ai-keys';
 
 export const SETTINGS_ID = 1;
 const TELEGRAM_API = 'https://api.telegram.org';
@@ -33,6 +33,19 @@ export interface AppSettingsView {
   /** NULL until the first-run wizard finishes or is skipped — `/` redirects to /welcome meanwhile. */
   setupCompletedAt: Date | null;
   updatedAt: Date;
+}
+
+/**
+ * Creates the singleton AppSettings row if it is missing. Callers that reach
+ * for it with raw SQL — an atomic `jsonb_set`, a `FOR UPDATE` lock — need the
+ * row to exist first: an UPDATE or a lock over nothing is a silent no-op.
+ */
+export async function ensureSettingsRow(): Promise<void> {
+  await prisma.appSettings.upsert({
+    where: { id: SETTINGS_ID },
+    update: {},
+    create: { id: SETTINGS_ID },
+  });
 }
 
 /**
@@ -127,16 +140,33 @@ export async function getAiKeys(): Promise<AiKeys> {
   return parseAiKeys(row?.aiKeys ?? null);
 }
 
-/** Stores a pasted key, or removes it when `key` is blank. Logs the engine only. */
+/**
+ * Stores a pasted key, or removes it when `key` is blank. Logs the engine only.
+ *
+ * The merge is one SQL statement on purpose (issue #72). Read the map, merge
+ * in memory, write the map back and two tabs saving two engines lose one of
+ * them: the later write carries a snapshot taken before the earlier one. A
+ * transaction around the same read and write would not help — Postgres runs
+ * at Read Committed, so the read inside it still returns the version current
+ * when it started. `jsonb_set` (and `-` for a removal) touches one path and
+ * leaves every other engine's key exactly as the row has it, so the database
+ * does the merge and there is no window to lose.
+ */
 export async function setAiKey(id: AiKeyProviderId, key: string): Promise<void> {
-  const next = withAiKey(await getAiKeys(), id, key);
-  const value = next as unknown as Prisma.InputJsonValue;
-  await prisma.appSettings.upsert({
-    where: { id: SETTINGS_ID },
-    update: { aiKeys: value },
-    create: { id: SETTINGS_ID, aiKeys: value },
-  });
-  logger.info({ provider: id, stored: id in next }, 'settings: ai key updated');
+  const value = key.trim();
+  // The statement below is an UPDATE, so the singleton row has to exist.
+  await ensureSettingsRow();
+  if (value.length === 0) {
+    await prisma.$executeRaw`
+      UPDATE app_settings SET "aiKeys" = COALESCE("aiKeys", '{}'::jsonb) - ${id}
+      WHERE id = ${SETTINGS_ID}`;
+  } else {
+    await prisma.$executeRaw`
+      UPDATE app_settings SET "aiKeys" =
+        jsonb_set(COALESCE("aiKeys", '{}'::jsonb), ARRAY[${id}], to_jsonb(${value}::text), true)
+      WHERE id = ${SETTINGS_ID}`;
+  }
+  logger.info({ provider: id, stored: value.length > 0 }, 'settings: ai key updated');
 }
 
 export async function setTelegramEnabled(enabled: boolean): Promise<void> {

--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -1,0 +1,203 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import { csrfProtection } from './csrf';
+
+function createTestApp(): Hono {
+  const app = new Hono();
+  app.use('*', csrfProtection());
+  app.get('/test', (c) => c.text('get-ok'));
+  app.post('/test', (c) => c.text('post-ok'));
+  app.put('/test', (c) => c.text('put-ok'));
+  app.delete('/test', (c) => c.text('delete-ok'));
+  return app;
+}
+
+describe('csrfProtection', () => {
+  const app = createTestApp();
+
+  it('allows safe methods (GET, HEAD, OPTIONS) without restriction', async () => {
+    const getRes = await app.request('/test', {
+      method: 'GET',
+      headers: {
+        'sec-fetch-site': 'cross-site',
+        origin: 'http://evil.com',
+      },
+    });
+    assert.equal(getRes.status, 200);
+    assert.equal(await getRes.text(), 'get-ok');
+
+    const headRes = await app.request('/test', {
+      method: 'HEAD',
+      headers: {
+        'sec-fetch-site': 'cross-site',
+        origin: 'http://evil.com',
+      },
+    });
+    assert.equal(headRes.status, 200);
+  });
+
+  it('rejects cross-site Sec-Fetch-Site with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        'sec-fetch-site': 'cross-site',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Cross-site request rejected/);
+  });
+
+  it('allows same-origin Sec-Fetch-Site', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        'sec-fetch-site': 'same-origin',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('allows Sec-Fetch-Site none', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        'sec-fetch-site': 'none',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('rejects malicious Origin with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        origin: 'http://evil.com',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Invalid request origin/);
+  });
+
+  it('allows valid same-origin Origin', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        origin: 'http://127.0.0.1:4747',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('rejects cross-port localhost Origin with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: 'localhost:4747',
+        origin: 'http://localhost:3000',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Invalid request origin/);
+  });
+
+  it('rejects malformed Origin header with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        origin: 'not-a-valid-url',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Malformed Origin header/);
+  });
+
+  it('supports reverse proxy via X-Forwarded-Host', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        'x-forwarded-host': 'dashboard.example.com',
+        origin: 'https://dashboard.example.com',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('rejects malicious Referer fallback with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        referer: 'http://evil.com/attacker-form',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Invalid request referer/);
+  });
+
+  it('allows valid same-origin Referer fallback', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        referer: 'http://127.0.0.1:4747/jobs/123',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('rejects malformed Referer header with 403', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+        referer: ':::invalid-url',
+      },
+    });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Forbidden: Malformed Referer header/);
+  });
+
+  it('allows non-browser clients with no browser security headers', async () => {
+    const res = await app.request('/test', {
+      method: 'POST',
+      headers: {
+        host: '127.0.0.1:4747',
+      },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'post-ok');
+  });
+
+  it('protects PUT and DELETE methods as well', async () => {
+    const putRes = await app.request('/test', {
+      method: 'PUT',
+      headers: {
+        host: '127.0.0.1:4747',
+        'sec-fetch-site': 'cross-site',
+      },
+    });
+    assert.equal(putRes.status, 403);
+
+    const deleteRes = await app.request('/test', {
+      method: 'DELETE',
+      headers: {
+        host: '127.0.0.1:4747',
+        origin: 'http://evil.com',
+      },
+    });
+    assert.equal(deleteRes.status, 403);
+  });
+});

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -1,0 +1,95 @@
+import type { Context, MiddlewareHandler } from 'hono';
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export interface CsrfOptions {
+  logger?: { warn: (obj: Record<string, unknown>, msg: string) => void };
+}
+
+/**
+ * Validates that mutating requests originate from the same host/port.
+ * Blocks cross-site attacks via Sec-Fetch-Site, Origin, and Referer header checks.
+ */
+export function csrfProtection(options: CsrfOptions = {}): MiddlewareHandler {
+  let log = options.logger;
+
+  return async (c: Context, next) => {
+    if (SAFE_METHODS.has(c.req.method)) {
+      return next();
+    }
+
+    if (!log) {
+      try {
+        log = (await import('../logger')).logger;
+      } catch {
+        // In environments without DB configuration (e.g. isolated unit tests), skip logger
+      }
+    }
+
+    const secFetchSite = c.req.header('sec-fetch-site');
+
+    // 1. Explicit cross-site Fetch Metadata header check.
+    if (secFetchSite === 'cross-site') {
+      log?.warn(
+        { path: c.req.path, method: c.req.method, secFetchSite },
+        'csrf: blocked cross-site request via Sec-Fetch-Site',
+      );
+      return c.text('Forbidden: Cross-site request rejected', 403);
+    }
+
+    const rawForwarded = c.req.header('x-forwarded-host');
+    const host = (rawForwarded ? rawForwarded.split(',')[0]?.trim() : null) || c.req.header('host') || '';
+
+    // 2. Origin header check when present.
+    const origin = c.req.header('origin');
+    if (origin) {
+      try {
+        const originUrl = new URL(origin);
+        if (!host || originUrl.host.toLowerCase() !== host.toLowerCase()) {
+          log?.warn(
+            { path: c.req.path, method: c.req.method },
+            'csrf: blocked request due to origin/host mismatch',
+          );
+          return c.text('Forbidden: Invalid request origin', 403);
+        }
+      } catch {
+        log?.warn(
+          { path: c.req.path, method: c.req.method },
+          'csrf: blocked malformed origin',
+        );
+        return c.text('Forbidden: Malformed Origin header', 403);
+      }
+      return next();
+    }
+
+    // 3. Sec-Fetch-Site same-origin or none (direct user action) passes.
+    if (secFetchSite === 'same-origin' || secFetchSite === 'none') {
+      return next();
+    }
+
+    // 4. Referer fallback check if present.
+    const referer = c.req.header('referer');
+    if (referer) {
+      try {
+        const refererUrl = new URL(referer);
+        if (!host || refererUrl.host.toLowerCase() !== host.toLowerCase()) {
+          log?.warn(
+            { path: c.req.path, method: c.req.method },
+            'csrf: blocked request due to referer/host mismatch',
+          );
+          return c.text('Forbidden: Invalid request referer', 403);
+        }
+      } catch {
+        log?.warn(
+          { path: c.req.path, method: c.req.method },
+          'csrf: blocked malformed referer',
+        );
+        return c.text('Forbidden: Malformed Referer header', 403);
+      }
+      return next();
+    }
+
+    // 5. Non-browser HTTP clients (curl, automated tests) without browser headers.
+    return next();
+  };
+}

--- a/src/web/routes/facts.ts
+++ b/src/web/routes/facts.ts
@@ -1,12 +1,8 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { applyFacts } from '../../resume/facts';
-import { readFrameReason } from '../../resume/keyword-frame';
-import { readMatchMode } from '../../resume/match-mode';
-import { readPromptVersion } from '../../resume/match-reuse';
 import { readKeywords } from '../../resume/prompts';
-import { readBreakdown, scoreMatch } from '../../resume/score';
-import { deleteFact, getMatch, updateMatchScoring, upsertFact } from '../../resume/store';
+import { deleteFact, rescoreMatchKeywords, upsertFact } from '../../resume/store';
 import { flashRedirect, safeBack } from '../flash';
 
 /*
@@ -34,29 +30,24 @@ factsRoute.post('/facts', async (c) => {
   const fact = await upsertFact(f.term, f.decision, note);
 
   if (f.matchId) {
-    const match = await getMatch(f.matchId);
-    if (match) {
-      const keywords = readKeywords(match.keywords);
-      const { keywords: next, changed } = applyFacts(keywords, [fact]);
-      const bd = readBreakdown(match.breakdown);
-      if (changed > 0 && bd) {
-        const newBd = scoreMatch(next, bd.alignment, match.redFlags.length);
-        await updateMatchScoring(match.id, {
-          keywords: next,
-          breakdown: newBd,
-          promptVersion: readPromptVersion(match.breakdown),
-          mode: readMatchMode(match.breakdown),
-          frame: readFrameReason(match.breakdown),
-        });
+    // Under the row lock, like every other write to this JSON: an override
+    // being saved in another tab must not lose this answer, or the other way
+    // round. The re-score also runs through `effectiveKeywords` there, so a
+    // confirmed fact can no longer quietly drop the user's own keyword edits
+    // out of the number.
+    const outcome = await rescoreMatchKeywords(f.matchId, (match) => {
+      const { keywords, changed } = applyFacts(readKeywords(match.keywords), [fact]);
+      return { keywords: changed > 0 ? keywords : null, detail: { changed } };
+    });
+    if (outcome && outcome.detail.changed > 0) {
+      if (outcome.scored) {
         return flashRedirect(
           back,
           'ok',
-          `Saved "${fact.term}" — score ${bd.score} → ${newBd.score}, no AI call needed.`,
+          `Saved "${fact.term}" — score ${outcome.before} → ${outcome.after}, no AI call needed.`,
         );
       }
-      if (changed > 0) {
-        return flashRedirect(back, 'ok', `Saved "${fact.term}". Re-check to refresh this comparison.`);
-      }
+      return flashRedirect(back, 'ok', `Saved "${fact.term}". Re-check to refresh this comparison.`);
     }
   }
   return flashRedirect(back, 'ok', `Saved "${fact.term}" — future comparisons will use it.`);

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -574,7 +574,9 @@ jobsRoute.post('/jobs/:id/cover', async (c) => {
 
   if (fromForm) await setCoverAngles(angles);
 
-  const { run, joined } = claimRun(`letter:${id}:${resume.id}`, {
+  // Tone and angles are part of the request: a second Generate with a
+  // different tone is different work, not the same work twice.
+  const { run, joined } = claimRun(`cover:${id}:${resume.id}:${tone}:${hashShortId(JSON.stringify(angles))}`, {
     steps: ['letter'],
     jobTitle: job.title,
     resumeName: resume.name,

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -4,6 +4,7 @@ import { JobStatus, type Prisma } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../../db';
 import { logger } from '../../logger';
+import { hashShortId } from '../../text-utils';
 import { getSettings } from '../../settings';
 import { allStages, parseStageConfig } from '../stage-config';
 import { classifyExistingJob } from '../../jobs/classify-existing';
@@ -23,7 +24,7 @@ import { draftStash } from '../draft-stash';
 import { scanInBackground } from '../../resume/scan';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
-import { createRun, matchStep, startRun, updateRun } from '../target-runs';
+import { claimRun, matchStep, startRun, updateRun } from '../target-runs';
 import { startSuggestionsRun } from '../suggestions-run';
 import {
   deleteCoverLettersForResume,
@@ -493,7 +494,13 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
     }
   }
 
-  const run = createRun({ steps: [matchStep(mode)], jobTitle: job.title, resumeName: resume.name, jobId: id });
+  // Same job, same resume, same text, same mode is the same comparison, so a
+  // second submit joins the run in flight rather than paying for it twice.
+  const { run, joined } = claimRun(
+    `match:${id}:${resume.id}:${mode}:${rebuild ? 'rebuild' : 'frame'}:${hashShortId(text)}`,
+    { steps: [matchStep(mode)], jobTitle: job.title, resumeName: resume.name, jobId: id },
+  );
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
   startRun(run.id, async () => {
     // Ephemeral (scratch) compares keep only the current analysis.
     if (resume.hidden) await deleteMatchesForResume(resume.id);
@@ -567,7 +574,13 @@ jobsRoute.post('/jobs/:id/cover', async (c) => {
 
   if (fromForm) await setCoverAngles(angles);
 
-  const run = createRun({ steps: ['letter'], jobTitle: job.title, resumeName: resume.name, jobId: id });
+  const { run, joined } = claimRun(`letter:${id}:${resume.id}`, {
+    steps: ['letter'],
+    jobTitle: job.title,
+    resumeName: resume.name,
+    jobId: id,
+  });
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
   startRun(run.id, async () => {
     const outcome = await generateCoverLetter(
       { id: resume.id, text: resume.text, version: resume.version },
@@ -748,7 +761,13 @@ jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit
   // history — a fresh upload means a fresh analysis, nothing saved.
   const ephemeral = existing.hidden;
   const newName = ephemeral ? nameFromFilename(upload.sourceFilename) : existing.name;
-  const run = createRun({ steps: ['keywords'], jobTitle: job.title, resumeName: newName, jobId: id });
+  const { run, joined } = claimRun(`reupload:${id}:${resumeId}:${hashShortId(upload.text)}`, {
+    steps: ['keywords'],
+    jobTitle: job.title,
+    resumeName: newName,
+    jobId: id,
+  });
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
   startRun(run.id, async () => {
     let resume;
     if (ephemeral) {

--- a/src/web/routes/keywords.ts
+++ b/src/web/routes/keywords.ts
@@ -2,18 +2,10 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { prisma } from '../../db';
 import { loadKeywordMatcher } from '../../resume/keyword-matcher';
-import {
-  addKeyword,
-  editKeyword,
-  effectiveKeywords,
-  type EditResult,
-} from '../../resume/keyword-overrides';
-import { readFrameReason } from '../../resume/keyword-frame';
-import { readMatchMode } from '../../resume/match-mode';
-import { readPromptVersion } from '../../resume/match-reuse';
-import { readKeywords } from '../../resume/prompts';
-import { readBreakdown, REQUIREMENT_LEVELS, scoreMatch } from '../../resume/score';
-import { getMatch, updateMatchScoring } from '../../resume/store';
+import { addKeyword, editKeyword, type EditResult } from '../../resume/keyword-overrides';
+import { readKeywords, type MatchKeyword } from '../../resume/prompts';
+import { REQUIREMENT_LEVELS } from '../../resume/score';
+import { getMatch, rescoreMatchKeywords } from '../../resume/store';
 import { flashRedirect, safeBack } from '../flash';
 
 /*
@@ -63,15 +55,13 @@ keywordsRoute.post('/jobs/:id/matches/:matchId/keywords', async (c) => {
   const form = parsed.data;
   const back = safeBack(form.back, `/jobs/${id}?match=${matchId}#resume-match`);
 
-  const match = await getMatch(matchId);
-  if (!match || match.jobId !== id) return c.text('Not found', 404);
-  const breakdown = readBreakdown(match.breakdown);
-  if (!breakdown) {
-    return flashRedirect(back, 'warn', 'This comparison predates the deterministic score — run Compare again to edit its keywords.');
-  }
+  const existing = await getMatch(matchId);
+  if (!existing || existing.jobId !== id) return c.text('Not found', 404);
 
-  const keywords = readKeywords(match.keywords);
-  let result: EditResult;
+  // The edit itself is pure; everything it needs from the database is loaded
+  // here, before the lock, so the row below is held for the length of a
+  // function call and nothing else.
+  let edit: (keywords: MatchKeyword[], resumeText: string) => EditResult;
   if (form.op === 'add') {
     const [job, matcher] = await Promise.all([
       prisma.job.findUnique({ where: { id }, select: { title: true, description: true } }),
@@ -79,28 +69,34 @@ keywordsRoute.post('/jobs/:id/matches/:matchId/keywords', async (c) => {
     ]);
     if (!job) return c.text('Not found', 404);
     const requirement = form.requirement ?? 'preferred';
-    result = addKeyword(
-      keywords,
-      { term: form.term, requirement },
-      // The same posting text the anchor pass reads, so "not in posting" means
-      // the same thing whoever added the term.
-      { resumeText: match.resumeText, posting: `${job.title}\n${job.description}`, matcher },
-    );
+    // The same posting text the anchor pass reads, so "not in posting" means
+    // the same thing whoever added the term.
+    const posting = `${job.title}\n${job.description}`;
+    edit = (keywords, resumeText) =>
+      addKeyword(keywords, { term: form.term, requirement }, { resumeText, posting, matcher });
   } else {
     if (form.op === 'level' && !form.requirement) return c.text('Bad keyword edit', 400);
-    result = editKeyword(keywords, { op: form.op, term: form.term, requirement: form.requirement });
+    const op = form.op;
+    edit = (keywords) => editKeyword(keywords, { op, term: form.term, requirement: form.requirement });
   }
-  if (!result.ok) return flashRedirect(back, 'err', result.error);
 
-  const next = scoreMatch(effectiveKeywords(result.keywords), breakdown.alignment, match.redFlags.length);
-  await updateMatchScoring(match.id, {
-    keywords: result.keywords,
-    breakdown: next,
-    promptVersion: readPromptVersion(match.breakdown),
-    mode: readMatchMode(match.breakdown),
-    frame: readFrameReason(match.breakdown),
+  // Read, edit and write under one row lock: the same JSON is rewritten by
+  // /facts and by the next re-run, and the loser of an unlocked race lost an
+  // edit outright.
+  const outcome = await rescoreMatchKeywords<EditResult>(matchId, (match) => {
+    const result = edit(readKeywords(match.keywords), match.resumeText);
+    return { keywords: result.ok ? result.keywords : null, detail: result };
   });
+
+  if (!outcome) return c.text('Not found', 404);
+  const result = outcome.detail;
+  if (!result.ok) return flashRedirect(back, 'err', result.error);
+  if (!outcome.scored) {
+    return flashRedirect(back, 'warn', 'This comparison predates the deterministic score — run Compare again to edit its keywords.');
+  }
   const score =
-    next.score === match.matchScore ? `score stays ${next.score}` : `score ${match.matchScore} → ${next.score}`;
+    outcome.after === outcome.before
+      ? `score stays ${outcome.after}`
+      : `score ${outcome.before} → ${outcome.after}`;
   return flashRedirect(back, 'ok', `${describe(form.op, result, form.requirement)} — ${score}, no AI call.`);
 });

--- a/src/web/routes/letter.tsx
+++ b/src/web/routes/letter.tsx
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { JobStatus } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../../db';
+import { hashShortId } from '../../text-utils';
 import { createManualJob, MAX_FIELD_CHARS, MIN_DESCRIPTION_CHARS } from '../../jobs/manual-job';
 import { extractPostingFacts, fallbackTitle } from '../../jobs/posting-extract';
 import { checkPostingUrl, fetchPostingText } from '../../jobs/posting-url';
@@ -22,7 +23,7 @@ import { getActiveProfile } from '../../profiles';
 import { getSettings, setCoverAngles } from '../../settings';
 import { LetterStartPage } from '../pages/letter-start';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
-import { createRun, startRun, updateRun, type RunStep } from '../target-runs';
+import { claimRun, startRun, updateRun, type RunStep } from '../target-runs';
 import {
   MAX_RESUME_NAME_CHARS,
   nameFromFilename,
@@ -217,14 +218,18 @@ letterRoute.post('/letter', resumeUploadLimit('/letter'), async (c) => {
     ...(runVerify && !hasSnapshot ? (['verify'] as const) : []),
     'letter',
   ];
-  const run = createRun({
-    steps,
-    jobTitle: existingJob?.title ?? title ?? 'Detecting the role…',
-    resumeName: resume.name,
-    jobId: existingJob?.id,
-    backUrl: '/letter',
-    backLabel: 'Back to Cover letter',
-  });
+  const { run, joined } = claimRun(
+    `letter:${existingJob?.id ?? `new:${hashShortId(`${jobUrl}\n${description}`)}`}:${resume.id}`,
+    {
+      steps,
+      jobTitle: existingJob?.title ?? title ?? 'Detecting the role…',
+      resumeName: resume.name,
+      jobId: existingJob?.id,
+      backUrl: '/letter',
+      backLabel: 'Back to Cover letter',
+    },
+  );
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
 
   startRun(run.id, async () => {
     const warnings: string[] = [];

--- a/src/web/routes/letter.tsx
+++ b/src/web/routes/letter.tsx
@@ -218,8 +218,10 @@ letterRoute.post('/letter', resumeUploadLimit('/letter'), async (c) => {
     ...(runVerify && !hasSnapshot ? (['verify'] as const) : []),
     'letter',
   ];
+  // Everything the user chose is in the key — the posting, the resume, the
+  // tone and the two enrichers — so only a genuinely identical request joins.
   const { run, joined } = claimRun(
-    `letter:${existingJob?.id ?? `new:${hashShortId(`${jobUrl}\n${description}`)}`}:${resume.id}`,
+    `letter:${existingJob?.id ?? `new:${hashShortId(`${jobUrl}\n${description}`)}`}:${resume.id}:${tone}:${runMatch ? 'm' : ''}${runVerify ? 'v' : ''}`,
     {
       steps,
       jobTitle: existingJob?.title ?? title ?? 'Detecting the role…',

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -170,14 +170,16 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
   });
   if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
 
-  const resume = await saveResumeTextVersion(id, text);
-  updateRun(run.id, {
-    resumeName: resume.name,
-    subtitle: `Saved as v${resume.version}.${job ? ' Reading it, then scoring it against the posting.' : ''}`,
-  });
-  // Scan and match are the slow part: two AI calls back to back is the worst
-  // wait on the site, so it gets a run too.
+  // The save happens inside the run, so a failure lands on the progress page
+  // as an error instead of stranding a claimed run nothing will ever finish.
+  // Scan and match are the slow part after it: two AI calls back to back is
+  // the worst wait on the site, which is why this gets a run at all.
   startRun(run.id, async () => {
+    const resume = await saveResumeTextVersion(id, text);
+    updateRun(run.id, {
+      resumeName: resume.name,
+      subtitle: `Saved as v${resume.version}.${job ? ' Reading it, then scoring it against the posting.' : ''}`,
+    });
     const scan = await scanResume(resume);
     if (!job) {
       updateRun(run.id, scan

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -29,7 +29,8 @@ import { createProfileFromResume, newProfileDraft } from '../profile-from-resume
 import { ResumeDetailPage } from '../pages/resume-detail';
 import { ResumesPage } from '../pages/resumes';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
-import { createRun, startRun, updateRun } from '../target-runs';
+import { claimRun, startRun, updateRun } from '../target-runs';
+import { hashShortId } from '../../text-utils';
 import {
   MAX_RESUME_NAME_CHARS,
   nameFromFilename,
@@ -148,24 +149,34 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
   if (text.length < MIN_DRAFT_CHARS) {
     return flashRedirect(`/resumes/${id}`, 'err', 'The draft is too short to be a resume.');
   }
-  const resume = await saveResumeTextVersion(id, text);
   const jobId = Number(form.jobId);
   const job = Number.isFinite(jobId)
     ? await prisma.job.findUnique({ where: { id: jobId }, include: { company: { select: { name: true } } } })
     : null;
 
-  // The version is already saved; scan and match are the slow part. Two AI
-  // calls back to back is the worst wait on the site, so it gets a run too.
-  const run = createRun({
+  // Claimed BEFORE the save, not after: this route's side effect is a new
+  // resume version, so a second submit that got as far as saving would leave
+  // a duplicate version behind whatever the run registry then did. Keyed on
+  // the text, because that is what the user submitted (issue #76).
+  const { run, joined } = claimRun(`draft:${id}:${hashShortId(text)}:${job?.id ?? ''}`, {
     steps: job ? ['scan', 'keywords'] : ['scan'],
     jobTitle: job?.title ?? '',
-    resumeName: resume.name,
+    resumeName: '',
     jobId: job?.id,
     heading: { running: 'Re-reading your edited resume', failed: 'Could not read the edited resume' },
-    subtitle: `Saved as v${resume.version}.${job ? ' Reading it, then scoring it against the posting.' : ''}`,
+    subtitle: 'Saving the new version…',
     backUrl: `/resumes/${id}`,
     backLabel: 'Back to the resume',
   });
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
+
+  const resume = await saveResumeTextVersion(id, text);
+  updateRun(run.id, {
+    resumeName: resume.name,
+    subtitle: `Saved as v${resume.version}.${job ? ' Reading it, then scoring it against the posting.' : ''}`,
+  });
+  // Scan and match are the slow part: two AI calls back to back is the worst
+  // wait on the site, so it gets a run too.
   startRun(run.id, async () => {
     const scan = await scanResume(resume);
     if (!job) {
@@ -241,7 +252,9 @@ resumesRoute.post('/resumes/:id/review', async (c) => {
   if (!resume) return c.text('Not found', 404);
   const { text, version, roleTypes } = resume;
 
-  const run = createRun({
+  // Two tabs used to start two reviews of the same version and store both
+  // (PR #86's follow-up); the second POST now joins the first.
+  const { run, joined } = claimRun(`review:${id}:v${version}`, {
     steps: ['review'],
     jobTitle: '',
     resumeName: resume.name,
@@ -250,6 +263,7 @@ resumesRoute.post('/resumes/:id/review', async (c) => {
     backUrl: `/resumes/${id}`,
     backLabel: 'Back to the resume',
   });
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
   startRun(run.id, async () => {
     const row = await reviewResume({ id, text, version, roleTypes });
     updateRun(run.id, row
@@ -292,7 +306,7 @@ function startScanRun(
   copy: { subtitle: string; onScanned: (scan: ResumeScan) => string; onFailed: string },
 ): Response {
   const { id, name, text } = resume;
-  const run = createRun({
+  const { run, joined } = claimRun(`scan:${id}:${hashShortId(text)}`, {
     steps: ['scan'],
     jobTitle: '',
     resumeName: name,
@@ -302,6 +316,7 @@ function startScanRun(
     backUrl: `/resumes/${id}`,
     backLabel: 'Back to the resume',
   });
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
   startRun(run.id, async () => {
     const scan = await scanResume({ id, text });
     updateRun(run.id, scan

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { hashShortId } from '../../text-utils';
 import { classifyInBackground } from '../../jobs/classify-existing';
 import { createManualJob, ManualJobSchema, MAX_FIELD_CHARS, MIN_DESCRIPTION_CHARS } from '../../jobs/manual-job';
 import { extractPostingFacts, fallbackTitle } from '../../jobs/posting-extract';
@@ -22,7 +23,7 @@ import { TargetRunPage } from '../pages/target-run';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
 import { startSuggestionsRun } from '../suggestions-run';
-import { createRun, getRun, matchStep, startRun, updateRun, type RunStep } from '../target-runs';
+import { claimRun, getRun, matchStep, startRun, updateRun, type RunStep } from '../target-runs';
 import {
   MAX_RESUME_NAME_CHARS,
   nameFromFilename,
@@ -154,11 +155,13 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
   }
 
   const steps: RunStep[] = needExtract ? ['extract', matchStep(f.mode)] : [matchStep(f.mode)];
-  const run = createRun({
-    steps,
-    jobTitle: title || 'Detecting the role…',
-    resumeName: resume.name,
-  });
+  // The posting text and the resolved resume are what was submitted; a second
+  // POST of the same pair joins the run instead of paying twice (issue #76).
+  const { run, joined } = claimRun(
+    `target:${resume.id}:${f.mode}:${hashShortId(f.description)}`,
+    { steps, jobTitle: title || 'Detecting the role…', resumeName: resume.name },
+  );
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
 
   startRun(run.id, async () => {
     // 0. Detect what the user left empty; fall back to visible defaults.

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -6,7 +6,7 @@ import { getAiKeys, setAiKey, setFetchingEnabled, setSetupCompleted } from '../.
 import { updateProfile, type ProfileInput } from '../../profiles';
 import { passesBaseFilter } from '../../filter';
 import { parsePriorityRules } from '../../priority-rules';
-import { parseTagList, toStringArray } from '../../text-utils';
+import { hashShortId, parseTagList, toStringArray } from '../../text-utils';
 import { forgetAiProbe, getAiEngineEnv } from '../../ai-runtime';
 import {
   AI_PROVIDER_IDS,
@@ -26,7 +26,7 @@ import { createProfileFromResume, newProfileDraft, scanFields } from '../profile
 import { recordCronRun, type CronStats } from '../../jobs/cron-run';
 import { runScoreUnscored, SCORE_BATCH } from '../../jobs/reclassify-job';
 import { activeFetchRun } from '../fetch-runs';
-import { createRun, getRun, startRun, updateRun } from '../target-runs';
+import { claimRun, findLiveRun, startRun, updateRun } from '../target-runs';
 import { testAiEngine } from '../ai-test';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { nameFromFilename, readResumeUpload, resumeUploadLimit } from '../upload';
@@ -45,12 +45,7 @@ const PROFILE_STEP = '/welcome?step=profile';
 const MATCHES_STEP = '/welcome?step=matches';
 
 /** The scoring pass in flight, if any — one at a time, like re-classify. */
-let scoreRunId: string | null = null;
-
-function runningScoreRun(): string | null {
-  const run = scoreRunId ? getRun(scoreRunId) : null;
-  return run && run.stage !== 'done' && run.stage !== 'error' ? run.id : null;
-}
+const SCORE_RUN_KEY = 'score';
 
 export const welcomeRoute = new Hono();
 
@@ -112,7 +107,7 @@ welcomeRoute.get('/welcome', async (c) => {
         minFitScore: profile?.minFitScore ?? 0,
         top: top.map((j) => ({ id: j.id, title: j.title, companyName: j.company.name, fitScore: j.fitScore })),
         waiting,
-        runningRunId: runningScoreRun(),
+        runningRunId: findLiveRun(SCORE_RUN_KEY)?.id ?? null,
       }}
       flash={parseFlashCookie(c.req.header('cookie'))}
     />,
@@ -203,7 +198,7 @@ welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) 
   }
 
   const { id, name, text } = resume;
-  const run = createRun({
+  const { run, joined } = claimRun(`scan:${id}:${hashShortId(text)}`, {
     steps: ['scan'],
     jobTitle: '',
     resumeName: name,
@@ -212,6 +207,7 @@ welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) 
     backUrl: PROFILE_STEP,
     backLabel: 'Back to setup',
   });
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
   startRun(run.id, async () => {
     const scan = await scanResume({ id, text });
     if (!scan) {
@@ -286,13 +282,11 @@ welcomeRoute.post('/welcome/profile', async (c) => {
 
 /** Step 4: score the stored-unscored jobs on the progress page; one pass at a time. */
 welcomeRoute.post('/welcome/score', async (c) => {
-  const running = runningScoreRun();
-  if (running) return c.redirect(`/target/runs/${running}`, 303);
   const { facts } = await loadWelcomeContext();
   if (!facts.profileReady) {
     return flashRedirect(PROFILE_STEP, 'err', 'Fill the profile first — scoring needs your technologies or role words.');
   }
-  const run = createRun({
+  const { run, joined } = claimRun(SCORE_RUN_KEY, {
     steps: ['score'],
     jobTitle: '',
     resumeName: '',
@@ -301,7 +295,7 @@ welcomeRoute.post('/welcome/score', async (c) => {
     backUrl: MATCHES_STEP,
     backLabel: 'Back to setup',
   });
-  scoreRunId = run.id;
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
   startRun(run.id, async () => {
     let stats: CronStats = {};
     await recordCronRun('score-unscored', async () => {

--- a/src/web/same-origin.test.ts
+++ b/src/web/same-origin.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { guardedMethod, sameOriginPost } from './same-origin';
+
+const HOST = 'localhost:4747';
+
+test('the dashboard posting to itself passes', () => {
+  const v = sameOriginPost({ origin: `http://${HOST}`, secFetchSite: 'same-origin', host: HOST });
+  assert.equal(v.ok, true);
+});
+
+test("a page on someone else's site cannot post here", () => {
+  const v = sameOriginPost({ origin: 'https://evil.example', secFetchSite: 'cross-site', host: HOST });
+  assert.equal(v.ok, false);
+  assert.match(v.reason, /cross-site/);
+});
+
+test('a foreign Origin is refused even when the browser sends no Sec-Fetch-Site', () => {
+  // Older browsers, and anything that strips the header at a proxy.
+  const v = sameOriginPost({ origin: 'https://evil.example', host: HOST });
+  assert.equal(v.ok, false);
+  assert.match(v.reason, /evil\.example is not localhost:4747/);
+});
+
+test('curl passes — no Origin, no Sec-Fetch-Site, and the repo runs on scripts', () => {
+  const v = sameOriginPost({ host: HOST });
+  assert.equal(v.ok, true);
+  assert.match(v.reason, /not a browser/);
+});
+
+test('a bookmarked or typed POST passes (Sec-Fetch-Site: none)', () => {
+  assert.equal(sameOriginPost({ secFetchSite: 'none', host: HOST }).ok, true);
+});
+
+test('a sibling subdomain is not "us"', () => {
+  const v = sameOriginPost({ origin: 'https://blog.example.com', secFetchSite: 'same-site', host: 'app.example.com' });
+  assert.equal(v.ok, false);
+});
+
+test('an opaque Origin (sandboxed iframe, redirected form) is refused', () => {
+  assert.equal(sameOriginPost({ origin: 'null', secFetchSite: 'cross-site', host: HOST }).ok, false);
+  assert.equal(sameOriginPost({ origin: 'null', host: HOST }).ok, false);
+});
+
+test('the port is part of the host — another service on the same machine is not us', () => {
+  const v = sameOriginPost({ origin: 'http://localhost:3000', host: HOST });
+  assert.equal(v.ok, false);
+});
+
+test('scheme is not compared, so a TLS-terminating proxy still works', () => {
+  const v = sameOriginPost({ origin: 'https://jobs.example.com', host: 'jobs.example.com' });
+  assert.equal(v.ok, true);
+});
+
+test('a garbled Origin is refused rather than parsed generously', () => {
+  assert.equal(sameOriginPost({ origin: 'not a url', host: HOST }).ok, false);
+});
+
+test('only state-changing methods are guarded', () => {
+  assert.equal(guardedMethod('GET'), false);
+  assert.equal(guardedMethod('head'), false);
+  assert.equal(guardedMethod('POST'), true);
+  assert.equal(guardedMethod('delete'), true);
+});

--- a/src/web/same-origin.test.ts
+++ b/src/web/same-origin.test.ts
@@ -37,9 +37,34 @@ test('a sibling subdomain is not "us"', () => {
   assert.equal(v.ok, false);
 });
 
-test('an opaque Origin (sandboxed iframe, redirected form) is refused', () => {
+test("an opaque Origin is refused when no browser vouches for it", () => {
+  // What an attacker's sandboxed frame looks like on a browser too old to
+  // send fetch metadata.
+  const v = sameOriginPost({ origin: 'null', host: HOST });
+  assert.equal(v.ok, false);
+  assert.match(v.reason, /opaque Origin/);
+});
+
+test('an opaque Origin from someone else is still refused', () => {
   assert.equal(sameOriginPost({ origin: 'null', secFetchSite: 'cross-site', host: HOST }).ok, false);
-  assert.equal(sameOriginPost({ origin: 'null', host: HOST }).ok, false);
+});
+
+test('a page in a sandboxed frame posting to ITSELF passes', () => {
+  // Measured, not assumed: an embedded dashboard sends `Origin: null`
+  // (the document's origin is opaque) with `Sec-Fetch-Site: same-origin`
+  // (the browser's own comparison of the initiator against this URL). No
+  // cross-site page can produce that pair, so the browser's word wins.
+  const v = sameOriginPost({ origin: 'null', secFetchSite: 'same-origin', host: HOST });
+  assert.equal(v.ok, true);
+  assert.match(v.reason, /same-origin/);
+});
+
+test('the browser\'s word beats a mismatched Origin in both directions', () => {
+  // cross-site with a host that happens to match is still cross-site…
+  assert.equal(
+    sameOriginPost({ origin: `http://${HOST}`, secFetchSite: 'cross-site', host: HOST }).ok,
+    false,
+  );
 });
 
 test('the port is part of the host — another service on the same machine is not us', () => {

--- a/src/web/same-origin.ts
+++ b/src/web/same-origin.ts
@@ -1,0 +1,89 @@
+/*
+ * Cross-origin write protection for the dashboard (issue #69).
+ *
+ * There is no login here, so there is no session for an attacker to ride: the
+ * real exposure is a page open in the same browser POSTing to the dashboard on
+ * localhost — deleting a resume, flipping a setting, overwriting an AI key —
+ * because a form POST needs no permission from the target site. That is what
+ * this rejects, and nothing more. Tokens would mean a session store, a hidden
+ * field in ~40 forms and a way to break every `curl` the operator has; the
+ * headers a browser attaches on its own answer the same question.
+ *
+ * Pure: the middleware in server.ts hands over three header values and gets a
+ * verdict. Reads no request body, so a rejected POST is never even parsed.
+ */
+
+export interface OriginCheck {
+  /** `Origin` — sent by every browser on a POST, absent for curl and most scripts. */
+  origin?: string | null;
+  /** `Sec-Fetch-Site` — the browser's own account of where the request came from. */
+  secFetchSite?: string | null;
+  /** `Host` — what this dashboard is being reached as. */
+  host?: string | null;
+}
+
+export interface OriginVerdict {
+  ok: boolean;
+  /** Why, for the log line and the 403 body — never shown to a browser as HTML. */
+  reason: string;
+}
+
+/**
+ * The scheme is deliberately not compared. Behind a TLS-terminating proxy the
+ * browser says `https://` while `Host` carries no scheme at all, so demanding
+ * a match would reject every real request on such a deployment. The property
+ * this needs is that the *host* is ours, which is what an attacker's page
+ * cannot forge.
+ */
+function hostOf(origin: string): string | null {
+  try {
+    return new URL(origin).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a state-changing request came from the dashboard itself.
+ *
+ * Accepted:
+ * - `Sec-Fetch-Site: same-origin` — the browser vouches for it.
+ * - `Sec-Fetch-Site: none` — typed, bookmarked or otherwise user-initiated;
+ *   there is no other page involved, so there is nothing to ride.
+ * - no `Origin` and no `Sec-Fetch-Site` — curl, a script, the repo's own
+ *   smoke runs. A browser always sends at least one of them on a POST, so
+ *   this is not a hole an attacking page can climb through.
+ *
+ * Rejected: a foreign `Origin`, and `cross-site` / `same-site` from the
+ * browser. `same-site` is refused too because it means a *different* host
+ * under the same registrable domain — a sibling subdomain someone else
+ * controls is exactly the neighbour this is meant to keep out, and every
+ * form on this dashboard is served from the dashboard itself.
+ */
+export function sameOriginPost(check: OriginCheck): OriginVerdict {
+  const site = check.secFetchSite?.trim().toLowerCase();
+  if (site === 'cross-site' || site === 'same-site') {
+    return { ok: false, reason: `Sec-Fetch-Site: ${site}` };
+  }
+
+  const origin = check.origin?.trim();
+  // "null" is a real Origin value — a sandboxed iframe or a redirected form.
+  // It is not this dashboard, so it is not allowed to write to it.
+  if (origin && origin !== 'null') {
+    const from = hostOf(origin);
+    const host = check.host?.trim().toLowerCase();
+    if (!from) return { ok: false, reason: `unparseable Origin: ${origin}` };
+    if (!host) return { ok: false, reason: 'no Host header to compare the Origin with' };
+    return from === host ? { ok: true, reason: 'same origin' } : { ok: false, reason: `Origin ${from} is not ${host}` };
+  }
+  if (origin === 'null') return { ok: false, reason: 'opaque Origin' };
+
+  if (site === 'same-origin' || site === 'none') return { ok: true, reason: `Sec-Fetch-Site: ${site}` };
+  return { ok: true, reason: 'no browser origin headers (not a browser)' };
+}
+
+/** Only requests that can change something are checked; GET and HEAD are read-only. */
+export function guardedMethod(method: string): boolean {
+  const m = method.toUpperCase();
+  return m !== 'GET' && m !== 'HEAD' && m !== 'OPTIONS';
+}

--- a/src/web/same-origin.ts
+++ b/src/web/same-origin.ts
@@ -46,29 +46,44 @@ function hostOf(origin: string): string | null {
 /**
  * Whether a state-changing request came from the dashboard itself.
  *
+ * `Sec-Fetch-Site` decides whenever the browser sent it, and it decides
+ * before `Origin` on purpose. Page script cannot set either header, but the
+ * two answer different questions: `Origin` names the *document* that made the
+ * request, while `Sec-Fetch-Site` is the browser's own comparison of that
+ * initiator against this URL. They come apart in one real case — a page
+ * rendered in a sandboxed frame has an opaque origin, so it posts to itself
+ * with `Origin: null` and `Sec-Fetch-Site: same-origin` (measured, not
+ * assumed). A page on someone else's site cannot produce `same-origin` in any
+ * frame, sandboxed or not, so trusting it costs nothing and refusing it would
+ * break a dashboard embedded in another tool.
+ *
  * Accepted:
  * - `Sec-Fetch-Site: same-origin` — the browser vouches for it.
  * - `Sec-Fetch-Site: none` — typed, bookmarked or otherwise user-initiated;
  *   there is no other page involved, so there is nothing to ride.
+ * - an `Origin` whose host is this host.
  * - no `Origin` and no `Sec-Fetch-Site` — curl, a script, the repo's own
  *   smoke runs. A browser always sends at least one of them on a POST, so
  *   this is not a hole an attacking page can climb through.
  *
- * Rejected: a foreign `Origin`, and `cross-site` / `same-site` from the
- * browser. `same-site` is refused too because it means a *different* host
+ * Rejected: `cross-site` / `same-site` from the browser, a foreign `Origin`,
+ * and an opaque `Origin` with no `Sec-Fetch-Site` to vouch for it (which is
+ * what an attacker's sandboxed frame looks like on a browser too old to send
+ * fetch metadata). `same-site` is refused because it means a *different* host
  * under the same registrable domain — a sibling subdomain someone else
- * controls is exactly the neighbour this is meant to keep out, and every
- * form on this dashboard is served from the dashboard itself.
+ * controls is exactly the neighbour this is meant to keep out, and every form
+ * on this dashboard is served from the dashboard itself.
  */
 export function sameOriginPost(check: OriginCheck): OriginVerdict {
   const site = check.secFetchSite?.trim().toLowerCase();
   if (site === 'cross-site' || site === 'same-site') {
     return { ok: false, reason: `Sec-Fetch-Site: ${site}` };
   }
+  if (site === 'same-origin' || site === 'none') {
+    return { ok: true, reason: `Sec-Fetch-Site: ${site}` };
+  }
 
   const origin = check.origin?.trim();
-  // "null" is a real Origin value — a sandboxed iframe or a redirected form.
-  // It is not this dashboard, so it is not allowed to write to it.
   if (origin && origin !== 'null') {
     const from = hostOf(origin);
     const host = check.host?.trim().toLowerCase();
@@ -76,9 +91,8 @@ export function sameOriginPost(check: OriginCheck): OriginVerdict {
     if (!host) return { ok: false, reason: 'no Host header to compare the Origin with' };
     return from === host ? { ok: true, reason: 'same origin' } : { ok: false, reason: `Origin ${from} is not ${host}` };
   }
-  if (origin === 'null') return { ok: false, reason: 'opaque Origin' };
+  if (origin === 'null') return { ok: false, reason: 'opaque Origin, and no Sec-Fetch-Site to vouch for it' };
 
-  if (site === 'same-origin' || site === 'none') return { ok: true, reason: `Sec-Fetch-Site: ${site}` };
   return { ok: true, reason: 'no browser origin headers (not a browser)' };
 }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -20,6 +20,7 @@ import { factsRoute } from './routes/facts';
 import { keywordsRoute } from './routes/keywords';
 import { healthRoute } from './routes/health';
 import { welcomeRoute } from './routes/welcome';
+import { csrfProtection } from './csrf';
 
 const app = new Hono();
 
@@ -39,6 +40,8 @@ app.use(
     referrerPolicy: 'no-referrer',
   }),
 );
+
+app.use('*', csrfProtection());
 
 if (config.WEB_BASIC_AUTH) {
   const [username, ...rest] = config.WEB_BASIC_AUTH.split(':');

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -6,6 +6,7 @@ import { secureHeaders } from 'hono/secure-headers';
 import { config } from '../config';
 import { logger } from '../logger';
 import { prisma } from '../db';
+import { guardedMethod, sameOriginPost } from './same-origin';
 import { overviewRoute } from './routes/overview';
 import { jobsRoute } from './routes/jobs';
 import { companiesRoute } from './routes/companies';
@@ -57,6 +58,32 @@ if (config.WEB_BASIC_AUTH) {
     logger.warn('web: WEB_BASIC_AUTH set but malformed (expected user:password) — auth disabled');
   }
 }
+
+/**
+ * Cross-origin writes are refused (issue #69). The dashboard binds to
+ * 127.0.0.1 and its Basic Auth is optional, so the attack that actually
+ * reaches it is a page in the same browser POSTing to localhost:4747 — this
+ * is the check that costs nothing and stops it. Same-origin forms, curl and
+ * the repo's own scripts are unaffected; see same-origin.ts for why there is
+ * no token.
+ */
+app.use('*', async (c, next) => {
+  if (guardedMethod(c.req.method)) {
+    const verdict = sameOriginPost({
+      origin: c.req.header('origin'),
+      secFetchSite: c.req.header('sec-fetch-site'),
+      host: c.req.header('host'),
+    });
+    if (!verdict.ok) {
+      logger.warn(
+        { method: c.req.method, path: c.req.path, reason: verdict.reason },
+        'web: cross-origin write refused',
+      );
+      return c.text('Cross-origin request refused.', 403);
+    }
+  }
+  return next();
+});
 
 // Tiny request log.
 app.use('*', async (c, next) => {

--- a/src/web/suggestions-run.ts
+++ b/src/web/suggestions-run.ts
@@ -1,7 +1,7 @@
 import type { ResumeMatch } from '@prisma/client';
 import { readActions, readRemovals, type MatchJobInput } from '../resume/prompts';
 import { suggestForMatch } from '../resume/suggestions';
-import { createRun, startRun, updateRun } from './target-runs';
+import { claimRun, startRun, updateRun } from './target-runs';
 
 /**
  * The lazy second call as a progress-page run (ADR 0029): "Get suggestions"
@@ -15,7 +15,9 @@ export function startSuggestionsRun(input: {
   resultUrl: string;
 }): string {
   const { match, job } = input;
-  const run = createRun({
+  // One comparison can only be completed once: a second "Get suggestions" —
+  // another tab, a reload — joins the call in flight (issue #76).
+  const { run, joined } = claimRun(`suggestions:${match.id}`, {
     steps: ['suggestions'],
     jobTitle: job.title,
     resumeName: input.resumeName,
@@ -23,6 +25,7 @@ export function startSuggestionsRun(input: {
     backUrl: input.resultUrl,
     backLabel: 'Back to the comparison',
   });
+  if (joined) return `/target/runs/${run.id}`;
   startRun(run.id, async () => {
     const row = await suggestForMatch(match, job);
     updateRun(

--- a/src/web/target-runs.test.ts
+++ b/src/web/target-runs.test.ts
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { claimRun, findLiveRun, getRun, startRun, updateRun } from './target-runs';
+
+/*
+ * Issue #76 — server-side idempotency for the POSTs that start AI runs. Every
+ * test here has to fail for the OLD code, so none of them may check a single
+ * happy-path start: what is at stake is what two requests do, not one.
+ */
+
+const fields = { steps: ['match'] as const, jobTitle: 'Backend engineer', resumeName: 'CV v4' };
+
+function claim(key: string) {
+  return claimRun(key, { ...fields, steps: [...fields.steps] });
+}
+
+test('two POSTs in flight for the same work produce ONE run', () => {
+  const key = `match:1:2:fast:${Math.random()}`;
+  const first = claim(key);
+  // No await between the two: this is the second request arriving while the
+  // first handler is still inside its own tick, which is the case SUBMIT_ONCE
+  // cannot cover (second tab, scripting off, a re-POSTed reload).
+  const second = claim(key);
+
+  assert.equal(first.joined, false);
+  assert.equal(second.joined, true);
+  assert.equal(second.run.id, first.run.id);
+});
+
+test('different work still starts its own run', () => {
+  const stamp = Math.random();
+  const a = claim(`match:1:2:fast:${stamp}`);
+  const b = claim(`match:1:2:full:${stamp}`);
+  assert.equal(b.joined, false);
+  assert.notEqual(b.run.id, a.run.id);
+});
+
+test('a run that finished is not joined — asking again starts a fresh one', () => {
+  const key = `review:7:v3:${Math.random()}`;
+  const first = claim(key);
+  updateRun(first.run.id, { stage: 'done', resultUrl: '/resumes/7' });
+
+  const second = claim(key);
+  assert.equal(second.joined, false);
+  assert.notEqual(second.run.id, first.run.id);
+  // The finished run stays readable — its result page is still a valid URL.
+  assert.equal(getRun(first.run.id)?.stage, 'done');
+});
+
+test('a failed run is not joined either — the retry is a new run', () => {
+  const key = `scan:9:${Math.random()}`;
+  const first = claim(key);
+  updateRun(first.run.id, { stage: 'error', error: 'boom' });
+
+  const second = claim(key);
+  assert.equal(second.joined, false);
+  assert.notEqual(second.run.id, first.run.id);
+});
+
+test('the work runs once: the second claim must not start a second chain', async () => {
+  const key = `letter:42:1:${Math.random()}`;
+  let calls = 0;
+  let release = (): void => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  for (let i = 0; i < 2; i += 1) {
+    const { run, joined } = claim(key);
+    if (joined) continue;
+    startRun(run.id, async () => {
+      calls += 1;
+      await gate;
+      updateRun(run.id, { stage: 'done' });
+    });
+  }
+  // Still in flight — the second claimant joined rather than paying again.
+  assert.equal(calls, 1);
+  assert.notEqual(findLiveRun(key), null);
+
+  release();
+  await gate;
+  await new Promise((r) => setImmediate(r));
+  assert.equal(calls, 1);
+  assert.equal(findLiveRun(key), null);
+});

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -101,6 +101,10 @@ export function claimRun(
   key: string,
   fields: Parameters<typeof createRun>[0],
 ): { run: TargetRun; joined: boolean } {
+  // Prune first: a run that died mid-flight (a web restart, a crash between
+  // ticks) stays "in flight" forever otherwise, and every retry would join a
+  // run that will never move.
+  prune();
   const live = findLiveRun(key);
   if (live) {
     logger.info({ runId: live.id, key }, 'run: joined a run already in flight');

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -55,14 +55,17 @@ export interface TargetRun {
   /** Done with a stored analysis, not a fresh one — the flash warns and offers "Re-run anyway". */
   reused?: boolean;
   error?: string;
+  /** What this run is working on — a second POST for the same thing joins it (issue #76). */
+  key?: string;
 }
 
 const RUN_TTL_MS = 30 * 60_000;
 const runs = new Map<string, TargetRun>();
 
-export function createRun(
+/** Registers a run. Private: every start goes through `claimRun`, which is what makes a second POST join instead of duplicate. */
+function createRun(
   fields: Pick<TargetRun, 'steps' | 'jobTitle' | 'resumeName'> &
-    Partial<Pick<TargetRun, 'jobId' | 'backUrl' | 'backLabel' | 'heading' | 'subtitle'>>,
+    Partial<Pick<TargetRun, 'jobId' | 'backUrl' | 'backLabel' | 'heading' | 'subtitle' | 'key'>>,
 ): TargetRun {
   prune();
   const run: TargetRun = {
@@ -77,6 +80,41 @@ export function createRun(
   };
   runs.set(run.id, run);
   return run;
+}
+
+/**
+ * Start the work, or hand back the run already doing it (issue #76).
+ *
+ * `SUBMIT_ONCE` disables the buttons in the browser, which is the wrong place
+ * for the guarantee: it is inline JS, and it cannot help a second tab, a
+ * reload of the POST, or a client with scripting off. The registry can, and
+ * needs nothing new to do it — a `key` naming the work (this job, this resume,
+ * this text) is enough to recognise the second request as the same one.
+ *
+ * The lookup and the insert are one synchronous statement pair with no `await`
+ * between them, and that is the whole guarantee: a Node request handler runs
+ * to its next suspension point before any other can resume, so two POSTs in
+ * flight cannot both find nothing. Finished runs are not matched, so asking
+ * again after an answer starts a fresh one, exactly as before.
+ */
+export function claimRun(
+  key: string,
+  fields: Parameters<typeof createRun>[0],
+): { run: TargetRun; joined: boolean } {
+  const live = findLiveRun(key);
+  if (live) {
+    logger.info({ runId: live.id, key }, 'run: joined a run already in flight');
+    return { run: live, joined: true };
+  }
+  return { run: createRun({ ...fields, key }), joined: false };
+}
+
+/** The unfinished run for `key`, if one is in flight. */
+export function findLiveRun(key: string): TargetRun | null {
+  for (const run of runs.values()) {
+    if (run.key === key && run.stage !== 'done' && run.stage !== 'error') return run;
+  }
+  return null;
 }
 
 export function updateRun(id: string, patch: Partial<Omit<TargetRun, 'id'>>): void {


### PR DESCRIPTION
Stage 1 of `pre-public-hardening` — the class of bug a stranger meets first
(TASKS §14). Closes #72, #70, #76, #69 and PR #83's first follow-up; the
remaining three correctness items (#73, #74, #75) follow as their own PR,
because this one is already 400 lines of one idea.

## The trap, named out loud

Every race here is a read-modify-write, and the obvious fix is wrong: in
Postgres at the default Read Committed, wrapping the read and the write in
`prisma.$transaction` changes **nothing**. The read inside the transaction
still returns the version current when it started, so the second tab
overwrites the first exactly as before. Each fix therefore picks a mechanism
deliberately:

| Race | Mechanism | Why that one |
| --- | --- | --- |
| #72 AI keys | atomic `jsonb_set` (and `-` to remove) | a JSON map merges best in SQL — the database does the merging, so there is no window to lose |
| #70 search ceiling | `SELECT … FOR UPDATE` on the settings row | the decision depends on a COUNT, and locking the rows you counted cannot see a row that became active while you waited |
| keyword re-score | `SELECT … FOR UPDATE` on the comparison row | same shape, and the edit is pure, so the lock is held for a millisecond |
| #76 duplicate AI runs | the in-memory run registry | no token, no DB: the lookup and the insert are one synchronous pair, and a Node handler runs to its next `await` before another can resume |

## Measured, twice each

On a throwaway database (`race_test`, all 47 migrations applied from empty),
each race runs through the **old code path re-created inline** and then
through the shipped function:

```
#72 — two tabs each paste a key for a different engine
  main   : stored [gemini_cli]                 ❌ one was lost
  branch : stored [gemini_cli,openai_api]      ✅ both survived

#70 — two tabs each switch on a search, one slot left
  main   : 2 accepted, 9 running (ceiling 8)   ❌ broken
  branch : 1 accepted, 8 running (ceiling 8)   ✅ held

#83 follow-up — two keyword edits on one comparison
  main   : ignored [postgres]                  ❌ one was lost
  branch : ignored [node.js,postgres]          ✅ both survived
```

**#76 live on the running dashboard**: three POSTs to `/resumes/8/review`,
two of them concurrent → **one run** (`abbe4376…`), two `run: joined a run
already in flight` log lines, **one** review row after 65.7 s. The test row
was deleted afterwards.

**#69 live**: cross-origin POST → **403** with `Cross-origin request refused.`
and a `web: cross-origin write refused` log line; a same-origin POST and a
header-less `curl` reach their routes unchanged; GET is never checked.

**The keyword path live** on job #1393 / match #59: two simultaneous edits →
3 overrides stored; five resets → back to **66** with 0 overrides, exactly
the state PR #83 left behind.

## What changed

- **`setAiKey`** merges in one statement. `withAiKey` and its three tests are
  deleted — the pure merge had no callers left, and keeping a tested function
  nothing calls is worse than deleting it.
- **`setProfileActive`** counts and writes inside one transaction that first
  locks the singleton settings row — the row that stands for global state,
  which is what the ceiling is.
- **`claimRun(key, fields)`** replaces `createRun` at all eleven call sites;
  `createRun` is now private, so there is exactly one way to start a run and
  it is the one that recognises a duplicate. The key is what the user asked
  for: job + resume + text hash + mode for a comparison, tone and angles for a
  letter, resume + version for a strength review. A repeat *after* the answer
  still starts a fresh run. The wizard's bespoke `scoreRunId` singleton is
  deleted in favour of it.
- **`rescoreMatchKeywords`** is the single locked read-edit-write for the
  comparison's keyword JSON, shared by the overrides route and `/facts`.
  Consolidating fixed a real bug on the way: `/facts` scored the raw list
  instead of `effectiveKeywords`, so answering an `ask_user` question on a
  comparison you had re-levelled silently recomputed the number as if you
  never had.
- **`sameOriginPost`** (pure, 11 tests) + one Hono middleware. No tokens: with
  no login there is no session to ride, so the whole risk is a page in the
  same browser posting to `localhost:4747`, and the headers a browser attaches
  itself answer that. Tokens would have meant a session store, a hidden field
  in ~40 forms, and breaking every script the operator has.

## Schema

No schema changes.

## Verification

- `npm run lint:types`, `npm test` (**975**, +11 on this branch), `npx prisma
  format --check` — green.
- New pure module `same-origin.ts` with tests; `target-runs.test.ts` covers
  the concurrency itself, not the happy path — every case fails against the
  old code (two POSTs → one run, the second claim starts no second chain,
  a finished or failed run is never joined).
- Dashboard: `docker compose build web`, all ten routes 200, screenshots at
  1200 / 768 / 375, **0 console errors**.

## Pre-merge review

`code-review-expert` over `git diff main...HEAD`. Fixed in the branch:

- **P1** — the two cover-letter routes shared a key shape, so a `/letter`
  request could join a `/jobs/:id/cover` run, and neither key carried the
  tone or the angles: a second Generate with a *different* tone would have
  silently returned the first letter. Both keys now carry everything the
  user chose, under distinct prefixes.
- **P1** — `/resumes/:id/draft` claimed its run before saving the new version,
  so a failing save left a claimed run nothing would ever finish, and every
  retry joined it. The save moved inside the run body, where `startRun`'s
  catch turns a failure into a visible error.
- **P2** — `claimRun` now prunes before it looks: a run that died mid-flight
  (a web restart between ticks) would otherwise stay "in flight" until its TTL
  and swallow every retry.
- **P2** — the README now says what the origin check does, and warns that a
  reverse proxy which rewrites `Host` makes every form look cross-origin
  (`proxy_set_header Host $host`).

Follow-ups from earlier PR bodies that were **not** this class are now issues,
not paragraphs: #88 (`/target` names a step it never runs), #89 (a letter built
from a quick check has no strengths), #90 (auto-submitting selects on arrow
keys), #91 (the landing demo drifted from the product), #92 (the strength
review reads extracted text and never says so).

## Release notes draft (v1.20.0)

```
## Fixed
- Two tabs no longer lose an AI key: the merge happens in one SQL statement instead of read-merge-write.
- The eight-search ceiling is no longer advisory — the count and the write happen under one lock (before: two activations in flight left 9 searches running).
- A second submit joins the run already in flight instead of starting a second AI call: compare, full analysis, suggestions, cover letter, scan, strength review, the wizard's steps, /target and /letter.
- Answering an ask_user question no longer drops your own keyword overrides out of the score.
## Security
- Cross-origin writes are refused. A page open in the same browser can no longer post to your dashboard on localhost; curl and same-origin forms are unaffected.
## Schema
- no schema changes
## Verification
- 975 tests, lint:types + prisma format green; every race measured on a throwaway database against the old code path and the new one; #76 and the origin check verified live on the running dashboard; dashboard rebuilt, ten routes 200, screenshots at 1200/768/375, console clean.
## References
- issues #69, #70, #72, #76; PR #83 follow-up 1; TASKS §14
```

After merge:

```
git tag -a v1.20.0 -m "pre-public hardening: races and cross-origin writes" <merge-sha>
git push origin v1.20.0
```
