### PR TITLE
applied resume: record it where the application is recorded, and show what went out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.21.0] — 2026-09-02
+
+### Added
+- **"Applied with" on the Application tracking card** (#75). Until now only
+  the "Mark applied" button ever recorded which resume went out; dragging a
+  card into Applied on the board, or filling in the application form, left it
+  blank with no way to say afterwards. In the live database that was **eight
+  applications and not one recorded resume**. The form now carries the
+  question, and a job that is in the funnel with no answer says so — with the
+  resume the page would have guessed, named in the hint rather than
+  preselected. Moving a card cannot ask, and the app does not answer for you.
+- **"The text that went out"** (#74). The resume snapshot stored with every
+  application has been written since v1.11.0 and read by nothing. It is now a
+  disclosure on the job page: the words as they were on the day, which is the
+  point of storing them — a resume version is edited in place, so the name and
+  the number stop being an answer the moment you upload a new one.
+
+### Fixed
+- **A profile saved against a deleted resume or Telegram target says so**
+  (#73). Both ids come from dropdowns rendered when the page loaded; deleting
+  either row in another tab used to answer the save with a raw foreign-key
+  error — a 500 page with a constraint name on it, and the whole edit lost.
+  The save now checks first and flashes "That resume no longer exists —
+  reload the page and pick another one. Nothing was saved."
+
 ## [1.20.0] — 2026-09-02
 
 ### Fixed
@@ -1219,6 +1244,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.21.0]: https://github.com/applypack/applypack/compare/v1.20.0...v1.21.0
 [1.20.0]: https://github.com/applypack/applypack/compare/v1.19.0...v1.20.0
 [1.19.0]: https://github.com/applypack/applypack/compare/v1.18.0...v1.19.0
 [1.18.0]: https://github.com/applypack/applypack/compare/v1.17.0...v1.18.0

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -993,10 +993,19 @@ before anyone else installs this.
         pure `sameOriginPost`.
       - Five follow-ups that had only ever lived in PR bodies became issues
         #88-#92; three of the same class were fixed here instead.
-- [ ] `pre-public-hardening` C — #73 (a stale `resumeId` in the profile
-      form raises a raw FK error), #74 + #75 (`appliedResumeText` is written
-      and never read; the board's drag and the application form leave the
-      applied-resume columns NULL).
+- [x] `pre-public-hardening` C — #73, #74, #75, branch
+      `applied-resume-truth` (stacked on the above).
+      - **#75 measured in the live database first**: 8 rows with a pipeline
+        stage or `APPLIED` status, **0** of them recording a resume. The
+        application form now asks; the board's drag deliberately does not
+        guess (a drag carries no picker, and a guess written into the record
+        is worse than a blank), so the job page shows the gap and offers the
+        answer instead.
+      - **#74** the snapshot is rendered as a disclosure — it had been
+        written since v1.11.0 and read by nothing.
+      - **#73** verified live: a `resumeId` that no longer exists flashes
+        *"That resume no longer exists — reload the page and pick another
+        one. Nothing was saved."* and `profile.updatedAt` does not move.
 - [ ] `pre-public-check` — the six-point audit before strangers arrive:
       clean install from an empty database, migrations, secrets, exposure,
       README against the live UI, delete blast radius + a backup recipe.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/applied-resume.test.ts
+++ b/src/web/applied-resume.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  appliedResumeColumns,
+  needsAppliedResume,
+  readAppliedResumeChoice,
+} from './applied-resume';
+
+describe('readAppliedResumeChoice', () => {
+  it('an absent field says nothing — a page with no picker must not erase a record', () => {
+    assert.deepEqual(readAppliedResumeChoice(undefined), { kind: 'keep' });
+    assert.deepEqual(readAppliedResumeChoice(null), { kind: 'keep' });
+  });
+
+  it('an empty value is a real answer: record nothing', () => {
+    assert.deepEqual(readAppliedResumeChoice(''), { kind: 'clear' });
+    assert.deepEqual(readAppliedResumeChoice('   '), { kind: 'clear' });
+  });
+
+  it('an id is the answer it looks like', () => {
+    assert.deepEqual(readAppliedResumeChoice('7'), { kind: 'set', id: 7 });
+    assert.deepEqual(readAppliedResumeChoice(7), { kind: 'set', id: 7 });
+  });
+
+  it('junk changes nothing rather than clearing a recorded application', () => {
+    assert.deepEqual(readAppliedResumeChoice('abc'), { kind: 'keep' });
+    assert.deepEqual(readAppliedResumeChoice('-3'), { kind: 'keep' });
+    assert.deepEqual(readAppliedResumeChoice('1.5'), { kind: 'keep' });
+  });
+});
+
+describe('appliedResumeColumns', () => {
+  const resume = { id: 4, version: 3, text: 'Senior backend engineer…', hidden: false };
+
+  it('records the id, the version AND the text — the bytes move under the version', () => {
+    assert.deepEqual(appliedResumeColumns(resume), {
+      appliedResumeId: 4,
+      appliedResumeVersion: 3,
+      appliedResumeText: 'Senior backend engineer…',
+    });
+  });
+
+  it('a resume deleted in another tab records nothing instead of blocking the change', () => {
+    assert.deepEqual(appliedResumeColumns(null), {
+      appliedResumeId: null,
+      appliedResumeVersion: null,
+      appliedResumeText: null,
+    });
+  });
+
+  it('the /target scratch row is never an application', () => {
+    assert.equal(appliedResumeColumns({ ...resume, hidden: true }).appliedResumeId, null);
+  });
+});
+
+describe('needsAppliedResume', () => {
+  const applied = { appliedResumeId: null, appliedAt: null, pipelineStage: null, status: 'NEW' };
+
+  it('a card dragged into a funnel column left the question unanswered', () => {
+    assert.equal(needsAppliedResume({ ...applied, pipelineStage: 'applied' }), true);
+  });
+
+  it('so did the application form with a date and no resume', () => {
+    assert.equal(needsAppliedResume({ ...applied, appliedAt: new Date() }), true);
+  });
+
+  it('and so did "Mark applied" with the picker set to "don\'t record"', () => {
+    assert.equal(needsAppliedResume({ ...applied, status: 'APPLIED' }), true);
+  });
+
+  it('never asks once an answer is stored', () => {
+    assert.equal(needsAppliedResume({ ...applied, appliedResumeId: 4, status: 'APPLIED' }), false);
+  });
+
+  it('never asks about a job that was never applied to', () => {
+    assert.equal(needsAppliedResume(applied), false);
+  });
+});

--- a/src/web/applied-resume.ts
+++ b/src/web/applied-resume.ts
@@ -1,0 +1,80 @@
+/*
+ * "Which resume did I send?" — the three `Job` columns that answer it
+ * (`appliedResumeId`, `appliedResumeVersion`, `appliedResumeText`) and the
+ * rules for writing them (issues #74, #75).
+ *
+ * The text snapshot is the point: a resume's bytes are replaced in place on
+ * "Upload a new version", so the id and the version alone would name v3 and
+ * hand back v5's words. It was written from one route and read by none —
+ * this module gives every write path the same rules and the page something
+ * to show.
+ *
+ * Pure. The caller loads the resume; what counts as a recordable one, and
+ * what an absent form field means, are decided here.
+ */
+
+/** What a form said about the applied resume. */
+export type AppliedResumeChoice =
+  | { kind: 'keep' }
+  | { kind: 'clear' }
+  | { kind: 'set'; id: number };
+
+/**
+ * A form field that is not there has said nothing — a page with no resume
+ * picker must not silently erase what another page recorded. An empty value
+ * is a real answer ("don't record one"), and so is an id.
+ */
+export function readAppliedResumeChoice(raw: unknown): AppliedResumeChoice {
+  if (raw === undefined || raw === null) return { kind: 'keep' };
+  const value = String(raw).trim();
+  if (value.length === 0) return { kind: 'clear' };
+  const id = Number(value);
+  return Number.isSafeInteger(id) && id > 0 ? { kind: 'set', id } : { kind: 'keep' };
+}
+
+export interface RecordableResume {
+  id: number;
+  version: number;
+  text: string;
+  /** The /target scratch row: replaced in place on every compare, never an application. */
+  hidden: boolean;
+}
+
+export interface AppliedResumeColumns {
+  appliedResumeId: number | null;
+  appliedResumeVersion: number | null;
+  appliedResumeText: string | null;
+}
+
+/**
+ * The columns to write for a resolved resume. A resume that was deleted in
+ * another tab, or the hidden scratch row, records nothing rather than
+ * blocking the status change — "I don't know" is a true answer, a wrong id
+ * is not.
+ */
+export function appliedResumeColumns(resume: RecordableResume | null): AppliedResumeColumns {
+  if (!resume || resume.hidden) {
+    return { appliedResumeId: null, appliedResumeVersion: null, appliedResumeText: null };
+  }
+  return {
+    appliedResumeId: resume.id,
+    appliedResumeVersion: resume.version,
+    appliedResumeText: resume.text,
+  };
+}
+
+/**
+ * Whether to ask "which resume did you send?" — the job is in the funnel past
+ * the point of applying, and nothing was recorded. That is the gap a card
+ * dragged into Applied leaves behind: the board carries no picker, and
+ * guessing on the user's behalf would state a fact they never gave.
+ */
+export function needsAppliedResume(job: {
+  appliedResumeId: number | null;
+  appliedAt: Date | null;
+  pipelineStage: string | null;
+  status: string;
+}): boolean {
+  if (job.appliedResumeId !== null) return false;
+  return job.status === 'APPLIED' || job.appliedAt !== null || job.pipelineStage !== null;
+}

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -19,6 +19,7 @@ import {
 } from '../ui';
 import { formatDate, formatSalary } from '../format';
 import { appliedWithLabel } from '../../jobs/applied-with';
+import { needsAppliedResume } from '../applied-resume';
 import type { FlashMessage } from '../flash';
 import { CoverLetterCard, type CoverLetterCardProps } from './cover-letter-card';
 import { ResumeMatchCard, type ResumeMatchCardProps } from './resume-match-card';
@@ -43,7 +44,10 @@ interface JobDetail {
   externalId: string;
   company: { id: number; name: string; atsType: string };
   appliedAt: Date | null;
+  appliedResumeId: number | null;
   appliedResumeVersion: number | null;
+  /** The resume's words as they were on the day — a version is edited in place (#74). */
+  appliedResumeText: string | null;
   /** null once the resume row is deleted — the snapshot outlives it. */
   appliedResume: { name: string } | null;
   pipelineStage: string | null;
@@ -196,6 +200,7 @@ export const JobDetailPage: FC<JobDetailProps> = ({
                   value={job.appliedAt ? job.appliedAt.toISOString().slice(0, 10) : ''}
                 />
               </Field>
+              <AppliedWithField job={job} picker={appliedResumePicker} />
               <Field label="Recruiter contact">
                 <Input
                   type="text"
@@ -211,6 +216,7 @@ export const JobDetailPage: FC<JobDetailProps> = ({
               </Field>
               <Button>Save application</Button>
             </form>
+            <AppliedTextDisclosure job={job} />
           </Card>
         )}
       </div>
@@ -412,6 +418,57 @@ const MarkAppliedForm: FC<{ job: JobDetail; picker: JobDetailProps['appliedResum
       </Button>
     </ActionForm>
   );
+
+/**
+ * "Which resume did I send?" on the card that records the application (#75).
+ *
+ * Never preselected when nothing is stored: a card dragged into Applied on the
+ * board carries no picker, and filling this in on the user's behalf would turn
+ * a guess into a recorded fact. The hint says which one the page would have
+ * suggested; choosing it stays the user's move.
+ */
+const AppliedWithField: FC<{ job: JobDetail; picker: JobDetailProps['appliedResumePicker'] }> = ({
+  job,
+  picker,
+}) => {
+  if (picker.resumes.length === 0) return null;
+  const asking = needsAppliedResume(job);
+  const suggestion = picker.resumes.find((r) => r.id === picker.suggestedId);
+  return (
+    <Field
+      label="Applied with"
+      hint={
+        asking
+          ? `Not recorded — pick the one you sent.${suggestion ? ` Most likely "${suggestion.name}".` : ''}`
+          : 'Kept as it was on the day, so a later edit cannot rewrite history.'
+      }
+    >
+      <Select name="appliedResumeId">
+        <option value="" selected={job.appliedResumeId === null}>
+          — not recorded —
+        </option>
+        {picker.resumes.map((r) => (
+          <option value={r.id} selected={r.id === job.appliedResumeId}>
+            {r.name}
+          </option>
+        ))}
+      </Select>
+    </Field>
+  );
+};
+
+/** The words that actually went out (#74) — written since v1.11.0, read by nothing until now. */
+const AppliedTextDisclosure: FC<{ job: JobDetail }> = ({ job }) =>
+  job.appliedResumeText ? (
+    <details class="mt-3 rounded-md border border-line px-3 py-2">
+      <summary class="cursor-pointer select-none text-[13px] font-medium text-ink-muted transition-colors duration-150 hover:text-ink">
+        The text that went out ({job.appliedResumeText.length.toLocaleString()} chars)
+      </summary>
+      <pre class="mt-3 whitespace-pre-wrap break-words font-sans text-[13px] leading-6 text-ink-muted">
+        {job.appliedResumeText}
+      </pre>
+    </details>
+  ) : null;
 
 /** Silent until an application recorded its resume — most rows never will. */
 const AppliedWithRow: FC<{ job: JobDetail }> = ({ job }) => {

--- a/src/web/profile-links.test.ts
+++ b/src/web/profile-links.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { missingLinkMessage } from './profile-links';
+
+test('both links intact — the save goes through', () => {
+  assert.equal(missingLinkMessage({ resumeGone: false, telegramTargetGone: false }), null);
+});
+
+test('a resume deleted in another tab is named, not thrown', () => {
+  const msg = missingLinkMessage({ resumeGone: true, telegramTargetGone: false });
+  assert.match(msg ?? '', /resume no longer exists/);
+  assert.match(msg ?? '', /Nothing was saved/);
+});
+
+test('a deleted Telegram target says which one it was', () => {
+  const msg = missingLinkMessage({ resumeGone: false, telegramTargetGone: true });
+  assert.match(msg ?? '', /Telegram target no longer exists/);
+});
+
+test('both gone at once is one sentence, not two flashes', () => {
+  const msg = missingLinkMessage({ resumeGone: true, telegramTargetGone: true });
+  assert.match(msg ?? '', /resume and that Telegram target/);
+});

--- a/src/web/profile-links.ts
+++ b/src/web/profile-links.ts
@@ -1,0 +1,34 @@
+/*
+ * The two rows a search profile points at — its resume and its Telegram
+ * target — are picked from dropdowns rendered when the page loaded. Either
+ * can be deleted in another tab before the form is submitted, and handing a
+ * dead id to Prisma answers with a raw foreign-key error: a 500 page with a
+ * constraint name on it, and the whole edit lost (issue #73).
+ *
+ * Pure: the route looks the ids up, this decides what to say.
+ */
+
+export interface ProfileLinks {
+  /** True when the form named a resume that no longer exists. */
+  resumeGone: boolean;
+  /** True when the form named a Telegram target that no longer exists. */
+  telegramTargetGone: boolean;
+}
+
+/**
+ * The flash for a save that cannot go through, or null when both links are
+ * fine. Names what went and what to do, because the dropdown the user is
+ * sent back to will no longer contain it.
+ */
+export function missingLinkMessage(links: ProfileLinks): string | null {
+  if (links.resumeGone && links.telegramTargetGone) {
+    return 'That resume and that Telegram target no longer exist — reload the page and pick again. Nothing was saved.';
+  }
+  if (links.resumeGone) {
+    return 'That resume no longer exists — reload the page and pick another one. Nothing was saved.';
+  }
+  if (links.telegramTargetGone) {
+    return 'That Telegram target no longer exists — reload the page and pick another one. Nothing was saved.';
+  }
+  return null;
+}

--- a/src/web/routes/applications.tsx
+++ b/src/web/routes/applications.tsx
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { prisma } from '../../db';
 import { getSettings } from '../../settings';
+import { getResume } from '../../resume/store';
+import { appliedResumeColumns, readAppliedResumeChoice } from '../applied-resume';
 import { flashRedirect, parseFlashCookie } from '../flash';
 import { ApplicationsPage } from '../pages/applications';
 import { allStages, labelFor, parseStageConfig } from '../stage-config';
@@ -16,6 +18,9 @@ export const ApplicationFormSchema = z.object({
   appliedAt: z.string().optional(),
   recruiterContact: z.string().optional(),
   applicationNotes: z.string().optional(),
+  // Absent when the page had no resumes to offer — "keep what is stored"
+  // rather than "erase it" (applied-resume.ts).
+  appliedResumeId: z.string().optional(),
 });
 
 export const applicationsRoute = new Hono();
@@ -153,12 +158,22 @@ applicationsRoute.post('/jobs/:id/application', async (c) => {
     appliedAt: form.appliedAt,
     recruiterContact: form.recruiterContact,
     applicationNotes: form.applicationNotes,
+    appliedResumeId: form.appliedResumeId,
   });
   if (!parsed.success) {
     return c.text('Invalid form values', 400);
   }
   const { pipelineStage, appliedAt, recruiterContact, applicationNotes } =
     parsed.data;
+
+  // "Which resume did I send?" is part of the application, so the form that
+  // records the application records it too (#75). Until now only "Mark
+  // applied" ever wrote these columns, and this form silently left them NULL.
+  const choice = readAppliedResumeChoice(parsed.data.appliedResumeId);
+  const appliedResume =
+    choice.kind === 'keep'
+      ? null
+      : appliedResumeColumns(choice.kind === 'set' ? await getResume(choice.id) : null);
 
   const stageValue =
     pipelineStage && pipelineStage.length > 0 ? pipelineStage : null;
@@ -202,6 +217,7 @@ applicationsRoute.post('/jobs/:id/application', async (c) => {
         applicationNotes && applicationNotes.trim().length > 0
           ? applicationNotes
           : null,
+      ...(appliedResume ?? {}),
     },
   });
   if (event) {

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { prisma } from '../../db';
 import { logger } from '../../logger';
 import { hashShortId } from '../../text-utils';
+import { appliedResumeColumns } from '../applied-resume';
 import { getSettings } from '../../settings';
 import { allStages, parseStageConfig } from '../stage-config';
 import { classifyExistingJob } from '../../jobs/classify-existing';
@@ -364,15 +365,17 @@ jobsRoute.post('/jobs/:id/status', async (c) => {
 
     // Stage C. The snapshot is what makes this answerable later: the bytes of
     // a resume are replaced in place on "Upload a new version", so the id and
-    // the version alone would name v3 and hand back v5's words. The select is
-    // the whole answer — an empty pick, a resume deleted in another tab and the
-    // /target scratch row all record nothing rather than block the status change.
+    // the version alone would name v3 and hand back v5's words. The rules for
+    // what counts live in applied-resume.ts, shared with the two paths on
+    // /applications that used to record nothing at all (#75).
     const requested = parsed.data.appliedResumeId;
     const picked = requested ? await getResume(requested) : null;
-    const applied = picked && !picked.hidden ? picked : null;
-    data.appliedResume = applied ? { connect: { id: applied.id } } : { disconnect: true };
-    data.appliedResumeVersion = applied?.version ?? null;
-    data.appliedResumeText = applied?.text ?? null;
+    const columns = appliedResumeColumns(picked);
+    data.appliedResume = columns.appliedResumeId
+      ? { connect: { id: columns.appliedResumeId } }
+      : { disconnect: true };
+    data.appliedResumeVersion = columns.appliedResumeVersion;
+    data.appliedResumeText = columns.appliedResumeText;
   }
 
   const update = prisma.job.update({ where: { id }, data });

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -79,6 +79,7 @@ import { isBlankProfile } from '../../profile-guards';
 import { isSettingsTab, SettingsPage } from '../pages/settings';
 import { sourceLabel } from '../source-names';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
+import { missingLinkMessage } from '../profile-links';
 import { createResume, getResume, listResumes } from '../../resume/store';
 import { scanResume } from '../../resume/scan';
 import { buildProfileDraft } from '../../resume/profile-draft';
@@ -757,6 +758,21 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
       `Priority rules — line ${first.line}: ${first.reason}. Profile not saved.`,
     );
   }
+
+  // Both ids come from dropdowns rendered when the page loaded; either row
+  // can be gone by the time the form arrives (issue #73). Prisma's answer to
+  // a dead id is a raw foreign-key error — a 500 with the whole edit lost.
+  const [resumeRow, targetRow] = await Promise.all([
+    resumeId === null ? null : getResume(resumeId),
+    telegramTargetId === null
+      ? null
+      : prisma.telegramTarget.findUnique({ where: { id: telegramTargetId }, select: { id: true } }),
+  ]);
+  const missing = missingLinkMessage({
+    resumeGone: resumeId !== null && resumeRow === null,
+    telegramTargetGone: telegramTargetId !== null && targetRow === null,
+  });
+  if (missing) return flashRedirect('/settings?tab=profile', 'err', missing);
 
   const input = {
     name: f.name,


### PR DESCRIPTION
Stage 1 part C of `pre-public-hardening` — the three correctness bugs a user
meets, split out of #93 so neither PR is 1000 lines of two ideas. Closes #73,
#74 and #75.

**Stacked on `pre-public-hardening` (#93)** — review that one first; this
branch's base retargets to `main` when it merges.

## #75 — measured before it was fixed

```sql
SELECT id, status, "pipelineStage", "appliedResumeId" FROM job
WHERE "pipelineStage" IS NOT NULL OR status = 'APPLIED';
```

**8 rows. Zero recorded resumes.** Every application in the live database
answers "which resume did I send?" with NULL, because only the "Mark applied"
button ever wrote those columns — dragging a card into Applied on the board
and filling in the application form both left them blank, with no way to say
so afterwards.

## What it does

- **The application form carries the question.** The form that records the
  application now records the resume too, with the same tri-state the rest of
  the app needs: an absent field means "keep what is stored" (a page with no
  resumes to offer must not erase a record), an empty value means "don't
  record one", an id means that resume.
- **The board's drag deliberately does not guess.** A drag carries no picker,
  and writing the page's best guess into the record would turn a suggestion
  into a fact the user never gave. Instead the job page shows the gap — the
  "Applied with" field reads *"Not recorded — pick the one you sent. Most
  likely "PHP/JS/React"."* — and never preselects. Choosing stays the user's
  move; that is the "set the resume afterwards" action #75 asked for.
- **#74 — the snapshot is finally readable.** `appliedResumeText` has been
  written since v1.11.0 and read by nothing. It is now a disclosure on the job
  page: *The text that went out (5,916 chars)*. That is the whole point of
  storing it — a resume version is edited in place, so the name and the number
  stop being an answer the moment a new version is uploaded.
- **#73 — a dead dropdown id is a sentence, not a stack trace.** Both profile
  links are checked before the write; a deleted resume or Telegram target
  flashes *"That resume no longer exists — reload the page and pick another
  one. Nothing was saved."*

## Shape

- `src/web/applied-resume.ts` — pure, 12 tests: what a form field means when
  it is absent, and what counts as a recordable resume (a deleted row and the
  `/target` scratch row record nothing rather than blocking the change).
  `/jobs/:id/status` now shares those rules instead of carrying its own copy.
- `src/web/profile-links.ts` — pure, 4 tests: the sentence for one, the other,
  or both.
- No schema change. The three columns have existed since v1.11.0; this reads
  and writes what was already there.

## Verification

- `npm run lint:types`, `npm test` (**994**, +16), `npx prisma format --check`
  — green.
- **Live on job #28** (a real April application, `applied`, no resume
  recorded): the form recorded id 5 / v1 / **5 908 chars** of snapshot, the
  stage and the applied date survived untouched, the Details card grew an
  "Applied with — PHP/JS/React v1" row and the disclosure rendered the text.
  The row was reset to NULL afterwards — that resume choice was a test, not
  Nazar's record.
- **Live on #73**: submitting the profile editor with a `resumeId` that no
  longer exists returns the flash above, and `profile.updatedAt` does not
  move.
- Dashboard: `docker compose build web`, `/jobs/:id`, `/settings`,
  `/applications` 200, screenshots at 1200 / 375, **0 console errors** in a
  fresh tab.

## Pre-merge review

`code-review-expert` over the branch diff. Fixed here:

- **P2** — the disclosure's wrapper rendered an empty `<div>` for every job
  with no snapshot; the margin moved onto the `<details>` itself.
- **P2** — the "not recorded" hint blamed the board's drag for a gap that a
  "Mark applied" with the picker set to "don't record" produces just as well.
  It now says what to do without claiming to know how the gap arose.
- **P3** — `z.union([z.string(), z.undefined()]).optional()` is
  `z.string().optional()`.

## Release notes draft (v1.21.0)

```
## What's new
- "Applied with" is part of the application form, not just the Mark applied button: record which resume went out from the job page, and fill it in afterwards for applications that never recorded one.
- The resume text an application went out with is now readable on the job page — the words as they were on the day, which a later version cannot rewrite.
## Fixed
- Saving a search profile whose resume or Telegram target was deleted in another tab now says which one went, instead of failing with a database error and losing the edit.
## Schema
- no schema changes
## Verification
- 994 tests, lint:types + prisma format green; live on a real application (snapshot recorded and read back, stage and date untouched) and on a deleted-resume profile save; dashboard rebuilt, routes 200, console clean.
## References
- issues #73, #74, #75; TASKS §14
```

After merge (once v1.20.0 is tagged):

```
git tag -a v1.21.0 -m "the applied resume, recorded where it is recorded" <merge-sha>
git push origin v1.21.0
```
