### PR TITLE
resume strength loop: answers fold into the next review (closes §12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.22.0] — 2026-09-02
+
+### Added
+- **The review's questions can be answered, and the answer changes the next
+  one** ([ADR 0030](docs/adr/0030-resume-strength-review.md) phase 3, TASKS
+  §12). The strength review refuses to invent a number: where a stronger line
+  needs one your resume doesn't carry, it asks instead. That was a dead end —
+  nothing could be answered, so the next run asked again. Now each question
+  has a box: the answer is stored on the resume and read into the next review,
+  which writes the figure into the rewritten line and stops asking. Measured
+  on a real resume: 4 questions, 2 answered, re-run asked **2** and both
+  figures appeared verbatim in the rewrites.
+- **What moved since the last review.** A second run of the same resume now
+  says whether the edits worked — the score before and after, and every
+  dimension whose grade changed. When the two runs used different rubric
+  versions it says so instead of subtracting them, because that difference is
+  not a measurement.
+- **Facts can be added and flipped from `/resumes`.** The "do you have this?"
+  answers fed every future comparison but could only be created by a
+  comparison that happened to ask. Add a skill nothing asked about, or turn a
+  wrong answer around, from the resumes page. No AI call either way.
+- **Rename a resume.** The name is what every picker, flash and "applied with"
+  line says, and it used to be whatever the uploaded file was called.
+- **Comparisons group per job.** Re-checking one posting used to produce
+  unrelated rows; they now read as one progression — *5 runs · 62 → 70 → 64 →
+  66 → 68*, each score still its own link, with the change since the previous
+  run beside the latest score.
+
+### Changed
+- `REVIEW_PROMPT_VERSION` 1 → 2: the rubric now receives the candidate's
+  supplied metrics and is told to write them in rather than ask again — and
+  told, just as explicitly, that a metric the document does not carry is a
+  reason for advice, never for a better grade. The resume is graded as
+  written.
+
+### Schema
+- `resume.answers` (JSONB, default `[]`) — hand-written migration
+  `20260902200000_add_resume_answers`. On the resume rather than the review
+  row: an answer is a fact about the document and has to outlive the run that
+  asked for it.
+
 ## [1.21.0] — 2026-09-02
 
 ### Added
@@ -1244,6 +1285,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.22.0]: https://github.com/applypack/applypack/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/applypack/applypack/compare/v1.20.0...v1.21.0
 [1.20.0]: https://github.com/applypack/applypack/compare/v1.19.0...v1.20.0
 [1.19.0]: https://github.com/applypack/applypack/compare/v1.18.0...v1.19.0

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -775,10 +775,10 @@ Telegram explicitly optional.
 
 ## 12. /resumes overhaul + on-demand resume strength review (analysis 2026-08-31)
 
-Full plan: [docs/resumes-plan.md](./resumes-plan.md). **Part A shipped in
-v1.12.0, Part B's review shipped 2026-09-02**; what is left is the
-metric-ask loop and three quick wins. Original audit: browser pass over the
-live page at desktop + 375px, plus code verification.
+Full plan: [docs/resumes-plan.md](./resumes-plan.md). **Section closed
+2026-09-02**: Part A shipped in v1.12.0, Part B's review the same day, and the
+metric-ask loop plus the quick wins in `resume-strength-loop`. Original audit:
+browser pass over the live page at desktop + 375px, plus code verification.
 
 Driver: `/resumes` shows inventory, not effectiveness — no per-resume
 match signal, upload & scan freezes the browser ~60 s (double-submit
@@ -820,11 +820,32 @@ icon; progress visible step-by-step via the target-run registry pattern.
       characters, 8 advice items, 4 asks. **Zero invented facts across 23
       advice items** — several rewrites removed unsupportable percentages
       instead of adding numbers.
-- [ ] `resume-strength-loop` — metric asks → user answers → re-run
-      deltas; version-over-version strength trend
-- [ ] quick wins ride along where touched: facts add/flip on `/resumes`
-      (existing `POST /facts` covers it), rename route, version badge in
-      hub, grouped per-job score history (`diff.ts`)
+- [x] `resume-strength-loop` — metric asks → user answers → re-run deltas,
+      done 2026-09-02, branch `resume-strength-loop`. One column
+      (`Resume.answers`, hand-written migration) rather than a table or a
+      `CandidateFact` row: an answer belongs to the DOCUMENT, has to outlive
+      the run that asked, and "1.2M requests/day" would poison the skill
+      vocabulary that feeds the match prompt. `REVIEW_PROMPT_VERSION` 1 → 2.
+      **Measured live on resume 1** (Opus, CLI engine): 4 asks → answered 2 →
+      re-run in 69.3 s with `answersUsed: 2` and **asks 4 → 2**, and both
+      figures were written into the rewrites verbatim ("Consolidated 3
+      microservices into 1 and retired 2 paid SaaS licences, cutting cloud
+      spend by ~$40k/year"). The score stayed 45, which is correct: the prompt
+      forbids a supplied metric from moving a grade on its own, because the
+      resume is graded as WRITTEN. The delta against the earlier run said so
+      out loud — *"2 dimensions moved — but the two runs used different rubric
+      versions, so the difference is not a measurement"* — which is the whole
+      point of storing the prompt version. Test rows removed afterwards.
+      **Not built:** the version-over-version trend. Two reviews exist on two
+      different resumes and no resume has two comparable runs — n = 0, the
+      same trap the repo closed F18 with.
+- [x] quick wins: facts add/flip on `/resumes` (the existing `POST /facts`
+      took any term; only the form was missing), a rename route + header
+      form, and comparisons grouped per job — 14 flat rows became 10, with
+      the five-run posting reading **5 runs · 62 → 70 → 64 → 66 → 68**, every
+      score still its own link. The plan's fourth item, "version badge in
+      hub", shipped with `resumes-page-p0`; removed from the list rather than
+      built twice.
 
 ## 13. /target compare speed (30-40 s) + keyword-matcher accuracy (analysis 2026-08-31)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/prisma/migrations/20260902200000_add_resume_answers/migration.sql
+++ b/prisma/migrations/20260902200000_add_resume_answers/migration.sql
@@ -1,0 +1,21 @@
+-- Answers to the strength review's questions (ADR 0030 phase 3).
+--
+-- The review asks for the numbers only the candidate has ("how many requests
+-- per day did that service handle?") instead of inventing them. Until now the
+-- question was a dead end: nothing could be answered, so the next run asked
+-- again. The answer goes into the next prompt, and the model rewrites the line
+-- with the real figure.
+--
+-- On "resume", not on "resume_review", and deliberately:
+--   * an answer is a fact about the DOCUMENT, not about one run of the rubric,
+--     and it must survive the re-run it feeds (a review row is per-press);
+--   * it must not go into candidate_fact either — that dictionary is skill
+--     vocabulary that feeds the MATCH prompt, and "1.2M requests/day" would
+--     poison it as a keyword;
+--   * one JSON column, no new table, cascade already handled by the resume row.
+--
+-- Shape: [{ "question": string, "answer": string, "answeredAt": ISO string }].
+-- Default '[]' so every existing resume reads as "nothing answered yet"; no
+-- backfill is possible or needed.
+
+ALTER TABLE "resume" ADD COLUMN "answers" JSONB NOT NULL DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -387,6 +387,11 @@ model Resume {
   summary         String?        @db.Text
   // [{ section, issue, fix }] — job-agnostic ATS / recruiter problems.
   issues          Json           @default("[]")
+  // [{ question, answer, answeredAt }] — the metrics the strength review asked
+  // for and the candidate supplied. On the RESUME, not the review row: an
+  // answer is a fact about this document and has to outlive the run that
+  // asked (ADR 0030 phase 3).
+  answers         Json           @default("[]")
   createdAt       DateTime       @default(now())
   updatedAt       DateTime       @updatedAt
   matches         ResumeMatch[]

--- a/src/resume/answers.test.ts
+++ b/src/resume/answers.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  answerFor,
+  answerLines,
+  MAX_ANSWERS,
+  MAX_ANSWER_CHARS,
+  readAnswers,
+  unansweredAsks,
+  upsertAnswer,
+} from './answers';
+
+const AT = new Date('2026-09-02T18:00:00Z');
+const Q = 'how many requests per day did that service handle?';
+
+describe('readAnswers', () => {
+  it('reads what upsertAnswer wrote', () => {
+    const stored = upsertAnswer([], Q, '1.2M', AT);
+    assert.deepEqual(readAnswers(stored), [
+      { question: Q, answer: '1.2M', answeredAt: AT.toISOString() },
+    ]);
+  });
+
+  it('a hand-edited row degrades to nothing answered rather than throwing', () => {
+    assert.deepEqual(readAnswers(null), []);
+    assert.deepEqual(readAnswers('nonsense'), []);
+    assert.deepEqual(readAnswers([{ question: 1, answer: [] }]), []);
+  });
+
+  it('drops half-written entries — a question with no answer says nothing', () => {
+    const raw = [
+      { question: Q, answer: '   ', answeredAt: AT.toISOString() },
+      { question: '  ', answer: '1.2M', answeredAt: AT.toISOString() },
+    ];
+    assert.deepEqual(readAnswers(raw), []);
+  });
+
+  it('clips an answer instead of storing an essay', () => {
+    const raw = [{ question: Q, answer: 'x'.repeat(MAX_ANSWER_CHARS + 50), answeredAt: '' }];
+    assert.equal(readAnswers(raw)[0]?.answer.length, MAX_ANSWER_CHARS);
+  });
+});
+
+describe('upsertAnswer', () => {
+  it('a corrected figure replaces the old one — both must never reach the prompt', () => {
+    const once = upsertAnswer([], Q, '1.2M', AT);
+    const twice = upsertAnswer(once, Q, '2.4M', AT);
+    assert.equal(twice.length, 1);
+    assert.equal(twice[0]?.answer, '2.4M');
+  });
+
+  it('a blank answer takes back what was said', () => {
+    const once = upsertAnswer([], Q, '1.2M', AT);
+    assert.deepEqual(upsertAnswer(once, Q, '  ', AT), []);
+  });
+
+  it('ignores an empty question', () => {
+    assert.deepEqual(upsertAnswer([], '   ', '1.2M', AT), []);
+  });
+
+  it('keeps the newest when the list runs over', () => {
+    let answers = [] as ReturnType<typeof upsertAnswer>;
+    for (let i = 0; i < MAX_ANSWERS + 5; i += 1) {
+      answers = upsertAnswer(answers, `question ${i}`, `answer ${i}`, AT);
+    }
+    assert.equal(answers.length, MAX_ANSWERS);
+    assert.equal(answers[answers.length - 1]?.answer, `answer ${MAX_ANSWERS + 4}`);
+  });
+
+  it('does not mutate the list it was given', () => {
+    const before = upsertAnswer([], Q, '1.2M', AT);
+    upsertAnswer(before, Q, '2.4M', AT);
+    assert.equal(before[0]?.answer, '1.2M');
+  });
+});
+
+describe('unansweredAsks', () => {
+  const answers = upsertAnswer([], Q, '1.2M', AT);
+
+  it('counts only what is still open', () => {
+    assert.deepEqual(unansweredAsks([Q, 'what did the migration save?'], answers), [
+      'what did the migration save?',
+    ]);
+  });
+
+  it('ignores advice with no question at all', () => {
+    assert.deepEqual(unansweredAsks([null, null], answers), []);
+  });
+
+  it('asks the same question once', () => {
+    const twice = ['what did the migration save?', 'what did the migration save?'];
+    assert.equal(unansweredAsks(twice, []).length, 1);
+  });
+});
+
+describe('answerLines', () => {
+  it('says nothing when nothing was answered', () => {
+    assert.deepEqual(answerLines([]), []);
+  });
+
+  it('tells the model to write the figure in rather than ask again', () => {
+    const lines = answerLines(upsertAnswer([], Q, '1.2M', AT));
+    assert.match(lines[0] ?? '', /CANDIDATE-SUPPLIED METRICS/);
+    assert.match(lines[0] ?? '', /instead of asking again/);
+    assert.equal(lines[1], `- ${Q} → 1.2M`);
+  });
+});

--- a/src/resume/answers.ts
+++ b/src/resume/answers.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod';
+
+/*
+ * The strength review's questions, answered (ADR 0030 phase 3).
+ *
+ * The rubric refuses to invent a number: where a stronger line needs one the
+ * resume does not carry, the advice asks for it instead ("how many requests
+ * per day did that service handle?"). That was a dead end — nothing could be
+ * answered, so the next run asked again. These are the answers, stored on the
+ * resume so they outlive the run that asked, and read back into the next
+ * prompt so the model can rewrite the line with the real figure.
+ *
+ * NOT `CandidateFact`: that dictionary is skill vocabulary and it feeds the
+ * MATCH prompt, where "1.2M requests/day" would be a keyword nobody wants.
+ *
+ * Pure — parsing, merging and prompt lines. `store.ts` owns the column.
+ */
+
+export interface ReviewAnswer {
+  /** The `advice[].ask` this answers, verbatim, so the next run can match it up. */
+  question: string;
+  /** What the candidate typed. Their words, never rewritten. */
+  answer: string;
+  answeredAt: string;
+}
+
+/** A question is a sentence; an answer is a figure with its context, not an essay. */
+export const MAX_QUESTION_CHARS = 300;
+export const MAX_ANSWER_CHARS = 300;
+/**
+ * How many answers ride into a prompt. Six dimensions ask at most a couple of
+ * questions each, and a list this long already says more about the resume than
+ * the resume does; past it the oldest fall off.
+ */
+export const MAX_ANSWERS = 30;
+
+const AnswerSchema = z.object({
+  question: z.string(),
+  answer: z.string(),
+  answeredAt: z.string(),
+});
+
+/** Tolerant reader for the stored JSON: a hand-edited row degrades to "nothing answered". */
+export function readAnswers(raw: unknown): ReviewAnswer[] {
+  const parsed = z.array(AnswerSchema).safeParse(raw ?? []);
+  if (!parsed.success) return [];
+  return parsed.data
+    .map((a) => ({
+      question: a.question.trim().slice(0, MAX_QUESTION_CHARS),
+      answer: a.answer.trim().slice(0, MAX_ANSWER_CHARS),
+      answeredAt: a.answeredAt,
+    }))
+    .filter((a) => a.question.length > 0 && a.answer.length > 0)
+    .slice(-MAX_ANSWERS);
+}
+
+/**
+ * Records one answer, replacing any earlier answer to the same question — the
+ * user correcting a figure must not leave the old one in the prompt. A blank
+ * answer removes it: that is how you take back something you said.
+ */
+export function upsertAnswer(
+  answers: ReviewAnswer[],
+  question: string,
+  answer: string,
+  now: Date = new Date(),
+): ReviewAnswer[] {
+  const q = question.trim().slice(0, MAX_QUESTION_CHARS);
+  if (q.length === 0) return answers;
+  const rest = answers.filter((a) => a.question !== q);
+  const value = answer.trim().slice(0, MAX_ANSWER_CHARS);
+  if (value.length === 0) return rest;
+  return [...rest, { question: q, answer: value, answeredAt: now.toISOString() }].slice(-MAX_ANSWERS);
+}
+
+/** Look one up — what the card puts back in the box next to its question. */
+export function answerFor(answers: ReviewAnswer[], question: string): ReviewAnswer | null {
+  return answers.find((a) => a.question === question.trim().slice(0, MAX_QUESTION_CHARS)) ?? null;
+}
+
+/**
+ * The asks a review made that are still unanswered — what the card counts, and
+ * what makes "3 of 4 answered" an honest sentence rather than a guess.
+ */
+export function unansweredAsks(asks: (string | null)[], answers: ReviewAnswer[]): string[] {
+  const answered = new Set(answers.map((a) => a.question));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const ask of asks) {
+    const q = ask?.trim().slice(0, MAX_QUESTION_CHARS);
+    if (!q || answered.has(q) || seen.has(q)) continue;
+    seen.add(q);
+    out.push(q);
+  }
+  return out;
+}
+
+/**
+ * The prompt block. Kept OUTSIDE the untrusted fence, like `Profile.notes` and
+ * the confirmed ask_user facts: this is the user talking to their own tool, not
+ * text some job board wrote (CLAUDE.md file rules, ADR 0022's carve-out).
+ */
+export function answerLines(answers: ReviewAnswer[]): string[] {
+  if (answers.length === 0) return [];
+  return [
+    'CANDIDATE-SUPPLIED METRICS (the candidate answered these questions from an earlier review — treat the figures as true and WRITE THEM INTO the "example" rewrites instead of asking again):',
+    ...answers.map((a) => `- ${a.question} → ${a.answer}`),
+    '',
+  ];
+}

--- a/src/resume/prompts.ts
+++ b/src/resume/prompts.ts
@@ -206,8 +206,12 @@ export type CoverResult = z.infer<typeof CoverSchema>;
 
 export const REVIEW_MAX_TOKENS = 6_000;
 
-/** Bumped when the rubric or its rules change materially; stored with the score. */
-export const REVIEW_PROMPT_VERSION = 1;
+/**
+ * Bumped when the rubric or its rules change materially; stored with the score.
+ * v2: the candidate's answers to earlier asks ride into the prompt, and the
+ * rules say to write the figure into the rewrite instead of asking again.
+ */
+export const REVIEW_PROMPT_VERSION = 2;
 
 export const REVIEW_PRIORITIES = ACTION_PRIORITIES;
 
@@ -488,6 +492,7 @@ ADVICE — 3 to 8 items, the ones that would change a hiring decision first:
 - "issue" names what is wrong with THIS document, "why" says what a recruiter or an ATS does about it, "fix" is the concrete change to make. "quote" carries the verbatim line the item points at, or null.
 - "example" is a rewritten line built ONLY from facts the resume already contains. NO INVENTION: never add a number, employer, title, date, team size or technology that is not already in the text.
 - When the better line NEEDS a number the resume does not have, leave "example" null and put the question in "ask" ("how many requests per day did that service handle?"). Asking is the honest path to a stronger resume; inventing is fraud the candidate has to defend in the interview.
+- When a CANDIDATE-SUPPLIED METRICS block is present, those figures are answers the candidate already gave you. Treat them as true, WRITE THEM INTO the "example" rewrite, and set "ask" to null for that item — asking a second time for a number you have been given is the one thing this rubric must never do. Never carry a supplied figure into a line it does not belong to, and never let it change a grade on its own: the resume is graded as WRITTEN, and a metric the document does not carry is a reason for advice, not for a better grade.
 - Judge the document, never the person. A gap in the dates is a presentation problem ("say what you did with that time"), never a guess about someone's life.
 - No generic career advice. "Tailor your resume to each posting" is not advice; "your Vodwork bullet says migrated, not what the migration bought" is.
 
@@ -817,6 +822,12 @@ export interface ReviewContext {
   atsChecks?: string[];
   /** The role types the scan read out of this resume; keyword coverage is judged against them. */
   roleTypes?: string[];
+  /**
+   * The candidate's answers to earlier asks (answers.ts). Outside the fence
+   * on purpose — like `Profile.notes` and the confirmed ask_user facts, this
+   * is the user talking to their own tool, not text a job board wrote.
+   */
+  answers?: string[];
 }
 
 export function buildReviewPrompt(resumeText: string, context: ReviewContext = {}): Prompt {
@@ -830,6 +841,7 @@ export function buildReviewPrompt(resumeText: string, context: ReviewContext = {
   if (checks.length > 0) {
     lines.push('ATS CHECKS (deterministic, already verified — weigh them under "clarity"):', ...checks.map((w) => `- ${w}`), '');
   }
+  lines.push(...(context.answers ?? []));
   return {
     system: REVIEW_SYSTEM,
     user: [fence('RESUME', clip(resumeText, MAX_RESUME_CHARS)), '', ...lines, 'Return raw JSON only.'].join('\n'),

--- a/src/resume/review-delta.test.ts
+++ b/src/resume/review-delta.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { deltaSentence, reviewDelta, type ReviewSnapshot } from './review-delta';
+
+const base: ReviewSnapshot = {
+  score: 45,
+  version: 4,
+  promptVersion: 2,
+  grades: [
+    { dimension: 'first_impression', grade: 'ok' },
+    { dimension: 'impact', grade: 'weak' },
+    { dimension: 'seniority_signal', grade: 'ok' },
+    { dimension: 'clarity', grade: 'weak' },
+    { dimension: 'keyword_coverage', grade: 'strong' },
+    { dimension: 'polish', grade: 'ok' },
+  ],
+};
+
+const improved: ReviewSnapshot = {
+  ...base,
+  score: 70,
+  version: 5,
+  grades: base.grades.map((g) =>
+    g.dimension === 'impact' ? { ...g, grade: 'ok' as const } : g.dimension === 'clarity' ? { ...g, grade: 'strong' as const } : g,
+  ),
+};
+
+describe('reviewDelta', () => {
+  it('is null with no earlier run — the card then shows the score alone', () => {
+    assert.equal(reviewDelta(null, improved), null);
+  });
+
+  it('is null when the earlier run has no grades to compare', () => {
+    assert.equal(reviewDelta({ ...base, grades: [] }, improved), null);
+  });
+
+  it('names every dimension that moved, and which way', () => {
+    const d = reviewDelta(base, improved);
+    assert.equal(d?.points, 25);
+    assert.deepEqual(
+      d?.moves.map((m) => [m.dimension, m.from, m.to, m.up]),
+      [
+        ['impact', 'weak', 'ok', true],
+        ['clarity', 'weak', 'strong', true],
+      ],
+    );
+  });
+
+  it('reports a fall as a fall', () => {
+    const d = reviewDelta(improved, base);
+    assert.equal(d?.points, -25);
+    assert.equal(d?.moves.every((m) => m.up === false), true);
+  });
+
+  it('a re-run of the same text is marked as such', () => {
+    const d = reviewDelta(base, { ...base, score: 48 });
+    assert.equal(d?.sameVersion, true);
+    assert.equal(d?.moves.length, 0);
+  });
+
+  it('two rubric versions are not a measurement', () => {
+    const d = reviewDelta({ ...base, promptVersion: 1 }, improved);
+    assert.equal(d?.incomparable, true);
+  });
+
+  it('a dimension the newer run did not grade is not a move', () => {
+    const partial = { ...improved, grades: improved.grades.filter((g) => g.dimension !== 'impact') };
+    const d = reviewDelta(base, partial);
+    assert.deepEqual(d?.moves.map((m) => m.dimension), ['clarity']);
+  });
+});
+
+describe('deltaSentence', () => {
+  it('leads with the number and says what moved', () => {
+    const s = deltaSentence(reviewDelta(base, improved)!);
+    assert.match(s, /Strength 45 → 70, up 25/);
+    assert.match(s, /2 dimensions moved/);
+  });
+
+  it('says "no change" out loud rather than going silent', () => {
+    const s = deltaSentence(reviewDelta(base, { ...base })!);
+    assert.match(s, /unchanged from the last review/);
+    assert.match(s, /no dimension changed grade/);
+    assert.match(s, /same text, re-judged/);
+  });
+
+  it('warns instead of comparing across rubric versions', () => {
+    const s = deltaSentence(reviewDelta({ ...base, promptVersion: 1 }, improved)!);
+    assert.match(s, /not a measurement/);
+  });
+
+  it('uses the singular for one moved dimension', () => {
+    const one = { ...base, score: 50, grades: base.grades.map((g) => (g.dimension === 'polish' ? { ...g, grade: 'strong' as const } : g)) };
+    assert.match(deltaSentence(reviewDelta(base, one)!), /1 dimension moved/);
+  });
+});

--- a/src/resume/review-delta.ts
+++ b/src/resume/review-delta.ts
@@ -1,0 +1,106 @@
+import { REVIEW_DIMENSIONS, REVIEW_GRADES, type ReviewDimension, type ReviewGrade } from './review-score';
+
+/*
+ * What changed between two strength reviews of the SAME resume (ADR 0030
+ * phase 3). The card can then answer the question a second run actually
+ * raises — "did the edits work?" — instead of showing a fresh number with no
+ * memory of the one before it.
+ *
+ * Deliberately narrow: two runs of the same rubric on the same resume, never
+ * a trend across resumes or a chart. With prompt versions in the mix a
+ * comparison can also be meaningless, and this says so rather than drawing a
+ * line between two numbers that were never measured the same way.
+ *
+ * Pure.
+ */
+
+export interface ReviewSnapshot {
+  score: number;
+  version: number;
+  promptVersion: number | null;
+  grades: { dimension: ReviewDimension; grade: ReviewGrade }[];
+}
+
+export interface DimensionMove {
+  dimension: ReviewDimension;
+  from: ReviewGrade;
+  to: ReviewGrade;
+  /** True when the grade improved — the card colours the two directions apart. */
+  up: boolean;
+}
+
+export interface ReviewDelta {
+  scoreFrom: number;
+  scoreTo: number;
+  /** Positive when the resume got stronger. */
+  points: number;
+  /** Every dimension whose grade changed, strongest weight first. */
+  moves: DimensionMove[];
+  /** Same text, re-judged: the resume did not move, the model did. */
+  sameVersion: boolean;
+  /**
+   * Set when the two runs used different prompt versions — the numbers come
+   * from different rubrics, so the difference is not a measurement.
+   */
+  incomparable: boolean;
+}
+
+const RANK: Record<ReviewGrade, number> = { weak: 0, ok: 1, strong: 2 };
+
+function gradeMap(snapshot: ReviewSnapshot): Map<ReviewDimension, ReviewGrade> {
+  return new Map(snapshot.grades.map((g) => [g.dimension, g.grade]));
+}
+
+/**
+ * `null` when there is nothing honest to compare: no earlier run, or one whose
+ * grades did not survive (a pre-rubric row). The caller then shows the score
+ * alone, exactly as it did before this existed.
+ */
+export function reviewDelta(previous: ReviewSnapshot | null, current: ReviewSnapshot): ReviewDelta | null {
+  if (!previous || previous.grades.length === 0) return null;
+  const before = gradeMap(previous);
+  const after = gradeMap(current);
+  const moves: DimensionMove[] = [];
+  for (const dimension of REVIEW_DIMENSIONS) {
+    const from = before.get(dimension);
+    const to = after.get(dimension);
+    if (!from || !to || from === to) continue;
+    moves.push({ dimension, from, to, up: RANK[to] > RANK[from] });
+  }
+  return {
+    scoreFrom: previous.score,
+    scoreTo: current.score,
+    points: current.score - previous.score,
+    moves,
+    sameVersion: previous.version === current.version,
+    incomparable: previous.promptVersion !== current.promptVersion,
+  };
+}
+
+/**
+ * The one sentence above the grades. Says what moved and, when nothing did,
+ * says that too — "no change" is a result, and a silent card looks broken.
+ */
+export function deltaSentence(delta: ReviewDelta): string {
+  const { points, scoreFrom, scoreTo } = delta;
+  const direction = points > 0 ? `up ${points}` : points < 0 ? `down ${Math.abs(points)}` : 'unchanged';
+  const head =
+    points === 0
+      ? `Strength ${scoreTo}, ${direction} from the last review`
+      : `Strength ${scoreFrom} → ${scoreTo}, ${direction}`;
+  const moved =
+    delta.moves.length === 0
+      ? 'no dimension changed grade'
+      : `${delta.moves.length} dimension${delta.moves.length === 1 ? '' : 's'} moved`;
+  const caveat = delta.incomparable
+    ? ' — but the two runs used different rubric versions, so the difference is not a measurement'
+    : delta.sameVersion
+      ? ' — same text, re-judged'
+      : '';
+  return `${head}; ${moved}${caveat}.`;
+}
+
+/** True for every grade string the delta can be built from. */
+export function isReviewGrade(v: unknown): v is ReviewGrade {
+  return typeof v === 'string' && (REVIEW_GRADES as readonly string[]).includes(v);
+}

--- a/src/resume/review-score.ts
+++ b/src/resume/review-score.ts
@@ -163,6 +163,17 @@ export function readReviewBreakdown(v: unknown): ReviewBreakdown | null {
 }
 
 /**
+ * The rubric version a stored review was graded under. Two runs from
+ * different versions are two different measurements, which is what the delta
+ * has to say out loud instead of subtracting them (review-delta.ts).
+ */
+export function readReviewPromptVersion(breakdown: unknown): number | null {
+  if (typeof breakdown !== 'object' || breakdown === null) return null;
+  const v = (breakdown as { promptVersion?: unknown }).promptVersion;
+  return Number.isInteger(v) ? (v as number) : null;
+}
+
+/**
  * A review describes the version it read. Once the resume moves on, its
  * verdict is about text that no longer exists — the card says so rather than
  * quietly ageing.

--- a/src/resume/review.ts
+++ b/src/resume/review.ts
@@ -1,6 +1,7 @@
 import type { ResumeReview } from '@prisma/client';
 import { logger } from '../logger';
 import { getAiRuntime } from '../ai-runtime';
+import { answerLines, readAnswers } from './answers';
 import { parseWarnings } from './parse-warnings';
 import {
   buildReviewPrompt,
@@ -29,10 +30,14 @@ export async function reviewResume(resume: {
   text: string;
   version: number;
   roleTypes: string[];
+  /** Raw Resume.answers JSON — the figures an earlier run asked for (ADR 0030 phase 3). */
+  answers?: unknown;
 }): Promise<ResumeReview | null> {
+  const answers = readAnswers(resume.answers);
   const prompt = buildReviewPrompt(resume.text, {
     atsChecks: parseWarnings(resume.text).map((w) => w.message),
     roleTypes: resume.roleTypes,
+    answers: answerLines(answers),
   });
   const ai = await getAiRuntime();
   for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
@@ -69,6 +74,8 @@ export async function reviewResume(resume: {
           missing: breakdown.missing.length,
           advice: parsed.data.advice.length,
           asks: parsed.data.advice.filter((a) => a.ask !== null).length,
+          // The point of the loop: answered figures should make asks go down.
+          answersUsed: answers.length,
           chars: out.text.length,
           ms: Date.now() - started,
         },

--- a/src/resume/store.ts
+++ b/src/resume/store.ts
@@ -1,6 +1,7 @@
 import type { CandidateFact, CoverLetter, Prisma, Resume, ResumeMatch, ResumeReview } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../logger';
+import { readAnswers, upsertAnswer, type ReviewAnswer } from './answers';
 import { readFrameReason, type FrameReason } from './keyword-frame';
 import { effectiveKeywords } from './keyword-overrides';
 import { readMatchMode, storedBreakdown, withSuggestionsMode, type MatchMode } from './match-mode';
@@ -114,6 +115,13 @@ export async function replaceResumeFile(
   });
   logger.info({ id, version: row.version, chars: input.text.length }, 'resume: new version');
   return row;
+}
+
+/** Renames a resume; null when the row is gone (deleted in another tab). */
+export async function renameResume(id: number, name: string): Promise<ResumeSummary | null> {
+  return prisma.resume
+    .update({ where: { id }, data: { name }, omit: WITHOUT_ORIGINAL })
+    .catch(() => null);
 }
 
 export async function deleteResume(id: number): Promise<void> {
@@ -240,6 +248,41 @@ export async function createReview(input: {
 /** The review a resume page shows: the most recent run, whatever version it read. */
 export async function getLatestReviewForResume(resumeId: number): Promise<ResumeReview | null> {
   return prisma.resumeReview.findFirst({ where: { resumeId }, orderBy: { createdAt: 'desc' } });
+}
+
+/**
+ * The run before a given one, for the delta (review-delta.ts). Ordered by id,
+ * not by `createdAt`: two runs a second apart are exactly what "answer, then
+ * re-run" produces, and a timestamp tie would pick arbitrarily.
+ */
+export async function getPreviousReview(resumeId: number, beforeId: number): Promise<ResumeReview | null> {
+  return prisma.resumeReview.findFirst({
+    where: { resumeId, id: { lt: beforeId } },
+    orderBy: { id: 'desc' },
+  });
+}
+
+/**
+ * The candidate's answers to the review's questions (answers.ts). Read-modify-
+ * write of one JSON column, so it takes the row lock the same way a keyword
+ * edit does — two answers typed in two tabs must both survive.
+ */
+export async function saveReviewAnswer(
+  resumeId: number,
+  question: string,
+  answer: string,
+): Promise<ReviewAnswer[] | null> {
+  return prisma.$transaction(async (tx) => {
+    const locked = await tx.$queryRaw<{ id: number }[]>`SELECT id FROM resume WHERE id = ${resumeId} FOR UPDATE`;
+    if (locked.length === 0) return null;
+    const row = await tx.resume.findUniqueOrThrow({ where: { id: resumeId }, select: { answers: true } });
+    const next = upsertAnswer(readAnswers(row.answers), question, answer);
+    await tx.resume.update({
+      where: { id: resumeId },
+      data: { answers: next as unknown as Prisma.InputJsonValue },
+    });
+    return next;
+  });
 }
 
 export type ReviewSummary = Pick<ResumeReview, 'resumeId' | 'resumeVersion' | 'reviewScore' | 'createdAt'>;

--- a/src/web/match-history.test.ts
+++ b/src/web/match-history.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { groupMatchesByJob, historyLabel, progression } from './match-history';
+
+const job = (id: number, title: string) => ({ id, title });
+const run = (id: number, j: { id: number; title: string }, score: number, day: number, version = 1) => ({
+  id,
+  job: j,
+  matchScore: score,
+  resumeVersion: version,
+  draft: false,
+  createdAt: new Date(`2026-09-0${day}T10:00:00Z`),
+});
+
+const backend = job(1, 'Backend engineer');
+const platform = job(2, 'Platform engineer');
+
+describe('groupMatchesByJob', () => {
+  it('three runs against one posting are one story, not three rows', () => {
+    const grouped = groupMatchesByJob([
+      run(3, backend, 71, 5, 3),
+      run(2, backend, 68, 3, 2),
+      run(1, backend, 66, 1, 1),
+    ]);
+    assert.equal(grouped.length, 1);
+    assert.deepEqual(grouped[0]?.runs.map((r) => r.matchScore), [71, 68, 66]);
+    assert.equal(grouped[0]?.delta, 3);
+    assert.equal(grouped[0]?.previous?.matchScore, 68);
+  });
+
+  it('orders groups by their newest run, so the page opens on what just happened', () => {
+    const grouped = groupMatchesByJob([
+      run(1, backend, 66, 1),
+      run(2, platform, 80, 4),
+      run(3, backend, 71, 2),
+    ]);
+    assert.deepEqual(grouped.map((g) => g.job.id), [2, 1]);
+  });
+
+  it('sorts inside a group by time, not by the order it was handed', () => {
+    const grouped = groupMatchesByJob([run(1, backend, 66, 1), run(2, backend, 71, 5)]);
+    assert.equal(grouped[0]?.latest.matchScore, 71);
+    assert.equal(grouped[0]?.delta, 5);
+  });
+
+  it('a posting checked once has no delta to show', () => {
+    const grouped = groupMatchesByJob([run(1, backend, 66, 1)]);
+    assert.equal(grouped[0]?.previous, null);
+    assert.equal(grouped[0]?.delta, null);
+  });
+
+  it('reports a fall as a fall', () => {
+    const grouped = groupMatchesByJob([run(2, backend, 60, 5), run(1, backend, 66, 1)]);
+    assert.equal(grouped[0]?.delta, -6);
+  });
+
+  it('handles no comparisons at all', () => {
+    assert.deepEqual(groupMatchesByJob([]), []);
+  });
+});
+
+describe('progression', () => {
+  it('runs oldest first — the order the story happened in', () => {
+    const [g] = groupMatchesByJob([run(3, backend, 71, 5), run(2, backend, 68, 3), run(1, backend, 66, 1)]);
+    assert.deepEqual(progression(g!).map((r) => r.matchScore), [66, 68, 71]);
+    assert.equal(historyLabel(g!), '3 runs');
+  });
+
+  it('stays silent for a posting checked once — there is no story yet', () => {
+    const [g] = groupMatchesByJob([run(1, backend, 66, 1)]);
+    assert.deepEqual(progression(g!), []);
+    assert.equal(historyLabel(g!), null);
+  });
+
+  it('does not reorder the group it was given', () => {
+    const [g] = groupMatchesByJob([run(2, backend, 71, 5), run(1, backend, 66, 1)]);
+    progression(g!);
+    assert.equal(g!.runs[0]?.matchScore, 71);
+  });
+});

--- a/src/web/match-history.ts
+++ b/src/web/match-history.ts
@@ -1,0 +1,80 @@
+/*
+ * Comparisons on a resume page, grouped by the posting they were run against
+ * (TASKS §12 quick win).
+ *
+ * A flat list is the wrong shape once a resume has been re-checked: three runs
+ * against the same job read as three unrelated rows, when what they actually
+ * are is one story — 66, then 68 after the edits, then 71. Grouping turns the
+ * table into that story and leaves every individual run reachable.
+ *
+ * Pure. The delta here is arithmetic on stored scores, never a re-score.
+ */
+
+export interface MatchRun {
+  id: number;
+  matchScore: number;
+  resumeVersion: number;
+  draft: boolean;
+  createdAt: Date;
+}
+
+export interface JobHistory<J> {
+  job: J;
+  /** Newest first, like the flat list this replaces. */
+  runs: MatchRun[];
+  latest: MatchRun;
+  /** The run before the latest, or null when this posting was checked once. */
+  previous: MatchRun | null;
+  /** Points gained since that run; null when there is nothing to compare with. */
+  delta: number | null;
+}
+
+/**
+ * Groups by job id, newest run first inside each group and the group with the
+ * newest run first overall — so the page still opens on what just happened.
+ */
+export function groupMatchesByJob<J extends { id: number }>(
+  matches: (MatchRun & { job: J })[],
+): JobHistory<J>[] {
+  const groups = new Map<number, { job: J; runs: MatchRun[] }>();
+  for (const m of matches) {
+    const group = groups.get(m.job.id) ?? { job: m.job, runs: [] };
+    group.runs.push({
+      id: m.id,
+      matchScore: m.matchScore,
+      resumeVersion: m.resumeVersion,
+      draft: m.draft,
+      createdAt: m.createdAt,
+    });
+    groups.set(m.job.id, group);
+  }
+  const out: JobHistory<J>[] = [];
+  for (const { job, runs } of groups.values()) {
+    const sorted = [...runs].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    const latest = sorted[0];
+    if (!latest) continue;
+    const previous = sorted[1] ?? null;
+    out.push({
+      job,
+      runs: sorted,
+      latest,
+      previous,
+      delta: previous ? latest.matchScore - previous.matchScore : null,
+    });
+  }
+  return out.sort((a, b) => b.latest.createdAt.getTime() - a.latest.createdAt.getTime());
+}
+
+/**
+ * The runs oldest first — the order the story happened in, which is not the
+ * order the table lists them in. Empty for a posting checked once, where
+ * there is no progression to show.
+ */
+export function progression<J>(history: JobHistory<J>): MatchRun[] {
+  return history.runs.length < 2 ? [] : [...history.runs].reverse();
+}
+
+/** "5 runs" — the count that labels the progression. Null when there is one. */
+export function historyLabel<J>(history: JobHistory<J>): string | null {
+  return history.runs.length < 2 ? null : `${history.runs.length} runs`;
+}

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -28,6 +28,8 @@ import { formatDate, formatRelative } from '../format';
 import type { ResumeReview } from '@prisma/client';
 import type { MatchWithJob, ResumeSummary } from '../../resume/store';
 import { ResumeReviewCard } from './resume-review-card';
+import type { ReviewAnswer } from '../../resume/answers';
+import type { ReviewDelta } from '../../resume/review-delta';
 import { reviewIsStale } from '../../resume/review-score';
 import { readIssues } from '../../resume/prompts';
 import type { ParseWarning } from '../../resume/parse-warnings';
@@ -38,6 +40,10 @@ export interface ResumeDetailProps {
   matches: MatchWithJob[];
   /** The latest strength review, or null when the user has never asked for one. */
   review: ResumeReview | null;
+  /** The candidate's answers to the review's questions (ADR 0030 phase 3). */
+  answers: ReviewAnswer[];
+  /** What moved since the previous run of this resume, when there was one. */
+  reviewDelta: ReviewDelta | null;
   /** What Delete would cascade — named in the confirm: comparisons, letters and reviews. */
   deleteImpact: { matches: number; letters: number; reviews: number };
   /** Deterministic ATS-parseability checks over the extracted text. */
@@ -54,6 +60,8 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
   resume,
   matches,
   review,
+  answers,
+  reviewDelta,
   deleteImpact,
   warnings,
   search,
@@ -109,7 +117,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
       </PageHeader>
       <Flash flash={flash} />
 
-      <ResumeReviewCard resume={resume} review={review} />
+      <ResumeReviewCard resume={resume} review={review} answers={answers} delta={reviewDelta} />
 
       <div class="mt-4 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <Card>

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -30,6 +30,7 @@ import type { MatchWithJob, ResumeSummary } from '../../resume/store';
 import { ResumeReviewCard } from './resume-review-card';
 import type { ReviewAnswer } from '../../resume/answers';
 import type { ReviewDelta } from '../../resume/review-delta';
+import { groupMatchesByJob, historyLabel, progression } from '../match-history';
 import { reviewIsStale } from '../../resume/review-score';
 import { readIssues } from '../../resume/prompts';
 import type { ParseWarning } from '../../resume/parse-warnings';
@@ -106,6 +107,21 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
         }
       >
         <span class="flex flex-wrap items-center gap-2">
+          {/* The name is what every picker, flash and "applied with" line
+              says, and it starts as whatever the uploaded file was called. */}
+          <form method="post" action={`/resumes/${resume.id}/rename`} class="flex items-center gap-1.5">
+            <Input
+              name="name"
+              value={resume.name}
+              maxlength="120"
+              required
+              aria-label="Resume name"
+              class="!w-56 !px-2 !py-1 !text-xs"
+            />
+            <Button size="sm" variant="ghost">
+              Rename
+            </Button>
+          </form>
           <span class="break-all font-mono text-xs">{resume.sourceFilename}</span>
           <Badge tone="info">v{resume.version}</Badge>
           {resume.isDefault && <Badge tone="ok">default</Badge>}
@@ -211,32 +227,62 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
           </div>
         ) : (
           <Table columns={['Job', 'Company', 'Version', 'Match', <span class="block text-right">When</span>]}>
-            {matches.map((m) => (
-              <Tr>
-                <Td class="max-w-[24rem]">
-                  <a
-                    href={`/jobs/${m.job.id}/target?match=${m.id}`}
-                    class="block truncate font-medium text-ink transition-colors duration-150 hover:text-accent-strong"
-                    title={m.job.title}
-                  >
-                    {m.job.title}
-                  </a>
-                </Td>
-                <Td class="max-w-[14rem] text-ink-muted">
-                  <div class="truncate">{m.job.company.name}</div>
-                </Td>
-                <Td class="whitespace-nowrap font-mono text-xs text-ink-faint">
-                  v{m.resumeVersion}
-                  {m.draft ? ' draft' : ''}
-                </Td>
-                <Td>
-                  <FitBadge score={m.matchScore} label="match" />
-                </Td>
-                <Td class="whitespace-nowrap text-right text-[13px] text-ink-faint">
-                  {formatDate(m.createdAt)}
-                </Td>
-              </Tr>
-            ))}
+            {groupMatchesByJob(matches).map((h) => {
+              const line = historyLabel(h);
+              const runs = progression(h);
+              return (
+                <Tr>
+                  <Td class="max-w-[24rem]">
+                    <a
+                      href={`/jobs/${h.job.id}/target?match=${h.latest.id}`}
+                      class="block truncate font-medium text-ink transition-colors duration-150 hover:text-accent-strong"
+                      title={h.job.title}
+                    >
+                      {h.job.title}
+                    </a>
+                    {/* Every earlier run stays one click away — grouping must
+                        not hide history, only stop repeating the job title. */}
+                    {line && (
+                      <div class="mt-0.5 flex flex-wrap items-center gap-x-1 text-xs text-ink-faint">
+                        <span class="mr-0.5">{line} ·</span>
+                        {runs.map((r, i) => (
+                          <>
+                            {i > 0 && <span aria-hidden="true">→</span>}
+                            <a
+                              href={`/jobs/${h.job.id}/target?match=${r.id}`}
+                              class="font-mono transition-colors duration-150 hover:text-accent-strong"
+                              title={`${formatDate(r.createdAt)} · v${r.resumeVersion}`}
+                            >
+                              {r.matchScore}
+                            </a>
+                          </>
+                        ))}
+                      </div>
+                    )}
+                  </Td>
+                  <Td class="max-w-[14rem] text-ink-muted">
+                    <div class="truncate">{h.job.company.name}</div>
+                  </Td>
+                  <Td class="whitespace-nowrap font-mono text-xs text-ink-faint">
+                    v{h.latest.resumeVersion}
+                    {h.latest.draft ? ' draft' : ''}
+                  </Td>
+                  <Td>
+                    <div class="flex items-center gap-1.5">
+                      <FitBadge score={h.latest.matchScore} label="match" />
+                      {h.delta !== null && h.delta !== 0 && (
+                        <Badge tone={h.delta > 0 ? 'ok' : 'danger'}>
+                          {h.delta > 0 ? `+${h.delta}` : h.delta}
+                        </Badge>
+                      )}
+                    </div>
+                  </Td>
+                  <Td class="whitespace-nowrap text-right text-[13px] text-ink-faint">
+                    {formatDate(h.latest.createdAt)}
+                  </Td>
+                </Tr>
+              );
+            })}
           </Table>
         )}
       </Card>

--- a/src/web/pages/resume-review-card.tsx
+++ b/src/web/pages/resume-review-card.tsx
@@ -1,10 +1,12 @@
 /** @jsxImportSource hono/jsx */
 import type { FC } from 'hono/jsx';
 import type { ResumeReview } from '@prisma/client';
-import { ActionForm, Badge, Button, Card, FitBadge, Hint, SectionTitle } from '../ui';
+import { ActionForm, Badge, Button, Card, FitBadge, Hint, Input, SectionTitle } from '../ui';
 import type { Tone } from '../format';
 import { formatRelative } from '../format';
 import { readReviewAdvice, readReviewGrades, type ReviewAdvice } from '../../resume/prompts';
+import { answerFor, unansweredAsks, type ReviewAnswer } from '../../resume/answers';
+import { deltaSentence, type ReviewDelta } from '../../resume/review-delta';
 import {
   capExplanation,
   readReviewBreakdown,
@@ -57,11 +59,18 @@ const PRIORITY_TONE: Record<ReviewAdvice['priority'], Tone> = {
 
 const SUBHEAD = 'mb-2 text-[13px] font-medium text-ink-muted';
 
-export const ResumeReviewCard: FC<{
+export interface ResumeReviewCardProps {
   resume: { id: number; version: number; scannedAt: Date | null };
   review: ResumeReview | null;
-}> = ({ resume, review }) => (
-  <Card class="mt-4">
+  /** The candidate's stored answers to earlier asks (answers.ts). */
+  answers: ReviewAnswer[];
+  /** What moved since the previous run of this resume, when there was one. */
+  delta: ReviewDelta | null;
+}
+
+export const ResumeReviewCard: FC<ResumeReviewCardProps> = ({ resume, review, answers, delta }) => (
+  <div id="resume-strength">
+   <Card class="mt-4">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <SectionTitle>Resume strength</SectionTitle>
       <ActionForm action={`/resumes/${resume.id}/review`} once>
@@ -70,8 +79,13 @@ export const ResumeReviewCard: FC<{
         </Button>
       </ActionForm>
     </div>
-    {review ? <ReviewReport resume={resume} review={review} /> : <ReviewExplainer />}
-  </Card>
+    {review ? (
+      <ReviewReport resume={resume} review={review} answers={answers} delta={delta} />
+    ) : (
+      <ReviewExplainer />
+    )}
+   </Card>
+  </div>
 );
 
 /** The state before the first run: what it checks, what comes back, what it costs. */
@@ -97,9 +111,11 @@ const ReviewExplainer: FC = () => (
 );
 
 const ReviewReport: FC<{
-  resume: { version: number };
+  resume: { id: number; version: number };
   review: ResumeReview;
-}> = ({ resume, review }) => {
+  answers: ReviewAnswer[];
+  delta: ReviewDelta | null;
+}> = ({ resume, review, answers, delta }) => {
   const bd = readReviewBreakdown(review.breakdown);
   const grades = readReviewGrades(review.grades);
   const advice = readReviewAdvice(review.advice);
@@ -121,6 +137,7 @@ const ReviewReport: FC<{
         </span>
       </div>
       <p class="text-sm leading-6 text-ink">{review.headline}</p>
+      {delta && <DeltaLine delta={delta} />}
       {capLine && (
         <p class="rounded-md border border-warn/40 bg-surface-overlay/50 px-3 py-2 text-[13px] leading-5 text-ink">
           {capLine}
@@ -199,6 +216,8 @@ const ReviewReport: FC<{
         </div>
       )}
 
+      <AnswerBlock resumeId={resume.id} advice={advice} answers={answers} />
+
       {review.strengths.length > 0 && (
         <div>
           <div class={SUBHEAD}>Keep these — they already work</div>
@@ -214,6 +233,90 @@ const ReviewReport: FC<{
           </ul>
         </div>
       )}
+    </div>
+  );
+};
+
+/**
+ * What moved since the previous run of THIS resume (review-delta.ts). A second
+ * review raises exactly one question — did the edits work? — and a bare new
+ * number does not answer it.
+ */
+const DeltaLine: FC<{ delta: ReviewDelta }> = ({ delta }) => (
+  <div class="space-y-2 rounded-md border border-line bg-surface-overlay/50 px-3 py-2">
+    <div class="text-[13px] leading-5 text-ink">{deltaSentence(delta)}</div>
+    {delta.moves.length > 0 && (
+      <ul class="flex flex-wrap gap-1.5">
+        {delta.moves.map((m) => (
+          <li>
+            <Badge tone={m.up ? 'ok' : 'danger'}>
+              {DIMENSION_LABEL[m.dimension]} {m.from} → {m.to}
+            </Badge>
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+);
+
+/**
+ * The asks, answerable (ADR 0030 phase 3). The rubric refuses to invent a
+ * number and asks for it instead; until now that was a dead end, so the next
+ * run asked the same question again. An answer is stored on the resume and
+ * read into the NEXT prompt — nothing here spends an AI call, and the copy
+ * says so, because a button that costs nothing should not look like one that
+ * does.
+ */
+const AnswerBlock: FC<{ resumeId: number; advice: ReviewAdvice[]; answers: ReviewAnswer[] }> = ({
+  resumeId,
+  advice,
+  answers,
+}) => {
+  const open = unansweredAsks(advice.map((a) => a.ask), answers);
+  // Every stored answer, not just the ones this run happens to ask about: a
+  // question that was answered stops being asked, and an answer you cannot
+  // see is one you cannot correct.
+  const answered = answers.map((a) => a.question);
+  if (open.length === 0 && answered.length === 0) return null;
+  return (
+    <div>
+      <div class={SUBHEAD}>
+        Only you can answer these — {answered.length} answered,{' '}
+        {open.length === 0 ? 'none open' : `${open.length} open`}
+      </div>
+      <ul class="divide-y divide-line rounded-md border border-violet/30">
+        {[...open, ...answered].map((question) => {
+          const stored = answerFor(answers, question);
+          return (
+            <li class="space-y-2 p-3">
+              <div class="text-[13px] leading-5 text-ink">{question}</div>
+              <form
+                method="post"
+                action={`/resumes/${resumeId}/answers`}
+                class="flex flex-wrap items-center gap-1.5"
+              >
+                <input type="hidden" name="question" value={question} />
+                <Input
+                  name="answer"
+                  maxlength="300"
+                  value={stored?.answer ?? ''}
+                  placeholder="the figure, in your words"
+                  aria-label={question}
+                  class="!w-64 !px-2 !py-1 !text-xs"
+                />
+                <Button size="sm" variant={stored ? 'secondary' : 'violet'}>
+                  {stored ? 'Update' : 'Save'}
+                </Button>
+                {stored && <Badge tone="ok">answered</Badge>}
+              </form>
+            </li>
+          );
+        })}
+      </ul>
+      <Hint class="mt-2">
+        Saving costs nothing — the figure goes into the next review, which rewrites the line with
+        it instead of asking again.
+      </Hint>
     </div>
   );
 };

--- a/src/web/pages/resumes.tsx
+++ b/src/web/pages/resumes.tsx
@@ -152,14 +152,18 @@ export const ResumesPage: FC<{
       </Hint>
       {facts.length > 0 && (
         <ul class="mb-3 divide-y divide-line">
+          {/* Two deliberate lines below sm rather than a ragged wrap: the
+              term reads first, the two actions sit together under it. */}
           {facts.map((f) => (
-            <li class="flex flex-wrap items-center gap-2 py-2 first:pt-0">
-              <Badge tone={f.status === 'confirmed' ? 'ok' : 'neutral'}>
-                {f.status === 'confirmed' ? 'have it' : "don't"}
-              </Badge>
-              <span class="text-sm font-medium text-ink">{f.term}</span>
-              {f.note && <span class="min-w-0 text-xs text-ink-faint">— {f.note}</span>}
-              <div class="ml-auto flex items-center gap-1.5">
+            <li class="flex flex-col gap-1 py-2 first:pt-0 sm:flex-row sm:items-center sm:gap-2">
+              <div class="flex min-w-0 items-center gap-2">
+                <Badge tone={f.status === 'confirmed' ? 'ok' : 'neutral'}>
+                  {f.status === 'confirmed' ? 'have it' : "don't"}
+                </Badge>
+                <span class="truncate text-sm font-medium text-ink">{f.term}</span>
+              </div>
+              {f.note && <span class="min-w-0 truncate text-xs text-ink-faint sm:before:content-['—_']">{f.note}</span>}
+              <div class="flex items-center gap-1.5 sm:ml-auto">
                 {/* The same POST /facts the comparison uses, with the answer
                     turned around — no second endpoint for the same decision. */}
                 <ActionForm

--- a/src/web/pages/resumes.tsx
+++ b/src/web/pages/resumes.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
-import { ActionForm, Badge, Button, Card, Empty, Field, FILE_INPUT_CLASS, FitBadge, Flash, Hint, Input, PageHeader, SectionTitle, SUBMIT_ONCE, Table, Tag, Td, Tr } from '../ui';
+import { ActionForm, Badge, Button, Card, Empty, Field, FILE_INPUT_CLASS, FitBadge, Flash, Hint, Input, PageHeader, SectionTitle, Select, SUBMIT_ONCE, Table, Tag, Td, Tr } from '../ui';
 import type { FlashMessage } from '../flash';
 import { formatRelative } from '../format';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
@@ -143,32 +143,75 @@ export const ResumesPage: FC<{
       <ResumeUploadForm />
     </Card>
 
-    {facts.length > 0 && (
-      <Card class="mt-4">
-        <SectionTitle>Confirmed facts</SectionTitle>
-        <Hint class="mb-3">
-          Your answers to "do you have this?" questions from comparisons. They feed every future
-          match — delete one if it's wrong.
-        </Hint>
-        <ul class="divide-y divide-line">
+    <Card class="mt-4">
+      <SectionTitle>Confirmed facts</SectionTitle>
+      <Hint class="mb-3">
+        Your answers to "do you have this?" questions from comparisons. They feed every future
+        match, so a skill you have but never wrote down is worth adding here — and a wrong one is
+        worth flipping. None of this calls the AI.
+      </Hint>
+      {facts.length > 0 && (
+        <ul class="mb-3 divide-y divide-line">
           {facts.map((f) => (
-            <li class="flex flex-wrap items-center gap-2 py-2 first:pt-0 last:pb-0">
+            <li class="flex flex-wrap items-center gap-2 py-2 first:pt-0">
               <Badge tone={f.status === 'confirmed' ? 'ok' : 'neutral'}>
                 {f.status === 'confirmed' ? 'have it' : "don't"}
               </Badge>
               <span class="text-sm font-medium text-ink">{f.term}</span>
               {f.note && <span class="min-w-0 text-xs text-ink-faint">— {f.note}</span>}
-              <ActionForm action="/facts/delete" hidden={{ term: f.term, back: '/resumes' }} class="ml-auto">
-                <Button size="sm" variant="ghost">
-                  Forget
-                </Button>
-              </ActionForm>
+              <div class="ml-auto flex items-center gap-1.5">
+                {/* The same POST /facts the comparison uses, with the answer
+                    turned around — no second endpoint for the same decision. */}
+                <ActionForm
+                  action="/facts"
+                  hidden={{
+                    term: f.term,
+                    decision: f.status === 'confirmed' ? 'denied' : 'confirmed',
+                    note: f.note ?? '',
+                    back: '/resumes',
+                  }}
+                >
+                  <Button size="sm" variant="ghost">
+                    {f.status === 'confirmed' ? "I don't, actually" : 'I do have it'}
+                  </Button>
+                </ActionForm>
+                <ActionForm action="/facts/delete" hidden={{ term: f.term, back: '/resumes' }}>
+                  <Button size="sm" variant="ghost">
+                    Forget
+                  </Button>
+                </ActionForm>
+              </div>
             </li>
           ))}
         </ul>
-      </Card>
-    )}
+      )}
+      <AddFactForm />
+    </Card>
   </Layout>
+);
+
+/**
+ * Adding a fact by hand (§12 quick win). `POST /facts` already accepted any
+ * term — it was only ever reachable from a comparison that happened to ask
+ * about one, so a skill no posting had asked about could not be recorded.
+ */
+const AddFactForm: FC = () => (
+  <form method="post" action="/facts" class="flex flex-wrap items-end gap-2">
+    <input type="hidden" name="back" value="/resumes" />
+    <Field label="Skill or tool" class="min-w-[10rem] flex-1">
+      <Input name="term" maxlength="100" required placeholder="kubernetes" />
+    </Field>
+    <Field label="Do you have it?" class="w-40">
+      <Select name="decision">
+        <option value="confirmed">I have it</option>
+        <option value="denied">I don't</option>
+      </Select>
+    </Field>
+    <Field label="Where / when" class="min-w-[12rem] flex-[2]" hint="Optional — the match prompt quotes it.">
+      <Input name="note" maxlength="300" placeholder="ran the cluster at Vodwork, 2023-2025" />
+    </Field>
+    <Button variant="violet">Remember this</Button>
+  </form>
 );
 
 /**

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import { Hono, type Context } from 'hono';
 import { logger } from '../../logger';
+import type { ResumeReview } from '@prisma/client';
 import { reviewResume } from '../../resume/review';
 import { scanResume } from '../../resume/scan';
 import type { ResumeScan } from '../../resume/prompts';
@@ -11,6 +12,7 @@ import {
   deleteImpact,
   deleteResume,
   getLatestReviewForResume,
+  getPreviousReview,
   getResume,
   getResumeOriginal,
   latestReviewByResume,
@@ -18,11 +20,17 @@ import {
   listMatchesForResume,
   listResumes,
   matchStatsByResume,
+  renameResume,
   replaceResumeFile,
   type ResumeSummary,
+  saveReviewAnswer,
   saveResumeTextVersion,
   setDefaultResume,
 } from '../../resume/store';
+import { readAnswers, unansweredAsks } from '../../resume/answers';
+import { deltaSentence, reviewDelta, type ReviewSnapshot } from '../../resume/review-delta';
+import { readReviewAdvice, readReviewGrades } from '../../resume/prompts';
+import { readReviewPromptVersion } from '../../resume/review-score';
 import { parseWarnings } from '../../resume/parse-warnings';
 import { listProfilesForResume } from '../../profiles';
 import { createProfileFromResume, newProfileDraft } from '../profile-from-resume';
@@ -106,11 +114,15 @@ resumesRoute.get('/resumes/:id', async (c) => {
     deleteImpact(id),
   ]);
   if (!resume) return c.text('Not found', 404);
+  // The run before this one, so the card can say what the edits changed.
+  const previous = review ? await getPreviousReview(id, review.id) : null;
   return c.html(
     <ResumeDetailPage
       resume={resume}
       matches={matches}
       review={review}
+      answers={readAnswers(resume.answers)}
+      reviewDelta={review ? reviewDelta(snapshotOf(previous), snapshotOf(review)!) : null}
       deleteImpact={impact}
       warnings={parseWarnings(resume.text)}
       // The draft the "Create a search" button would save — rendered, not
@@ -242,6 +254,17 @@ resumesRoute.post('/resumes/:id/rescan', async (c) => {
   });
 });
 
+/** A stored review as the delta reads it; null passes straight through. */
+function snapshotOf(review: ResumeReview | null): ReviewSnapshot | null {
+  if (!review) return null;
+  return {
+    score: review.reviewScore,
+    version: review.resumeVersion,
+    promptVersion: readReviewPromptVersion(review.breakdown),
+    grades: readReviewGrades(review.grades).map((g) => ({ dimension: g.dimension, grade: g.grade })),
+  };
+}
+
 /**
  * "Run strength review" — one AI call, on demand only (resumes-plan §B.1). The
  * run registry shows the rubric being walked instead of a spinner; nothing
@@ -252,11 +275,14 @@ resumesRoute.post('/resumes/:id/review', async (c) => {
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const resume = await getResume(id);
   if (!resume) return c.text('Not found', 404);
-  const { text, version, roleTypes } = resume;
+  const { text, version, roleTypes, answers } = resume;
+  const answered = readAnswers(answers);
 
   // Two tabs used to start two reviews of the same version and store both
-  // (PR #86's follow-up); the second POST now joins the first.
-  const { run, joined } = claimRun(`review:${id}:v${version}`, {
+  // (PR #86's follow-up); the second POST now joins the first. The answers
+  // are part of the key: answering a question and re-running is a DIFFERENT
+  // review of the same version, and must not join the run that predates it.
+  const { run, joined } = claimRun(`review:${id}:v${version}:a${answered.length}`, {
     steps: ['review'],
     jobTitle: '',
     resumeName: resume.name,
@@ -267,16 +293,70 @@ resumesRoute.post('/resumes/:id/review', async (c) => {
   });
   if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
   startRun(run.id, async () => {
-    const row = await reviewResume({ id, text, version, roleTypes });
+    const row = await reviewResume({ id, text, version, roleTypes, answers });
+    const previous = row ? await getPreviousReview(id, row.id) : null;
+    const delta = row ? reviewDelta(snapshotOf(previous), snapshotOf(row)!) : null;
     updateRun(run.id, row
       ? {
           stage: 'done',
           resultUrl: `/resumes/${id}`,
-          flash: `Strength ${row.reviewScore}/100 — ${row.headline}`,
+          flash: delta
+            ? deltaSentence(delta)
+            : `Strength ${row.reviewScore}/100 — ${row.headline}`,
         }
       : { stage: 'error', error: 'The review failed — see the web logs.' });
   });
   return c.redirect(`/target/runs/${run.id}`, 303);
+});
+
+/**
+ * One answer to one of the review's questions (ADR 0030 phase 3). No AI call
+ * and no re-run: the answer is stored, and the NEXT review reads it. Saying so
+ * in the flash matters — this is a button that spends nothing, and the user
+ * should know which button does.
+ */
+resumesRoute.post('/resumes/:id/answers', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!Number.isFinite(id)) return c.text('Bad id', 400);
+  const form = await c.req.parseBody();
+  const question = typeof form.question === 'string' ? form.question : '';
+  const answer = typeof form.answer === 'string' ? form.answer : '';
+  if (question.trim().length === 0) return c.text('Bad answer', 400);
+
+  const saved = await saveReviewAnswer(id, question, answer);
+  if (saved === null) return c.text('Not found', 404);
+  const open = unansweredAsks(
+    readReviewAdvice((await getLatestReviewForResume(id))?.advice).map((a) => a.ask),
+    saved,
+  ).length;
+  const cleared = answer.trim().length === 0;
+  logger.info({ resumeId: id, answers: saved.length, open, cleared }, 'resume: review answer saved');
+  return flashRedirect(
+    `/resumes/${id}#resume-strength`,
+    'ok',
+    cleared
+      ? 'Answer removed — the next review will ask again.'
+      : `Saved. ${open === 0 ? 'That was the last open question' : `${open} question${open === 1 ? '' : 's'} still open`} — run the review again to fold it in. No AI call was made.`,
+  );
+});
+
+/**
+ * Rename a resume (§12 quick win). The name is what every picker, flash and
+ * "applied with" line says, and until now it was whatever the uploaded file
+ * happened to be called — `nameFromFilename` on a download from a job board
+ * produces things like "Alex Doe Senior Backend Resume (3)".
+ */
+resumesRoute.post('/resumes/:id/rename', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (!Number.isFinite(id)) return c.text('Bad id', 400);
+  const form = await c.req.parseBody();
+  const name = (typeof form.name === 'string' ? form.name : '').trim().slice(0, MAX_RESUME_NAME_CHARS);
+  if (name.length === 0) {
+    return flashRedirect(`/resumes/${id}`, 'err', 'A resume needs a name.');
+  }
+  const renamed = await renameResume(id, name);
+  if (!renamed) return c.text('Not found', 404);
+  return flashRedirect(`/resumes/${id}`, 'ok', `Renamed to "${name}".`);
 });
 
 resumesRoute.post('/resumes/:id/default', async (c) => {

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -28,7 +28,7 @@ import {
   setDefaultResume,
 } from '../../resume/store';
 import { readAnswers, unansweredAsks } from '../../resume/answers';
-import { deltaSentence, reviewDelta, type ReviewSnapshot } from '../../resume/review-delta';
+import { deltaSentence, reviewDelta, type ReviewDelta, type ReviewSnapshot } from '../../resume/review-delta';
 import { readReviewAdvice, readReviewGrades } from '../../resume/prompts';
 import { readReviewPromptVersion } from '../../resume/review-score';
 import { parseWarnings } from '../../resume/parse-warnings';
@@ -122,7 +122,7 @@ resumesRoute.get('/resumes/:id', async (c) => {
       matches={matches}
       review={review}
       answers={readAnswers(resume.answers)}
-      reviewDelta={review ? reviewDelta(snapshotOf(previous), snapshotOf(review)!) : null}
+      reviewDelta={deltaFor(review, previous)}
       deleteImpact={impact}
       warnings={parseWarnings(resume.text)}
       // The draft the "Create a search" button would save — rendered, not
@@ -265,6 +265,12 @@ function snapshotOf(review: ResumeReview | null): ReviewSnapshot | null {
   };
 }
 
+/** What moved between two runs of one resume — null unless both exist. */
+function deltaFor(current: ResumeReview | null, previous: ResumeReview | null): ReviewDelta | null {
+  const now = snapshotOf(current);
+  return now ? reviewDelta(snapshotOf(previous), now) : null;
+}
+
 /**
  * "Run strength review" — one AI call, on demand only (resumes-plan §B.1). The
  * run registry shows the rubric being walked instead of a spinner; nothing
@@ -279,10 +285,11 @@ resumesRoute.post('/resumes/:id/review', async (c) => {
   const answered = readAnswers(answers);
 
   // Two tabs used to start two reviews of the same version and store both
-  // (PR #86's follow-up); the second POST now joins the first. The answers
-  // are part of the key: answering a question and re-running is a DIFFERENT
-  // review of the same version, and must not join the run that predates it.
-  const { run, joined } = claimRun(`review:${id}:v${version}:a${answered.length}`, {
+  // (PR #86's follow-up); the second POST now joins the first. The answers are
+  // part of the key, hashed rather than counted: correcting a figure leaves the
+  // count alone but is a different review, and must not join the run that
+  // predates it.
+  const { run, joined } = claimRun(`review:${id}:v${version}:${hashShortId(JSON.stringify(answered))}`, {
     steps: ['review'],
     jobTitle: '',
     resumeName: resume.name,
@@ -294,8 +301,7 @@ resumesRoute.post('/resumes/:id/review', async (c) => {
   if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
   startRun(run.id, async () => {
     const row = await reviewResume({ id, text, version, roleTypes, answers });
-    const previous = row ? await getPreviousReview(id, row.id) : null;
-    const delta = row ? reviewDelta(snapshotOf(previous), snapshotOf(row)!) : null;
+    const delta = deltaFor(row, row ? await getPreviousReview(id, row.id) : null);
     updateRun(run.id, row
       ? {
           stage: 'done',


### PR DESCRIPTION
Stage 2 — the strength review stops being a one-shot. **This closes TASKS §12
and, with it, every open item in the backlog except the pre-public audit.**
[ADR 0030](docs/adr/0030-resume-strength-review.md) phase 3.

**Stacked on `applied-resume-truth` (#94), which is stacked on
`pre-public-hardening` (#93)** — review those first; this branch's base
retargets as they merge.

## The dead end this fixes

The rubric refuses to invent a number: where a stronger line needs one your
resume doesn't carry, the advice asks for it instead. Nothing could be
answered, so the next run asked the same question again. The asks were honest
and useless.

Now each question has a box. The answer is stored on the resume, read into the
next review, and the rubric is told — in as many words — that asking twice for
a figure it has been given is the one thing it must never do.

## Measured live (resume 1, Opus, `claude_code`)

| | before | after answering 2 of 4 |
| --- | --- | --- |
| asks | 4 | **2** |
| `answersUsed` in the log | — | **2** |
| run time | 72.6 s (first ever) | 69.3 s |
| score | 45 | 45 |

Both figures were written into the rewrites verbatim:

> Consolidated 3 microservices into 1 and retired 2 paid SaaS licences,
> **cutting cloud spend by ~$40k/year** and reducing system complexity.

**The score not moving is the correct answer, not a miss.** The prompt says a
supplied metric may not change a grade on its own: the resume is graded as
WRITTEN, and a figure the document does not carry is a reason for advice, not
for a better grade. It becomes a better grade when the candidate puts the
rewritten line into the resume and uploads it — which is what the delta is for.

The delta against the earlier run said the honest thing rather than the
flattering one:

> Strength 45, unchanged from the last review; 2 dimensions moved — **but the
> two runs used different rubric versions, so the difference is not a
> measurement.**

That is `REVIEW_PROMPT_VERSION` 1 → 2 doing its job. Test rows (the answers and
the review they produced) were deleted afterwards — the figures above were mine
for the test, not Nazar's.

## The storage decision, and why not the obvious one

One column: `resume.answers` (JSONB, default `[]`, hand-written migration).

- **Not `CandidateFact`.** That dictionary is skill *vocabulary* and it feeds
  the match prompt — "1.2M requests/day" would become a keyword. The two look
  alike (both are "the user answering a question") and are not the same thing.
- **Not on `resume_review`.** A review row is per button press; an answer is a
  fact about the document that has to outlive the run that asked for it.
- **No new table, no ADR**: the resume row already cascades, and this is one
  more JSON column beside `issues`.

**One deliberate deviation from the brief**: the brief said the metrics block
should be fenced (ADR 0022). It is *not*. CLAUDE.md's file rules put operator
input — `Profile.notes`, cover angles, confirmed `ask_user` facts — OUTSIDE the
fence, because that is the user's own instruction channel; a metric the user
typed into their own tool is the same kind of text as a confirmed fact, and
`factLines()` next door treats it that way. Fencing it would have been harmless
but inconsistent. Say the word and it moves.

## Also in this branch — the three §12 quick wins

- **Facts add / flip on `/resumes`.** `POST /facts` always accepted an
  arbitrary term; it was only reachable from a comparison that happened to ask
  about one, so a skill no posting had mentioned could not be recorded. There
  is now a form, and a one-click flip that posts the same endpoint with the
  answer turned around. No AI call either way, and the copy says so.
- **Rename a resume.** The name is what every picker, flash and "applied with"
  line says, and it was whatever the uploaded file happened to be called.
- **Comparisons group per job.** 14 flat rows became 10, and the posting
  checked five times reads **5 runs · 62 → 70 → 64 → 66 → 68** with every score
  still its own link and the change since the previous run beside the latest.

The plan's fourth quick win, "version badge in hub", shipped with
`resumes-page-p0`; it is removed from the list rather than built twice.

## Not built, deliberately

**The version-over-version strength trend.** The database holds two reviews, on
two different resumes, and no resume has two comparable runs — n = 0. Charting
that is the trap the repo closed F18 with. The delta between two runs is what
the data supports, and that is what shipped.

The weights and caps in `review-score.ts` are untouched: three live scores
(45 / 78 / 78) are all the evidence there is, and they behave.

## Shape

- `src/resume/answers.ts` — pure, 14 tests: an absent answer, a corrected one
  (the old figure must never reach the prompt), a blank one (taking back what
  you said), the cap, and the prompt block.
- `src/resume/review-delta.ts` — pure, 11 tests: what moved, which way, and the
  three cases where a comparison would be dishonest (no earlier run, no grades,
  two rubric versions).
- `src/web/match-history.ts` — pure, 8 tests: grouping, ordering, the
  progression.
- `saveReviewAnswer` takes the same row lock the keyword edits took in #93 —
  two answers typed in two tabs both survive.

## Verification

- `npm run lint:types`, `npm test` (**1028**, +34), `npx prisma format --check`
  — green.
- Migration applied to the live database and the column verified.
- Live cycle above; the three quick wins exercised live (a fact added, flipped
  and forgotten; a resume renamed and renamed back) — every test row restored.
- Dashboard: `docker compose build web`, six routes 200, screenshots at 1200
  and 375, **0 console errors**, no horizontal overflow.

## Pre-merge review

`code-review-expert` over the branch diff. Fixed here:

- **P1** — the review run key counted the answers, so *correcting* a figure
  (count unchanged) could join a run started before the correction. It hashes
  them now.
- **P2** — the answers block only listed questions the *current* review asks,
  so an answer disappeared the moment the model stopped asking — invisible and
  impossible to correct. It now lists every stored answer. Caught by the live
  run, not by a test.
- **P2** — the fact rows wrapped raggedly at 375 px (badge and buttons landing
  on different lines per row); the small-screen layout is now deliberate.
- **P3** — two non-null assertions in the delta wiring folded into one helper.

## Release notes draft (v1.22.0)

```
## What's new
- The strength review's questions can be answered. Type the figure it asked for; the next review writes it into the rewritten line instead of asking again. Measured on a real resume: 4 questions, 2 answered, the re-run asked 2 and used both figures verbatim.
- A second review says what moved: the score before and after, and every dimension whose grade changed — or that the two runs used different rubric versions and the difference is not a measurement.
- Confirmed facts can be added and flipped from the Resumes page, not only when a comparison happens to ask.
- Resumes can be renamed.
- Comparisons group per posting: re-runs read as one progression (5 runs · 62 → 70 → 64 → 66 → 68) instead of unrelated rows.
## Schema
- resume.answers (JSONB, default []) — hand-written migration
## Verification
- 1028 tests, lint:types + prisma format green; live answer → re-run cycle on a real resume; migration applied and verified; dashboard rebuilt, six routes 200, screenshots at 1200/375, console clean.
## References
- ADR 0030 phase 3; TASKS §12 (closed)
```

After merge (once v1.21.0 is tagged):

```
git tag -a v1.22.0 -m "answers fold into the next strength review" <merge-sha>
git push origin v1.22.0
```
