### PR TITLE
pre-public audit: the exposed database, the empty-install path, and a backup recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.23.0] — 2026-09-02
+
+The pre-public audit: six checks nobody had run against this project as an
+outsider would (TASKS §14). Two of them found something.
+
+### Security
+- **The database is no longer published to your whole network.** `docker
+  compose up` published Postgres on **every interface** with the password that
+  sits in the compose file, so anyone on the same Wi-Fi could read the entire
+  database — jobs, resumes, cover letters, applications, and any AI key pasted
+  into the dashboard (`AppSettings.aiKeys`, stored in plaintext by design).
+  Demonstrated from another address before the fix. It is now published on
+  **`127.0.0.1:5433`**: loopback only, and on 5433 so it cannot be shadowed by
+  a Postgres already running on 5432. The app never used this port — it reaches
+  Postgres over the compose network — so only host tools are affected: use
+  `localhost:5433`.
+
+### Added
+- **Backup and restore, documented and verified.** A project whose whole pitch
+  is "your data in your own Postgres" had no instructions for keeping it. The
+  README now carries both commands; the dump they produce was checked (8.7 MB,
+  all 16 tables) and reloaded into an empty database with no errors.
+
+### Fixed
+- **The setup wizard no longer runs a scoring pass with no AI connected.** Step
+  1 can be skipped, and step 4 would then spend a minute failing ten calls one
+  by one before admitting nothing could be scored. It now says so before
+  starting and sends you back to step 1 — the jobs already found stay put.
+- **Deleting a company says what goes with it.** The confirm counted the jobs
+  only; on real data "Delete "Reddit" and all its 73 jobs?" was hiding six
+  tracked applications and a cover letter. It names them now, the way the
+  resume delete has since v1.19.0.
+
 ## [1.22.0] — 2026-09-02
 
 ### Added
@@ -1285,6 +1318,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.23.0]: https://github.com/applypack/applypack/compare/v1.22.0...v1.23.0
 [1.22.0]: https://github.com/applypack/applypack/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/applypack/applypack/compare/v1.20.0...v1.21.0
 [1.20.0]: https://github.com/applypack/applypack/compare/v1.19.0...v1.20.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -477,6 +477,8 @@ Always:
 | Tail the worker | `docker compose logs -f app` |
 | Tail the dashboard | `docker compose logs -f web` |
 | psql into the DB | `docker compose exec postgres psql -U jobhunter -d jobhunter` |
+| psql / Prisma from the HOST | port **5433** (`postgresql://jobhunter:jobhunter@localhost:5433/jobhunter`) — compose publishes the DB on loopback only, on 5433 so a host Postgres on 5432 cannot shadow it |
+| Back up the database | `docker compose exec -T postgres pg_dump -U jobhunter jobhunter > applypack-$(date +%F).sql` (verified: 8.7 MB, 16 tables; restore into an empty DB with `psql < dump`) |
 | Re-clean stored descriptions (rows with leftover markup) | `docker compose exec app node dist/scripts/backfill-descriptions.js --dry-run`, then without the flag |
 | Fingerprint existing jobs + link cross-listings | `docker compose exec app node dist/scripts/backfill-fingerprints.js --dry-run`, then without the flag |
 | Flag apply links on already-stored jobs | `docker compose exec app node dist/scripts/backfill-apply-link-flags.js --dry-run`, then without the flag |

--- a/README.md
+++ b/README.md
@@ -297,6 +297,44 @@ draft feels right, "Re-analyze with AI" gives the honest rubric score and
 the delta is real because the scoring is deterministic.
 
 <details>
+<summary><b>Your data, and how to keep it</b> (backup, restore, what a delete takes)</summary>
+
+Everything lives in one Postgres database — jobs, resumes and their versions,
+comparisons, cover letters, applications, and your AI keys if you pasted them
+into the dashboard instead of `.env`. Nothing is sent anywhere but the AI
+engine you chose and, if you set it up, your own Telegram bot.
+
+Back it up with one command; it is a plain SQL dump:
+
+```bash
+docker compose exec -T postgres pg_dump -U jobhunter jobhunter > applypack-$(date +%F).sql
+```
+
+Restore into an empty database (stop the app first so nothing writes while it
+loads):
+
+```bash
+docker compose stop app web
+docker compose exec -T postgres psql -U jobhunter -d jobhunter < applypack-2026-09-02.sql
+docker compose start app web
+```
+
+`docker compose down` keeps the data (it lives in the `pgdata` volume);
+`docker compose down -v` deletes it. There is no undo, so take a dump first.
+
+The database port is published on **`127.0.0.1:5433`** for `psql` and Prisma on
+the host — loopback only, and 5433 so it does not collide with a Postgres you
+already run on 5432. The app itself never uses that port; it reaches Postgres
+over the compose network.
+
+Deletes inside the dashboard cascade, and each confirm names what it will take:
+deleting a resume takes its comparisons, its cover letters and its strength
+reviews; deleting a company takes every job it posted, and with each job the
+application you tracked against it.
+
+</details>
+
+<details>
 <summary><b>The worker's schedule</b> (six cron jobs, <code>TZ</code> from <code>.env</code>)</summary>
 
 | Cron | Job | What it does |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,15 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      # Loopback only, and 5433 on purpose. "5432:5432" published the database
+      # on every interface with the password above — on any shared network that
+      # is the whole dataset (resumes, applications, and the AI keys in
+      # app_settings) one connection away. The app itself never uses this port:
+      # it reaches Postgres over the compose network as postgres:5432. This
+      # publish exists for psql and Prisma on the host, and 5433 keeps it clear
+      # of a Postgres already running there — which would otherwise shadow
+      # localhost:5432 and silently answer host tools from the wrong database.
+      - "127.0.0.1:5433:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U jobhunter -d jobhunter"]
       interval: 5s

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1027,6 +1027,55 @@ before anyone else installs this.
       - **#73** verified live: a `resumeId` that no longer exists flashes
         *"That resume no longer exists — reload the page and pick another
         one. Nothing was saved."* and `profile.updatedAt` does not move.
-- [ ] `pre-public-check` — the six-point audit before strangers arrive:
-      clean install from an empty database, migrations, secrets, exposure,
-      README against the live UI, delete blast radius + a backup recipe.
+- [x] `pre-public-check` — the six-point audit, done 2026-09-02, branch
+      `pre-public-check`. Six checks, each with its evidence; **two P1s found
+      and fixed here**, two findings filed as issues.
+
+      1. **Clean install from nothing** — the check nobody had ever run. The
+         real stack down, `cp .env.example .env` (no keys of any kind), a
+         separate compose project on a fresh volume. `/` redirected to
+         `/welcome`, step 1 reported each engine honestly ("2.1.251 installed,
+         but not logged in"), step 2 fetched **2 633 jobs from 32/32 sources in
+         93 s with no AI**, step 3's no-resume fallback saved a profile, and
+         "Start the hourly watch" set `setupCompletedAt` and stopped the
+         redirect. **P1 found:** step 4 ran a full scoring pass with no engine
+         connected — ten failing calls and a minute of progress bar to be told
+         nothing could be scored. It now checks `facts.aiReady` (which the
+         wizard already computed) and sends the user back to step 1. The
+         missing *reason* on every other failure path is issue #97.
+      2. **Migrations** — all **47** applied to the empty database in order,
+         16 tables, `0` rows left unfinished in `_prisma_migrations`.
+      3. **Secrets** — `.env` is gitignored and untracked (only `.env.example`
+         is in the tree), a regex sweep for key shapes over the tracked files
+         found nothing, and `.env` has never been committed. Every variable
+         `config.ts` reads is present in `.env.example`; the two extras there
+         (`CLAUDE_CODE_OAUTH_TOKEN`, `GEMINI_API_KEY`) are the CLI credentials
+         `ai-keys.ts` reads, and both key paths (`.env` and
+         `AppSettings.aiKeys`) are documented.
+      4. **Exposure — P1, the worst finding.** The dashboard was carefully
+         bound to loopback while compose published **Postgres on
+         `0.0.0.0:5432` with the password in the compose file**. Demonstrated,
+         not theorised: `psql -h <LAN ip> -U jobhunter` from another address
+         connected and read the database — every job, resume, letter and
+         application, plus `app_settings.aiKeys`, where a pasted AI key lives
+         in plaintext (ADR 0027). Now `127.0.0.1:5433:5432`: loopback only, and
+         5433 because a host Postgres on 5432 would otherwise shadow it — the
+         gotcha this repo had been working around by hand. Re-checked after the
+         change: both LAN ports refused, host tools work on 5433, the app
+         (which uses the compose network, never this port) unaffected.
+      5. **README against the live UI** — text accurate: "22 sources" is
+         exactly the `AtsType` count minus `MANUAL`, "five AI backends" is
+         exactly `AI_PROVIDER_IDS`, and the page table already calls `/target`
+         "Compare". `overview.png` and `jobs.png` are current;
+         `target.png` is four releases stale (its nav still says "Target") →
+         issue #96, because re-shooting it needs the demo fixture that is not
+         in the repo.
+      6. **Data — P1.** There were **no backup instructions anywhere**, in a
+         project whose pitch is "your data in your own Postgres". The README
+         now carries a verified recipe: the documented `pg_dump` produced an
+         **8.7 MB dump of all 16 tables**, and the documented restore loaded it
+         into an empty database with **0 errors** (1 016 jobs, 4 resumes, 17
+         letters). Delete confirmations were re-checked against the schema's
+         cascades: the resume one was fixed in v1.19.0, but "Delete "Reddit"
+         and all its 73 jobs?" was hiding **6 tracked applications and a cover
+         letter**. Company deletes now name them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/delete-confirm.test.ts
+++ b/src/web/delete-confirm.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { deleteConfirm } from './delete-confirm';
+import { companyDeleteConfirm, deleteConfirm } from './delete-confirm';
 
 describe('deleteConfirm', () => {
   it('names every cascade — letters and strength reviews included', () => {
@@ -36,6 +36,38 @@ describe('deleteConfirm', () => {
     assert.equal(
       deleteConfirm('CV', { matches: 1, letters: 1, reviews: 1 }),
       'Delete "CV" and 1 comparison, 1 cover letter and 1 strength review? This cannot be undone.',
+    );
+  });
+});
+
+describe('companyDeleteConfirm', () => {
+  it('names what rides along with the jobs', () => {
+    // Measured on the live database: "Delete Reddit and all its 73 jobs?" was
+    // hiding six applications and a cover letter.
+    assert.equal(
+      companyDeleteConfirm('Reddit', { jobs: 73, applications: 6, comparisons: 0, letters: 1 }),
+      'Delete "Reddit", 73 jobs, and with them 6 tracked applications and 1 cover letter? This cannot be undone.',
+    );
+  });
+
+  it('stays short when only the jobs would go', () => {
+    assert.equal(
+      companyDeleteConfirm('Acme', { jobs: 12, applications: 0, comparisons: 0, letters: 0 }),
+      'Delete "Acme" and 12 jobs? This cannot be undone.',
+    );
+  });
+
+  it('handles a company that never posted anything', () => {
+    assert.match(
+      companyDeleteConfirm('Acme', { jobs: 0, applications: 0, comparisons: 0, letters: 0 }),
+      /and no jobs\?/,
+    );
+  });
+
+  it('uses the singular for one of each', () => {
+    assert.match(
+      companyDeleteConfirm('Acme', { jobs: 1, applications: 1, comparisons: 1, letters: 1 }),
+      /1 job, and with them 1 tracked application, 1 resume comparison and 1 cover letter/,
     );
   });
 });

--- a/src/web/delete-confirm.ts
+++ b/src/web/delete-confirm.ts
@@ -1,8 +1,11 @@
 /**
- * The confirm text for "Delete this resume". Pure so the blast radius can be
- * unit-tested: deleting cascades every comparison, every cover letter —
- * including the letters the user edited by hand — and every strength review,
- * and the old wording named only the comparisons.
+ * Confirm text for the two deletes that cascade (audit, TASKS §14). Pure so the
+ * blast radius can be unit-tested rather than trusted.
+ *
+ * Deleting a resume takes every comparison, every cover letter — including the
+ * ones the user edited by hand — and every strength review. Deleting a company
+ * takes every job it posted, and with each job the application tracked against
+ * it. Both wordings used to name only the obvious half.
  */
 
 export interface DeleteImpact {
@@ -20,6 +23,32 @@ export function deleteConfirm(name: string, impact: DeleteImpact): string {
 
   if (parts.length === 0) return `Delete "${name}"? Nothing else is attached to it.`;
   return `Delete "${name}" and ${joinList(parts)}? This cannot be undone.`;
+}
+
+export interface CompanyDeleteImpact {
+  jobs: number;
+  /** Jobs in the funnel or marked applied — the rows that took real work. */
+  applications: number;
+  comparisons: number;
+  letters: number;
+}
+
+/**
+ * The confirm text for "Delete this company". Deleting one cascades every job
+ * it ever posted, and a job carries the application you tracked, the
+ * comparisons you ran and the letters you wrote (schema `onDelete: Cascade`).
+ * The old wording counted the jobs only, so on real data "Delete Reddit and
+ * all its 73 jobs?" was hiding six applications and a cover letter.
+ */
+export function companyDeleteConfirm(name: string, impact: CompanyDeleteImpact): string {
+  const jobs = countOf(impact.jobs, 'job', 'jobs') ?? 'no jobs';
+  const rest = [
+    countOf(impact.applications, 'tracked application', 'tracked applications'),
+    countOf(impact.comparisons, 'resume comparison', 'resume comparisons'),
+    countOf(impact.letters, 'cover letter', 'cover letters'),
+  ].filter((p): p is string => p !== null);
+  if (rest.length === 0) return `Delete "${name}" and ${jobs}? This cannot be undone.`;
+  return `Delete "${name}", ${jobs}, and with them ${joinList(rest)}? This cannot be undone.`;
 }
 
 function countOf(n: number, one: string, many: string): string | null {

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -22,6 +22,7 @@ import {
   Tr,
 } from '../ui';
 import { formatRelative } from '../format';
+import { companyDeleteConfirm, type CompanyDeleteImpact } from '../delete-confirm';
 import {
   QUIET_STREAK,
   SILENT_DAYS,
@@ -40,6 +41,8 @@ interface CompanyRow {
   active: boolean;
   careerUrl: string | null;
   jobsTotal: number;
+  /** What Delete would cascade — jobs, and the work recorded against them. */
+  deleteImpact: CompanyDeleteImpact;
   alertedTotal: number;
   lastFetchedAt: Date | null;
   lastFetchStatus: string | null;
@@ -300,7 +303,7 @@ export const CompaniesPage: FC<CompaniesProps> = ({
                   <Td>
                     <ActionForm
                       action={`/companies/${c.id}/delete`}
-                      confirm={`Delete "${c.name}" and all its ${c.jobsTotal} jobs?`}
+                      confirm={companyDeleteConfirm(c.name, c.deleteImpact)}
                       class="flex justify-end"
                     >
                       <Button size="sm" variant="danger">

--- a/src/web/routes/companies.tsx
+++ b/src/web/routes/companies.tsx
@@ -49,6 +49,12 @@ const NewCompanySchema = z.object({
 
 export const companiesRoute = new Hono();
 
+/** One "how many rows point at this company" row, from a grouped count. */
+interface CompanyTally {
+  companyId: number;
+  n: number;
+}
+
 companiesRoute.get('/companies', async (c) => {
   const companies = await prisma.company.findMany({
     where: { atsType: { not: AtsType.MANUAL } },
@@ -83,17 +89,19 @@ companiesRoute.get('/companies', async (c) => {
     _count: { _all: true },
   });
   const applicationMap = new Map(applicationCounts.map((r) => [r.companyId, r._count._all]));
-  const [matchRows, letterRows] = await Promise.all([
-    prisma.resumeMatch.findMany({ select: { job: { select: { companyId: true } } } }),
-    prisma.coverLetter.findMany({ select: { job: { select: { companyId: true } } } }),
+  // Counted in SQL, one row per company: `groupBy` cannot group across a
+  // relation, and loading every match and every letter to tally them in
+  // memory would grow with the user's whole history for a confirm string.
+  const [matchCounts, letterCounts] = await Promise.all([
+    prisma.$queryRaw<CompanyTally[]>`
+      SELECT j."companyId" AS "companyId", count(*)::int AS n
+      FROM resume_match m JOIN job j ON j.id = m."jobId" GROUP BY j."companyId"`,
+    prisma.$queryRaw<CompanyTally[]>`
+      SELECT j."companyId" AS "companyId", count(*)::int AS n
+      FROM cover_letter l JOIN job j ON j.id = l."jobId" GROUP BY j."companyId"`,
   ]);
-  const tally = (rows: { job: { companyId: number } }[]): Map<number, number> => {
-    const m = new Map<number, number>();
-    for (const r of rows) m.set(r.job.companyId, (m.get(r.job.companyId) ?? 0) + 1);
-    return m;
-  };
-  const matchMap = tally(matchRows);
-  const letterMap = tally(letterRows);
+  const matchMap = new Map(matchCounts.map((r) => [r.companyId, r.n]));
+  const letterMap = new Map(letterCounts.map((r) => [r.companyId, r.n]));
 
   const settings = await getSettings();
   const now = new Date();

--- a/src/web/routes/companies.tsx
+++ b/src/web/routes/companies.tsx
@@ -73,6 +73,28 @@ companiesRoute.get('/companies', async (c) => {
     alertedMap.set(row.companyId, row._count._all);
   }
 
+  // What "Delete" would take beyond the jobs. A job cascades to the
+  // application tracked against it, its comparisons and its letters, and the
+  // confirm used to count the jobs only — on real data that hid six
+  // applications behind "and all its 73 jobs?" (audit, TASKS §14).
+  const applicationCounts = await prisma.job.groupBy({
+    by: ['companyId'],
+    where: { OR: [{ pipelineStage: { not: null } }, { status: JobStatus.APPLIED }] },
+    _count: { _all: true },
+  });
+  const applicationMap = new Map(applicationCounts.map((r) => [r.companyId, r._count._all]));
+  const [matchRows, letterRows] = await Promise.all([
+    prisma.resumeMatch.findMany({ select: { job: { select: { companyId: true } } } }),
+    prisma.coverLetter.findMany({ select: { job: { select: { companyId: true } } } }),
+  ]);
+  const tally = (rows: { job: { companyId: number } }[]): Map<number, number> => {
+    const m = new Map<number, number>();
+    for (const r of rows) m.set(r.job.companyId, (m.get(r.job.companyId) ?? 0) + 1);
+    return m;
+  };
+  const matchMap = tally(matchRows);
+  const letterMap = tally(letterRows);
+
   const settings = await getSettings();
   const now = new Date();
   const rows = companies.map((c) => ({
@@ -84,6 +106,12 @@ companiesRoute.get('/companies', async (c) => {
     careerUrl: c.careerUrl,
     jobsTotal: c._count.jobs,
     alertedTotal: alertedMap.get(c.id) ?? 0,
+    deleteImpact: {
+      jobs: c._count.jobs,
+      applications: applicationMap.get(c.id) ?? 0,
+      comparisons: matchMap.get(c.id) ?? 0,
+      letters: letterMap.get(c.id) ?? 0,
+    },
     lastFetchedAt: c.jobs[0]?.fetchedAt ?? null,
     lastFetchStatus: c.lastFetchStatus,
     consecutiveFailures: c.consecutiveFailures,

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -41,6 +41,7 @@ import {
 } from '../welcome-steps';
 
 const TOP_MATCHES = 5;
+const AI_STEP = '/welcome?step=ai';
 const PROFILE_STEP = '/welcome?step=profile';
 const MATCHES_STEP = '/welcome?step=matches';
 
@@ -285,6 +286,16 @@ welcomeRoute.post('/welcome/score', async (c) => {
   const { facts } = await loadWelcomeContext();
   if (!facts.profileReady) {
     return flashRedirect(PROFILE_STEP, 'err', 'Fill the profile first — scoring needs your technologies or role words.');
+  }
+  // Step 1 can be skipped, and then every call in this pass fails one by one:
+  // a minute of watching a progress bar to be told nothing could be scored.
+  // The wizard already knows whether an engine answers — ask it first.
+  if (!facts.aiReady) {
+    return flashRedirect(
+      AI_STEP,
+      'err',
+      'No AI engine answered, so there is nothing to score with. Connect one here first — the jobs we found are already stored and stay put.',
+    );
   }
   const { run, joined } = claimRun(SCORE_RUN_KEY, {
     steps: ['score'],


### PR DESCRIPTION
Stage 3 — the six-point check before strangers arrive (TASKS §14). **This
closes the last open item in `docs/TASKS.md`.**

**Stacked on `resume-strength-loop` (#95) → `applied-resume-truth` (#94) →
`pre-public-hardening` (#93).** Review in that order; bases retarget as they
merge.

> **One deviation from the brief, flagged up front.** The brief called for a
> docs-only PR with no tag. The audit found two P1s and a security bug, so
> this branch carries code and a `1.23.0` CHANGELOG section. Shipping a change
> that moves the database port and closes a network exposure *inside a "docs"
> PR* would hide it. If you'd rather it stayed untagged, dropping the version
> bump is one commit.

## 1. Clean install from nothing — the check nobody had ever run

Real stack down, `cp .env.example .env` (no keys of any kind), a separate
compose project on a fresh volume, walked as a first-time user.

- `/` redirected to `/welcome`; step 1 reported each engine honestly
  ("2.1.251 (Claude Code) installed, but not logged in").
- Step 2 fetched **2 633 jobs from 32/32 sources in 93 s, with no AI at all** —
  the promise the wizard makes, kept.
- Step 3's no-resume fallback saved a profile; "Start the hourly watch" set
  `setupCompletedAt` and `/` stopped redirecting.

**P1 found and fixed.** Step 1 can be skipped — and then step 4 ran the whole
scoring pass anyway: ten calls failing one after another, a minute of progress
bar, ending in "Scored 0 jobs; 10 could not be scored". The wizard already
computes `facts.aiReady`; step 4 now asks it first and sends you back to step 1
with the jobs it found left in place. (The missing *reason* on every other
failure path is #97.)

## 2. Migrations

All **47** applied to the empty database in order — 16 tables, `0` rows left
unfinished in `_prisma_migrations`.

## 3. Secrets

`.env` gitignored and untracked (only `.env.example` in the tree), never
committed, and a regex sweep for key shapes over the tracked files found
nothing. Every variable `config.ts` reads is in `.env.example`; the two extras
there (`CLAUDE_CODE_OAUTH_TOKEN`, `GEMINI_API_KEY`) are the CLI credentials
`ai-keys.ts` reads, and both key paths (`.env` and `AppSettings.aiKeys`) are
documented.

## 4. Exposure — the worst finding, and it was real

The dashboard is carefully bound to loopback. The database was not:

```yaml
ports:
  - "5432:5432"      # every interface, with the password in the file above
```

Demonstrated rather than theorised — from another address on the network:

```
$ PGPASSWORD=jobhunter psql -h <LAN ip> -U jobhunter -d jobhunter
 REACHABLE FROM THE LAN with the compose password
```

That is every job, resume, cover letter and application, plus
`app_settings."aiKeys"` — where a key pasted into the dashboard lives in
plaintext by design (ADR 0027). Any shared Wi-Fi, one connection.

Now `127.0.0.1:5433:5432`. Loopback only, and **5433** deliberately: a Postgres
already running on the host holds `127.0.0.1:5432`, so binding there would fail
outright — and it is exactly what has been shadowing `localhost:5432` and
answering host tools from the wrong database (the workaround this repo has been
carrying by hand). After the change: both LAN ports refuse the connection, host
tools work on `localhost:5433`, and the app is untouched because it reaches
Postgres over the compose network and never used the published port.

## 5. README against the live UI

Text checked claim by claim and accurate: "22 source integrations" is exactly
the `AtsType` count minus `MANUAL`; "five AI backends" is exactly
`AI_PROVIDER_IDS`; the page table already calls `/target` "Compare".
`overview.png` and `jobs.png` are current. `target.png` is four releases stale
— its sidebar still says "Target", and it shows suggestions on a fresh
comparison, which v1.16.0 ended. Re-shooting needs the demo fixture that is not
in the repo → **#96**.

## 6. Data

**There were no backup instructions anywhere** — in a project whose pitch is
"your data in your own Postgres". The README now carries both commands, and
both were run before being documented: the `pg_dump` produced **8.7 MB across
all 16 tables**, and the restore loaded it into an empty database with **0
errors** (1 016 jobs, 4 resumes, 17 letters).

Delete confirmations re-checked against the schema's cascades. The resume one
was fixed in v1.19.0; the company one was not:

> Delete "Reddit" and all its 73 jobs?

That delete would also have taken **6 tracked applications and a cover letter**.
Live, after the fix:

```
Delete "Reddit", 73 jobs, and with them 6 tracked applications and 1 cover letter?
Delete "LaraJobs Feed", 13 jobs, and with them 2 resume comparisons and 5 cover letters?
Delete "Affirm", 207 jobs, and with them 1 tracked application?
```

## Verification

- `npm run lint:types`, `npm test` (**1032**, +4), `npx prisma format --check`
  — green.
- Every number above is from a command run in this session, not an estimate.
- The real stack was restored afterwards and re-checked: 1 016 jobs, 4 resumes,
  21 comparisons, 17 letters, 2 reviews — untouched.

## Pre-merge review

`code-review-expert` over the branch diff. Fixed here:

- **P1** — the new company tallies loaded **every** `resume_match` and
  `cover_letter` row on each `/companies` view to count them in memory. They
  are two grouped SQL counts now, one row per company. (The applications route
  next door carries a comment warning about exactly this shape.)

## Release notes draft (v1.23.0, if you want the tag)

```
## Security
- The database is no longer published to your whole network. `docker compose up` published Postgres on every interface with the password from the compose file — anyone on the same Wi-Fi could read every job, resume, letter and application, plus any AI key pasted into the dashboard. It now binds to 127.0.0.1:5433. Host tools: use localhost:5433; the app is unaffected.
## Added
- Backup and restore, documented and verified, for a project whose data is meant to stay yours.
## Fixed
- The setup wizard no longer spends a minute failing when no AI engine is connected — it says so and sends you back to step 1.
- Deleting a company names the applications, comparisons and letters that go with its jobs.
## Verification
- 1032 tests, lint:types + prisma format green; a clean install from an empty database walked end to end (2 633 jobs from 32/32 sources with no AI); all 47 migrations applied to an empty database; the exposure demonstrated before the fix and refused after it; the backup recipe run and restored with 0 errors.
## References
- TASKS §14; issues #96, #97
```
