### PR TITLE
origin guard: read the Referer and X-Forwarded-Host it was given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.23.1] — 2026-09-02
+
+### Fixed
+- **The cross-origin guard reads the two headers it was given in v1.20.0.**
+  Merging the two CSRF implementations (#93 and #87) taught the check to
+  consult `Referer` when a browser sends no `Origin`, and `X-Forwarded-Host`
+  when a reverse proxy rewrites `Host` — but the middleware went on passing
+  three headers to it, so the running dashboard kept the old behaviour: a
+  foreign `Referer` was not refused, and a dashboard behind a proxy refused
+  its own forms. Every unit test stayed green because they call the pure
+  function directly. The wiring now lives in `src/web/origin-guard.ts` with
+  tests that drive a real Hono app — the shape PR #87 used, and the one that
+  catches this class of bug. Caught by the live smoke run, not by the suite.
+
 ## [1.23.0] — 2026-09-02
 
 The pre-public audit: six checks nobody had run against this project as an
@@ -1318,6 +1332,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.23.1]: https://github.com/applypack/applypack/compare/v1.23.0...v1.23.1
 [1.23.0]: https://github.com/applypack/applypack/compare/v1.22.0...v1.23.0
 [1.22.0]: https://github.com/applypack/applypack/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/applypack/applypack/compare/v1.20.0...v1.21.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/origin-guard.test.ts
+++ b/src/web/origin-guard.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import { originGuard } from './origin-guard';
+
+/*
+ * These drive a real Hono app rather than calling the pure check, because the
+ * bug this file exists for was in the wiring, not the decision: the check
+ * learned to read `Referer` and `X-Forwarded-Host` while the middleware went
+ * on passing three headers, and every unit test stayed green because they call
+ * `sameOriginPost` directly. The testing shape came in with PR #87.
+ */
+
+function app(): Hono {
+  const a = new Hono();
+  a.use('*', originGuard());
+  a.get('/t', (c) => c.text('get-ok'));
+  a.post('/t', (c) => c.text('post-ok'));
+  return a;
+}
+
+const HOST = '127.0.0.1:4747';
+const post = async (headers: Record<string, string>): Promise<Response> =>
+  app().request('/t', { method: 'POST', headers: { host: HOST, ...headers } });
+
+describe('originGuard', () => {
+  it('lets a same-origin form through', async () => {
+    const res = await post({ origin: `http://${HOST}`, 'sec-fetch-site': 'same-origin' });
+    assert.equal(res.status, 200);
+  });
+
+  it('refuses a cross-site POST', async () => {
+    const res = await post({ origin: 'https://evil.example', 'sec-fetch-site': 'cross-site' });
+    assert.equal(res.status, 403);
+    assert.match(await res.text(), /Cross-origin request refused/);
+  });
+
+  it('refuses a foreign Origin with no fetch metadata', async () => {
+    assert.equal((await post({ origin: 'https://evil.example' })).status, 403);
+  });
+
+  it('reads the Referer — the header the middleware used to drop', async () => {
+    assert.equal((await post({ referer: 'http://evil.example/attacker-form' })).status, 403);
+    assert.equal((await post({ referer: `http://${HOST}/jobs/123` })).status, 200);
+  });
+
+  it('reads X-Forwarded-Host — the other header it used to drop', async () => {
+    // A reverse proxy passing Host: localhost upstream must not make every
+    // same-origin form on the public hostname look foreign.
+    const res = await post({
+      origin: 'https://jobs.example.com',
+      'x-forwarded-host': 'jobs.example.com',
+    });
+    assert.equal(res.status, 200);
+    // …and it still has to agree with the Origin.
+    const bad = await post({ origin: 'https://evil.example', 'x-forwarded-host': 'jobs.example.com' });
+    assert.equal(bad.status, 403);
+  });
+
+  it('lets a page in a sandboxed frame post to itself', async () => {
+    const res = await post({ origin: 'null', 'sec-fetch-site': 'same-origin' });
+    assert.equal(res.status, 200);
+  });
+
+  it('refuses an opaque Origin with nothing vouching for it', async () => {
+    assert.equal((await post({ origin: 'null' })).status, 403);
+  });
+
+  it('lets a header-less client through — curl is not the attack', async () => {
+    assert.equal((await post({})).status, 200);
+  });
+
+  it('never checks a GET', async () => {
+    const res = await app().request('/t', {
+      headers: { host: HOST, origin: 'https://evil.example', 'sec-fetch-site': 'cross-site' },
+    });
+    assert.equal(res.status, 200);
+  });
+});

--- a/src/web/origin-guard.ts
+++ b/src/web/origin-guard.ts
@@ -1,0 +1,34 @@
+import type { MiddlewareHandler } from 'hono';
+import { logger } from '../logger';
+import { guardedMethod, sameOriginPost } from './same-origin';
+
+/*
+ * The middleware half of the cross-origin write guard (issue #69). The
+ * decision is pure and lives in same-origin.ts; this reads the four headers
+ * it needs off the request and turns a refusal into a 403.
+ *
+ * It exists as its own module because the first version of it lived inline in
+ * server.ts, where nothing could test it: when the check learned to read
+ * `Referer` and `X-Forwarded-Host` (PR #87), the pure module and its tests
+ * were updated and the inline reader was not, so the running dashboard quietly
+ * kept the old behaviour with a green suite. server.ts cannot be imported by a
+ * test — it starts listening — so the wiring gets a seam of its own.
+ */
+export function originGuard(): MiddlewareHandler {
+  return async (c, next) => {
+    if (!guardedMethod(c.req.method)) return next();
+    const verdict = sameOriginPost({
+      origin: c.req.header('origin'),
+      secFetchSite: c.req.header('sec-fetch-site'),
+      host: c.req.header('host'),
+      forwardedHost: c.req.header('x-forwarded-host'),
+      referer: c.req.header('referer'),
+    });
+    if (verdict.ok) return next();
+    logger.warn(
+      { method: c.req.method, path: c.req.path, reason: verdict.reason },
+      'web: cross-origin write refused',
+    );
+    return c.text('Cross-origin request refused.', 403);
+  };
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -6,7 +6,7 @@ import { secureHeaders } from 'hono/secure-headers';
 import { config } from '../config';
 import { logger } from '../logger';
 import { prisma } from '../db';
-import { guardedMethod, sameOriginPost } from './same-origin';
+import { originGuard } from './origin-guard';
 import { overviewRoute } from './routes/overview';
 import { jobsRoute } from './routes/jobs';
 import { companiesRoute } from './routes/companies';
@@ -65,25 +65,9 @@ if (config.WEB_BASIC_AUTH) {
  * reaches it is a page in the same browser POSTing to localhost:4747 — this
  * is the check that costs nothing and stops it. Same-origin forms, curl and
  * the repo's own scripts are unaffected; see same-origin.ts for why there is
- * no token.
+ * no token, and origin-guard.ts for why the wiring is not inline here.
  */
-app.use('*', async (c, next) => {
-  if (guardedMethod(c.req.method)) {
-    const verdict = sameOriginPost({
-      origin: c.req.header('origin'),
-      secFetchSite: c.req.header('sec-fetch-site'),
-      host: c.req.header('host'),
-    });
-    if (!verdict.ok) {
-      logger.warn(
-        { method: c.req.method, path: c.req.path, reason: verdict.reason },
-        'web: cross-origin write refused',
-      );
-      return c.text('Cross-origin request refused.', 403);
-    }
-  }
-  return next();
-});
+app.use('*', originGuard());
 
 // Tiny request log.
 app.use('*', async (c, next) => {


### PR DESCRIPTION
A bug I introduced in the #93/#87 merge resolution, caught by the live smoke
run on `main` after tagging — not by the test suite, which is the point.

## What happened

Merging the two CSRF implementations taught the pure check to consult
`Referer` (when a browser sends no `Origin`) and `X-Forwarded-Host` (when a
reverse proxy rewrites `Host`) — both from @rayulumukku's PR #87. The
middleware in `server.ts` went on passing three headers to it.

Every unit test stayed green, because they call `sameOriginPost` directly. The
running dashboard did not:

```
foreign Referer   → 404 (the route, not the guard — it was let through)
proxy XFH+Origin  → 403 (a dashboard behind a proxy refusing its own forms)
```

So v1.20.0 shipped release notes naming two features that were in the module
and not in the request path.

## The fix, and the seam

The wiring moved out of `server.ts` into `src/web/origin-guard.ts`, because
`server.ts` starts listening on import and therefore cannot be imported by a
test — which is exactly why nothing caught this. `origin-guard.test.ts` drives
a real Hono app (the shape PR #87's tests used) and asserts the behaviour a
request actually gets.

Proof the test earns its place: with the two headers removed from the
middleware again, **2 of its 9 cases fail**; with them, all 9 pass.

## Verification

- `npm run lint:types`, `npm test` (**1049**, +9), `npx prisma format --check`
  — green.
- Live on the rebuilt dashboard, every case re-run: cross-site 403, foreign
  Origin 403, **foreign Referer 403**, opaque Origin 403, sandboxed frame
  (opaque Origin + `Sec-Fetch-Site: same-origin`) allowed, same-origin Referer
  allowed, **proxy `X-Forwarded-Host` allowed**, header-less curl allowed, GET
  never checked.

## Release notes draft (v1.23.1)

```
## Fixed
- The cross-origin guard now reads the Referer and X-Forwarded-Host headers it was given in v1.20.0: a foreign Referer is refused, and a dashboard behind a reverse proxy stops refusing its own forms. The wiring has its own module and tests that drive a real request, because the pure-function tests could not see this.
## Verification
- 1049 tests; every origin case re-verified live on the rebuilt dashboard.
```