### PR TITLE
fixed the button rows that had drifted out of line

### DIFF
--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -94,7 +94,11 @@ export interface JobDetailProps {
   flash?: FlashMessage | null;
 }
 
-// "Mark applied" is not here — it carries the resume select, so MarkAppliedForm owns it.
+/** The id the out-of-form select and the in-row button both post through. */
+const MARK_APPLIED_FORM = 'mark-applied';
+
+// "Mark applied" is not in this list: it posts through MARK_APPLIED_FORM so the
+// resume select can sit above the row while the button stays inside it.
 const STATUS_ACTIONS: { status: JobStatus; label: string; variant: ButtonVariant }[] = [
   { status: 'SAVED', label: 'Save', variant: 'violet' },
   { status: 'DISMISSED', label: 'Dismiss', variant: 'secondary' },
@@ -135,8 +139,13 @@ export const JobDetailPage: FC<JobDetailProps> = ({
       <div class="min-w-0 space-y-4 xl:order-2">
         <Card>
           <SectionTitle>Actions</SectionTitle>
-          <MarkAppliedForm job={job} picker={appliedResumePicker} />
+          <MarkAppliedPicker job={job} picker={appliedResumePicker} />
           <div class="flex flex-wrap items-center gap-2">
+            {job.status !== 'APPLIED' && (
+              <Button variant="primary" size="sm" form={MARK_APPLIED_FORM}>
+                Mark applied
+              </Button>
+            )}
             {STATUS_ACTIONS.filter((a) => a.status !== job.status).map((a) => (
               <ActionForm action={`/jobs/${job.id}/status`} hidden={{ status: a.status }}>
                 <Button variant={a.variant} size="sm">
@@ -391,19 +400,32 @@ const PageHeaderBlock: FC<{ job: JobDetail }> = ({ job }) => (
  * applying, and a resume is edited in place afterwards, so the route stores a
  * text snapshot alongside the id (Stage C).
  */
-const MarkAppliedForm: FC<{ job: JobDetail; picker: JobDetailProps['appliedResumePicker'] }> = ({
-  job,
-  picker,
-}) =>
+/**
+ * The full-width "Applied with" select, plus the empty form its select and its
+ * button both post through.
+ *
+ * They are bound by the HTML `form` attribute rather than nesting, because the
+ * two want opposite layouts: the select is a full-width labelled field, while
+ * "Mark applied" belongs on the same row as Save / Dismiss / Re-classify.
+ * Wrapping both in one form put the primary action on a line of its own above
+ * the others, which read as two unrelated groups of buttons.
+ */
+const MarkAppliedPicker: FC<{
+  job: JobDetail;
+  picker: JobDetailProps['appliedResumePicker'];
+}> = ({ job, picker }) =>
   job.status === 'APPLIED' ? null : (
-    <ActionForm
-      action={`/jobs/${job.id}/status`}
-      hidden={{ status: 'APPLIED' }}
-      class={picker.resumes.length > 0 ? 'mb-3 space-y-2' : 'mb-3'}
-    >
+    <>
+      <form id={MARK_APPLIED_FORM} method="post" action={`/jobs/${job.id}/status`}>
+        <input type="hidden" name="status" value="APPLIED" />
+      </form>
       {picker.resumes.length > 0 && (
-        <Field label="Applied with" hint="Recorded with the version you sent, for the follow-up nudge.">
-          <Select name="appliedResumeId">
+        <Field
+          label="Applied with"
+          hint="Recorded with the version you sent, for the follow-up nudge."
+          class="mb-3"
+        >
+          <Select name="appliedResumeId" form={MARK_APPLIED_FORM}>
             <option value="">— don't record a resume —</option>
             {picker.resumes.map((r) => (
               <option value={r.id} selected={r.id === picker.suggestedId}>
@@ -413,10 +435,7 @@ const MarkAppliedForm: FC<{ job: JobDetail; picker: JobDetailProps['appliedResum
           </Select>
         </Field>
       )}
-      <Button variant="primary" size="sm">
-        Mark applied
-      </Button>
-    </ActionForm>
+    </>
   );
 
 /**

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -609,22 +609,29 @@ export const SettingsPage: FC<SettingsProps> = ({
         desc="Telegram bots and chats that receive job alerts."
       >
         <Card>
-          <ToggleRow
-            label="Telegram alerts"
-            enabled={telegramEnabled}
-            action="/settings/telegram-toggle"
-          >
-            When off, nothing is sent regardless of targets. Jobs are still classified and
-            stored.
-          </ToggleRow>
-          <ToggleRow
-            label="Source health alerts"
-            enabled={sourceHealthAlerts}
-            action="/settings/source-health-toggle"
-          >
-            Adds one line to the daily digest when a tracked board stops answering —
-            usually a rotated slug. The quiet-sources card on Companies is always on.
-          </ToggleRow>
+          {/* Same spacing and rule as the General tab's toggle pair: bare
+              siblings here had the two rows touching, so the second row's
+              button looked like it belonged to the first. */}
+          <div class="space-y-5">
+            <ToggleRow
+              label="Telegram alerts"
+              enabled={telegramEnabled}
+              action="/settings/telegram-toggle"
+            >
+              When off, nothing is sent regardless of targets. Jobs are still classified and
+              stored.
+            </ToggleRow>
+            <div class="border-t border-line pt-5">
+              <ToggleRow
+                label="Source health alerts"
+                enabled={sourceHealthAlerts}
+                action="/settings/source-health-toggle"
+              >
+                Adds one line to the daily digest when a tracked board stops answering —
+                usually a rotated slug. The quiet-sources card on Companies is always on.
+              </ToggleRow>
+            </div>
+          </div>
         </Card>
 
         {targets.length === 0 ? (

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -551,7 +551,10 @@ export const ToggleRow: FC<
       </div>
       <Hint class="mt-1">{children}</Hint>
     </div>
-    <div class="flex shrink-0 flex-col items-end gap-2">
+    {/* Row, not column: a card with an `extra` action (Discovery's "Run now")
+        stacked its two buttons vertically, which read as one button dropped
+        below the other. They wrap only when the card is too narrow for both. */}
+    <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
       <ActionForm action={action}>
         <Button variant={enabled ? 'secondary' : 'primary'}>
           {enabled ? disableText : enableText}


### PR DESCRIPTION
A layout review across every dashboard page, prompted by "on some pages the buttons are scattered — one sits higher than another". Three cards were putting a button on a line of its own. All three are fixed here; two further findings are filed rather than fixed, because both are design decisions rather than CSS.

## Fixed

**1. `/jobs/:id` — the primary action was orphaned above the row.** Stage C (v1.11.0) wrapped the "Applied with" select and the **Mark applied** button in one form so the select's value would submit with the button. That forced the primary action onto its own line above **Save / Dismiss / Re-classify**, so the card read as two unrelated groups.

The select and the button want opposite layouts: one is a full-width labelled field, the other belongs on the shared row. They are now bound by the HTML `form` attribute instead of by nesting — an empty `<form id="mark-applied">` carries the hidden `status`, and both the out-of-form `<select form="mark-applied">` and the in-row `<button form="mark-applied">` post through it.

Verified in the browser that the out-of-form select really travels: `new FormData(document.getElementById('mark-applied'))` returns `status=APPLIED, appliedResumeId=1`, and a real submit on job 1344 stored `appliedResumeId=1, version=4, snapshot=6004 bytes` — the resume picked by hand, not the suggested one. The stage ledger stayed at 3 rows (the row already had a `pipelineStage`, so the seeding branch correctly did not fire), and the test row was restored afterwards.

**2. `ToggleRow` stacked its buttons vertically.** The primitive's action column was `flex-col`, so any card passing an `extra` action drew the two buttons one above the other — visible on `/discovery`, where **Run now** sat under **Disable**. Now `flex-wrap` in a row: side by side, wrapping only when the card is genuinely too narrow. One usage today (`pages/discovery.tsx`), but it is a shared primitive, so every future `extra` inherits the fix.

**3. `/settings` → Notifications had no separation between its two toggles.** The General tab wraps its toggle pair in `space-y-5` with a `border-t … pt-5` rule between them; Notifications had the two `ToggleRow`s as bare siblings inside the card, so the rows touched and the second row's **Disable** looked like it belonged to the first. Same wrapper as General now.

## Checked and clean

`/`, `/jobs`, `/applications`, `/resumes`, `/resumes/:id`, `/companies`, `/runs`, `/target`, `/letter` and the General / Profile / AI engine / Sources tabs — button rows already aligned. Reviewed at 1440 and 375; 0 console errors.

## Filed, not fixed

- **#100** — `Re-classify` now wraps to its own line in the 340px `xl` rail, because four buttons are a few pixels over. The real fix is moving it into the Classifier card, next to the verdict it replaces, which first needs that card to render unconditionally (today it is hidden on an unscored job — exactly when the button matters most).
- **#101** — the job page asks "Applied with" twice, in the Actions card and in the Application tracking card, with different blank labels and different defaults. Deliberate on both sides (#75 refuses to preselect a guess), but the page still poses one question twice and honours whichever form is submitted last.

## Verification

`npm run lint:types`, `npm test` (1049 pass), web rebuilt and restarted, every changed page re-checked at 1440 and 375 with 0 console errors, and the Mark-applied round-trip exercised against the live database and rolled back.

No schema changes, no new dependencies, no behaviour change beyond layout.