### PR TITLE
fixed the /applications ledger read to the jobs on the board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.23.3] — 2026-09-02
+
+### Fixed
+- **The board read the whole ledger to date a handful of cards.**
+  `/applications` loaded every `job_stage_event` row ever written, grouped
+  them all by job, then used only the ones belonging to a card on screen.
+  The ledger is append-only by ADR 0024 — it grows with every stage move
+  forever — while the board is bounded by how many applications are open, so
+  the read got steadily more wasteful with no ceiling. Measured on the live
+  database: 26 rows loaded, 24 used, 2 discarded. Same class as the v1.11.0
+  fix on this route, which pulled whole `Job` rows; that query at least had a
+  `where`, this one had none. The query is now scoped to the jobs the board
+  draws, and an empty board skips it entirely. The grouping moved out of the
+  route into `stage-time.ts:groupEventsByJob`, where it is unit-tested.
+
 ## [1.23.2] — 2026-09-02
 
 ### Fixed
@@ -1353,6 +1368,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.23.3]: https://github.com/applypack/applypack/compare/v1.23.2...v1.23.3
 [1.23.2]: https://github.com/applypack/applypack/compare/v1.23.1...v1.23.2
 [1.23.1]: https://github.com/applypack/applypack/compare/v1.23.0...v1.23.1
 [1.23.0]: https://github.com/applypack/applypack/compare/v1.22.0...v1.23.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.23.2",
+      "version": "1.23.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/routes/applications.tsx
+++ b/src/web/routes/applications.tsx
@@ -9,7 +9,7 @@ import { flashRedirect, parseFlashCookie } from '../flash';
 import { ApplicationsPage } from '../pages/applications';
 import { allStages, labelFor, parseStageConfig } from '../stage-config';
 import { appliedDateCorrection, stageChangeEvent } from '../stage-events';
-import { stageTimeLine, type StageTimeLine } from '../stage-time';
+import { groupEventsByJob, stageTimeLine, type StageTimeLine } from '../stage-time';
 
 // Stage keys are validated at runtime against the configured list
 // (ADR 0025) — an enum would freeze what is now user data.
@@ -48,16 +48,18 @@ applicationsRoute.get('/applications', async (c) => {
   });
 
   // The ledger dates each card's time-in-stage (ADR 0024 keeps recording
-  // even though the funnel cards are gone — ADR 0025).
-  const events = settings.applicationTrackingEnabled
-    ? await prisma.jobStageEvent.findMany({ orderBy: { recordedAt: 'asc' } })
-    : [];
-  const eventsByJob = new Map<number, typeof events>();
-  for (const e of events) {
-    const list = eventsByJob.get(e.jobId);
-    if (list) list.push(e);
-    else eventsByJob.set(e.jobId, [e]);
-  }
+  // even though the funnel cards are gone — ADR 0025). Scoped to the cards
+  // on screen: the ledger is append-only, so it grows with every stage move
+  // ever made while the board only dates the jobs it draws.
+  const boardIds = rows.map((r) => r.id);
+  const events =
+    settings.applicationTrackingEnabled && boardIds.length > 0
+      ? await prisma.jobStageEvent.findMany({
+          where: { jobId: { in: boardIds } },
+          orderBy: { recordedAt: 'asc' },
+        })
+      : [];
+  const eventsByJob = groupEventsByJob(events, boardIds);
 
   const now = new Date();
   const byStage = Object.fromEntries(stageKeys.map((k) => [k, []])) as Record<

--- a/src/web/stage-time.test.ts
+++ b/src/web/stage-time.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { stageTimeLine, type StageTimeEvent } from './stage-time';
+import { groupEventsByJob, stageTimeLine, type StageTimeEvent } from './stage-time';
 
 const NOW = new Date('2026-09-01T12:00:00Z');
 
@@ -107,4 +107,30 @@ test('a custom label replaces the key in the text', () => {
 test('a future since-day clamps to zero days', () => {
   const line = stageTimeLine('applied', daysAgo(-3), [], NOW);
   assert.equal(line?.text, 'applied today');
+});
+
+// groupEventsByJob — the board's ledger lookup.
+
+const row = (jobId: number, toStage: string) => ({ jobId, toStage });
+
+test('events are keyed by job, in the order they arrived', () => {
+  const byJob = groupEventsByJob(
+    [row(1, 'applied'), row(2, 'applied'), row(1, 'screen')],
+    [1, 2],
+  );
+  assert.deepEqual([...byJob.keys()], [1, 2]);
+  assert.deepEqual(byJob.get(1), [row(1, 'applied'), row(1, 'screen')]);
+  assert.deepEqual(byJob.get(2), [row(2, 'applied')]);
+});
+
+test('an event for a job that is not on the board is dropped', () => {
+  const byJob = groupEventsByJob([row(1, 'applied'), row(99, 'ghosted')], [1]);
+  assert.deepEqual([...byJob.keys()], [1]);
+  assert.equal(byJob.get(99), undefined);
+});
+
+test('no cards means an empty map, whatever the ledger holds', () => {
+  assert.equal(groupEventsByJob([row(1, 'applied')], []).size, 0);
+  assert.equal(groupEventsByJob([], []).size, 0);
+  assert.equal(groupEventsByJob([], [1, 2]).size, 0);
 });

--- a/src/web/stage-time.ts
+++ b/src/web/stage-time.ts
@@ -62,3 +62,24 @@ export function stageTimeLine(
   const stale = !terminal && entryKnown && days > STALE_DAYS;
   return { text: stale ? `${text} · stalled` : text, stale, since };
 }
+
+/**
+ * Ledger rows keyed by job, dropping any row whose job is not on the board.
+ * The query is scoped the same way (applications.tsx) — grouping here keeps
+ * the map honest if it ever isn't, and testable without Prisma. Generic so
+ * the caller keeps its own row type; only `jobId` is read.
+ */
+export function groupEventsByJob<E extends { jobId: number }>(
+  events: readonly E[],
+  jobIds: readonly number[],
+): Map<number, E[]> {
+  const onBoard = new Set(jobIds);
+  const byJob = new Map<number, E[]>();
+  for (const e of events) {
+    if (!onBoard.has(e.jobId)) continue;
+    const list = byJob.get(e.jobId);
+    if (list) list.push(e);
+    else byJob.set(e.jobId, [e]);
+  }
+  return byJob;
+}


### PR DESCRIPTION
`/applications` loaded **every** `job_stage_event` row ever written:

```ts
await prisma.jobStageEvent.findMany({ orderBy: { recordedAt: 'asc' } })
```

No `where` at all. The rows were grouped into a `Map` by `jobId`, and then only
the entries belonging to a card on screen were ever read back. The ledger is
append-only by ADR 0024 — it grows with every stage move forever — while the
board is bounded by how many applications are open, so the numerator climbs
without limit and the denominator does not.

Measured on the live database:

```
 loaded_by_page | actually_used | discarded
----------------+---------------+-----------
             26 |            24 |         2
```

Small today; the point is which of the two numbers grows.

Same class as the v1.11.0 fix on this very route, which was pulling whole `Job`
rows through an `include`. That one at least had a `where` on the stage — this
query had no filter of any kind.

## The fix

- The query is scoped to the jobs the board draws (`jobId: { in: boardIds }`),
  and an empty board skips the round-trip entirely. Verified that Prisma
  answers `in: []` with 0 rows rather than throwing, so the guard is an
  optimisation and not a crutch.
- Grouping moved out of the route into `stage-time.ts:groupEventsByJob` —
  pure, generic over the row type, reading only `jobId`. It sits with
  `stageTimeLine`, which owns `StageTimeEvent` and consumes exactly this map;
  a file of its own would have split one concern in two. Same shape as the
  existing `match-history.ts:groupMatchesByJob` precedent.
- The new query can use the existing `@@index([jobId, recordedAt])`; the
  unfiltered one could not.

## Verification

- `npm run lint:types` clean, `npm test` 1052 pass, `npx prisma format --check` clean.
- Three new unit tests. Proven to fail against the pre-fix behaviour: dropping
  the board filter from `groupEventsByJob` (which is what the route did) fails
  2 of them, restoring it passes 18/18.
- Live re-query after the change: 24 of 26 rows, matching the SQL above.
- `docker compose build web` + restart. `/applications` renders the same 8
  cards with the same time-in-stage lines as before, including the
  `applied 125d ago · stalled` one that exercises the ledger path. Screenshots
  at 1200 / 768 / 375, 0 console errors in a fresh tab.

## Follow-up (P3, not fixed here)

The `IN` list is unbounded in the number of tracked applications. So is `rows`
itself — the route's own comment says as much — and the old code loaded
strictly more, so this is not a regression. It would only matter past tens of
thousands of open applications, where the page has other problems first.
