### PR TITLE
the resume delete dialog now names the searches it unlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.23.4] — 2026-09-02
+
+### Fixed
+- **Deleting a resume said nothing about the searches hunting with it.** The
+  confirm dialog counted the three Cascade children — comparisons, cover
+  letters, strength reviews — and stopped there. Two `SetNull` consequences
+  stayed invisible: a search linked to the resume silently lost the link and
+  went back to guessing by skill overlap (`resume/pick.ts`), and applications
+  recorded as sent with it kept their text snapshot but lost the name,
+  degrading to "a deleted resume v4". The first is the one that bites — you
+  do not find out until job pages start preselecting the wrong resume.
+  Both are now counted and named. They get their own clause rather than
+  joining the list of deletions, because they are the opposite of deleted:
+  saying "and 1 search" would read as though the search went too. Same class
+  as the v1.23.0 company fix, where "Delete Reddit and all its 73 jobs?" hid
+  six applications and a cover letter; the resume half of that audit left the
+  search link behind.
+
 ## [1.23.3] — 2026-09-02
 
 ### Fixed
@@ -1368,6 +1386,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.23.4]: https://github.com/applypack/applypack/compare/v1.23.3...v1.23.4
 [1.23.3]: https://github.com/applypack/applypack/compare/v1.23.2...v1.23.3
 [1.23.2]: https://github.com/applypack/applypack/compare/v1.23.1...v1.23.2
 [1.23.1]: https://github.com/applypack/applypack/compare/v1.23.0...v1.23.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.23.3",
+      "version": "1.23.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/jobs/applied-with.ts
+++ b/src/jobs/applied-with.ts
@@ -14,8 +14,12 @@ export interface AppliedResume {
   version: number | null;
 }
 
-/** A deleted resume still counts as an answer: we know it was sent, just not what it was called. */
-const DELETED_LABEL = 'a deleted resume';
+/**
+ * A deleted resume still counts as an answer: we know it was sent, just not
+ * what it was called. Exported so the delete dialog can promise the exact
+ * words the page will show afterwards.
+ */
+export const DELETED_LABEL = 'a deleted resume';
 
 /**
  * Short label for the resume: `Senior Backend v3`. Null when nothing was

--- a/src/resume/store.ts
+++ b/src/resume/store.ts
@@ -181,18 +181,27 @@ export async function listMatchesForResume(resumeId: number): Promise<MatchWithJ
 }
 
 /**
- * What deleting a resume takes with it. Both cascade, and the letters carry
- * the user's own edited text — the confirm dialog has to say so.
+ * What deleting a resume touches. The first three cascade, and the letters
+ * carry the user's own edited text — the confirm dialog has to say so. The
+ * last two are SetNull: a search keeps running but goes back to guessing its
+ * resume by skill overlap, and an application keeps its text snapshot but
+ * loses the name. Silent either way until the dialog names them.
  */
-export async function deleteImpact(
-  resumeId: number,
-): Promise<{ matches: number; letters: number; reviews: number }> {
-  const [matches, letters, reviews] = await Promise.all([
+export async function deleteImpact(resumeId: number): Promise<{
+  matches: number;
+  letters: number;
+  reviews: number;
+  searches: number;
+  applications: number;
+}> {
+  const [matches, letters, reviews, searches, applications] = await Promise.all([
     prisma.resumeMatch.count({ where: { resumeId } }),
     prisma.coverLetter.count({ where: { resumeId } }),
     prisma.resumeReview.count({ where: { resumeId } }),
+    prisma.profile.count({ where: { resumeId } }),
+    prisma.job.count({ where: { appliedResumeId: resumeId } }),
   ]);
-  return { matches, letters, reviews };
+  return { matches, letters, reviews, searches, applications };
 }
 
 export interface ResumeMatchStats {

--- a/src/web/delete-confirm.test.ts
+++ b/src/web/delete-confirm.test.ts
@@ -1,41 +1,88 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { companyDeleteConfirm, deleteConfirm } from './delete-confirm';
+import { companyDeleteConfirm, deleteConfirm, type DeleteImpact } from './delete-confirm';
+
+const NONE: DeleteImpact = {
+  matches: 0,
+  letters: 0,
+  reviews: 0,
+  searches: 0,
+  applications: 0,
+};
 
 describe('deleteConfirm', () => {
   it('names every cascade — letters and strength reviews included', () => {
     assert.equal(
-      deleteConfirm('Senior Backend', { matches: 12, letters: 3, reviews: 2 }),
+      deleteConfirm('Senior Backend', { ...NONE, matches: 12, letters: 3, reviews: 2 }),
       'Delete "Senior Backend" and 12 comparisons, 3 cover letters and 2 strength reviews? This cannot be undone.',
     );
   });
 
   it('drops the parts that are empty', () => {
     assert.equal(
-      deleteConfirm('Senior Backend', { matches: 4, letters: 0, reviews: 0 }),
+      deleteConfirm('Senior Backend', { ...NONE, matches: 4 }),
       'Delete "Senior Backend" and 4 comparisons? This cannot be undone.',
     );
     assert.equal(
-      deleteConfirm('Senior Backend', { matches: 0, letters: 2, reviews: 0 }),
+      deleteConfirm('Senior Backend', { ...NONE, letters: 2 }),
       'Delete "Senior Backend" and 2 cover letters? This cannot be undone.',
     );
     assert.equal(
-      deleteConfirm('Senior Backend', { matches: 0, letters: 0, reviews: 1 }),
+      deleteConfirm('Senior Backend', { ...NONE, reviews: 1 }),
       'Delete "Senior Backend" and 1 strength review? This cannot be undone.',
     );
   });
 
   it('says so plainly when nothing is attached', () => {
     assert.equal(
-      deleteConfirm('Draft', { matches: 0, letters: 0, reviews: 0 }),
+      deleteConfirm('Draft', NONE),
       'Delete "Draft"? Nothing else is attached to it.',
     );
   });
 
   it('speaks singular for one of each', () => {
     assert.equal(
-      deleteConfirm('CV', { matches: 1, letters: 1, reviews: 1 }),
+      deleteConfirm('CV', { ...NONE, matches: 1, letters: 1, reviews: 1 }),
       'Delete "CV" and 1 comparison, 1 cover letter and 1 strength review? This cannot be undone.',
+    );
+  });
+
+  // SetNull, not Cascade: these survive the delete. The dialog said nothing
+  // about either, so a search silently fell back to guessing its resume.
+  it('names the searches that stop hunting with it', () => {
+    assert.equal(
+      deleteConfirm('Senior Backend', { ...NONE, searches: 1 }),
+      'Delete "Senior Backend"? 1 search stops hunting with it. This cannot be undone.',
+    );
+    assert.equal(
+      deleteConfirm('Senior Backend', { ...NONE, searches: 3 }),
+      'Delete "Senior Backend"? 3 searches stop hunting with it. This cannot be undone.',
+    );
+  });
+
+  it('names the applications that lose the resume name', () => {
+    assert.equal(
+      deleteConfirm('Senior Backend', { ...NONE, applications: 1 }),
+      'Delete "Senior Backend"? 1 application will show "a deleted resume" instead. This cannot be undone.',
+    );
+    assert.equal(
+      deleteConfirm('Senior Backend', { ...NONE, applications: 2 }),
+      'Delete "Senior Backend"? 2 applications will show "a deleted resume" instead. This cannot be undone.',
+    );
+  });
+
+  it('keeps what is deleted and what merely unlinks in separate clauses', () => {
+    assert.equal(
+      deleteConfirm('Senior Backend', {
+        matches: 12,
+        letters: 3,
+        reviews: 0,
+        searches: 1,
+        applications: 2,
+      }),
+      'Delete "Senior Backend" and 12 comparisons and 3 cover letters?' +
+        ' 1 search stops hunting with it and 2 applications will show "a deleted resume" instead.' +
+        ' This cannot be undone.',
     );
   });
 });

--- a/src/web/delete-confirm.ts
+++ b/src/web/delete-confirm.ts
@@ -1,3 +1,5 @@
+import { DELETED_LABEL } from '../jobs/applied-with';
+
 /**
  * Confirm text for the two deletes that cascade (audit, TASKS §14). Pure so the
  * blast radius can be unit-tested rather than trusted.
@@ -6,6 +8,10 @@
  * ones the user edited by hand — and every strength review. Deleting a company
  * takes every job it posted, and with each job the application tracked against
  * it. Both wordings used to name only the obvious half.
+ *
+ * A resume also has two SetNull dependants that neither deletes nor survives
+ * unchanged — the search that hunts with it and the applications it went out
+ * with. Those are named too, in a clause of their own.
  */
 
 export interface DeleteImpact {
@@ -40,7 +46,7 @@ export function deleteConfirm(name: string, impact: DeleteImpact): string {
       : `${impact.searches} ${impact.searches === 1 ? 'search stops' : 'searches stop'} hunting with it`,
     impact.applications === 0
       ? null
-      : `${impact.applications} ${impact.applications === 1 ? 'application' : 'applications'} will show "a deleted resume" instead`,
+      : `${impact.applications} ${impact.applications === 1 ? 'application' : 'applications'} will show "${DELETED_LABEL}" instead`,
   ].filter((p): p is string => p !== null);
 
   if (deleted.length === 0 && unlinked.length === 0) {

--- a/src/web/delete-confirm.ts
+++ b/src/web/delete-confirm.ts
@@ -12,17 +12,44 @@ export interface DeleteImpact {
   matches: number;
   letters: number;
   reviews: number;
+  /** Searches hunting with this resume. SetNull: the search lives on, unlinked. */
+  searches: number;
+  /** Applications that recorded it as the resume they went out with. */
+  applications: number;
 }
 
+/**
+ * Two clauses, because a resume has two kinds of dependant. The Cascade
+ * children are deleted with it and belong in the question. The SetNull ones
+ * survive with a link cleared — a search that loses its resume goes back to
+ * guessing by skill overlap (`resume/pick.ts`), and an application keeps its
+ * text snapshot but loses the name (`jobs/applied-with.ts`). Listing those
+ * alongside the deletions would claim the search is deleted too, which is the
+ * opposite of what happens, so they get a sentence of their own.
+ */
 export function deleteConfirm(name: string, impact: DeleteImpact): string {
-  const parts = [
+  const deleted = [
     countOf(impact.matches, 'comparison', 'comparisons'),
     countOf(impact.letters, 'cover letter', 'cover letters'),
     countOf(impact.reviews, 'strength review', 'strength reviews'),
   ].filter((p): p is string => p !== null);
 
-  if (parts.length === 0) return `Delete "${name}"? Nothing else is attached to it.`;
-  return `Delete "${name}" and ${joinList(parts)}? This cannot be undone.`;
+  const unlinked = [
+    impact.searches === 0
+      ? null
+      : `${impact.searches} ${impact.searches === 1 ? 'search stops' : 'searches stop'} hunting with it`,
+    impact.applications === 0
+      ? null
+      : `${impact.applications} ${impact.applications === 1 ? 'application' : 'applications'} will show "a deleted resume" instead`,
+  ].filter((p): p is string => p !== null);
+
+  if (deleted.length === 0 && unlinked.length === 0) {
+    return `Delete "${name}"? Nothing else is attached to it.`;
+  }
+  const head =
+    deleted.length === 0 ? `Delete "${name}"?` : `Delete "${name}" and ${joinList(deleted)}?`;
+  const side = unlinked.length === 0 ? '' : ` ${joinList(unlinked)}.`;
+  return `${head}${side} This cannot be undone.`;
 }
 
 export interface CompanyDeleteImpact {

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -20,7 +20,7 @@ import {
   Td,
   Tr,
 } from '../ui';
-import { deleteConfirm } from '../delete-confirm';
+import { deleteConfirm, type DeleteImpact } from '../delete-confirm';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
 import { MAX_UPLOAD_MB } from '../upload';
 import type { FlashMessage } from '../flash';
@@ -46,7 +46,7 @@ export interface ResumeDetailProps {
   /** What moved since the previous run of this resume, when there was one. */
   reviewDelta: ReviewDelta | null;
   /** What Delete would cascade — named in the confirm: comparisons, letters and reviews. */
-  deleteImpact: { matches: number; letters: number; reviews: number };
+  deleteImpact: DeleteImpact;
   /** Deterministic ATS-parseability checks over the extracted text. */
   warnings: ParseWarning[];
   /** Searches already linked to this resume, and the one a click would create. */

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -45,7 +45,7 @@ export interface ResumeDetailProps {
   answers: ReviewAnswer[];
   /** What moved since the previous run of this resume, when there was one. */
   reviewDelta: ReviewDelta | null;
-  /** What Delete would cascade — named in the confirm: comparisons, letters and reviews. */
+  /** What Delete would take, and what it would merely unlink — both named in the confirm. */
   deleteImpact: DeleteImpact;
   /** Deterministic ATS-parseability checks over the extracted text. */
   warnings: ParseWarning[];


### PR DESCRIPTION
`deleteImpact` counted the three Cascade children — comparisons, cover letters,
strength reviews — and `deleteConfirm` named them. Two `SetNull` consequences
stayed invisible:

- **`Profile.resumeId`** (`schema.prisma:349`). The search that hunts with this
  resume silently loses the link and goes back to guessing by skill overlap
  (`resume/pick.ts:preselectResume`). This is the one that bites: nothing tells
  you, and you only notice later when job pages start preselecting the wrong
  resume.
- **`Job.appliedResumeId`** (`schema.prisma:120`). Applications keep the version
  and the text snapshot but lose the name, degrading to `a deleted resume v4`.
  That degradation is deliberate (`jobs/applied-with.ts`) and behaves correctly
  — but the dialog should still say it is coming.

Same class as the v1.23.0 company fix, where `Delete "Reddit" and all its 73
jobs?` was hiding six applications and a cover letter. The resume half of that
audit left the search link behind.

## The wording

The two kinds get **separate clauses**, not one list:

```
Delete "PHP/JS/React" and 6 comparisons and 1 strength review?
2 searches stop hunting with it and 2 applications will show "a deleted resume" instead.
This cannot be undone.
```

Folding them into the deletions — `…and 2 searches?` — would claim the searches
are deleted too, which is the opposite of what SetNull does, and would scare a
user out of a delete that is actually safe. Empty categories are still omitted
entirely, so a resume with nothing attached reads exactly as before.

The `"a deleted resume"` wording is now imported from `jobs/applied-with.ts`
rather than retyped, so the dialog cannot promise words the page will not show.

## Verification

- `npm run lint:types` clean, `npm test` 1055 pass, `npx prisma format --check` clean.
- Three new unit tests, **proven to fail pre-fix**: with the SetNull clause
  removed (what the old code did) 3 of 11 fail; restored, 11/11 pass.
- Existing cases now spread a zero-valued `NONE`, so they double as the
  regression guard that the old wording is untouched when nothing is linked.
- `docker compose build web` + restart. The database had 0 linked searches and
  0 applications, so I set `profile.resumeId` and `job.appliedResumeId` on two
  rows each, read the rendered `onsubmit`, and set them back to NULL —
  confirmed with the same query before and after. I changed only those columns
  rather than driving the profile form, to keep the blast radius of my own
  verification to one field.
  - linked: `Delete "PHP/JS/React" and 6 comparisons and 1 strength review? 2 searches stop hunting with it and 2 applications will show "a deleted resume" instead. This cannot be undone.`
  - unlinked (`/resumes/8`): `Delete "with photo"? Nothing else is attached to it.` — unchanged.
- Nested quotes survive `JSON.stringify` into the `onsubmit` attribute, as they
  already did for the resume name.
- Screenshots at 1200 / 768 / 375, 0 console errors.

## Notes

- `deleteImpact` keeps a structural return type instead of importing
  `DeleteImpact`: `src/resume/` does not import from `src/web/` anywhere today
  and this is not the change that should start it. The page prop now uses the
  named type, so the compiler checks the two line up at the route.
- Two findings from the pre-PR review, fixed in the branch: a prop comment that
  still said "what Delete would cascade" (the exact distinction this PR draws),
  and the duplicated label above.
