### PR TITLE
removed two dead exports, wrote up the 2026-09 audit

### DIFF
--- a/docs/audit-2026-09.md
+++ b/docs/audit-2026-09.md
@@ -1,0 +1,97 @@
+# Audit — 2026-09
+
+A pass over the tree after §14 "Pre-public hardening" closed. §14 already
+covered CSRF and the cross-origin guard, both race classes, POST idempotency
+for AI runs, the secret sweep, port exposure, a clean install and the backups —
+none of that is re-audited here.
+
+Three findings, all shipped. The clean results are listed too, with the command
+that produced each one, so the next audit can start somewhere else.
+
+## Found and fixed
+
+| What | Where | PR |
+| --- | --- | --- |
+| `/applications` loaded the entire append-only stage ledger to date the cards on screen | `web/routes/applications.tsx` | [#104](https://github.com/applypack/applypack/pull/104) |
+| Deleting a resume said nothing about the searches it unlinks, or the applications that lose its name | `resume/store.ts`, `web/delete-confirm.ts` | [#105](https://github.com/applypack/applypack/pull/105) |
+| Two exported symbols with no callers | `resume/bench-report.ts`, `resume/review-delta.ts` | this one |
+
+The first two repeat classes already fixed in v1.11.0 and v1.23.0: a query on
+that route reading more than it used, and a delete dialog naming half its blast
+radius. Both times the sibling case stayed behind.
+
+The dead exports: `BenchMode` and `isReviewGrade`, zero references across the
+whole tree including tests, scripts and docs. Removing `isReviewGrade` also
+freed its `REVIEW_GRADES` import — `ReviewGrade`, the type, is still used.
+
+`UncoveredVendor` in `starter-packs/resolve.ts` looks just as unused. It stays:
+it is an `AssertNever<...>` exhaustiveness check, so going unreferenced is how
+it does its job.
+
+## Checked and clean
+
+**The two cross-file invariants hold — both were broken on purpose to prove it.**
+
+- `score.mjs` ↔ `score.ts`: added `+ 1` to `raw` in the browser copy only
+  (`web/public/score.mjs:75`). `src/web/score.test.ts` failed 2 of its 4 tests.
+- Prompt fence: added `src/rogue-call-site.ts` calling
+  `getAiRuntime().complete` directly. `prompt-fence-registry.test.ts` failed
+  with the file named: *"new AI call site(s): rogue-call-site.ts — route the
+  prompt through a build\*Prompt and register it here"*.
+
+I reverted both probes byte-identically; `git diff` came back empty.
+
+**Foreign-key cascades.** All **15** relations carrying `fields:` in
+`schema.prisma` declare `onDelete` explicitly — 10 Cascade, 5 SetNull. None
+left to Prisma's default.
+
+```bash
+grep -E '@relation\(' prisma/schema.prisma | grep 'fields:' | grep -v 'onDelete:'
+```
+
+**CLAUDE.md.** 176 file references (markdown links plus backticked path-like
+tokens, `:symbol` suffixes stripped, bare basenames resolved against
+`git ls-files`), 0 broken. The count is higher than earlier passes reported
+because the extraction includes bare basenames mentioned in prose.
+
+**Gotchas 1, 4, 9, 12, 14** all hold in the code:
+
+- **1** — the only two forms with repeated field names are `/settings/sources`
+  (`enabled`) and the starter-pack picker (`pick`); both routes use
+  `parseBody({ all: true })`. Every `toStringArray` call site sits in an
+  `all: true` route. The third checkbox in the tree (`target.tsx:459`,
+  `show-matched`) is client-side and never submitted.
+- **4** — `remoteok.ts:49` still slices off the meta object at `array[0]`.
+- **9** — `fetch-job.ts:28` reads `getSettings()` per tick; nothing caches it.
+- **12** — `stripHtml` decodes entities before stripping tags (`http.ts:150`).
+- **14** — `ai-provider-parse.ts:111` still passes `'--'` before the prompt.
+
+**Fire-and-forget.** Four `void` sites start work nobody awaits, and all four
+handle rejection: `settings.tsx:930` and `discovery.tsx:68` / `:118` are async
+IIFEs with `try`/`catch`/`finally`; `ai-runtime.ts:162` calls `recordUsage`,
+which catches internally and logs at debug. (The other `void`s in the tree are
+`.catch()`-chained run wrappers or `$disconnect().finally(process.exit)` on
+shutdown paths.)
+
+## Left alone, deliberately
+
+**No process-level `unhandledRejection` / `uncaughtException` handler** in
+either process. Every path that could reject unhandled turned out to be
+handled, so adding one is defence-in-depth against a bug not yet demonstrated,
+not a fix. If it goes in later, it should be its own PR with a test that
+produces the unhandled rejection first.
+
+**`reclassify-job.ts:54` reads every unscored NEW job to use ten of them.**
+`runScoreUnscored` loads the full set, then `passesAnyBaseFilter` splits it and
+bulk-dismisses the rejects, then `rankByProfileFit` ranks what is left and
+`SCORE_BATCH = 10` takes the top slice. `welcome.tsx` step 4 is the caller. A
+`take` would change the answer: ranking by profile fit is a property of the
+whole set, and the bulk dismissal has to see every row anyway. On a fresh
+install that means thousands of rows to produce ten (§14 recorded 2633 after
+step 2); on this instance today it is 0, everything being scored already. Call
+it a priced-in compromise. If the fresh-install path ever needs to get faster,
+start here.
+
+**`Job.fitScore` keeps the numbers of a deleted search.** ADR 0028 accepts
+this; the record is
+[#71](https://github.com/applypack/applypack/issues/71).

--- a/docs/audit-2026-09.md
+++ b/docs/audit-2026-09.md
@@ -21,8 +21,11 @@ that route reading more than it used, and a delete dialog naming half its blast
 radius. Both times the sibling case stayed behind.
 
 The dead exports: `BenchMode` and `isReviewGrade`, zero references across the
-whole tree including tests, scripts and docs. Removing `isReviewGrade` also
-freed its `REVIEW_GRADES` import — `ReviewGrade`, the type, is still used.
+whole tree including tests, scripts and docs. Neither wanted adopting instead
+of deleting — `BenchMode` duplicated `MatchMode`, which `resume-bench-once.ts`
+already imports and parses, and nothing validates a grade string at a boundary.
+Removing `isReviewGrade` also freed its `REVIEW_GRADES` import; `ReviewGrade`,
+the type, is still used.
 
 `UncoveredVendor` in `starter-packs/resolve.ts` looks just as unused. It stays:
 it is an `AssertNever<...>` exhaustiveness check, so going unreferenced is how

--- a/src/resume/bench-report.ts
+++ b/src/resume/bench-report.ts
@@ -10,8 +10,6 @@ import { canonicalTerm } from './facts';
  * baseline run's — the number the Sonnet-vs-Opus decision rests on. No I/O.
  */
 
-export type BenchMode = 'fast' | 'full';
-
 const KeywordSchema = z.object({
   term: z.string(),
   status: z.string(),

--- a/src/resume/review-delta.ts
+++ b/src/resume/review-delta.ts
@@ -1,4 +1,4 @@
-import { REVIEW_DIMENSIONS, REVIEW_GRADES, type ReviewDimension, type ReviewGrade } from './review-score';
+import { REVIEW_DIMENSIONS, type ReviewDimension, type ReviewGrade } from './review-score';
 
 /*
  * What changed between two strength reviews of the SAME resume (ADR 0030
@@ -98,9 +98,4 @@ export function deltaSentence(delta: ReviewDelta): string {
       ? ' — same text, re-judged'
       : '';
   return `${head}; ${moved}${caveat}.`;
-}
-
-/** True for every grade string the delta can be built from. */
-export function isReviewGrade(v: unknown): v is ReviewGrade {
-  return typeof v === 'string' && (REVIEW_GRADES as readonly string[]).includes(v);
 }


### PR DESCRIPTION
Housekeeping from the same audit pass as #104 and #105. No runtime behaviour
changes, so **no version bump and no tag** — this rides along with the next
minor, per `release-discipline`.

## Two dead exports removed

`BenchMode` (`resume/bench-report.ts`) and `isReviewGrade`
(`resume/review-delta.ts`). Zero references anywhere in the tree — including
tests, scripts and docs — out of the exported symbols in `src/`.

Neither was a case of "should have been used instead of deleted":

- `BenchMode = 'fast' | 'full'` duplicated `MatchMode`, which
  `scripts/resume-bench-once.ts` already imports and parses with
  `parseMatchMode`.
- Nothing validates a grade string at a boundary, so `isReviewGrade` had no
  job waiting for it. Removing it also freed its `REVIEW_GRADES` import;
  `ReviewGrade`, the type, is still used throughout the file.

`UncoveredVendor` in `starter-packs/resolve.ts` looks equally unreferenced and
is **left alone**: it is an `AssertNever<...>` exhaustiveness check, so going
unreferenced is the mechanism, and there is a comment above it saying so.

## docs/audit-2026-09.md

The write-up. It records what came back clean as well as what was fixed, with
the command for each, so the next audit does not repeat this work.

Two invariants were broken on purpose to check they actually bite, then
reverted byte-identically:

- Added `+ 1` to `raw` in `web/public/score.mjs` only — `score.test.ts` failed
  2 of its 4 tests.
- Added `src/rogue-call-site.ts` calling `getAiRuntime().complete` directly —
  `prompt-fence-registry.test.ts` failed naming the file: *"new AI call site(s):
  rogue-call-site.ts — route the prompt through a build\*Prompt and register it
  here"*.

Also recorded: 15 FK relations all with an explicit `onDelete` (10 Cascade,
5 SetNull); 176 CLAUDE.md file references, 0 broken; gotchas 1, 4, 9, 12 and 14
each still holding at a named line; all four fire-and-forget `void` sites
handling rejection.

And three things left alone with the reason written down — no process-level
`unhandledRejection` handler (defence-in-depth against a bug I could not
demonstrate, so it wants its own PR with a failing test first), the unbounded
unscored-jobs read behind `SCORE_BATCH` (a `take` would change the answer), and
`Job.fitScore` outliving a deleted search (ADR 0028, issue #71).

Every `file:line` in the document was re-checked against the tree after the
deletions above.

## Verification

`npm run lint:types` clean, `npm test` 1055 pass, `npx prisma format --check`
clean. Web untouched, so no dashboard matrix.
