### PR TITLE
Make the free and open-source signal unmissable

### DIFF
--- a/site/public/demo/index.html
+++ b/site/public/demo/index.html
@@ -29,12 +29,13 @@
 
 <header class="top">
   <nav class="wrap nav" aria-label="Primary">
-    <a class="brand" href="../"><span class="mark" aria-hidden="true">AP</span>ApplyPack</a>
+    <a class="brand" href="../"><span class="mark" aria-hidden="true">AP</span><span class="word">ApplyPack</span></a>
     <div class="links">
-      <a class="key" href="../#what">What it does</a>
-      <a class="key" href="../#install">Install</a>
+      <a href="../#what">What it does</a>
+      <a class="open key" href="../#open">Open source</a>
+      <a href="../#install">Install</a>
     </div>
-    <a class="btn small" href="https://github.com/applypack/applypack">GitHub</a>
+    <a class="btn small gh-btn" href="https://github.com/applypack/applypack" aria-label="GitHub"><svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg><span>GitHub</span></a>
   </nav>
 </header>
 

--- a/site/public/index.html
+++ b/site/public/index.html
@@ -32,14 +32,14 @@
 
 <header class="top">
   <nav class="wrap nav" aria-label="Primary">
-    <a class="brand" href="/"><span class="mark" aria-hidden="true">AP</span>ApplyPack</a>
+    <a class="brand" href="/"><span class="mark" aria-hidden="true">AP</span><span class="word">ApplyPack</span></a>
     <div class="links">
-      <a class="key" href="#demo">Demo</a>
+      <a href="#demo">Demo</a>
       <a href="#what">What it does</a>
-      <a href="#open">Open source</a>
-      <a class="key" href="#install">Install</a>
+      <a class="open key" href="#open">Open source</a>
+      <a href="#install">Install</a>
     </div>
-    <a class="btn small" href="https://github.com/applypack/applypack">GitHub</a>
+    <a class="btn small gh-btn" href="https://github.com/applypack/applypack" aria-label="GitHub"><svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg><span>GitHub</span></a>
   </nav>
 </header>
 
@@ -47,15 +47,15 @@
   <section class="hero" aria-labelledby="hero-h">
     <div class="wrap hero-text">
       <h1 id="hero-h">Stop losing interviews to a missing keyword.</h1>
-      <p class="sub">ApplyPack finds real openings, shows exactly which words a posting wants and your resume lacks, helps you fix it in place, and writes the cover letter. Free and open source, on your own machine.</p>
+      <p class="free"><strong>Free and open source.</strong> MIT license, no subscription, no ads, no accounts.</p>
+      <p class="sub">ApplyPack finds real openings, shows exactly which words a posting wants and your resume lacks, helps you fix it in place, and writes the cover letter. On your own machine.</p>
       <div class="cta">
         <a class="btn primary" href="#demo">Try the live demo</a>
         <a class="btn" href="#install">Install with Docker</a>
       </div>
       <ul class="trust" role="list" aria-label="The short version">
-        <li>Open source, MIT</li>
-        <li>No ads, no payments, no accounts</li>
         <li>Runs locally or in Docker</li>
+        <li>Your data stays in your Postgres</li>
         <li>22 job sources</li>
         <li><a href="https://github.com/applypack/applypack/releases"><img src="https://img.shields.io/github/v/release/applypack/applypack?display_name=tag&amp;label=latest&amp;labelColor=1e293b&amp;color=047857" alt="Latest release" width="104" height="20"></a></li>
       </ul>

--- a/site/public/style.css
+++ b/site/public/style.css
@@ -106,8 +106,11 @@ h3 { font-size: var(--text-lg); font-weight: 600; line-height: 1.3; }
   display: grid; place-items: center; font-size: 13px; font-weight: 700; flex: none;
 }
 .nav .links { display: flex; gap: var(--s-2); margin-left: auto; }
-.nav .links a { color: var(--ink-2); font-size: 14.5px; padding: var(--s-2) var(--s-3); border-radius: var(--r-sm); }
+.nav .links a { color: var(--ink-2); font-size: 14.5px; padding: var(--s-2) var(--s-3); border-radius: var(--r-sm); white-space: nowrap; }
 .nav .links a:hover { color: var(--ink); background: var(--overlay); text-decoration: none; }
+/* the one nav item that answers "is this a subscription?" before anything else */
+.nav .links a.open { background: var(--accent-soft); color: var(--accent-ink); font-weight: 600; border: 1px solid rgb(4 120 87 / 0.25); }
+.nav .links a.open:hover { background: #d1fae5; color: var(--accent-deep); }
 
 /* buttons */
 .btn {
@@ -121,6 +124,7 @@ h3 { font-size: var(--text-lg); font-weight: 600; line-height: 1.3; }
 .btn.primary { background: var(--accent-ink); border-color: var(--accent-ink); color: #fff; }
 .btn.primary:hover { background: var(--accent-deep); border-color: var(--accent-deep); }
 .btn.small { min-height: 36px; padding: 0 var(--s-4); font-size: 14px; }
+.btn svg { width: 16px; height: 16px; flex: none; }
 
 /* hero */
 .hero { padding: var(--s-8) 0 var(--s-7); }
@@ -128,7 +132,13 @@ h3 { font-size: var(--text-lg); font-weight: 600; line-height: 1.3; }
 .hero h1 {
   font-size: var(--text-3xl); font-weight: 700; line-height: 1.05; letter-spacing: -0.03em;
 }
-.hero .sub { margin: var(--s-5) auto 0; max-width: 620px; font-size: var(--text-lg); color: var(--ink-2); }
+.free {
+  display: inline-block; margin: var(--s-5) auto 0; padding: 7px 16px; max-width: none;
+  border-radius: 999px; background: var(--accent-soft); border: 1px solid rgb(4 120 87 / 0.25);
+  color: var(--accent-deep); font-size: var(--text-sm); line-height: 1.5;
+}
+.free strong { color: var(--accent-ink); font-weight: 700; }
+.hero .sub { margin: var(--s-4) auto 0; max-width: 620px; font-size: var(--text-lg); color: var(--ink-2); }
 .cta { margin-top: var(--s-6); display: flex; gap: var(--s-3); justify-content: center; flex-wrap: wrap; }
 .trust {
   margin: var(--s-5) auto 0; display: flex; flex-wrap: wrap; justify-content: center; align-items: center;
@@ -341,6 +351,12 @@ footer { border-top: 1px solid var(--line); background: var(--surface); padding:
 /* phone */
 @media (max-width: 640px) {
   .nav .links a:not(.key) { display: none; }
+  .gh-btn { padding: 0 11px; }
+  .gh-btn span { display: none; }
+  .free { border-radius: 10px; text-align: left; }
+  .demo-head { flex-wrap: wrap; }
+  .demo-head .dots { display: none; }
+  .demo-head a { margin-left: 0; flex-basis: 100%; }
   .hero { padding: var(--s-6) 0 var(--s-6); }
   .hero-text, .hero .sub { text-align: left; margin-left: 0; }
   .hero h1 { font-size: clamp(32px, 9.5vw, 40px); }
@@ -361,4 +377,8 @@ footer { border-top: 1px solid var(--line); background: var(--surface); padding:
   .pipe { grid-template-columns: 1fr; }
   .term pre { font-size: 13px; }
   .foot .links { margin-left: 0; }
+}
+/* the narrowest phones: the mark alone identifies the site, the nav keeps its two items */
+@media (max-width: 360px) {
+  .top .brand .word { display: none; }
 }


### PR DESCRIPTION
## Summary

Follow-up to #107 from the owner's first look: a visitor could still read the hero as "another subscription", and the GitHub button had no mark.

- **Hero:** a highlighted line directly under the H1 — *Free and open source. MIT license, no subscription, no ads, no accounts.* The subtitle drops the duplicate and the trust line now carries new facts (runs locally or in Docker · your data stays in your Postgres · 22 sources · live release badge).
- **Nav:** *Open source* is an emerald pill, the one item that stays visible on phones; the GitHub button gets the Octicons mark (inline SVG, `aria-label`) and goes icon-only on phones.
- **Phones:** nav links no longer wrap, the wordmark hides under 360 px so the two nav items and the button fit, and the demo header wraps its link onto its own line instead of squeezing the text.

## Verification

- Lighthouse mobile on the preview: performance 99, accessibility 100, CLS 0.
- Computed layout at 375 and 320 px: no horizontal overflow; nav = mark (+ wordmark at 375) · Open source pill (41 px, one line) · GitHub icon (36 px).
- `npm run lint:types && npm test` green; the vendored demo modules are untouched.

## Release notes

Site only, no version tag.
