### PR TITLE
Jobicy follows the searches: one geo feed per place (stage 3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.26.0] — 2026-09-03
+
+### Added
+- **Jobicy follows the searches.** The fetcher used to read one unfiltered
+  feed (~200 rows, 58 of them US-only). It now reads one `geo=` feed per
+  place the running searches hunt in — a PL + DE + EU search pulls
+  `poland`, `germany` and `europe` — and keeps a posting listed in several
+  of them once. Jobicy's `geo` has eligibility semantics (`poland` also
+  returns Europe / EMEA / Anywhere rows), so nothing a search could want is
+  lost, and the US-only rows a European search never wanted stop arriving.
+  A search that hunts anywhere, or a place Jobicy has no slug for, falls
+  back to the whole feed. Verified live: an unknown slug returns an EMPTY
+  feed, which is why only the 13 slugs the API echoed back are ever sent.
+- Every fetcher now receives the searches' places (`FetchContext`, the
+  union of the active non-blank profiles' countries and regions, built once
+  per tick); sources without a geo filter ignore it. Plan §4.2, stage 3a.
+
 ## [1.25.0] — 2026-09-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | HTML → plaintext (entities, paragraphs, bullets) | `src/http.ts:stripHtml` + `decodeHtmlEntities` (gotcha 12) |
 | Pure helpers (parsing, hashing, masking) | `src/text-utils.ts` |
 | Near-duplicate detection across sources (SimHash, Hamming) | `src/fingerprint.ts` (ADR 0018); wired in `jobs/process-jobs.ts` |
+| Where the running searches hunt, handed to every fetcher (`FetchContext`: union of countries + regions; anywhere = empty) | `src/fetchers/fetch-context.ts:searchPlaces` (pure) built once per tick in `fetchers/index.ts:runAllFetchers`; a source with a geo filter maps it (`jobicy.ts:JOBICY_GEO` / `jobicySlugsFor`), the rest ignore it |
 | Per-source health (error→status, failure streak, quiet/silent) | `src/fetchers/source-health.ts` (pure, ADR 0019); recorded by the wrapper in `fetchers/index.ts:runAllFetchers` |
 | Apply-link flags (missing / unusable / shortened / not-an-application) | `src/apply-link.ts` (pure, ADR 0023); merged into `Job.redFlags` at all three persist paths |
 | Where a SEARCH hunts (countries / regions / workplace on the profile), the set filter with group expansion | `prisma/schema.prisma:Profile` (ADR 0032) → `src/profiles.ts:ProfileInput` → `src/filter.ts:locationMatches` / `placesOverlap` (pure); the prompt line `classifier.ts:describeLocation` (codes only); the editor control `pages/settings.tsx` Location fieldset + `public/countries.mjs` over `GET /countries.json` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -71,7 +71,9 @@ Per-tick flow inside `runFetchJob`:
 runAllFetchers()         filter by Company.active and AppSettings.disabledSources
    ↓
 NormalizedJob[]          unified shape (companyId, externalId, title, location, …)
-                         + locationHints where the feed has structured geodata (ADR 0031)
+                         + locationHints where the feed has structured geodata (ADR 0031);
+                         geo-filtered sources (Jobicy) read the FetchContext — the union of the
+                         running searches' countries + regions — instead of the whole feed
    ↓
 passesAnyBaseFilter()    admit if ANY running search admits it (title contains its
                          stackRequired OR roleTypes; its stackExclude rejects)

--- a/docs/country-search-plan.md
+++ b/docs/country-search-plan.md
@@ -546,9 +546,14 @@ adopted or rejected.
 
 **3a — use the geodata we already receive** (no new source)
 - WWR: register `region` and `country` in `customFields`; `country` is the
-  allow-list, `region` the coarse label.
-- Jobicy: one Company row per `geo` slug the user's countries map to
-  (`JOBICY` / `atsToken = "poland"`), RSS with `industry=engineering`.
+  allow-list, `region` the coarse label. *(done in stage 1)*
+- Jobicy: ~~one Company row per `geo` slug~~ — amended 2026-09-03: the one
+  Jobicy row follows the running searches. `runAllFetchers` builds a
+  `FetchContext` (union of the active searches' countries + regions) and the
+  fetcher reads one `geo=` feed per slug it maps to, merged by guid. One row
+  per slug would have stored the same posting under several company ids
+  (the `(companyId, externalId)` key), and a hand-edited token is a hidden
+  setting the plan's own ground rules forbid. *(done: v1.26.0)*
 - Himalayas: switch to `/jobs/api/search?country=…&exclude_worldwide=true`
   per profile country, plus one `worldwide=true` row.
 - 4dayweek: `country=` from profile countries, `work_arrangement` hint.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.25.0",
+      "version": "1.26.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/fetchers/fetch-context.test.ts
+++ b/src/fetchers/fetch-context.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { EMPTY_CONTEXT, searchPlaces } from './fetch-context';
+
+describe('searchPlaces', () => {
+  it('unions the places of every running search, once each', () => {
+    assert.deepEqual(
+      searchPlaces([
+        { countries: ['PL', 'DE'], regions: ['EU'] },
+        { countries: ['DE', 'US'], regions: [] },
+      ]),
+      { countries: ['PL', 'DE', 'US'], regions: ['EU'] },
+    );
+  });
+
+  it('one search that hunts anywhere makes the context anywhere', () => {
+    assert.deepEqual(searchPlaces([{ countries: ['PL'], regions: [] }, { countries: [], regions: [] }]), EMPTY_CONTEXT);
+    assert.deepEqual(searchPlaces([{ countries: ['PL'], regions: ['WORLDWIDE'] }]), EMPTY_CONTEXT);
+  });
+
+  it('no searches is anywhere too', () => {
+    assert.deepEqual(searchPlaces([]), EMPTY_CONTEXT);
+  });
+});

--- a/src/fetchers/fetch-context.ts
+++ b/src/fetchers/fetch-context.ts
@@ -1,0 +1,35 @@
+/**
+ * What every fetcher may know about the searches that are running (plan
+ * §4.2, stage 3a): the union of their places. A source with a geo filter
+ * asks for those places instead of the whole world; a source without one
+ * ignores the context. Pure — the wrapper in index.ts builds it once per
+ * tick from the active, non-blank profiles.
+ */
+
+export interface FetchContext {
+  /** ISO-2 codes every running search hunts in, once each. */
+  countries: string[];
+  /** Group codes (EU, EUROPE, WORLDWIDE, …), once each. */
+  regions: string[];
+}
+
+export const EMPTY_CONTEXT: FetchContext = { countries: [], regions: [] };
+
+/**
+ * The union of the searches' places. One search that hunts anywhere (no
+ * countries, no regions, or WORLDWIDE) makes the whole context "anywhere" —
+ * a geo filter would hide rows that search wants.
+ */
+export function searchPlaces(
+  profiles: readonly { countries: string[]; regions: string[] }[],
+): FetchContext {
+  const countries = new Set<string>();
+  const regions = new Set<string>();
+  for (const p of profiles) {
+    const anywhere = (p.countries.length === 0 && p.regions.length === 0) || p.regions.includes('WORLDWIDE');
+    if (anywhere) return EMPTY_CONTEXT;
+    for (const c of p.countries) countries.add(c);
+    for (const r of p.regions) regions.add(r);
+  }
+  return { countries: [...countries], regions: [...regions] };
+}

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -3,6 +3,9 @@ import { prisma } from '../db';
 import { logger } from '../logger';
 import { sleep } from '../http';
 import { getSettings, toAtsTypes } from '../settings';
+import { listActiveProfiles } from '../profiles';
+import { isBlankProfile } from '../profile-guards';
+import { EMPTY_CONTEXT, searchPlaces, type FetchContext } from './fetch-context';
 import {
   QUIET_STREAK,
   classifyFetchCount,
@@ -68,6 +71,14 @@ export async function runAllFetchers(
     orderBy: { id: 'asc' },
   });
 
+  // Where the running searches hunt (stage 3a): sources with a geo filter
+  // ask for these places instead of the whole world. Blank searches are
+  // left out here as they are in process-jobs — they gate on nothing.
+  const context = searchPlaces((await listActiveProfiles()).filter((p) => !isBlankProfile(p)));
+  if (context.countries.length > 0 || context.regions.length > 0) {
+    logger.info(context, 'fetchers: geo-filtered sources follow the searches');
+  }
+
   const out: FetcherResult[] = [];
   let done = 0;
 
@@ -83,7 +94,7 @@ export async function runAllFetchers(
     let status: FetchStatus;
     let count = 0;
     try {
-      const jobs = await fetchOne(company);
+      const jobs = await fetchOne(company, context);
       count = jobs.length;
       // Status comes from the RAW count, before passesBaseFilter — a profile
       // that matches nothing is not a broken board (ADR 0019).
@@ -140,11 +151,10 @@ async function recordFetchHealth(
   }
 }
 
-export async function fetchOne(company: {
-  id: number;
-  atsType: AtsType;
-  atsToken: string;
-}): Promise<NormalizedJob[]> {
+export async function fetchOne(
+  company: { id: number; atsType: AtsType; atsToken: string },
+  context: FetchContext = EMPTY_CONTEXT,
+): Promise<NormalizedJob[]> {
   switch (company.atsType) {
     case AtsType.GREENHOUSE:
       return fetchGreenhouse({ id: company.id, atsToken: company.atsToken });
@@ -177,7 +187,7 @@ export async function fetchOne(company: {
     case AtsType.GOLANGPROJECTS:
       return fetchGolangProjects(company.id);
     case AtsType.JOBICY:
-      return fetchJobicy(company.id);
+      return fetchJobicy(company.id, context);
     case AtsType.HN_JOBS:
       return fetchHnJobs(company.id);
     case AtsType.WORKINGNOMADS:

--- a/src/fetchers/jobicy.test.ts
+++ b/src/fetchers/jobicy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mapJobicyItem, type JobicyItem } from './jobicy';
+import { JOBICY_GEO, jobicyFeedUrl, jobicySlugsFor, mapJobicyItem, type JobicyItem } from './jobicy';
 
 const COMPANY_ID = 99;
 
@@ -128,5 +128,26 @@ describe('mapJobicyItem — location hints (ADR 0031)', () => {
     );
     assert.equal(job.location, 'Europe, Norway');
     assert.deepEqual(job.locationHints, { workplace: 'REMOTE' });
+  });
+});
+
+describe('jobicySlugsFor — the feeds a set of searches needs (stage 3a)', () => {
+  it('maps countries and groups to the slugs Jobicy knows, once each', () => {
+    assert.deepEqual(jobicySlugsFor({ countries: ['PL', 'DE', 'GB'], regions: ['EU', 'EUROPE'] }), ['poland', 'germany', 'uk', 'europe']);
+  });
+
+  it('drops places Jobicy has no slug for, and an empty context means the whole feed', () => {
+    assert.deepEqual(jobicySlugsFor({ countries: ['LT', 'PL'], regions: ['DACH'] }), ['poland']);
+    assert.deepEqual(jobicySlugsFor({ countries: [], regions: [] }), []);
+  });
+
+  it('builds the feed URL with and without a geo', () => {
+    assert.equal(jobicyFeedUrl('dev', null), 'https://jobicy.com/?feed=job_feed&job_categories=dev');
+    assert.equal(jobicyFeedUrl('dev', 'poland'), 'https://jobicy.com/?feed=job_feed&job_categories=dev&geo=poland');
+  });
+
+  it('every slug in the table is one the API echoed back on 2026-09-03', () => {
+    const verified = ['usa', 'canada', 'uk', 'germany', 'poland', 'ukraine', 'netherlands', 'spain', 'france', 'europe', 'emea', 'latam', 'apac'];
+    for (const slug of Object.values(JOBICY_GEO)) assert.ok(verified.includes(slug), slug);
   });
 });

--- a/src/fetchers/jobicy.ts
+++ b/src/fetchers/jobicy.ts
@@ -1,16 +1,42 @@
 import Parser from 'rss-parser';
-import { stripHtml } from '../http';
+import { sleep, stripHtml } from '../http';
+import { logger } from '../logger';
 import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
+import { type FetchContext, EMPTY_CONTEXT } from './fetch-context';
 
-const FEED_URL_TEMPLATE = (category: string) =>
-  `https://jobicy.com/?feed=job_feed&job_categories=${encodeURIComponent(category)}`;
-const PARSER_TIMEOUT_MS = 15_000;
+const FEED_URL = 'https://jobicy.com/?feed=job_feed';
 const DEFAULT_CATEGORY = 'dev';
+const PARSER_TIMEOUT_MS = 15_000;
+/** One feed per place the searches hunt in; a pause between them (credit + link-back terms). */
+const FEED_DELAY_MS = 1_000;
+
+/**
+ * Jobicy's `geo` vocabulary, verified live 2026-09-03: the API echoes the
+ * slug in `appliedFilters`, the RSS answers an unknown slug with an EMPTY
+ * feed — which is why only these slugs are ever sent. `geo=poland` has
+ * eligibility semantics: it also returns Europe / EMEA / Anywhere rows.
+ */
+export const JOBICY_GEO: Readonly<Record<string, string>> = {
+  US: 'usa',
+  CA: 'canada',
+  GB: 'uk',
+  DE: 'germany',
+  PL: 'poland',
+  UA: 'ukraine',
+  NL: 'netherlands',
+  ES: 'spain',
+  FR: 'france',
+  EU: 'europe',
+  EUROPE: 'europe',
+  EMEA: 'emea',
+  LATAM: 'latam',
+  APAC: 'apac',
+};
 
 /**
  * Jobicy is a cross-company remote-job aggregator. Their RSS feed
- * `https://jobicy.com/?feed=job_feed&job_categories=dev` returns ~50
+ * `https://jobicy.com/?feed=job_feed&job_categories=dev` returns ~200
  * recent jobs spanning many employers (PSI CRO, ManTech, Mindrift,
  * etc.) — none of which we'd ever seed individually. This is the
  * mechanism for "see jobs at companies I don't track yet".
@@ -47,12 +73,50 @@ const parser: Parser<unknown, JobicyItem> = new Parser({
   },
 });
 
+/**
+ * One feed per place the running searches hunt in (stage 3a): a PL + DE + EU
+ * search pulls `geo=poland`, `geo=germany` and `geo=europe` instead of the
+ * whole feed, and a posting listed in several of them is kept once. A search
+ * that hunts anywhere — or one whose places Jobicy has no slug for — falls
+ * back to the unfiltered feed, exactly as before.
+ */
 export async function fetchJobicy(
   companyId: number,
+  context: FetchContext = EMPTY_CONTEXT,
   category: string = DEFAULT_CATEGORY,
 ): Promise<NormalizedJob[]> {
-  const feed = await parser.parseURL(FEED_URL_TEMPLATE(category));
-  return feed.items.flatMap((item) => mapJobicyItem(item, companyId) ?? []);
+  const slugs = jobicySlugsFor(context);
+  const feeds = slugs.length > 0 ? slugs : [null];
+  const out = new Map<string, NormalizedJob>();
+  for (const [i, slug] of feeds.entries()) {
+    if (i > 0) await sleep(FEED_DELAY_MS);
+    const feed = await parser.parseURL(jobicyFeedUrl(category, slug));
+    let added = 0;
+    for (const item of feed.items) {
+      const job = mapJobicyItem(item, companyId);
+      if (job && !out.has(job.externalId)) {
+        out.set(job.externalId, job);
+        added++;
+      }
+    }
+    logger.debug({ slug, items: feed.items.length, added }, 'jobicy: feed read');
+  }
+  return [...out.values()];
+}
+
+/** The slugs Jobicy knows for the searches' places, once each, in context order. */
+export function jobicySlugsFor(context: FetchContext): string[] {
+  const slugs: string[] = [];
+  for (const code of [...context.countries, ...context.regions]) {
+    const slug = JOBICY_GEO[code];
+    if (slug && !slugs.includes(slug)) slugs.push(slug);
+  }
+  return slugs;
+}
+
+export function jobicyFeedUrl(category: string, slug: string | null): string {
+  const geo = slug ? `&geo=${encodeURIComponent(slug)}` : '';
+  return `${FEED_URL}&job_categories=${encodeURIComponent(category)}${geo}`;
 }
 
 /**


### PR DESCRIPTION
Stage 3a of the country-aware search plan ([docs/country-search-plan.md §4.2](docs/country-search-plan.md)), first source: Jobicy reads one `geo=` feed per place the running searches hunt in, instead of the whole feed. Follows #112 (stage 2, v1.25.0).

## Analysis note (pre-work §4.1, 2026-09-03)

- **Endpoint re-verified with the project User-Agent.** `https://jobicy.com/?feed=job_feed&job_categories=dev&geo=poland` → 200, `application/rss+xml`, 139 items (the unfiltered feed: 200). Locations in the `poland` feed: Anywhere 46, Europe 29, EMEA 20, "USA, Canada, EMEA, LATAM" 11, Poland 4 — the eligibility semantics the plan described. `geo=germany` → 141 items, 3 "Germany". The API (`/api/v2/remote-jobs?geo=…`) echoes the slug in `appliedFilters`; all of `poland, germany, ukraine, uk, usa, europe, emea, latam, apac, anywhere, netherlands, spain, france, canada` are accepted. **An unknown slug (`narnia`) returns an EMPTY RSS feed**, not an error — a silent `empty` forever under ADR 0019, so the fetcher only ever sends slugs from its own table (`JOBICY_GEO`, 13 codes) and a place it cannot map is simply not requested.
- **robots.txt** (jobicy.com): `Content-Signal: ai-train=yes, search=yes, ai-input=yes`; the disallows are query-pattern paths (`/*?s=`, `/*?p=`, `/*?q=`, `/*_type=job_listing`, …); `/?feed=job_feed&job_categories=…&geo=…` matches none of them. Terms as recorded in the plan: credit + link-back — the source card on `/companies` already links jobicy.com.
- **atsToken shape.** The plan said one Company row per geo slug. Amended: the one `jobicy` row follows the searches. Two reasons. `(companyId, externalId)` is the unique key, so the same posting in the `poland` and `europe` feeds would have become two Job rows under two company ids — two classifications and a cross-listing note for one job. And a token holding a geo list is a hidden setting nobody edits on `/companies`; the searches already say where they hunt. `runAllFetchers` builds a `FetchContext` (union of the active, non-blank searches' countries + regions, built once per tick) and hands it to `fetchOne`; sources without a geo filter ignore it. Blank searches are left out exactly as `process-jobs` leaves them out.
- **Mapping on paper.** `FetchContext` → `jobicySlugsFor` → one feed per slug, merged by guid; a search that hunts anywhere (no places, or WORLDWIDE) or a context Jobicy has no slug for → the unfiltered feed, i.e. today's behaviour. The mapper, the description folding and the `locationHints` are unchanged.
- **Volume per tick.** One feed per slug, 1 s apart; a PL + DE + EU search reads three feeds (~1 MB each) an hour. Measured: 3 feeds in 4.8 s, 182 unique rows against 200 unfiltered.
- **Nothing in §0.4 changed.**

## Verification

- `npm run lint:types && npm test`: 1 421 tests (context union, slug mapping, feed URL, the slug allow-list pinned to the 13 the API echoed).
- Smoke against the live feeds: `fetchJobicy(897, { countries: [PL, DE], regions: [EU] })` → 3 feeds (`poland`, `germany`, `europe`) in 4.8 s, **182 unique rows** (Anywhere 46, Europe 29, EMEA 20, "USA, Canada, EMEA, LATAM" 11, UK 10, Poland 4 …), **0 rows naming only US/CA** — against 200 rows in the unfiltered feed, 58 of them `USA`. The unfiltered fallback still returns 200.
- Source health: `ok` / `empty` semantics unchanged — the row's status still comes from the raw count.

## Follow-ups

- Himalayas (`/jobs/api/search?country=…&exclude_worldwide=true`, verified live) and 4dayweek (`country=Germany,Poland`, verified live) take the same `FetchContext` next — one PR each; Arbeitnow gets `links.next` pagination and the `visa_sponsorship=true` row.
- "Enable sources for your countries" (plan §4.3) becomes a card for NEW sources only (DOU, Djinni, …): the aggregators already installed follow the searches by themselves now.

## Release notes (draft, v1.26.0)

**Jobicy follows the searches.** Instead of one unfiltered feed, the fetcher reads one `geo=` feed per place your running searches hunt in — a PL + DE + EU search pulls `poland`, `germany` and `europe` — and keeps a posting listed in several of them once. The US-only rows a European search never wanted stop arriving; a search that hunts anywhere still gets the whole feed. Every fetcher now receives the searches' places; sources without a geo filter ignore them. Plan §4.2, stage 3a.
