### PR TITLE
Arbeitnow: three pages via links.next and a visa-sponsorship row (stage 3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.29.0] — 2026-09-03
+
+### Added
+- **Arbeitnow reads three pages and has a visa-sponsorship feed.** The
+  fetcher followed nothing beyond page 1 (175 rows of 650+); it now walks
+  the API's own `links.next` for up to three pages, a second apart, on the
+  board's host only, and keeps a posting once. A second Company row,
+  "Arbeitnow · visa sponsorship" (`atsToken: visa`), reads
+  `?visa_sponsorship=true` — a server-side filter the rows themselves do
+  not carry, so it is a feed of its own. Both rows stay off until a search
+  needs them: the board is German and British office jobs first. Plan §4.2,
+  stage 3a.
+
 ## [1.28.0] — 2026-09-03
 
 ### Added

--- a/SPEC.md
+++ b/SPEC.md
@@ -72,8 +72,8 @@ runAllFetchers()         filter by Company.active and AppSettings.disabledSource
    ↓
 NormalizedJob[]          unified shape (companyId, externalId, title, location, …)
                          + locationHints where the feed has structured geodata (ADR 0031);
-                         geo-filtered sources (Jobicy) read the FetchContext — the union of the
-                         running searches' countries + regions — instead of the whole feed
+                         geo-filtered sources (Jobicy, Himalayas, 4dayweek) read the FetchContext —
+                         the union of the running searches' countries + regions — instead of the whole feed
    ↓
 passesAnyBaseFilter()    admit if ANY running search admits it (title contains its
                          stackRequired OR roleTypes; its stackExclude rejects)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1136,8 +1136,11 @@ seeded inactive. Sources verified 2026-09-03 with robots.txt are in the plan
       page. The wizard's step 3 and "Fill from a resume" reuse the editor
       unchanged — neither speaks for location.
 - [ ] **Stage 3 sources** (one PR + tag per source, acceptance checklist in
-      feature-expansion-plan §0.3): 3a use existing geodata (WWR, Jobicy
-      `geo`, Himalayas search, 4dayweek `country`, Arbeitnow on + paginated);
+      feature-expansion-plan §0.3): 3a use existing geodata — **done**
+      2026-09-03 (WWR in stage 1; Jobicy `geo` v1.26.0, Himalayas search
+      v1.27.0, 4dayweek `country` v1.28.0, Arbeitnow paginated + visa row
+      v1.29.0 — the installed aggregators follow the searches through the
+      `FetchContext`, so §4.3's card is for new sources only);
       3b Ukraine (DOU RSS, Djinni RSS, UA-friendly pack + N-iX / Ajax /
       Genesis, re-probe `sigmasoftware`); 3c EU boards (solid.jobs,
       GermanTechJobs / DevITjobs, Landing.jobs Atom, JobTech); 3d EU ATS

--- a/docs/country-search-plan.md
+++ b/docs/country-search-plan.md
@@ -565,7 +565,10 @@ adopted or rejected.
   matters; rows without a location are dropped from a scoped fetch because an
   unknown value answers those ~141 rows instead of an error)*
 - Arbeitnow: enable, paginate via `links.next`, map `remote`, expose
-  `visa_sponsorship=true` as a second row.
+  `visa_sponsorship=true` as a second row. *(done: v1.29.0 — three pages
+  via `links.next` on the board's host only, the `remote` hint since stage 1,
+  a second seeded row `visa`; both rows stay seeded inactive — "enable" is
+  the user's switch on /companies, not a default for every deployment)*
 - golangprojects: read the region from the URL slug.
 
 **3b — Ukraine**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/fetchers/arbeitnow.test.ts
+++ b/src/fetchers/arbeitnow.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mapArbeitnowFeed } from './arbeitnow';
+import { arbeitnowUrl, mapArbeitnowFeed, nextPageUrl } from './arbeitnow';
 
 describe('mapArbeitnowFeed', () => {
   it('parses a typical data payload', () => {
@@ -129,5 +129,23 @@ describe('mapArbeitnowFeed — location hints (ADR 0031)', () => {
     );
     assert.deepEqual(out[0]?.locationHints, { workplace: 'REMOTE' });
     assert.deepEqual(out[1]?.locationHints, { workplace: 'UNKNOWN' });
+  });
+});
+
+describe('arbeitnow pagination and the visa feed (stage 3a)', () => {
+  it('the visa token selects the sponsorship feed; any other token the plain board', () => {
+    assert.equal(arbeitnowUrl('visa'), 'https://www.arbeitnow.com/api/job-board-api?visa_sponsorship=true');
+    assert.equal(arbeitnowUrl('arbeitnow'), 'https://www.arbeitnow.com/api/job-board-api');
+  });
+
+  it("follows the API's next link only on its own host", () => {
+    assert.equal(
+      nextPageUrl({ data: [], links: { next: 'https://www.arbeitnow.com/api/job-board-api?page=2' } }),
+      'https://www.arbeitnow.com/api/job-board-api?page=2',
+    );
+    assert.equal(nextPageUrl({ data: [], links: { next: 'https://evil.example/api/job-board-api?page=2' } }), null);
+    assert.equal(nextPageUrl({ data: [], links: { next: null } }), null);
+    assert.equal(nextPageUrl({ data: [] }), null);
+    assert.equal(nextPageUrl('nonsense'), null);
   });
 });

--- a/src/fetchers/arbeitnow.ts
+++ b/src/fetchers/arbeitnow.ts
@@ -1,9 +1,22 @@
 import { z } from 'zod';
-import { fetchWithRetry, stripHtml } from '../http';
+import { fetchWithRetry, sleep, stripHtml } from '../http';
+import { logger } from '../logger';
 import { hashShortId } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
 const ENDPOINT = 'https://www.arbeitnow.com/api/job-board-api';
+// 175 rows a page, no total, `links.next` until the end (verified live
+// 2026-09-03). Three pages an hour is well inside "please do not abuse";
+// the base filter culls the rest by title before any AI call.
+const MAX_PAGES = 3;
+const PAGE_DELAY_MS = 1_000;
+
+/**
+ * The second Company row (stage 3a): `visa_sponsorship=true` is a server-side
+ * filter — the rows carry no visa field of their own — so it is a feed of
+ * its own, keyed by this token. Any other token is the plain board.
+ */
+export const VISA_TOKEN = 'visa';
 
 const ArbeitnowJobSchema = z
   .object({
@@ -26,15 +39,41 @@ type ArbeitnowJob = z.infer<typeof ArbeitnowJobSchema>;
 const ArbeitnowResponseSchema = z
   .object({
     data: z.array(z.unknown()),
+    links: z.object({ next: z.string().nullable().optional() }).passthrough().optional(),
   })
   .passthrough();
 
-export async function fetchArbeitnow(companyId: number): Promise<NormalizedJob[]> {
-  // TODO(phase-4): paginate via response.links.next; current call returns
-  // ~100 jobs (page 1) which is enough for now.
-  const resp = await fetchWithRetry(ENDPOINT);
-  const raw: unknown = await resp.json();
-  return mapArbeitnowFeed(raw, companyId);
+export interface ArbeitnowCompany {
+  id: number;
+  /** `visa` for the sponsorship feed; anything else is the plain board. */
+  atsToken: string;
+}
+
+export async function fetchArbeitnow(company: ArbeitnowCompany): Promise<NormalizedJob[]> {
+  const out = new Map<string, NormalizedJob>();
+  let url: string | null = arbeitnowUrl(company.atsToken);
+  for (let page = 1; url && page <= MAX_PAGES; page++) {
+    if (page > 1) await sleep(PAGE_DELAY_MS);
+    const resp = await fetchWithRetry(url);
+    const raw: unknown = await resp.json();
+    for (const job of mapArbeitnowFeed(raw, company.id)) {
+      if (!out.has(job.externalId)) out.set(job.externalId, job);
+    }
+    url = nextPageUrl(raw);
+    logger.debug({ page, rows: out.size, next: url }, 'arbeitnow: page read');
+  }
+  return [...out.values()];
+}
+
+export function arbeitnowUrl(token: string): string {
+  return token === VISA_TOKEN ? `${ENDPOINT}?visa_sponsorship=true` : ENDPOINT;
+}
+
+/** The API's own next link, followed only when it stays on the board's host. */
+export function nextPageUrl(raw: unknown): string | null {
+  const top = ArbeitnowResponseSchema.safeParse(raw);
+  const next = top.success ? top.data.links?.next : null;
+  return next && next.startsWith(`${ENDPOINT}?`) ? next : null;
 }
 
 export function mapArbeitnowFeed(raw: unknown, companyId: number): NormalizedJob[] {

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -169,7 +169,7 @@ export async function fetchOne(
     case AtsType.REMOTIVE:
       return fetchRemotive(company.id);
     case AtsType.ARBEITNOW:
-      return fetchArbeitnow(company.id);
+      return fetchArbeitnow({ id: company.id, atsToken: company.atsToken });
     case AtsType.HN_HIRING:
       return fetchHnHiring(company.id);
     case AtsType.WORKABLE:

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -210,6 +210,16 @@ const SEED_COMPANIES: SeedCompany[] = [
     careerUrl: 'https://www.arbeitnow.com',
     active: false,
   },
+  {
+    // Same board, only the postings whose employer sponsors a visa — a
+    // server-side filter, so a feed of its own (stage 3a). Off until a
+    // search needs it, like the plain feed.
+    name: 'Arbeitnow · visa sponsorship',
+    atsType: AtsType.ARBEITNOW,
+    atsToken: 'visa',
+    careerUrl: 'https://www.arbeitnow.com/?visa_sponsorship=true',
+    active: false,
+  },
 
   // HN /jobs — individual YC-job posts indexed by Algolia under
   // tags=job (separate from the monthly Who-is-hiring thread). Each


### PR DESCRIPTION
Stage 3a of the country-aware search plan ([docs/country-search-plan.md §4.2](docs/country-search-plan.md)), last source of the sub-stage: Arbeitnow walks three pages and gets a visa-sponsorship feed of its own. Follows #115 (4dayweek, v1.28.0).

## Analysis note (pre-work §4.1, 2026-09-03)

- **Endpoint re-verified with the project User-Agent.** `GET https://www.arbeitnow.com/api/job-board-api` → 200, `application/json`, 175 rows a page, `links.next` = `…?page=2` and so on, no total in `meta`. Page 2 works (`prev`/`next` both set). `?visa_sponsorship=true` → 132 rows, `next: null`; **the rows carry no visa field** (`slug, company_name, title, description, remote, url, tags, job_types, location, created_at`) — the filter exists only server-side, so it has to be a feed of its own. Locations are free text (`London` 40 of 175, `Berlin`, `Hamburg`, `München`, `Homeoffice`) the stage-1 parser already reads; `remote` is the stage-1 hint.
- **robots.txt** (www.arbeitnow.com): `Disallow:` (empty — allow all) plus `/*?__hstc`. Terms as recorded in the plan: "please do not abuse", link-back appreciated — the `/companies` card links the board.
- **atsToken shape.** `arbeitnow` = the plain board (unchanged); `visa` = `?visa_sponsorship=true`, a second seeded Company row "Arbeitnow · visa sponsorship". Both seeded **inactive**: the plan's "enable" is read as the user's switch on `/companies`, not a default — the board is German and British office jobs first (DE 217, GB 112 of 442 rows), and a US deployment does not want 442 rows an hour. The seed never touches `active` on an existing row, so nobody's choice is overwritten.
- **Mapping on paper.** `arbeitnowUrl(token)` → page 1; `nextPageUrl(raw)` follows the API's own link, and only when it stays on `https://www.arbeitnow.com/api/job-board-api?` (the acceptance checklist's host allowlist — the API hands us the URL, we do not trust it blindly); `MAX_PAGES = 3`, 1 s apart, rows merged by slug. The mapper and hints are unchanged. The `FetchContext` is not used: Arbeitnow has no geo parameter.
- **Volume per tick.** ≤ 3 requests per active row (≤ 6 with both rows), ≤ 525 + 132 rows, all culled by title before any AI call. Arbeitnow states no rate limit; three pages an hour is well inside "do not abuse".

## Verification

- `npm run lint:types && npm test`: 1 429 tests (token → URL, next-link host check, null / missing / nonsense links).
- Smoke against the live API: plain board → 3 pages in 2.9 s, **442 unique rows** (DE 217, GB 112, no country 106, AU 4; 34 remote); visa feed → 1 page in 0.3 s, **132 rows** (GB 66, DE 46; 12 remote).
- Seed: `Arbeitnow · visa sponsorship` (`ARBEITNOW` / `visa`) is created inactive on the next boot; the existing `arbeitnow` row is untouched.

## Follow-ups

- Stage 3a is complete with this PR (WWR and golangprojects landed in stage 1; Jobicy #113, Himalayas #114, 4dayweek #115). Next: 3b Ukraine — DOU and Djinni RSS, the UA-friendly pack refresh — each with its own §4.1 note.
- Plan §4.3 "Enable sources for your countries" is now a card for new sources only; the installed aggregators follow the searches by themselves.

## Release notes (draft, v1.29.0)

**Arbeitnow reads three pages and has a visa-sponsorship feed.** The fetcher walks the API's own `links.next` for up to three pages (it used to stop at the first 175 rows of 650+), and a second row, "Arbeitnow · visa sponsorship", reads only the postings whose employer sponsors a visa. Both rows stay off until you switch them on in Companies. Plan §4.2, stage 3a — the sub-stage is complete.
