### PR TITLE
DOU.ua as a source: one row per feed query, title-grammar parser (stage 3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.30.0] — 2026-09-03
+
+### Added
+- **DOU.ua as a source** (stage 3b, plan §4.2) — the Ukrainian tech job
+  board through its own RSS interface. One Company row per feed query,
+  which is the row's token: `category=PHP&remote`, `search=laravel`,
+  `city=Львів`, `exp=5plus`; add more on Companies, where the probe refuses
+  a query DOU answers with no vacancies (an unknown category is an empty
+  channel there, not an error). The title carries everything but the
+  description — "Backend Engineer в BetterMe, Київ, за кордоном, віддалено"
+  — so a small grammar parser splits role, employer, salary, cities and the
+  two markers: the employer and salary go into the description, the cities
+  and "віддалено" into the location the stage-1 parser already reads
+  (Cyrillic cities included). Seeded off as "DOU · PHP, remote". DOU
+  answers the default RSS User-Agent with 403, so the feed is fetched with
+  the project's. Terms: fine for a self-hosted personal tool with the
+  link-back kept; a hosted or commercial deployment needs DOU's consent.
+
 ## [1.29.0] — 2026-09-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -467,6 +467,7 @@ Three reference patterns, copy whichever fits the new source:
 | Shape of the new ATS | Reference file | Examples |
 | --- | --- | --- |
 | Single curated RSS | `src/fetchers/larajobs.ts` | RSS one feed for the whole site, no per-company config |
+| RSS whose title carries the structure, one row per query | `src/fetchers/dou.ts` + `dou-title.ts` | atsToken = the feed's query string; a pure title-grammar parser; fetched with the project UA because the board blocks rss-parser's |
 | Per-category RSS, atsToken = category slug | `src/fetchers/weworkremotely.ts` | Same pattern, atsToken changes per Company row |
 | Single JSON aggregator | `src/fetchers/remotive.ts` | One feed, structured JSON, all jobs under one synthetic Company |
 | Per-company GET JSON | `src/fetchers/ashby.ts` | atsToken = company slug, GET endpoint, no auth |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and wrong-fit postings, shows exactly which words a posting wants and your
 resume lacks, helps you fix it in place, and writes a cover letter that
 cannot invent. Then it tracks the application.
 
-- **Find real jobs.** 22 sources hourly, a classifier with strict stack
+- **Find real jobs.** 23 sources hourly, a classifier with strict stack
   and location rules, a ghost-job check with evidence links, Telegram only
   above your fit threshold, several searches at once.
 - **Fix the resume for this posting.** The model marks facts, code
@@ -182,7 +182,7 @@ green. Details per engine in [docs/ai-engines.md](./docs/ai-engines.md).
 ## How it works
 
 ```
- 22 sources ──▶ normalize ──▶ base filter ──▶ AI classifier ──▶ Postgres ──▶ Telegram
+ 23 sources ──▶ normalize ──▶ base filter ──▶ AI classifier ──▶ Postgres ──▶ Telegram
    hourly        + dedupe      pure code,      one call, a       dashboard    only when
    fetch                       zero cost       score per search               fit ≥ threshold
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -26,7 +26,7 @@ port.
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for diagrams.
 
-## Sources (22 ATS / aggregator types + MANUAL)
+## Sources (23 ATS / aggregator types + MANUAL)
 
 | AtsType            | Shape         | Auth      | Notes                                           |
 | ------------------ | ------------- | --------- | ----------------------------------------------- |
@@ -44,6 +44,7 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for diagrams.
 | REMOTEOK           | aggregator    | none      | First array element is meta (`legal:`) — dropped via `slice(1)` |
 | REMOTIVE           | aggregator    | none      | `?category=software-dev`                        |
 | ARBEITNOW          | aggregator    | none      | EU-skewed; **disabled by default**              |
+| DOU                | aggregator    | feed query (`category=PHP&remote`) | Ukraine's board via its RSS; one row per query; **disabled by default** (stage 3b) |
 | HN_HIRING          | aggregator    | none      | Algolia API → monthly "Ask HN: Who is hiring?" |
 | WEWORKREMOTELY     | aggregator    | none      | Per-category RSS, atsToken = category slug      |
 | GOLANGPROJECTS     | aggregator    | none      | Single RSS; **disabled by default** (Go-only)   |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1141,8 +1141,8 @@ seeded inactive. Sources verified 2026-09-03 with robots.txt are in the plan
       v1.27.0, 4dayweek `country` v1.28.0, Arbeitnow paginated + visa row
       v1.29.0 — the installed aggregators follow the searches through the
       `FetchContext`, so §4.3's card is for new sources only);
-      3b Ukraine (DOU RSS, Djinni RSS, UA-friendly pack + N-iX / Ajax /
-      Genesis, re-probe `sigmasoftware`); 3c EU boards (solid.jobs,
+      3b Ukraine (DOU RSS — **done** v1.30.0; Djinni RSS, UA-friendly pack +
+      N-iX / Ajax / Genesis, re-probe `sigmasoftware`); 3c EU boards (solid.jobs,
       GermanTechJobs / DevITjobs, Landing.jobs Atom, JobTech); 3d EU ATS
       types (Personio, Teamtailor; later Homerun, d.vinci); 3e keyed
       (France Travail, Adzuna) only after the robots-vs-licence decision.

--- a/docs/adr/0005-no-linkedin-indeed-workday.md
+++ b/docs/adr/0005-no-linkedin-indeed-workday.md
@@ -85,6 +85,7 @@ original decision (from the feature-expansion-plan ground rules):
 | The Muse | deferred | very high volume, low match density — re-decide at F10 |
 | WelcomeToTheJungle | deferred | search backend keys rotate per-run and are referer-locked — fragile |
 | TrueUp / Remote Rocketship / DevRelX / Tecnoempleo / JobFluent | rejected for now | no structured public feed found |
+| DOU.ua | adopted (v1.30.0) | RSS at `/vacancies/feeds/` is DOU's own interface (`utm_source=jobsrss`); `robots.txt` names no AI bots and allows the path; legal §2.5 forbids automated collection without consent and §3.2 licenses content CC BY-NC-SA — fine for a self-hosted personal tool with the link-back kept, a hosted or commercial deployment needs written consent. Fetched with the project User-Agent (the default RSS UA gets 403) (2026-09-03) |
 | Jooble | rejected | documented API, but "a total lifetime limit of 500 requests per key", snippets only, API terms unpublished (2026-09-03) |
 | Reed.co.uk | rejected | `robots.txt` `Disallow: /api/` in the group that names AnthropicBot (2026-09-03) |
 | Bundesagentur für Arbeit Jobsuche | rejected | an app backend behind a leaked client id, not a published API; Nutzungsbedingungen 2a(3) forbid reading content through interfaces for data collection (2026-09-03) |

--- a/docs/country-search-plan.md
+++ b/docs/country-search-plan.md
@@ -575,7 +575,12 @@ adopted or rejected.
 - `DOU` fetcher: RSS, `atsToken` = the query string (`category=PHP&remote`);
   title grammar parser `<Title> в <Company>[, $salary][, City…][, за
   кордоном][, віддалено]` as a pure function with tests; entities decoded
-  after XML parsing; salary USD ranges kept in the description.
+  after XML parsing; salary USD ranges kept in the description. *(done:
+  v1.30.0 — `dou-title.ts` reads the tail from the end so "Stape, Inc" keeps
+  its comma; the token is re-serialised through URLSearchParams because an
+  unencoded city answers 400; an unknown category answers an empty channel,
+  so the /companies probe refuses a query with no items; DOU blocks the
+  default RSS User-Agent, the feed is fetched with the project's)*
 - `DJINNI` fetcher: RSS, `atsToken` = the filter string
   (`primary_keyword=PHP&employment=remote&region=UKR`); company from prose
   or blank; region hint from the filter itself.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "applypack",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "private": true,
-  "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 22 sources, 5 swappable AI backends, your data in your own Postgres.",
+  "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 23 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",
   "author": "Nazar Boyko (https://github.com/nazboyko)",
   "repository": {

--- a/prisma/migrations/20260903190000_add_dou/migration.sql
+++ b/prisma/migrations/20260903190000_add_dou/migration.sql
@@ -1,0 +1,4 @@
+-- Stage 3b (plan §4.2): DOU.ua as a source. One Company row per feed query
+-- string (category / city / remote / search); the feed is DOU's own
+-- interface (utm_source=jobsrss) and is fetched with link-back kept.
+ALTER TYPE "AtsType" ADD VALUE 'DOU';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,8 @@ enum AtsType {
   PINPOINT
   RIPPLING
   FOURDAYWEEK
+  // Stage 3b: DOU.ua RSS, one row per query string (category / city / remote / search).
+  DOU
   // Phase 8.2: pasted by hand on /jobs/new. One inactive Company row per
   // employer; runAllFetchers never touches it.
   MANUAL

--- a/src/ats-probe.ts
+++ b/src/ats-probe.ts
@@ -1,5 +1,6 @@
 import { AtsType } from '@prisma/client';
 import { fetchWithRetry, HttpError } from './http';
+import { douFeedUrl } from './fetchers/dou';
 
 export interface ProbeResult {
   ok: boolean;
@@ -95,6 +96,15 @@ export async function probeAts(
           { timeoutMs: 8_000, init: { redirect: 'error' } },
         );
         break;
+      case AtsType.DOU: {
+        // The token is a feed query, not a slug: an unknown category answers
+        // an EMPTY channel (verified 2026-09-03), so "no items" is the failure.
+        const feed = await fetchWithRetry(douFeedUrl(trimmed), { timeoutMs: 8_000 });
+        const items = ((await feed.text()).match(/<item>/g) ?? []).length;
+        return items > 0
+          ? { ok: true, jobsCount: items }
+          : { ok: false, error: 'DOU answered no vacancies for this query — check the category spelling.' };
+      }
       case AtsType.SMARTRECRUITERS:
         resp = await fetchWithRetry(
           `https://api.smartrecruiters.com/v1/companies/${encodeURIComponent(trimmed)}/postings?limit=1`,

--- a/src/fetchers/dou-title.test.ts
+++ b/src/fetchers/dou-title.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { insideParens, parseDouTitle } from './dou-title';
+
+// Titles recorded from the PHP feed on 2026-09-03.
+describe('parseDouTitle', () => {
+  it('splits role, company and the markers', () => {
+    assert.deepEqual(parseDouTitle('Backend Engineer Core Team (Go + PHP) в BetterMe, Київ, за кордоном, віддалено'), {
+      title: 'Backend Engineer Core Team (Go + PHP)',
+      company: 'BetterMe',
+      salary: null,
+      places: ['Київ'],
+      remote: true,
+      abroad: true,
+    });
+  });
+
+  it('keeps a comma inside the company name', () => {
+    const t = parseDouTitle('PHP Team Lead в Stape, Inc, за кордоном, віддалено');
+    assert.equal(t.company, 'Stape, Inc');
+    assert.deepEqual(t.places, []);
+    assert.ok(t.remote && t.abroad);
+  });
+
+  it('reads the salary and a foreign city with its country in parentheses', () => {
+    assert.deepEqual(parseDouTitle('Senior Full-Stack Developer (PHP / Go / Vue.js) в Starlight Media, $2000–2500, віддалено'), {
+      title: 'Senior Full-Stack Developer (PHP / Go / Vue.js)',
+      company: 'Starlight Media',
+      salary: '$2000–2500',
+      places: [],
+      remote: true,
+      abroad: false,
+    });
+    const lisbon = parseDouTitle('fullstack engineer (php + angular) в meetFrankie, Лісабон (Португалія), віддалено');
+    assert.equal(lisbon.company, 'meetFrankie');
+    assert.deepEqual(lisbon.places, ['Лісабон (Португалія)']);
+  });
+
+  it('a Cyrillic city the gazetteer lacks is still a place; a Latin tail is the company', () => {
+    assert.deepEqual(parseDouTitle('Middle+ PHP Developer (with DevOps) в SendPulse, Чернігів, віддалено').places, ['Чернігів']);
+    assert.equal(parseDouTitle('Developer в Acme, LLC').company, 'Acme, LLC');
+  });
+
+  it('an office-only posting is not remote', () => {
+    const t = parseDouTitle('Senior PHP Yii2 Developer в iPOST, Київ');
+    assert.deepEqual([t.remote, t.abroad, t.places, t.company], [false, false, ['Київ'], 'iPOST']);
+  });
+
+  it('a title without " в " is just a title', () => {
+    assert.deepEqual(parseDouTitle('  PHP  Developer '), { title: 'PHP Developer', company: null, salary: null, places: [], remote: false, abroad: false });
+  });
+
+  it('insideParens', () => {
+    assert.equal(insideParens('Лісабон (Португалія)'), 'Португалія');
+    assert.equal(insideParens('Київ'), '');
+  });
+});

--- a/src/fetchers/dou-title.ts
+++ b/src/fetchers/dou-title.ts
@@ -1,0 +1,68 @@
+import { findCountry } from '../countries';
+
+/**
+ * DOU.ua puts everything but the description into the item title (stage 3b,
+ * verified live 2026-09-03):
+ *
+ *   <Title> в <Company>[, $salary][, City…][, за кордоном][, віддалено]
+ *
+ * "PHP Team Lead в Stape, Inc, за кордоном, віддалено" — the company itself
+ * may hold a comma, so the tail is read from the END: salary, the two fixed
+ * markers and places are peeled off while they are recognisable; whatever
+ * is left in front of them is the company. Pure, no I/O.
+ */
+
+/** " в " — the Ukrainian "at", with the spaces DOU always puts around it. */
+const AT_SEPARATOR = ' в ';
+const REMOTE_MARKER = 'віддалено';
+const ABROAD_MARKER = 'за кордоном';
+/** "$2000–2500", "$800–1300", "€3000" — a currency sign then digits. */
+const SALARY_RE = /^[$€£]\s?\d[\d\s.,–-]*$/u;
+/** A segment written in Cyrillic is a place even when the gazetteer lacks it ("Чернігів"). */
+const CYRILLIC_RE = /\p{Script=Cyrillic}/u;
+
+export interface DouTitle {
+  /** The role, without the " в Company…" tail. */
+  title: string;
+  company: string | null;
+  salary: string | null;
+  /** Cities as DOU wrote them ("Київ", "Лісабон (Португалія)"). */
+  places: string[];
+  remote: boolean;
+  /** "за кордоном": the employer also hires abroad. */
+  abroad: boolean;
+}
+
+export function parseDouTitle(raw: string): DouTitle {
+  const text = raw.replace(/\s+/g, ' ').trim();
+  const at = text.indexOf(AT_SEPARATOR);
+  if (at === -1) {
+    return { title: text, company: null, salary: null, places: [], remote: false, abroad: false };
+  }
+  const title = text.slice(0, at).trim();
+  const segments = text.slice(at + AT_SEPARATOR.length).split(',').map((s) => s.trim()).filter(Boolean);
+
+  const out: DouTitle = { title, company: null, salary: null, places: [], remote: false, abroad: false };
+  // Peel the tail from the end; stop at the first segment that is none of
+  // the known kinds — that one and everything before it is the company.
+  while (segments.length > 1) {
+    const last = segments[segments.length - 1]!;
+    if (last === REMOTE_MARKER) out.remote = true;
+    else if (last === ABROAD_MARKER) out.abroad = true;
+    else if (SALARY_RE.test(last)) out.salary = last;
+    else if (isPlace(last)) out.places.unshift(last);
+    else break;
+    segments.pop();
+  }
+  out.company = segments.join(', ') || null;
+  return out;
+}
+
+function isPlace(segment: string): boolean {
+  return findCountry(segment) !== null || findCountry(insideParens(segment)) !== null || CYRILLIC_RE.test(segment);
+}
+
+/** "Лісабон (Португалія)" → "Португалія"; '' when there are no parentheses. */
+export function insideParens(s: string): string {
+  return /\(([^)]+)\)/.exec(s)?.[1] ?? '';
+}

--- a/src/fetchers/dou.test.ts
+++ b/src/fetchers/dou.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { douFeedUrl, mapDouItem, type DouItem } from './dou';
+
+const COMPANY_ID = 3001;
+
+// Recorded from `?category=PHP&remote` on 2026-09-03 (descriptions trimmed).
+const betterme: DouItem = {
+  title: 'Backend Engineer Core Team (Go + PHP) в BetterMe, Київ, за кордоном, віддалено',
+  link: 'https://jobs.dou.ua/companies/betterme/vacancies/332846/?utm_source=jobsrss',
+  guid: 'https://jobs.dou.ua/companies/betterme/vacancies/332846/?1788429748',
+  pubDate: 'Thu, 03 Sep 2026 13:02:28 +0300',
+  content: '<p><strong>About us:</strong></p><p><strong>BetterMe</strong>&nbsp;— an all-in-one well-being ecosystem.</p><ul><li>Go and PHP</li></ul>',
+};
+
+const starlight: DouItem = {
+  title: 'Senior Full-Stack Developer (PHP / Go / Vue.js) в Starlight Media, $2000–2500, віддалено',
+  link: 'https://jobs.dou.ua/companies/starlight-media/vacancies/371880/?utm_source=jobsrss',
+  pubDate: 'Wed, 02 Sep 2026 10:00:00 +0300',
+  content: '<p>Ми шукаємо розробника.</p>',
+};
+
+describe('douFeedUrl', () => {
+  it('keeps the known keys, encodes values and writes remote bare', () => {
+    assert.equal(douFeedUrl('category=PHP&remote'), 'https://jobs.dou.ua/vacancies/feeds/?category=PHP&remote');
+    assert.equal(douFeedUrl('?category=Front End&city=Київ'), 'https://jobs.dou.ua/vacancies/feeds/?category=Front%20End&city=%D0%9A%D0%B8%D1%97%D0%B2');
+    assert.equal(douFeedUrl('search=laravel&exp=5plus&page=2'), 'https://jobs.dou.ua/vacancies/feeds/?search=laravel&exp=5plus&page=2');
+  });
+
+  it('drops unknown keys and an empty token is the newest fifty', () => {
+    assert.equal(douFeedUrl('category=PHP&utm_source=x'), 'https://jobs.dou.ua/vacancies/feeds/?category=PHP');
+    assert.equal(douFeedUrl(''), 'https://jobs.dou.ua/vacancies/feeds/');
+  });
+});
+
+describe('mapDouItem', () => {
+  it('maps the title grammar into title, employer, location and hints', () => {
+    const job = mapDouItem(betterme, COMPANY_ID);
+    assert.ok(job);
+    assert.equal(job.externalId, '332846');
+    assert.equal(job.title, 'Backend Engineer Core Team (Go + PHP)');
+    assert.equal(job.url, betterme.link);
+    assert.equal(job.location, 'Київ, за кордоном, віддалено');
+    assert.match(job.description, /^Hiring company: BetterMe\.\n\nAbout us:/);
+    assert.match(job.description, /BetterMe — an all-in-one well-being ecosystem\./);
+    assert.match(job.description, /• Go and PHP/);
+    assert.equal(job.postedAt.toISOString(), '2026-09-03T10:02:28.000Z');
+    assert.deepEqual(job.locationHints, { workplace: 'REMOTE', countries: ['UA'] });
+  });
+
+  it('folds the salary into the description and reads a foreign city through its country', () => {
+    const job = mapDouItem(starlight, COMPANY_ID);
+    assert.ok(job);
+    assert.match(job.description, /^Hiring company: Starlight Media\. Salary: \$2000–2500\.\n\nМи шукаємо розробника\./);
+    assert.equal(job.location, 'віддалено');
+    const lisbon = mapDouItem({ ...starlight, title: 'PHP Developer в meetFrankie, Лісабон (Португалія)' }, COMPANY_ID);
+    assert.equal(lisbon?.location, 'Лісабон (Португалія)');
+    assert.deepEqual(lisbon?.locationHints, { workplace: 'UNKNOWN', countries: ['PT'] });
+  });
+
+  it('falls back to the feed key when the link has no vacancy id, and skips an item with nothing', () => {
+    const odd = mapDouItem({ ...starlight, link: 'https://jobs.dou.ua/x' }, COMPANY_ID);
+    assert.ok(odd && odd.externalId.length > 0);
+    assert.equal(mapDouItem({ title: '' }, COMPANY_ID), null);
+  });
+});

--- a/src/fetchers/dou.ts
+++ b/src/fetchers/dou.ts
@@ -1,0 +1,106 @@
+import Parser from 'rss-parser';
+import { findCountry } from '../countries';
+import { stripHtml } from '../http';
+import { feedItemKey } from '../text-utils';
+import type { NormalizedJob } from '../types';
+import { insideParens, parseDouTitle } from './dou-title';
+
+/**
+ * DOU.ua — the Ukrainian tech job board (stage 3b, plan §4.2). The RSS at
+ * `/vacancies/feeds/` is DOU's own interface (every link carries
+ * `utm_source=jobsrss`) and takes the same filters as the site:
+ *   category=PHP (59 names)   city=Київ   remote   search=laravel
+ *   exp=0-1|1-3|3-5|5plus     page=2
+ * bare = the 50 newest, filtered = 25 a page. One Company row per query
+ * string, which is the `atsToken` ("category=PHP&remote"). Verified live
+ * 2026-09-03: an unknown category answers an EMPTY channel (not an error)
+ * and an unencoded city answers HTTP 400 — so the token is re-serialised
+ * through URLSearchParams and the probe refuses a query with no items.
+ *
+ * Terms (plan §0.5): fine for a self-hosted personal tool with the link-back
+ * kept; a hosted or commercial deployment needs DOU's written consent.
+ *
+ * The title carries everything but the description — role, company,
+ * salary, cities, "за кордоном", "віддалено" — see dou-title.ts.
+ */
+const FEED_URL = 'https://jobs.dou.ua/vacancies/feeds/';
+const PARSER_TIMEOUT_MS = 15_000;
+/** The query keys the feed understands; anything else is dropped from the token. */
+const FEED_PARAMS = ['category', 'city', 'remote', 'search', 'exp', 'page'] as const;
+
+export interface DouItem {
+  title?: string;
+  link?: string;
+  pubDate?: string;
+  content?: string;
+  contentSnippet?: string;
+  guid?: string;
+}
+
+const parser: Parser<unknown, DouItem> = new Parser({ timeout: PARSER_TIMEOUT_MS });
+
+export interface DouCompany {
+  id: number;
+  /** The feed's query string: "category=PHP&remote", "search=laravel", "" for the newest 50. */
+  atsToken: string;
+}
+
+export async function fetchDou(company: DouCompany): Promise<NormalizedJob[]> {
+  const feed = await parser.parseURL(douFeedUrl(company.atsToken));
+  return feed.items.flatMap((item) => mapDouItem(item, company.id) ?? []);
+}
+
+/** The token as a feed URL: known keys only, values encoded, `remote` kept bare as DOU writes it. */
+export function douFeedUrl(token: string): string {
+  const given = new URLSearchParams(token.trim().replace(/^\?/, ''));
+  const parts: string[] = [];
+  for (const key of FEED_PARAMS) {
+    if (!given.has(key)) continue;
+    const value = given.get(key) ?? '';
+    parts.push(key === 'remote' ? 'remote' : `${key}=${encodeURIComponent(value)}`);
+  }
+  return parts.length > 0 ? `${FEED_URL}?${parts.join('&')}` : FEED_URL;
+}
+
+/**
+ * Pure mapper. The employer goes into the description ("Hiring company: …")
+ * as every aggregator's does; the location string keeps DOU's own words
+ * ("Київ, за кордоном, віддалено") so the parser reads the city and the
+ * classifier reads the rest.
+ */
+export function mapDouItem(item: DouItem, companyId: number): NormalizedJob | null {
+  const link = item.link ?? '';
+  const externalId = vacancyId(link) ?? feedItemKey(link, item.title);
+  if (!externalId) return null;
+  const parsed = parseDouTitle(item.title ?? '');
+  const location = [...parsed.places, parsed.abroad ? 'за кордоном' : '', parsed.remote ? 'віддалено' : '']
+    .filter((s) => s.length > 0)
+    .join(', ');
+  const header = [
+    parsed.company ? `Hiring company: ${parsed.company}.` : '',
+    parsed.salary ? `Salary: ${parsed.salary}.` : '',
+  ]
+    .filter((s) => s.length > 0)
+    .join(' ');
+  // `content` is the HTML DOU escaped into the XML; rss-parser hands it back
+  // as HTML, and stripHtml decodes entities first (gotcha 12).
+  const body = stripHtml(item.content ?? item.contentSnippet ?? '');
+  return {
+    companyId,
+    externalId,
+    title: parsed.title || item.title || 'Untitled',
+    url: link,
+    location,
+    description: header && body ? `${header}\n\n${body}` : header || body,
+    postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+    locationHints: {
+      workplace: parsed.remote ? 'REMOTE' : 'UNKNOWN',
+      countries: parsed.places.flatMap((p) => findCountry(p)?.code ?? findCountry(insideParens(p))?.code ?? []),
+    },
+  } satisfies NormalizedJob;
+}
+
+/** "…/vacancies/332846/?utm_source=jobsrss" → "332846": stable across feeds and re-fetches. */
+function vacancyId(link: string): string | null {
+  return /\/vacancies\/(\d+)\//.exec(link)?.[1] ?? null;
+}

--- a/src/fetchers/dou.ts
+++ b/src/fetchers/dou.ts
@@ -1,6 +1,6 @@
 import Parser from 'rss-parser';
 import { findCountry } from '../countries';
-import { stripHtml } from '../http';
+import { fetchWithRetry, stripHtml } from '../http';
 import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
 import { insideParens, parseDouTitle } from './dou-title';
@@ -22,6 +22,10 @@ import { insideParens, parseDouTitle } from './dou-title';
  *
  * The title carries everything but the description — role, company,
  * salary, cities, "за кордоном", "віддалено" — see dou-title.ts.
+ *
+ * DOU answers rss-parser's own User-Agent with 403 (measured 2026-09-03),
+ * so the feed is fetched with the project's UA through fetchWithRetry and
+ * only parsed by rss-parser.
  */
 const FEED_URL = 'https://jobs.dou.ua/vacancies/feeds/';
 const PARSER_TIMEOUT_MS = 15_000;
@@ -46,7 +50,8 @@ export interface DouCompany {
 }
 
 export async function fetchDou(company: DouCompany): Promise<NormalizedJob[]> {
-  const feed = await parser.parseURL(douFeedUrl(company.atsToken));
+  const resp = await fetchWithRetry(douFeedUrl(company.atsToken), { timeoutMs: PARSER_TIMEOUT_MS });
+  const feed = await parser.parseString(await resp.text());
   return feed.items.flatMap((item) => mapDouItem(item, company.id) ?? []);
 }
 

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -35,6 +35,7 @@ import { fetchBamboo } from './bamboohr';
 import { fetchPinpoint } from './pinpoint';
 import { fetchRippling } from './rippling';
 import { fetchFourDayWeek } from './fourdayweek';
+import { fetchDou } from './dou';
 import type { NormalizedJob } from '../types';
 
 const POLITE_DELAY_MS = 1_000;
@@ -206,6 +207,8 @@ export async function fetchOne(
       return fetchRippling({ id: company.id, atsToken: company.atsToken });
     case AtsType.FOURDAYWEEK:
       return fetchFourDayWeek(company.id, context);
+    case AtsType.DOU:
+      return fetchDou({ id: company.id, atsToken: company.atsToken });
     case AtsType.MANUAL:
       // Pasted by hand on /jobs/new — nothing to fetch (and the row is inactive).
       return [];

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -221,6 +221,17 @@ const SEED_COMPANIES: SeedCompany[] = [
     active: false,
   },
 
+  // DOU.ua (stage 3b) — one row per feed query; the reference deployment's
+  // own search is PHP, so that is the seeded example. Off until a search
+  // hunts in Ukraine; add other queries on /companies (category=…, search=…).
+  {
+    name: 'DOU · PHP, remote',
+    atsType: AtsType.DOU,
+    atsToken: 'category=PHP&remote',
+    careerUrl: 'https://jobs.dou.ua/vacancies/?category=PHP&remote',
+    active: false,
+  },
+
   // HN /jobs — individual YC-job posts indexed by Algolia under
   // tags=job (separate from the monthly Who-is-hiring thread). Each
   // hit is a YC-portfolio company hiring continuously, with the post

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -152,6 +152,7 @@ const PROBEABLE_ATS: AtsType[] = [
   AtsType.BAMBOOHR,
   AtsType.PINPOINT,
   AtsType.RIPPLING,
+  AtsType.DOU,
 ];
 
 const AGGREGATORS = ['LARAJOBS', 'REMOTEOK', 'REMOTIVE', 'JOBICY', 'WEWORKREMOTELY', 'HN_HIRING'];
@@ -208,6 +209,8 @@ export const CompaniesPage: FC<CompaniesProps> = ({
       <Hint class="mb-4">
         We probe the public ATS endpoint before saving and refuse invalid tokens. Aggregator
         feeds have no per-company token — those are seeded once via <Code>src/seed.ts</Code>.
+        DOU takes a feed query instead of a slug: <Code>category=PHP&amp;remote</Code>,{' '}
+        <Code>search=laravel</Code>, <Code>city=Львів</Code>.
       </Hint>
       <form
         method="post"

--- a/src/web/routes/companies.tsx
+++ b/src/web/routes/companies.tsx
@@ -42,6 +42,7 @@ const NewCompanySchema = z.object({
     AtsType.BAMBOOHR,
     AtsType.PINPOINT,
     AtsType.RIPPLING,
+    AtsType.DOU,
   ] as const),
   atsToken: z.string().min(1).max(120),
   careerUrl: z.string().url().optional().or(z.literal('')),

--- a/src/web/source-names.ts
+++ b/src/web/source-names.ts
@@ -27,6 +27,7 @@ const SOURCE_NAMES: Record<string, string> = {
   PINPOINT: 'Pinpoint',
   RIPPLING: 'Rippling',
   FOURDAYWEEK: '4 Day Week',
+  DOU: 'DOU',
   MANUAL: 'Manual',
 };
 


### PR DESCRIPTION
Stage 3b of the country-aware search plan ([docs/country-search-plan.md §4.2](docs/country-search-plan.md)), first Ukrainian source: DOU.ua through its own RSS interface, one Company row per feed query. Follows #116 (Arbeitnow, v1.29.0 — stage 3a complete).

## Analysis note (pre-work §4.1, 2026-09-03)

- **Endpoint re-verified with the project User-Agent.** `GET https://jobs.dou.ua/vacancies/feeds/?category=PHP&remote` → 200, `application/rss+xml; charset=utf-8`, 25 items (bare feed: 50; `page=2`: 25 more). Items: `title, link, description, pubDate, guid` — the description is the full posting as escaped HTML, `guid` is the link plus a timestamp, `link` carries `utm_source=jobsrss`. Categories confirmed: PHP, JavaScript, Python, Node.js, Front End, QA, Java, Golang, DevOps, .NET, Ruby, Data Science, Android, Rust; `search=laravel` (13 items), `exp=5plus`, `city=Київ` (percent-encoded; **unencoded → HTTP 400**), `remote` bare or `remote=` alike. **An unknown category answers an empty channel with HTTP 200**, so the `/companies` probe treats "no items" as the failure. **DOU answers rss-parser's default User-Agent with 403** (found by the smoke run, not the curl); the feed is fetched with the project UA through `fetchWithRetry` and only parsed by rss-parser — a pattern the other RSS fetchers may need one day.
- **robots.txt** (jobs.dou.ua): `User-agent: *` disallows only ajax / comment / password paths; a list of SEO crawlers is banned by name; no AI-bot rules; `/vacancies/feeds/` is allowed. Terms as the plan recorded: legal §2.5 forbids automated collection without consent, §3.2 licenses content CC BY-NC-SA; the feed is DOU's own interface with its own `utm_source`, so a self-hosted personal tool that keeps the link-back is fine, a hosted or commercial deployment needs written consent — recorded in the ADR 0005 register and the source's header comment.
- **atsToken shape.** The feed's query string (`category=PHP&remote`, `search=laravel`, `city=Львів`, `exp=5plus`), re-serialised through `URLSearchParams` over the six known keys so a typed city is encoded and a stray `utm_source` is dropped. The add-company form on `/companies` takes it (the ATS select gains DOU; the hint names the shape); the probe fetches the feed and refuses a query with no items. One row is seeded off: "DOU · PHP, remote".
- **Mapping on paper.** The title carries everything but the description: `<Title> в <Company>[, $salary][, City…][, за кордоном][, віддалено]`. `dou-title.ts` reads the tail from the END — salary, the two markers and places are peeled while recognisable, the rest is the company — so "PHP Team Lead в Stape, Inc, за кордоном, віддалено" keeps the employer's comma. A place is anything the gazetteer knows (Cyrillic cities included, "Лісабон (Португалія)" through its parentheses) or any Cyrillic word ("Чернігів"). Employer and salary go into the description header, DOU's own place words into the location string the stage-1 parser reads; hints: `REMOTE` for "віддалено", the countries the places resolve to. `externalId` = the vacancy id in the link (stable across feeds). Description: `content` → `stripHtml` (decode-first, gotcha 12; `&nbsp;` present in the wild).
- **Volume per tick.** One request per row, 25–50 rows; no rate limit stated.

## Verification

- `npm run lint:types && npm test`: 1 441 tests (title grammar incl. the comma-in-company and foreign-city cases, feed URL encoding and key allow-list, the mapper on a recorded fixture, the empty-item skip).
- Migration `20260903190000_add_dou` (`ALTER TYPE "AtsType" ADD VALUE 'DOU'`): hand-written, `prisma format --check` clean, applied on a scratch database from empty.
- Smoke against the live feed: `fetchDou({ atsToken: 'category=PHP&remote' })` → 25 jobs in 0.4 s, every one `REMOTE`, countries UA 7 / PT 1 / none 17 (remote-only titles name no city), no short descriptions; probe `category=PHP&remote` → ok (25), `category=Narnia` → "DOU answered no vacancies for this query — check the category spelling."

## Follow-ups

- Djinni RSS next (`region=UKR|eu|…`, `primary_keyword=`, `employment=remote`; company only in prose), then the UA-friendly pack refresh (N-iX, Ajax, Genesis; re-probe `sigmasoftware`).
- Plan §4.3 "Enable sources for your countries": DOU rows are the first candidates for that card (UA in the searches → suggest `category=<primary stack>&remote`).
- `extractAtsToken` does not recognise a pasted `jobs.dou.ua/vacancies/?category=…` URL yet; the form takes the query string as is.

## Release notes (draft, v1.30.0)

**DOU.ua as a source.** The Ukrainian tech job board through its own RSS: one Companies row per feed query (`category=PHP&remote`, `search=laravel`, `city=Львів`), probed before saving. Role, employer, salary, cities and "віддалено" are read from the title, so the location and country columns fill from the first fetch. Seeded off as "DOU · PHP, remote"; switch it on when a search hunts in Ukraine. Self-hosted personal use with the link-back kept is within DOU's terms; a hosted or commercial deployment needs their consent. Plan §4.2, stage 3b.
