### PR TITLE
UA-friendly starter pack re-probed: add N-iX, Ajax Systems, Genesis; drop Sigma Software (stage 3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.32.0] — 2026-09-03
+
+### Changed
+- **The "UA-friendly remote" starter pack was re-probed and refreshed**
+  (stage 3b, plan §4.2). Every board was hit live: Preply 104 postings,
+  Solidgate 54, MacPaw 18, Gcore 13, Restream 8, Wirex 6, Skylum 4, Lemon.io
+  2, Reface 1, Namecheap 0 (an empty board, kept — the board is real). Sigma
+  Software's SmartRecruiters board holds one legacy posting since the company
+  moved hiring to its own site, so it leaves the pack (ADR 0017: a legacy
+  board is not shipped). Three Ukrainian employers join, each identified by
+  the board's own name field: N-iX (Greenhouse `nix`, 121 postings, 53 in
+  Ukraine), Ajax Systems (Lever `ajax`, 201, 112 in Ukraine), Genesis
+  (Breezy `gen-tech`, 85, 77 in Ukraine). Thirteen entries now.
+
 ## [1.31.0] — 2026-09-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ roadmap item.
 
 | | |
 | --- | --- |
-| 🔭 **22 source integrations, checked hourly** | The number counts *kinds* of board, not companies: ten ATS vendors — Greenhouse, Lever, Ashby, Workable, SmartRecruiters, Recruitee, Breezy, BambooHR, Pinpoint, Rippling — on as many companies as you care to add, plus 11 cross-company aggregators and the monthly HN "Who is hiring" thread. Curated **starter packs** add a whole segment of companies at once |
+| 🔭 **24 source integrations, checked hourly** | The number counts *kinds* of board, not companies: ten ATS vendors — Greenhouse, Lever, Ashby, Workable, SmartRecruiters, Recruitee, Breezy, BambooHR, Pinpoint, Rippling — on as many companies as you care to add, plus 13 cross-company aggregators (DOU and Djinni for Ukraine among them) and the monthly HN "Who is hiring" thread. Curated **starter packs** add a whole segment of companies at once |
 | 🚀 **A guided first run** | `/welcome` walks a first install through connecting an AI, proving the search works, turning a resume into a profile, and scoring the first matches — four clicks and one file pick |
 | 🎯 **Several searches at once** | Backend and QA, or contract and full-time: each search has its own stack, thresholds, resume and Telegram chat, and up to eight run in parallel. One AI call per posting scores all of them, so a second direction costs almost nothing |
 | 🧠 **A classifier with strict rules** | AI reads the full description against your stack, role types, seniority, regions and salary floor. "Full-stack" in a title is not a tech match, and "Remote · Germany" is not a US-remote job |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1141,9 +1141,9 @@ seeded inactive. Sources verified 2026-09-03 with robots.txt are in the plan
       v1.27.0, 4dayweek `country` v1.28.0, Arbeitnow paginated + visa row
       v1.29.0 — the installed aggregators follow the searches through the
       `FetchContext`, so §4.3's card is for new sources only);
-      3b Ukraine (DOU RSS — **done** v1.30.0; Djinni RSS — **done**
-      v1.31.0; UA-friendly pack + N-iX / Ajax / Genesis, re-probe
-      `sigmasoftware`); 3c EU boards (solid.jobs,
+      3b Ukraine — **done** (DOU RSS v1.30.0; Djinni RSS v1.31.0;
+      UA-friendly pack refreshed v1.32.0: + N-iX / Ajax / Genesis,
+      `sigmasoftware` dropped); 3c EU boards (solid.jobs,
       GermanTechJobs / DevITjobs, Landing.jobs Atom, JobTech); 3d EU ATS
       types (Personio, Teamtailor; later Homerun, d.vinci); 3e keyed
       (France Travail, Adzuna) only after the robots-vs-licence decision.

--- a/docs/country-search-plan.md
+++ b/docs/country-search-plan.md
@@ -592,6 +592,10 @@ adopted or rejected.
   categories — "Fullstack", not "Full Stack"; no "React")*
 - Starter pack "UA-friendly remote": add N-iX, Ajax Systems, Genesis;
   re-probe the eleven existing entries; drop or replace `sigmasoftware`.
+  *(done: v1.32.0 — all eleven re-probed live, Sigma Software dropped (one
+  legacy posting), the three added with their boards' own name fields
+  checked: "N-iX", company "Genesis", "Ajax Systems" in every description;
+  Namecheap answers an empty board and is kept)*
 - Docs line on DOU terms (self-hosted personal use, link-back kept).
 
 **3c — European boards without a key**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.31.0",
+      "version": "1.32.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/starter-packs/catalog.json
+++ b/src/starter-packs/catalog.json
@@ -115,8 +115,10 @@
     { "name": "Skylum", "segment": "ua-friendly", "atsType": "BAMBOOHR", "atsToken": "skylum" },
     { "name": "Lemon.io", "segment": "ua-friendly", "atsType": "BAMBOOHR", "atsToken": "lemonio" },
     { "name": "Namecheap", "segment": "ua-friendly", "atsType": "RECRUITEE", "atsToken": "namecheap" },
-    { "name": "Sigma Software", "segment": "ua-friendly", "atsType": "SMARTRECRUITERS", "atsToken": "sigmasoftware" },
     { "name": "Gcore", "segment": "ua-friendly", "atsType": "SMARTRECRUITERS", "atsToken": "gcore" },
-    { "name": "Wirex", "segment": "ua-friendly", "atsType": "BAMBOOHR", "atsToken": "wirex" }
+    { "name": "Wirex", "segment": "ua-friendly", "atsType": "BAMBOOHR", "atsToken": "wirex" },
+    { "name": "N-iX", "segment": "ua-friendly", "atsType": "GREENHOUSE", "atsToken": "nix" },
+    { "name": "Ajax Systems", "segment": "ua-friendly", "atsType": "LEVER", "atsToken": "ajax" },
+    { "name": "Genesis", "segment": "ua-friendly", "atsType": "BREEZY", "atsToken": "gen-tech" }
   ]
 }


### PR DESCRIPTION
Stage 3b of the country-aware search plan ([docs/country-search-plan.md §4.2](docs/country-search-plan.md)), last item: the "UA-friendly remote" starter pack re-probed live and refreshed. Follows #118 (Djinni, v1.31.0). Closes stage 3b.

## Analysis note (pre-work §4.1, 2026-09-03)

Every entry of the segment and the three candidates were fetched through the real fetchers with the project User-Agent (`fetchOne` per row, countries from the stage-1 parser):

| Board | Postings | Where | Verdict |
|---|---|---|---|
| Preply · Ashby `preply` | 104 | ES 42, GB 29, UA 24 | keep |
| Solidgate · Ashby `solidgate` | 54 | UA 30, UA+PL 7 | keep |
| MacPaw · Recruitee `macpaw` | 18 | UA 16 | keep |
| Gcore · SmartRecruiters `gcore` | 13 | GE/PL/RS/CY | keep — SmartRecruiters does answer with rows here, so gotcha 13's "0 for everyone" is per board, not global |
| Restream · Ashby `restream` | 8 | CZ 6 | keep |
| Wirex · BambooHR `wirex` | 6 | no country in the list rows | keep |
| Skylum · BambooHR `skylum` | 4 | — | keep |
| Lemon.io · BambooHR `lemonio` | 2 | — | keep |
| Reface · Breezy `reface` | 1 | UA | keep |
| Namecheap · Recruitee `namecheap` | **0** (`{"offers":[]}`, 200) | — | keep — a real, empty board; ADR 0019 treats `empty` as alive |
| Sigma Software · SmartRecruiters `sigmasoftware` | 1 ("Junior Test Engineer") | UA | **drop** — one legacy posting since hiring moved to the company's own site (plan §0.5); a legacy board is not shipped (ADR 0017) |
| **N-iX** · Greenhouse `nix` | 121 | UA 53, PL 10, RO 5 | **add** — board meta `name: "N-iX"` |
| **Ajax Systems** · Lever `ajax` | 201 | UA 112, IT 12, PL 8, TR 8 | **add** — every description opens "Ajax Systems is an international tech company…" |
| **Genesis** · Breezy `gen-tech` | 85 | UA 77 | **add** — position payload `company.name: "Genesis"`, `friendly_id: "gen-tech"` |

Identity was read from the boards' own fields, as ADR 0017 asks — not inferred from a probe hit. Nothing else changed: the segment blurb names no companies; the resolver, the preview and the import are untouched.

## Verification

- `npm run lint:types && npm test`: the catalog tests (unique tokens, every segment non-empty, every entry's vendor in the resolve order) pass on 13 entries.
- The table above is the smoke: 14 live fetches, one per board, 2026-09-03.

## Follow-ups

- Plan §4.3 "Enable sources for your countries" — with DOU and Djinni token-driven and this pack refreshed, the card can offer, for a search that lists UA: the pack, plus one DOU row and one Djinni row built from the search's primary stack.
- Namecheap's board is empty today; if it stays empty across a few weeks, drop it in the next refresh.

## Release notes (draft, v1.32.0)

**The UA-friendly starter pack, re-probed.** N-iX, Ajax Systems and Genesis join (121, 201 and 85 live postings, most in Ukraine); Sigma Software leaves — its board holds one legacy posting since hiring moved to the company's own site. Every remaining board was hit live and identified by its own name field. Stage 3b of the country-aware search plan is complete: DOU, Djinni and this pack.
