### PR TITLE
Sources for your searches (plan §4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.33.0] — 2026-09-03
+
+### Added
+- **Sources for your searches** (plan §4.3). Companies gets a card listing
+  the token-driven feeds the running searches' countries call for, built
+  from each search's stack: a search that names Ukraine gets DOU and Djinni
+  rows (`category=PHP&remote`, `primary_keyword=Laravel&employment=remote&region=UKR`),
+  a search that names Germany or the UK gets the two Arbeitnow rows. Each
+  row shows its state — Add (off), Enable, or On — and "Add" probes the feed
+  first, so a category the board does not know never becomes a silent empty
+  source; rows are added switched off, like a starter pack (ADR 0017).
+  Saving a search that has such feeds waiting says so in the flash. The
+  aggregators that already follow the searches (Jobicy, Himalayas,
+  4dayweek) need no suggestion and get none.
+
 ## [1.32.0] — 2026-09-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Where the running searches hunt, handed to every fetcher (`FetchContext`: union of countries + regions; anywhere = empty) | `src/fetchers/fetch-context.ts:searchPlaces` (pure) built once per tick in `fetchers/index.ts:runAllFetchers`; a source with a geo filter maps it (`jobicy.ts:jobicySlugsFor`, `himalayas.ts:himalayasUrls`, `fourdayweek.ts:fourDayWeekPlaces`), the rest ignore it |
 | Per-source health (error→status, failure streak, quiet/silent) | `src/fetchers/source-health.ts` (pure, ADR 0019); recorded by the wrapper in `fetchers/index.ts:runAllFetchers` |
 | Apply-link flags (missing / unusable / shortened / not-an-application) | `src/apply-link.ts` (pure, ADR 0023); merged into `Job.redFlags` at all three persist paths |
+| Which token-driven feeds a search's countries call for (DOU / Djinni for UA, Arbeitnow for DE / GB), and their state | `src/starter-packs/suggest.ts:suggestSources(searches, tracked)` (pure) → the "Sources for your searches" card on `/companies` (`POST /companies/suggested` probes, then adds off); the profile save flash counts what is waiting |
 | Where a SEARCH hunts (countries / regions / workplace on the profile), the set filter with group expansion | `prisma/schema.prisma:Profile` (ADR 0032) → `src/profiles.ts:ProfileInput` → `src/filter.ts:locationMatches` / `placesOverlap` (pure); the prompt line `classifier.ts:describeLocation` (codes only); the editor control `pages/settings.tsx` Location fieldset + `public/countries.mjs` over `GET /countries.json` |
 | The classifier's own reading of a posting's place, and how it meets the parser's | reply block `location` in `classifier.ts:LocationBlockSchema` → `src/jobs/location-merge.ts:mergeAiLocation` (pure: fill or narrow, never blank; `locationSource = 'ai'`) at all three write paths |
 | Why a verdict says "location mismatch" | `src/jobs/location-reason.ts:locationMismatchReason` (pure, columns only) → the Classifier card on `/jobs/:id` |
@@ -253,6 +254,7 @@ When the question is **"how does the user toggle / configure X?"**:
 | Paste an AI key without touching `.env` | `/settings` AI engine tab → the key row on each engine card, or step 1 of `/welcome` (ADR 0027) |
 | Add / remove tracked company | `/companies` (with manual probe before save) |
 | Bulk-add a curated segment of companies | `/companies` → "Add a starter pack" (preview → confirm → added disabled → "Enable all") |
+| Get the DOU / Djinni / Arbeitnow feeds a search's countries call for | `/companies` → "Sources for your searches" (shown when a running search names UA, DE, AT, CH or GB; Add (off) probes first, then the row's toggle enables it) |
 | Disable whole ATS family (e.g. all Workable) | `/settings` Sources tab |
 | Enable two-stage classifier (cheaper, less precise) | `/settings` AI engine tab → "Classifier" |
 | Edit profile (stack, role types, regions, fit threshold) | `/settings` Profile tab (excludes, notes, priority rules, thresholds live in its "Advanced" block) |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1143,7 +1143,8 @@ seeded inactive. Sources verified 2026-09-03 with robots.txt are in the plan
       `FetchContext`, so §4.3's card is for new sources only);
       3b Ukraine — **done** (DOU RSS v1.30.0; Djinni RSS v1.31.0;
       UA-friendly pack refreshed v1.32.0: + N-iX / Ajax / Genesis,
-      `sigmasoftware` dropped); 3c EU boards (solid.jobs,
+      `sigmasoftware` dropped); §4.3 "Sources for your searches" card —
+      **done** v1.33.0; 3c EU boards (solid.jobs,
       GermanTechJobs / DevITjobs, Landing.jobs Atom, JobTech); 3d EU ATS
       types (Personio, Teamtailor; later Homerun, d.vinci); 3e keyed
       (France Travail, Adzuna) only after the robots-vs-licence decision.

--- a/docs/country-search-plan.md
+++ b/docs/country-search-plan.md
@@ -641,6 +641,15 @@ This is the starter-pack flow (ADR 0017) reused, driven by a pure
 `src/starter-packs/`. Small countries on an hourly tick will often report
 `empty`; ADR 0019's two signals already handle that.
 
+*Done: v1.33.0 — `src/starter-packs/suggest.ts:suggestSources(searches,
+tracked)` and the "Sources for your searches" card on `/companies`. Amended
+against the text above: the card lives on Companies (where the rows are),
+the profile save only points at it; each row has one button for its state
+(Add off / Enable / On) instead of a preview step, because a suggestion is
+one known feed, not a list to resolve; and only the token-driven sources
+are suggested — Jobicy, Himalayas and 4dayweek follow the searches by
+themselves since 3a.*
+
 ### 4.4 Definition of done (per source)
 
 - Smoke run stores real rows with correct `countries` / `workplace` from

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/starter-packs/suggest.test.ts
+++ b/src/starter-packs/suggest.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { suggestSources, type SuggestSearch } from './suggest';
+
+const php: SuggestSearch = {
+  name: 'PHP/Laravel',
+  countries: ['UA', 'PL'],
+  regions: ['EU'],
+  workplace: ['REMOTE'],
+  stackRequired: ['php', 'laravel', 'mysql'],
+};
+
+describe('suggestSources', () => {
+  it('offers DOU and Djinni rows for a search that names Ukraine, from its stack', () => {
+    const out = suggestSources([php], []);
+    assert.deepEqual(
+      out.map((s) => [s.atsType, s.atsToken, s.name, s.state]),
+      [
+        ['DOU', 'category=PHP&remote', 'DOU · PHP, remote', 'missing'],
+        ['DJINNI', 'primary_keyword=PHP&employment=remote&region=UKR', 'Djinni · PHP, remote, Ukraine', 'missing'],
+        ['DJINNI', 'primary_keyword=Laravel&employment=remote&region=UKR', 'Djinni · Laravel, remote, Ukraine', 'missing'],
+      ],
+    );
+    assert.equal(out[0]?.reason, '🇺🇦 Ukraine in "PHP/Laravel"');
+    assert.equal(out[0]?.careerUrl, 'https://jobs.dou.ua/vacancies/?category=PHP&remote');
+  });
+
+  it('drops the remote filters for an office-only search and caps the feeds per search', () => {
+    const office = { ...php, workplace: ['ONSITE' as const], stackRequired: ['php', 'javascript', 'python', 'java', 'go'] };
+    const out = suggestSources([office], []);
+    assert.deepEqual(out.filter((s) => s.atsType === 'DOU').map((s) => s.atsToken), ['category=PHP', 'category=JavaScript', 'category=Python']);
+    assert.deepEqual(out.filter((s) => s.atsType === 'DJINNI').map((s) => s.atsToken), [
+      'primary_keyword=PHP&region=UKR',
+      'primary_keyword=JavaScript&region=UKR',
+      'primary_keyword=Python&region=UKR',
+    ]);
+  });
+
+  it('reads the state from the rows already tracked', () => {
+    const out = suggestSources([php], [
+      { id: 7, atsType: 'DOU', atsToken: 'category=PHP&remote', active: false },
+      { id: 8, atsType: 'DJINNI', atsToken: 'primary_keyword=PHP&employment=remote&region=UKR', active: true },
+    ]);
+    assert.deepEqual(out.map((s) => [s.state, s.companyId]), [['off', 7], ['on', 8], ['missing', null]]);
+  });
+
+  it('offers the two Arbeitnow rows for German-speaking and British searches', () => {
+    const de = { ...php, countries: ['DE'], regions: [], stackRequired: ['java'] };
+    const out = suggestSources([de], [{ id: 3, atsType: 'ARBEITNOW', atsToken: 'arbeitnow', active: false }]);
+    assert.deepEqual(out.map((s) => [s.atsType, s.atsToken, s.state]), [['ARBEITNOW', 'arbeitnow', 'off'], ['ARBEITNOW', 'visa', 'missing']]);
+    assert.equal(suggestSources([{ ...de, countries: [], regions: ['DACH'] }], []).length, 2);
+    assert.equal(suggestSources([{ ...de, countries: ['FR'], regions: ['EU'] }], []).length, 0);
+  });
+
+  it('says nothing for a search with no matching place, and merges two searches without duplicates', () => {
+    assert.deepEqual(suggestSources([{ ...php, countries: ['US'], regions: [] }], []), []);
+    const two = suggestSources([php, { ...php, name: 'Second', stackRequired: ['php'] }], []);
+    assert.equal(two.filter((s) => s.atsToken === 'category=PHP&remote').length, 1);
+  });
+
+  it('a stack with no known feed name offers nothing for that source', () => {
+    const out = suggestSources([{ ...php, stackRequired: ['cobol'] }], []);
+    assert.deepEqual(out, []);
+  });
+});

--- a/src/starter-packs/suggest.ts
+++ b/src/starter-packs/suggest.ts
@@ -1,0 +1,131 @@
+import type { WorkplaceCode } from '../location';
+
+/*
+ * "Enable sources for your countries" (plan §4.3): the token-driven sources
+ * a search's places and stack call for — DOU and Djinni rows for Ukraine,
+ * the Arbeitnow rows for the German-speaking and British markets. Pure: the
+ * route hands in the running searches and the rows already tracked, gets
+ * back what to offer and in which state. The aggregators that follow the
+ * searches by themselves (Jobicy, Himalayas, 4dayweek) need no suggestion.
+ */
+
+export interface SuggestSearch {
+  name: string;
+  countries: string[];
+  regions: string[];
+  workplace: WorkplaceCode[];
+  stackRequired: string[];
+}
+
+export interface TrackedRow {
+  id: number;
+  atsType: string;
+  atsToken: string;
+  active: boolean;
+}
+
+export interface SourceSuggestion {
+  name: string;
+  atsType: 'DOU' | 'DJINNI' | 'ARBEITNOW';
+  atsToken: string;
+  careerUrl: string;
+  /** Which search asked for it, in plain words: "🇺🇦 Ukraine in "PHP/Laravel"". */
+  reason: string;
+  /** missing = not tracked yet; off = tracked, inactive; on = running. */
+  state: 'missing' | 'off' | 'on';
+  companyId: number | null;
+}
+
+/** DOU `category=` names the feed knows (verified live 2026-09-03), by stack tag. */
+const DOU_CATEGORY: Readonly<Record<string, string>> = {
+  php: 'PHP', laravel: 'PHP', symfony: 'PHP', wordpress: 'PHP',
+  javascript: 'JavaScript', typescript: 'JavaScript', react: 'Front End', vue: 'Front End', angular: 'Front End',
+  node: 'Node.js', nodejs: 'Node.js', 'node.js': 'Node.js',
+  python: 'Python', django: 'Python', fastapi: 'Python',
+  java: 'Java', spring: 'Java', kotlin: 'Android',
+  go: 'Golang', golang: 'Golang',
+  'c#': '.NET', '.net': '.NET', dotnet: '.NET',
+  ruby: 'Ruby', rails: 'Ruby', rust: 'Rust',
+  qa: 'QA', devops: 'DevOps', kubernetes: 'DevOps',
+};
+
+/** Djinni `primary_keyword=` values from its channel category list (168, verified live 2026-09-03). */
+const DJINNI_KEYWORD: Readonly<Record<string, string>> = {
+  php: 'PHP', laravel: 'Laravel', symfony: 'PHP', wordpress: 'PHP',
+  javascript: 'JavaScript', typescript: 'JavaScript', react: 'JavaScript', vue: 'JavaScript', angular: 'JavaScript',
+  node: 'Node.js', nodejs: 'Node.js', 'node.js': 'Node.js',
+  python: 'Python', django: 'Python', fastapi: 'Python',
+  java: 'Java', spring: 'Java', kotlin: 'Java',
+  go: 'Golang', golang: 'Golang',
+  ruby: 'Ruby', rails: 'Ruby', rust: 'Rust',
+  qa: 'QA', devops: 'DevOps', kubernetes: 'DevOps',
+};
+
+/** At most this many DOU and Djinni rows per search — a search rarely wants more feeds than that. */
+const MAX_FEEDS_PER_SEARCH = 3;
+
+/** The countries and groups that make Arbeitnow worth switching on. */
+const ARBEITNOW_COUNTRIES = ['DE', 'AT', 'CH', 'GB'];
+const ARBEITNOW_REGIONS = ['DACH', 'UK_IE'];
+
+export function suggestSources(searches: readonly SuggestSearch[], tracked: readonly TrackedRow[]): SourceSuggestion[] {
+  const byKey = new Map(tracked.map((r) => [`${r.atsType}:${r.atsToken}`, r]));
+  const out = new Map<string, SourceSuggestion>();
+  const offer = (s: Omit<SourceSuggestion, 'state' | 'companyId'>) => {
+    const key = `${s.atsType}:${s.atsToken}`;
+    if (out.has(key)) return;
+    const row = byKey.get(key);
+    out.set(key, { ...s, state: row ? (row.active ? 'on' : 'off') : 'missing', companyId: row?.id ?? null });
+  };
+
+  for (const search of searches) {
+    const remote = search.workplace.length === 0 || search.workplace.includes('REMOTE');
+    if (search.countries.includes('UA') || search.regions.includes('CEE')) {
+      const reason = `🇺🇦 Ukraine in "${search.name}"`;
+      for (const category of pick(search.stackRequired, DOU_CATEGORY)) {
+        offer({
+          name: `DOU · ${category}${remote ? ', remote' : ''}`,
+          atsType: 'DOU',
+          atsToken: `category=${category}${remote ? '&remote' : ''}`,
+          careerUrl: `https://jobs.dou.ua/vacancies/?category=${encodeURIComponent(category)}${remote ? '&remote' : ''}`,
+          reason,
+        });
+      }
+      for (const keyword of pick(search.stackRequired, DJINNI_KEYWORD)) {
+        const employment = remote ? '&employment=remote' : '';
+        offer({
+          name: `Djinni · ${keyword}${remote ? ', remote' : ''}, Ukraine`,
+          atsType: 'DJINNI',
+          atsToken: `primary_keyword=${keyword}${employment}&region=UKR`,
+          careerUrl: `https://djinni.co/jobs/?primary_keyword=${encodeURIComponent(keyword)}${employment}&region=UKR`,
+          reason,
+        });
+      }
+    }
+    const germanOrBritish =
+      search.countries.some((c) => ARBEITNOW_COUNTRIES.includes(c)) || search.regions.some((r) => ARBEITNOW_REGIONS.includes(r));
+    if (germanOrBritish) {
+      const reason = `🇩🇪🇬🇧 Germany or the UK in "${search.name}"`;
+      offer({ name: 'Arbeitnow Feed', atsType: 'ARBEITNOW', atsToken: 'arbeitnow', careerUrl: 'https://www.arbeitnow.com', reason });
+      offer({
+        name: 'Arbeitnow · visa sponsorship',
+        atsType: 'ARBEITNOW',
+        atsToken: 'visa',
+        careerUrl: 'https://www.arbeitnow.com/?visa_sponsorship=true',
+        reason,
+      });
+    }
+  }
+  return [...out.values()];
+}
+
+/** The feed names a stack maps to, in the stack's order, once each, capped. */
+function pick(stack: readonly string[], table: Readonly<Record<string, string>>): string[] {
+  const names: string[] = [];
+  for (const tag of stack) {
+    const name = table[tag.trim().toLowerCase()];
+    if (name && !names.includes(name)) names.push(name);
+    if (names.length === MAX_FEEDS_PER_SEARCH) break;
+  }
+  return names;
+}

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../fetchers/source-health';
 import type { FlashMessage } from '../flash';
 import { StarterPackPicker, type PackSegmentChoice } from './starter-pack';
+import type { SourceSuggestion } from '../../starter-packs/suggest';
 
 interface CompanyRow {
   id: number;
@@ -54,6 +55,8 @@ interface CompanyRow {
 export interface CompaniesProps {
   companies: CompanyRow[];
   packs: PackSegmentChoice[];
+  /** Token-driven sources the running searches' countries call for (plan §4.3). */
+  suggestions: SourceSuggestion[];
   flash?: FlashMessage | null;
   fetchingEnabled: boolean;
 }
@@ -158,9 +161,54 @@ const PROBEABLE_ATS: AtsType[] = [
 
 const AGGREGATORS = ['LARAJOBS', 'REMOTEOK', 'REMOTIVE', 'JOBICY', 'WEWORKREMOTELY', 'HN_HIRING'];
 
+/**
+ * "Enable sources for your countries" (plan §4.3): DOU and Djinni rows for a
+ * search that names Ukraine, the Arbeitnow rows for Germany or the UK, built
+ * from each search's stack. Added off, like a pack; the row's own toggle
+ * switches it on. Nothing to show when no running search names such a place.
+ */
+const SuggestedSources: FC<{ suggestions: SourceSuggestion[] }> = ({ suggestions }) => {
+  if (suggestions.length === 0) return null;
+  return (
+    <Card class="mb-4">
+      <SectionTitle>Sources for your searches</SectionTitle>
+      <Hint class="mb-3">
+        Feeds that fit where your running searches hunt, built from their stack. Added switched off;
+        enable each one when you want it in the hourly tick.
+      </Hint>
+      <ul class="divide-y divide-line">
+        {suggestions.map((s) => (
+          <li class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 py-2">
+            <div class="min-w-0">
+              <div class="text-[13px] font-medium text-ink">{s.name}</div>
+              <div class="truncate text-xs text-ink-faint">
+                {s.reason} · <Code>{s.atsToken}</Code>
+              </div>
+            </div>
+            {s.state === 'missing' && (
+              <form method="post" action="/companies/suggested">
+                <input type="hidden" name="atsType" value={s.atsType} />
+                <input type="hidden" name="atsToken" value={s.atsToken} />
+                <Button size="sm" variant="secondary">Add (off)</Button>
+              </form>
+            )}
+            {s.state === 'off' && s.companyId !== null && (
+              <form method="post" action={`/companies/${s.companyId}/toggle-active`}>
+                <Button size="sm">Enable</Button>
+              </form>
+            )}
+            {s.state === 'on' && <Badge tone="ok">On</Badge>}
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
 export const CompaniesPage: FC<CompaniesProps> = ({
   companies,
   packs,
+  suggestions,
   flash,
   fetchingEnabled,
 }) => (
@@ -203,6 +251,7 @@ export const CompaniesPage: FC<CompaniesProps> = ({
       </div>
     </details>
 
+    <SuggestedSources suggestions={suggestions} />
     <StarterPackPicker segments={packs} />
 
     <Card class="mb-4">

--- a/src/web/routes/companies.tsx
+++ b/src/web/routes/companies.tsx
@@ -15,6 +15,9 @@ import {
   segments as packSegments,
 } from '../../starter-packs/catalog';
 import { resolvePack } from '../../starter-packs/probe';
+import { suggestSources, type SourceSuggestion } from '../../starter-packs/suggest';
+import { listActiveProfiles } from '../../profiles';
+import { isBlankProfile } from '../../profile-guards';
 import {
   boardUrl,
   buildPreview,
@@ -145,12 +148,51 @@ companiesRoute.get('/companies', async (c) => {
     <CompaniesPage
       companies={rows}
       packs={packs}
+      suggestions={await suggestedSources(companies)}
       flash={flash}
       fetchingEnabled={settings.fetchingEnabled}
     />,
     200,
     { 'Set-Cookie': clearFlashCookie() },
   );
+});
+
+// --- sources for the searches' countries (plan §4.3) -----------------------
+
+/** What the running searches' places and stacks call for, against the rows tracked. */
+async function suggestedSources(
+  tracked: readonly { id: number; atsType: string; atsToken: string; active: boolean }[],
+): Promise<SourceSuggestion[]> {
+  const searches = (await listActiveProfiles()).filter((p) => !isBlankProfile(p));
+  return suggestSources(searches, tracked);
+}
+
+const SuggestedAddSchema = z.object({ atsType: z.string(), atsToken: z.string().min(1).max(120) });
+
+/**
+ * Adds one suggested row, inactive like a pack import (ADR 0017). The pair is
+ * recomputed here and must be among today's suggestions — the browser
+ * round-trips it, so it is not trusted; and the feed is probed first, so a
+ * category the board does not know never becomes a silent empty source.
+ */
+companiesRoute.post('/companies/suggested', async (c) => {
+  const form = await c.req.parseBody();
+  const parsed = SuggestedAddSchema.safeParse({ atsType: form.atsType, atsToken: form.atsToken });
+  if (!parsed.success) return redirectWithFlash(c, 'err', 'Invalid form values.');
+  const tracked = await prisma.company.findMany({ select: { id: true, atsType: true, atsToken: true, active: true } });
+  const wanted = (await suggestedSources(tracked)).find(
+    (s) => s.atsType === parsed.data.atsType && s.atsToken === parsed.data.atsToken && s.state === 'missing',
+  );
+  if (!wanted) return redirectWithFlash(c, 'err', 'That source is not among today\'s suggestions.');
+
+  const probe = await probeAts(wanted.atsType, wanted.atsToken);
+  if (!probe.ok) return redirectWithFlash(c, 'err', `Probe failed: ${probe.error}`);
+
+  await prisma.company.create({
+    data: { name: wanted.name, atsType: wanted.atsType, atsToken: wanted.atsToken, careerUrl: wanted.careerUrl, active: false },
+  });
+  logger.info({ name: wanted.name, atsToken: wanted.atsToken, jobs: probe.jobsCount }, 'companies: suggested source added');
+  return redirectWithFlash(c, 'ok', `Added "${wanted.name}" (${probe.jobsCount ?? 0} postings), switched off — enable it when ready.`);
 });
 
 // --- starter packs ----------------------------------------------------------

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -79,6 +79,7 @@ import {
 } from '../../priority-rules';
 import { prisma } from '../../db';
 import { isBlankProfile } from '../../profile-guards';
+import type { Profile } from '@prisma/client';
 import { isSettingsTab, SettingsPage } from '../pages/settings';
 import { sourceLabel } from '../source-names';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
@@ -808,11 +809,6 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
     priorityRules,
   };
   const saved = await updateProfile(id, input);
-  // Plan §4.3: a search that names Ukraine, Germany or the UK has feeds
-  // waiting on /companies; say so once, on the save that made it true.
-  const tracked = await prisma.company.findMany({ select: { id: true, atsType: true, atsToken: true, active: true } });
-  const waiting = suggestSources([saved], tracked).filter((s) => s.state !== 'on').length;
-  const sourcesHint = waiting > 0 ? ` ${waiting} source${waiting === 1 ? '' : 's'} fit these countries — see Companies → "Sources for your searches".` : '';
 
   // The second half of "born inactive" (issue #50): the first save that gives
   // a blank search real content starts it running. Since ADR 0028 that no
@@ -828,6 +824,9 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
   const active = await getActiveProfile();
   const editorUrl =
     active?.id === id ? '/settings?tab=profile' : `/settings?tab=profile&profile=${id}`;
+  // Plan §4.3: a running search that names Ukraine, Germany or the UK has
+  // feeds waiting on /companies — say so on the save, where the countries were picked.
+  const sourcesHint = isActive ? await sourcesWaiting(saved) : '';
 
   if (f.action === 'save-and-reclassify') {
     if (!isActive) {
@@ -856,6 +855,14 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
   }
   return flashRedirect(editorUrl, 'ok', `Search saved.${sourcesHint}`);
 });
+
+/** " 2 sources fit these countries — see Companies → …", or '' when every suggested feed already runs. */
+async function sourcesWaiting(search: Profile): Promise<string> {
+  const tracked = await prisma.company.findMany({ select: { id: true, atsType: true, atsToken: true, active: true } });
+  const waiting = suggestSources([search], tracked).filter((s) => s.state !== 'on').length;
+  if (waiting === 0) return '';
+  return ` ${waiting} source${waiting === 1 ? '' : 's'} fit these countries — see Companies → "Sources for your searches".`;
+}
 
 // Prefill the editor from a resume's AI scan. Renders the draft directly —
 // nothing is saved until the user submits the profile form. With no resumes

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -71,6 +71,7 @@ import { recordCronRun } from '../../jobs/cron-run';
 import { parseTagList, toStringArray } from '../../text-utils';
 import { isRegionCode, resolveCountries } from '../../countries';
 import { isProfileWorkplace } from '../../location';
+import { suggestSources } from '../../starter-packs/suggest';
 import {
   formatPriorityRulesText,
   parsePriorityRules,
@@ -806,7 +807,12 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
     resumeId,
     priorityRules,
   };
-  await updateProfile(id, input);
+  const saved = await updateProfile(id, input);
+  // Plan §4.3: a search that names Ukraine, Germany or the UK has feeds
+  // waiting on /companies; say so once, on the save that made it true.
+  const tracked = await prisma.company.findMany({ select: { id: true, atsType: true, atsToken: true, active: true } });
+  const waiting = suggestSources([saved], tracked).filter((s) => s.state !== 'on').length;
+  const sourcesHint = waiting > 0 ? ` ${waiting} source${waiting === 1 ? '' : 's'} fit these countries — see Companies → "Sources for your searches".` : '';
 
   // The second half of "born inactive" (issue #50): the first save that gives
   // a blank search real content starts it running. Since ADR 0028 that no
@@ -835,11 +841,11 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
     return flashRedirect(
       editorUrl,
       'ok',
-      `Search saved${activated ? ' and started' : ''}. Re-classify started in the background — track progress at /runs.`,
+      `Search saved${activated ? ' and started' : ''}. Re-classify started in the background — track progress at /runs.${sourcesHint}`,
     );
   }
   if (activated) {
-    return flashRedirect(editorUrl, 'ok', 'Search saved and started — it scores new postings from the next tick.');
+    return flashRedirect(editorUrl, 'ok', `Search saved and started — it scores new postings from the next tick.${sourcesHint}`);
   }
   if (!isActive && isBlankProfile(input)) {
     return flashRedirect(
@@ -848,7 +854,7 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
       'Search saved. It stays paused until it lists a required stack or role types.',
     );
   }
-  return flashRedirect(editorUrl, 'ok', 'Search saved.');
+  return flashRedirect(editorUrl, 'ok', `Search saved.${sourcesHint}`);
 });
 
 // Prefill the editor from a resume's AI scan. Renders the draft directly —


### PR DESCRIPTION
Plan §4.3 of the country-aware search plan ([docs/country-search-plan.md](docs/country-search-plan.md)): the "Sources for your searches" card. Follows #119 (UA-friendly pack, v1.32.0).

## Analysis note (pre-work, 2026-09-03)

**What needs suggesting at all.** Since stage 3a the installed aggregators follow the running searches by themselves — Jobicy, Himalayas and 4dayweek read the `FetchContext` and ask for the searches' countries on every tick. What does NOT follow is anything token-driven: DOU and Djinni need one Company row per feed filter, and Arbeitnow's two rows (`arbeitnow`, `visa`) are seeded off. So the card offers exactly those three sources, and only when a running search names a place they serve: UA (or the CEE group) → DOU + Djinni, DE / AT / CH / GB (or DACH / UK_IE) → Arbeitnow. A US-only search sees no card.

**Which feeds, from what.** A DOU or Djinni row is a category, and the category comes from the search's own `stackRequired`: `php`/`laravel` → DOU `category=PHP`, Djinni `primary_keyword=PHP` and `primary_keyword=Laravel`; `react` → DOU `Front End`, Djinni `JavaScript`; and so on through a small table of the names both feeds were verified to know (3b). Three feeds per source per search at most; a stack with no known name (`cobol`) offers nothing rather than guessing. `remote` / `employment=remote` ride along when the search's workplace includes REMOTE (or is empty), and are dropped for an office-only search.

**Amended against the plan text.** The plan sketched a preview → confirm → "Enable all" flow on the profile save. Three simplifications: the card lives on `/companies`, where the rows are and where a probe error can be read; the profile save only points at it in its flash (running searches only); and each row has one button for its state — **Add (off)**, **Enable**, or an **On** badge — because a suggestion is one known feed, not a pack to resolve. Add probes the feed first (`probeAts`), so a DOU category the board does not know never becomes a silent empty source, and the pair the browser posts back is recomputed server-side and must be among today's `missing` suggestions before anything is created.

## Changes

- `src/starter-packs/suggest.ts` (pure): `suggestSources(searches, tracked)` → rows with name, token, career URL, reason and state; tests in `suggest.test.ts`.
- `/companies`: the `SuggestedSources` card above the starter packs; `POST /companies/suggested` (probe → create inactive, ADR 0017); "Enable" reuses the existing toggle.
- Profile save flash: " N sources fit these countries — see Companies → …" when a running search has feeds waiting.
- Docs: CHANGELOG 1.33.0, plan §4.3 note, CLAUDE.md rows, TASKS §15.

## Verification

- `npm run lint:types && npm test`: 1453 pass, 0 fail (6 new tests: DOU + Djinni rows from a UA search's stack; office-only drops the remote filters and caps at 3; state from tracked rows; Arbeitnow for DE and DACH, nothing for FR/EU; no duplicates across searches; unknown stack → nothing).
- Dashboard smoke (Docker, live DB, test search #14 temporarily running with `PL, DE, UA`): the card lists 8 rows — DOU PHP / JavaScript / Node.js, Djinni PHP / Laravel / JavaScript, the two Arbeitnow rows — with the seeded ones as **Enable** and the rest as **Add (off)**. "Add (off)" on Djinni · Laravel → probe → `Added "Djinni · Laravel, remote, Ukraine" (10 postings), switched off`, row created inactive with its career URL, the card flips it to **Enable**. A hand-posted pair that is not suggested (`DOU`, `category=Foo`) → `That source is not among today's suggestions.` Saving the search → `Search saved. 8 sources fit these countries — see Companies → "Sources for your searches".` With only the US searches running the card does not render. Test search reverted and the smoke row deleted afterwards.
- Found while smoking, not caused by this branch: the worker image had not been rebuilt since v1.30.0, so the live enum lacked `DOU` / `DJINNI` until `docker compose build app && up -d app` re-ran `init.ts` (migrations + seed). Both images need a rebuild after a schema merge.

## Follow-ups

- The category tables cover the tags the two feeds were verified to know on 2026-09-03; a new stack tag needs a row there — worth a small guard test against the DOU category list when 3c lands more token-driven boards.
- Stage 3c (EU boards) can add its sources to the same table: one line per source, no new UI.

## Release notes (draft, v1.33.0)

**Sources for your searches.** Companies now lists the feeds your running searches' countries call for, built from each search's stack: a search that names Ukraine gets DOU and Djinni rows, a search that names Germany or the UK gets the two Arbeitnow rows. Each row shows its state — Add (off), Enable, or On — and "Add" probes the feed before creating the row, switched off like a starter pack. Saving a search that has such feeds waiting says so. Plan §4.3; no schema changes.

After merge:
```
git tag -a v1.33.0 -m "Sources for your searches" <merge-sha> && git push origin v1.33.0
```
