### PR TITLE
feat: show a progress bar while a page loads

### DIFF
--- a/src/web/layout.tsx
+++ b/src/web/layout.tsx
@@ -80,6 +80,19 @@ const TOKENS_CSS = `
   :focus-visible { outline: 2px solid rgb(var(--accent)); outline-offset: 2px; border-radius: 4px; }
   .skip-link { position: absolute; left: -999px; top: 8px; z-index: 50; }
   .skip-link:focus { left: 8px; }
+  /* Navigation progress (public/progress.mjs). Above the skip link and the
+     mobile sidebar, so it stays visible whatever is open. The transition
+     matches the script's tick, making the creep continuous rather than steppy;
+     reduced-motion flattens it via the global rule below. */
+  #page-progress {
+    position: fixed; top: 0; left: 0; z-index: 60; height: 3px; width: 100%;
+    background: rgb(var(--accent)); transform: scaleX(0); transform-origin: 0 50%;
+    transition: transform 120ms linear; pointer-events: none;
+    /* Same emerald as the AP mark, but a hairline reads lighter than a solid
+       square — the glow carries the brand colour at this thickness. */
+    box-shadow: 0 0 8px rgb(var(--accent) / 0.55);
+  }
+  #page-progress[hidden] { display: none; }
   @media (max-width: 767.98px) {
     .app-sidebar {
       position: fixed; top: 0; bottom: 0; left: 0; z-index: 40; width: 16rem;
@@ -144,6 +157,11 @@ FORM: Brief-pinned light ops console (Linear density, Stripe forms, GitHub table
 FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review, the verdict, DESIGN.md, and every shipping raster carrying its provenance.
 -->`;
 
+const PROGRESS_BOOT = `
+import { init } from '/static/progress.mjs';
+init();
+`;
+
 const NAV_JS = `
   (function () {
     var toggle = document.getElementById('nav-toggle');
@@ -191,6 +209,7 @@ export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
     </head>
     <body class="bg-surface font-sans text-sm text-ink antialiased">
       {raw(DIRECTION_CONTRACT)}
+      <div id="page-progress" aria-hidden="true" hidden></div>
       <a
         href="#main"
         class="skip-link rounded-md bg-accent-strong px-3 py-1.5 text-sm font-medium text-white"
@@ -214,6 +233,7 @@ export const Layout: FC<PropsWithChildren<LayoutProps>> = ({
       </div>
       <div id="nav-backdrop" class="nav-backdrop" aria-hidden="true"></div>
       <script dangerouslySetInnerHTML={{ __html: NAV_JS }} />
+      <script type="module" dangerouslySetInnerHTML={{ __html: PROGRESS_BOOT }} />
     </body>
   </html>
 );

--- a/src/web/progress.test.ts
+++ b/src/web/progress.test.ts
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+interface Link {
+  href: string;
+  target?: string | null;
+  download?: boolean;
+}
+interface Click {
+  defaultPrevented?: boolean;
+  button?: number;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+}
+
+// @ts-expect-error — plain JS with no declaration file; the shape is asserted below.
+const progress = import('./public/progress.mjs') as Promise<{
+  nextWidth: (current: number) => number;
+  shouldTrack: (link: Link | null, event: Click, currentUrl: string) => boolean;
+  init: unknown;
+}>;
+
+const HERE = 'http://127.0.0.1:4747/jobs?status=NEW';
+const plainClick: Click = { button: 0 };
+
+test('nextWidth creeps fast at first and slows toward the ceiling', async () => {
+  const { nextWidth } = await progress;
+  const first = nextWidth(0);
+  const late = nextWidth(80) - 80;
+  assert.ok(first > late, `first step ${first} should outpace late step ${late}`);
+});
+
+test('nextWidth never reaches 100 — only a new document ends the bar', async () => {
+  const { nextWidth } = await progress;
+  let w = 0;
+  for (let i = 0; i < 500; i++) w = nextWidth(w);
+  assert.equal(w, 90);
+});
+
+test('nextWidth keeps a visible floor so a long wait still moves', async () => {
+  const { nextWidth } = await progress;
+  assert.ok(nextWidth(89.9) > 89.9);
+  assert.equal(nextWidth(-5), 0);
+});
+
+test('shouldTrack follows an ordinary in-app link', async () => {
+  const { shouldTrack } = await progress;
+  assert.equal(shouldTrack({ href: 'http://127.0.0.1:4747/settings' }, plainClick, HERE), true);
+});
+
+test('shouldTrack ignores clicks that open somewhere else', async () => {
+  const { shouldTrack } = await progress;
+  const link = { href: 'http://127.0.0.1:4747/settings' };
+  assert.equal(shouldTrack({ ...link, target: '_blank' }, plainClick, HERE), false);
+  assert.equal(shouldTrack({ ...link, download: true }, plainClick, HERE), false);
+  assert.equal(shouldTrack(link, { ...plainClick, metaKey: true }, HERE), false);
+  assert.equal(shouldTrack(link, { ...plainClick, ctrlKey: true }, HERE), false);
+  assert.equal(shouldTrack(link, { button: 1 }, HERE), false);
+});
+
+test('shouldTrack ignores a link another handler already cancelled', async () => {
+  const { shouldTrack } = await progress;
+  const link = { href: 'http://127.0.0.1:4747/settings' };
+  assert.equal(shouldTrack(link, { ...plainClick, defaultPrevented: true }, HERE), false);
+});
+
+test('shouldTrack ignores anything that is not an http(s) page load', async () => {
+  const { shouldTrack } = await progress;
+  assert.equal(shouldTrack({ href: 'mailto:a@b.co' }, plainClick, HERE), false);
+  assert.equal(shouldTrack({ href: 'https://greenhouse.io/jobs/1' }, plainClick, HERE), false);
+  assert.equal(shouldTrack({ href: '' }, plainClick, HERE), false);
+  assert.equal(shouldTrack(null, plainClick, HERE), false);
+});
+
+test('shouldTrack ignores a fragment on the current page but follows one elsewhere', async () => {
+  const { shouldTrack } = await progress;
+  // The layout's skip link and #stages on settings only scroll.
+  assert.equal(shouldTrack({ href: `${HERE}#main` }, plainClick, HERE), false);
+  assert.equal(
+    shouldTrack({ href: 'http://127.0.0.1:4747/settings#stages' }, plainClick, HERE),
+    true,
+  );
+});

--- a/src/web/public/progress.mjs
+++ b/src/web/public/progress.mjs
@@ -1,0 +1,151 @@
+/**
+ * Navigation progress bar. The dashboard is server-rendered, so every link and
+ * every form submit is a full document load — between the click and the first
+ * byte nothing on screen moves, and a slow route (a re-classify, a big /jobs
+ * page) reads as a frozen tab. This draws that wait.
+ *
+ * Nothing here ever completes the bar: the new document replaces it. The one
+ * case that needs cleaning up is bfcache, which restores the old DOM with the
+ * bar still frozen mid-creep.
+ */
+
+// A warm local page swaps well under this, so the bar appears only when the
+// wait is real — otherwise every click flashes a bar for one frame.
+const SHOW_DELAY_MS = 150;
+const TICK_MS = 120;
+// Never reached on our own: the bar finishes by being replaced, so an
+// unexpectedly slow route keeps creeping instead of sitting at a fake 100%.
+const CEILING = 90;
+const MIN_STEP = 0.4;
+const EASE = 0.12;
+
+/**
+ * How far the bar creeps in one tick — large steps early, asymptotic near the
+ * ceiling. The floor keeps it visibly alive on a long wait, where proportional
+ * steps alone would round to nothing.
+ */
+export function nextWidth(current) {
+  if (!(current >= 0)) return 0;
+  if (current >= CEILING) return CEILING;
+  const step = Math.max(MIN_STEP, (CEILING - current) * EASE);
+  return Math.min(CEILING, current + step);
+}
+
+/**
+ * Whether clicking `link` replaces the current document. Everything that lands
+ * somewhere else — a new tab, a download, a mail client — or that only scrolls
+ * the page must leave the bar alone, because no load follows and nothing would
+ * ever take the bar away.
+ *
+ * `link` is a plain shape ({ href, target, download }) rather than an element,
+ * so the decision is testable without a DOM.
+ */
+export function shouldTrack(link, event, currentUrl) {
+  if (!link || typeof link.href !== 'string' || link.href.length === 0) return false;
+  if (event.defaultPrevented) return false;
+  // Anything but an unmodified left click opens elsewhere or does nothing.
+  if (event.button !== undefined && event.button !== 0) return false;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false;
+  if (link.target && link.target !== '_self') return false;
+  if (link.download) return false;
+
+  let target;
+  let here;
+  try {
+    target = new URL(link.href, currentUrl);
+    here = new URL(currentUrl);
+  } catch {
+    return false;
+  }
+  // mailto:, tel:, javascript: — the page stays put.
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') return false;
+  if (target.origin !== here.origin) return false;
+  // Same page, different fragment: the browser scrolls, it does not load.
+  // Live cases: the layout's "Skip to content" (#main) and #stages on settings.
+  if (target.hash && target.pathname === here.pathname && target.search === here.search) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Wires the bar to navigations.
+ *
+ * Both listeners sit in the BUBBLE phase on purpose. The dashboard's delete
+ * forms carry `if(!confirm(...))return false;` in their onsubmit attribute
+ * (ui.tsx ActionForm), and that runs at the target — a capture listener would
+ * start the bar before the user answers, then leave it stuck forever when they
+ * cancel. By the time the event bubbles up here, defaultPrevented tells the
+ * truth.
+ */
+export function init() {
+  const bar = document.getElementById('page-progress');
+  if (!bar) return;
+
+  const reduced =
+    typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let showTimer = null;
+  let tickTimer = null;
+  let width = 0;
+
+  function paint() {
+    bar.style.transform = `scaleX(${width / 100})`;
+  }
+
+  function start() {
+    if (showTimer !== null || tickTimer !== null) return;
+    showTimer = setTimeout(() => {
+      showTimer = null;
+      bar.hidden = false;
+      if (reduced) {
+        // No creep to watch: show the whole bar and leave it until the
+        // document is replaced.
+        width = CEILING;
+        paint();
+        return;
+      }
+      width = 0;
+      paint();
+      tickTimer = setInterval(() => {
+        width = nextWidth(width);
+        paint();
+      }, TICK_MS);
+    }, SHOW_DELAY_MS);
+  }
+
+  function stop() {
+    if (showTimer !== null) clearTimeout(showTimer);
+    if (tickTimer !== null) clearInterval(tickTimer);
+    showTimer = null;
+    tickTimer = null;
+    width = 0;
+    bar.hidden = true;
+    paint();
+  }
+
+  document.addEventListener('click', (event) => {
+    const anchor = event.target instanceof Element ? event.target.closest('a[href]') : null;
+    if (!anchor) return;
+    const link = {
+      href: anchor.href,
+      target: anchor.getAttribute('target'),
+      download: anchor.hasAttribute('download'),
+    };
+    if (shouldTrack(link, event, location.href)) start();
+  });
+
+  document.addEventListener('submit', (event) => {
+    if (!event.defaultPrevented) start();
+  });
+
+  // Restoring from bfcache brings back the DOM as it was — bar included.
+  addEventListener('pageshow', (event) => {
+    if (event.persisted) stop();
+  });
+
+  // Escape is how a browser cancels a load in progress; the bar has to go with
+  // it, or it sits there describing a navigation that is no longer happening.
+  addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') stop();
+  });
+}


### PR DESCRIPTION
The dashboard is server-rendered, so every link and every form submit is a
full document load. Between the click and the first byte nothing moves, and
a slow route — a big `/jobs` page, a re-classify — reads as a frozen tab.
This draws that wait: a 3px emerald line across the top.

## How it behaves

- Waits **150ms** before appearing, so fast navigations never flash a bar.
- Creeps asymptotically toward 90% and never completes on its own — the new
  document carries it away. A slow route keeps moving instead of parking at
  a fake 100%.
- Stays quiet where no load follows: `#` fragments (the layout skip link,
  `#stages` on settings), `target=_blank`, downloads, `mailto:`,
  ctrl/cmd-click, external hosts.
- Clears itself on bfcache restore and on Escape, which is how a browser
  cancels a load in flight.

## The one that nearly shipped broken

Both listeners are in the **bubble** phase, not capture. `ActionForm` puts
`if(!confirm(...))return false;` in the onsubmit attribute (`ui.tsx`), and
that runs at the target — a capture listener starts the bar *before* the
user answers, then leaves it stuck forever when they hit Cancel. Every
delete confirmation in the dashboard would have done it. Verified against
the real `/companies/:id/delete` form: cancelling now leaves no bar, and
the company is still there.

## Files

| File | |
|---|---|
| `src/web/public/progress.mjs` | new — dependency-free ES module, per the `public/` convention |
| `src/web/progress.test.ts` | new — 8 tests over the two pure functions |
| `src/web/layout.tsx` | markup, CSS on the `--accent` token, module boot |

Static files are served straight from `src/web/public`, so the `.mjs` needs
no build step.

## Verification

- `npm run lint:types` clean; `npm test` 1455 pass, 0 fail (8 new)
- In the browser: link click starts it, skip link does not, cancelled
  confirm leaves nothing stuck, Escape clears it, 0 console errors
- Screenshots at 1200 / 768 / 375; bar sits above the open mobile sidebar
  (z-index 60 vs 40)
- Colour asserted programmatically against the sidebar mark rather than by
  eye: both compute to `rgb(5, 150, 105)`

## Known scope

- Deliberately does **not** cover the in-place AI calls (Compare, Verify,
  Generate). Those need a completion signal per route; they already have
  their own progress pages.
- The bubble-phase behaviour is covered by browser verification, not a unit
  test — the pure half (`shouldTrack`, `nextWidth`) is what the suite holds.