### PR TITLE
Eligibility: where you live and whether you would move (stage 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.40.0] — 2026-09-04
+
+### Added
+- **Where you live, and whether you would move** (plan §5, ADR 0033). A
+  search now says "I live in" and picks one of three: I stay where I am,
+  I would relocate, I would relocate and need visa sponsorship. The
+  classifier reads both: a role open only to places you cannot work from
+  matches only if the posting itself opens it — relocation, sponsorship,
+  an employer of record or a contract abroad — and it flags
+  `work-permit-required` or `no-visa-sponsorship` when it does not.
+- **"Open to me"** on Jobs: only the roles a search of yours can actually
+  take, read from the same per-search verdict the fit chips read.
+- The job page says why a role is closed to you when the columns can prove
+  it: "open to European Union; you live in Ukraine and this search does not
+  relocate".
+- Telegram alerts show the country flags and the arrangement.
+
+### Schema
+- `Profile.residence`, `Profile.relocation` (migration
+  `20260904000000_add_profile_eligibility`).
+
 ## [1.39.0] — 2026-09-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Per-source health (error→status, failure streak, quiet/silent) | `src/fetchers/source-health.ts` (pure, ADR 0019); recorded by the wrapper in `fetchers/index.ts:runAllFetchers` |
 | Apply-link flags (missing / unusable / shortened / not-an-application) | `src/apply-link.ts` (pure, ADR 0023); merged into `Job.redFlags` at all three persist paths |
 | Which token-driven feeds a search's countries call for (DOU / Djinni for UA, Arbeitnow for DE / GB), and their state | `src/starter-packs/suggest.ts:suggestSources(searches, tracked)` (pure) → the "Sources for your searches" card on `/companies` (`POST /companies/suggested` probes, then adds off); the profile save flash counts what is waiting |
+| Where the candidate LIVES and whether they would move (ADR 0033) | `prisma/schema.prisma:Profile.residence / .relocation` → `src/eligibility.ts` (pure: the three relocation choices, `residenceCovered`) → the prompt's ELIGIBILITY block in `classifier.ts:describeEligibility` → the sentence in `jobs/location-reason.ts:livingReason`; editor on `/settings` → Profile → Location |
 | Where a SEARCH hunts (countries / regions / workplace on the profile), the set filter with group expansion | `prisma/schema.prisma:Profile` (ADR 0032) → `src/profiles.ts:ProfileInput` → `src/filter.ts:locationMatches` / `placesOverlap` (pure); the prompt line `classifier.ts:describeLocation` (codes only); the editor control `pages/settings.tsx` Location fieldset + `public/countries.mjs` over `GET /countries.json` |
 | The classifier's own reading of a posting's place, and how it meets the parser's | reply block `location` in `classifier.ts:LocationBlockSchema` → `src/jobs/location-merge.ts:mergeAiLocation` (pure: fill or narrow, never blank; `locationSource = 'ai'`) at all three write paths |
 | Why a verdict says "location mismatch" | `src/jobs/location-reason.ts:locationMismatchReason` (pure, columns only) → the Classifier card on `/jobs/:id` |
@@ -258,12 +259,14 @@ When the question is **"how does the user toggle / configure X?"**:
 | Disable whole ATS family (e.g. all Workable) | `/settings` Sources tab |
 | Enable two-stage classifier (cheaper, less precise) | `/settings` AI engine tab → "Classifier" |
 | Edit profile (stack, role types, regions, fit threshold) | `/settings` Profile tab (excludes, notes, priority rules, thresholds live in its "Advanced" block) |
+| Say where you live and whether you would relocate | `/settings` Profile tab → "Location" → "I live in" + the three relocation choices (ADR 0033); both stay empty-ish by default, and then nothing changes |
 | Say where a search hunts (countries, groups, remote / hybrid / on-site) | `/settings` Profile tab → "Location": arrangement pills, the Countries chip input (type "Poland", "Polska", "PL" or a city, pick from the list; any spelling works without JS), region pills (🇪🇺 European Union, Europe, DACH, 🌍 Worldwide …). Empty countries + regions = anywhere |
 | Fill the profile from a resume (AI draft, review before save) | `/settings` Profile tab → "Fill from a resume" |
 | Create a second search from another resume | `/resumes/:id` → "Search profile" card, or `/welcome?step=profile` → "Another resume for a different kind of role?" |
 | Which resume a search hunts with | `/settings` Profile tab → "Resume for this search" (empty = pick by skill overlap) |
 | Run / pause a search, or make one primary | `/settings` Profile tab → "Searches" list (up to 8 running; the primary always runs) |
 | See only one search's matches | `/jobs` → the search chips (the Fit column then shows that search's score) |
+| See only roles you could actually take from where you live | `/jobs` → the "Open to me" chip (reads each search's own location verdict; set "I live in" on `/settings` → Profile → Location first) |
 | See jobs in one country, region or arrangement, or posted this week | `/jobs` → the "Where" chips (🇵🇱 Poland, 🇪🇺 European Union, Unknown … — OR within the row, "More…" opens the rest), the "Work" chips (Remote / Hybrid / On-site / Unknown) and the "Posted" chips; the search box also matches the location string |
 | Fill the country columns on jobs stored before v1.24 | `docker compose exec app node dist/scripts/backfill-locations.js --dry-run`, read the distribution, then without the flag (no AI call; `location` and `description` untouched) |
 | What each search made of one posting | `/jobs/:id` → Classifier card → "By search" |

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1146,7 +1146,7 @@ seeded inactive. Sources verified 2026-09-03 with robots.txt are in the plan
       `sigmasoftware` dropped); §4.3 "Sources for your searches" card —
       **done** v1.33.0; 3c EU boards (solid.jobs **done** v1.34.0,
       DevITjobs family **done** v1.35.0, Landing.jobs **done** v1.36.0, JobTech **done** v1.37.0 — 3c complete,
-      3d Personio **done** v1.38.0, Teamtailor **done** v1.39.0,
+      3d Personio **done** v1.38.0, Teamtailor **done** v1.39.0 — 3d complete;
       GermanTechJobs / DevITjobs, Landing.jobs Atom, JobTech); 3d EU ATS
       types (Personio, Teamtailor; later Homerun, d.vinci); 3e keyed
       (France Travail, Adzuna) only after the robots-vs-licence decision.

--- a/docs/adr/0033-residence-and-relocation.md
+++ b/docs/adr/0033-residence-and-relocation.md
@@ -1,0 +1,72 @@
+# 0033 — A search says where its candidate lives; the model decides whether a posting is open to them
+
+**Status:** Accepted (2026-09-04)
+
+## Context
+
+ADR 0032 gave a search the job's vocabulary: `countries`, `regions`,
+`workplace`. That answers "where do I want to work". It cannot answer the
+question a Ukrainian, Polish or Indian candidate actually asks — "can I take
+this job from where I am". The two are different: a search that lists `PL`
+and `DE` is a wish; a candidate living in Ukraine still needs a work permit
+for a Warsaw office, and "Remote · EU only" means EU work rights, not EU
+geography.
+
+Nothing in the pipeline knew that. The classifier's location rules read the
+search's list against the posting's place, so "Remote · EU only" matched a
+search listing EU no matter who was doing the searching, and an on-site
+Berlin role matched anyone who had ticked Germany. The verdict was
+technically right and practically useless.
+
+Measured before this change, over the 1 059 stored postings: 115 mention
+"sponsorship" and only 12 state a policy. Of 24 sampled hits, 7 were real
+("authorized to work in the United States without … employer-sponsored work
+authorization"), 3 were the ATS application-form question scraped into the
+description, and 14 were benefits or an org chart ("co-sponsored Multisport
+card", "under the direct sponsorship of the CTO"). A keyword rule over that
+corpus would produce more noise than signal.
+
+## Decision
+
+**Two new fields on the search, and one rule about who decides.**
+
+- `Profile.residence` (ISO-2, nullable) — where the candidate lives now.
+  A fact, not a wish; it is never added to the places a search hunts in.
+- `Profile.relocation` (`no` | `yes` | `sponsorship`) — whether they would
+  move, and whether a visa has to come with the job.
+
+**The model decides eligibility; the code explains it.** The classifier
+prompt gains an ELIGIBILITY block (four lines, sent only once) and a
+per-search line naming the residence and the relocation choice — emitted
+only when one of them is set, so a search that does not care pays nothing.
+The two new red flags, `work-permit-required` and `no-visa-sponsorship`,
+are model verdicts like every other flag. `filter.ts` stays out of it: the
+evidence lives in prose that a regex reads wrong three times out of four.
+
+**Silence is not a refusal.** A posting that says nothing about permits
+keeps the verdict the ADR 0032 rules gave it. The absence of a sentence is
+not evidence, and a stricter default would hide most of the market.
+
+**The code answers only what the columns prove.** `src/eligibility.ts` is
+pure: the vocabulary, and `residenceCovered(job, residence)` — is this
+posting's own list of places one the candidate lives in, read through the
+gazetteer's groups. That is enough for the job page to say "open to
+European Union; you live in Ukraine and this search does not relocate",
+which is the sentence the search's own country list could never produce.
+Whether relocation, sponsorship, an employer of record or a B2B contract
+rescues the posting is left to the model, which read the text.
+
+## Consequences
+
+- `/jobs` gains an "Open to me" filter reading the same per-search
+  `locationMatch` the chips already read — honest now that residence exists.
+- The Telegram line shows the country flags and the arrangement from the
+  ADR 0031 columns, so a phone reader sees the place before the link.
+- The prompt budget guard now measures the worst case a user pays (eight
+  searches that all state a residence) and allows 12 000 characters.
+- Salary in EUR / PLN / GBP is still the model's silent conversion. It is
+  deliberately out of scope here; the plan's §5.0 note records the
+  measurements and recommends conversion constants in code when it lands.
+- A search created before this stage has `residence = null` and
+  `relocation = 'no'`: the eligibility rules stay dormant, and every
+  existing verdict keeps its meaning until the user says where they live.

--- a/docs/country-search-plan.md
+++ b/docs/country-search-plan.md
@@ -711,16 +711,61 @@ question a Ukrainian or any non-US candidate actually has.
 
 ### 5.0 Pre-work analysis
 
-- [ ] Read the stage-2 prompt and its guard tests; list the rules that
+- [x] Read the stage-2 prompt and its guard tests; list the rules that
       change when `residence` and `relocation` exist.
-- [ ] Collect 20 postings with "must have the right to work in …",
+- [x] Collect 20 postings with "must have the right to work in …",
       "no visa sponsorship", "relocation package", "EOR", "B2B contract",
       "remote from Ukraine" — the fixture for the new red flags.
-- [ ] Check how `salary_min_usd` is produced today for EUR / PLN / GBP
+- [x] Check how `salary_min_usd` is produced today for EUR / PLN / GBP
       postings (the model converts?) and how `minSalaryUsd` compares; decide
       between a conversion table with a monthly constant and a per-profile
       currency. Prefer the smaller change; write the alternative down.
-- [ ] Analysis note.
+- [x] Analysis note.
+
+**Findings (2026-09-04, over the 1 059 stored postings and the stage-2
+prompt).**
+
+*Which prompt rules change.* Four of the eight LOCATION lines are written
+as if the only question were where the search hunts. Residence splits them
+in two: a place the candidate may WORK FROM (`countries` / `regions` — the
+search's wish) and a place they may work from LEGALLY today (`residence` —
+a fact). The rules that change: region-locked remote ("EU only" fails a
+UA-resident search even when it lists EU, unless relocation covers it),
+on-site / hybrid (a listed city is enough only when the candidate can
+legally be there, or the posting offers relocation and the search accepts
+it), and the "when in doubt, false" default, which must not fire on a
+posting that says nothing about permits — silence is not a refusal. The
+tech-stack rules and the `location` block are untouched.
+
+*The fixture says the flags must come from the model.* 115 of 1 059
+postings contain "sponsorship"; only 12 state a policy. Sampling 24 hits:
+7 are real ("authorized to work in the United States without … employer-
+sponsored work authorization"; "visa sponsorship is not available for this
+position"; "able to offer visa sponsorship … but do require that someone
+is based in Spain"), 3 are the ATS application-form question scraped into
+the description ("Do you now, or will you in the future, require
+immigration sponsorship … ?"), and 14 are benefits or an org chart
+("co-sponsored Multisport card", "employer-sponsored group medical plan",
+"under the direct sponsorship of the CTO"). A keyword rule would flag more
+noise than signal, so `no-visa-sponsorship` and `work-permit-required` are
+model verdicts, like every other red flag; `filter.ts` stays out of it.
+Volumes for the other phrases: relocation 12, employer-of-record 2,
+B2B 1, work-permit wording 10 — the corpus is US-heavy, so the European
+sources of stage 3 are what will exercise these rules.
+
+*Salary.* The model already converts silently: the prompt asks for
+`salary_min_usd` with no rate and no currency field, `Job.salaryMin` is
+filled on 155 of 1 059 rows, and `Profile.minSalaryUsd` is only a prompt
+line ("lower fit_score for clearly under-market roles") — no code compares
+the two. Non-USD postings are 7 % today (€ 39, PLN 29, £ 7) and will grow
+with solid.jobs (PLN only), DevITjobs (€ / £), Landing.jobs (€) and
+JobTech (SEK). Decision: keep it out of this stage, as §5.1 says, and when
+it lands prefer **conversion constants in code** — the model reports the
+posting's own amount and currency, `src/currency.ts` converts with a table
+reviewed monthly — because that is the only shape where the number can be
+audited and a UA candidate's USD target keeps its meaning. The alternative,
+`minSalary` + `salaryCurrency` on the profile, does not remove the
+conversion, it moves it into the model's head for every comparison.
 
 ### 5.1 Design
 

--- a/docs/country-search-plan.md
+++ b/docs/country-search-plan.md
@@ -787,6 +787,11 @@ conversion, it moves it into the model's head for every comparison.
 - Bench: three gold fixtures with European postings added to
   `bench:resume`-style guard runs for the classifier rules.
 
+*Built (v1.40.0): `Profile.residence` + `Profile.relocation`, the prompt's
+ELIGIBILITY block and per-search line, the two red flags, the residence
+sentence on the job page, "Open to me" on /jobs, flags + arrangement in the
+Telegram line. The salary work stayed out, as this section says.*
+
 ### 5.2 Definition of done
 
 - A UA-resident search sees "Remote · EU only" as a mismatch with the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/prisma/migrations/20260904000000_add_profile_eligibility/migration.sql
+++ b/prisma/migrations/20260904000000_add_profile_eligibility/migration.sql
@@ -1,0 +1,4 @@
+-- Stage 4 (plan §5, ADR 0033): where the candidate lives and whether they
+-- would move. Both are preferences on the search, not facts about a job.
+ALTER TABLE "profile" ADD COLUMN "residence" TEXT;
+ALTER TABLE "profile" ADD COLUMN "relocation" TEXT NOT NULL DEFAULT 'no';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -360,6 +360,11 @@ model Profile {
   regions          String[]        @default([])
   workplace        Workplace[]     @default([REMOTE])
   onsiteCities     String[] // e.g. ["Austin, TX","Berlin"]
+  // Stage 4 (ADR 0033): where the candidate LIVES (ISO-2, null = not said)
+  // and whether they would move — no | yes | sponsorship. `countries` is a
+  // wish, `residence` is a fact; the classifier weighs them separately.
+  residence        String?
+  relocation       String          @default("no")
   // Thresholds
   minSalaryUsd     Int             @default(0) // 0 = don't filter on salary
   minFitScore      Int             @default(70)

--- a/src/classifier.test.ts
+++ b/src/classifier.test.ts
@@ -236,10 +236,35 @@ test('a search describes its place as codes only', () => {
   assert.doesNotMatch(line, /Poland|Germany|European Union/);
 });
 
+test('eligibility rules exist and speak of the candidate, not of a country list (ADR 0033)', () => {
+  const ua = { ...PROFILE, countries: ['PL', 'DE'], regions: ['EU'], residence: 'UA', relocation: 'sponsorship' } as Profile;
+  const { system } = buildClassifyPrompt(input('x'), [ua]);
+  assert.match(system, /- Candidate lives in: UA; would relocate but needs visa sponsorship/);
+  assert.match(system, /where it WANTS to work; "lives in" is where it may work today/);
+  assert.match(system, /Silence is not a refusal/);
+  assert.match(system, /"work-permit-required"/);
+  assert.match(system, /"no-visa-sponsorship"/);
+  assert.equal(system.split('ELIGIBILITY (only for a search').length - 1, 1);
+});
+
+test('a search that says neither residence nor relocation pays nothing for the eligibility line', () => {
+  const { system } = buildClassifyPrompt(input('x'), [{ ...PROFILE, residence: null, relocation: 'no' } as Profile]);
+  assert.doesNotMatch(system, /- Candidate lives in|residence not stated/);
+  // The rules stay: the model needs them for the searches that do say.
+  assert.match(system, /ELIGIBILITY \(only for a search/);
+  const moving = buildClassifyPrompt(input('x'), [{ ...PROFILE, residence: null, relocation: 'yes' } as Profile]).system;
+  assert.match(moving, /- Candidate residence not stated; would relocate, no sponsorship needed/);
+});
+
 test('eight searches keep the system prompt under the budget', () => {
-  const eight = Array.from({ length: 8 }, (_, i) => ({ ...PROFILE, id: 20 + i, name: `Search ${i}` }) as Profile);
+  // The worst case a user actually pays: every search says where its
+  // candidate lives, so the eligibility line repeats eight times on top of
+  // the rules block ADR 0033 added (~790 chars, once).
+  const eight = Array.from({ length: 8 }, (_, i) =>
+    ({ ...PROFILE, id: 20 + i, name: `Search ${i}`, residence: 'UA', relocation: 'sponsorship' }) as Profile,
+  );
   const { system } = buildClassifyPrompt(input('x'), eight);
-  assert.ok(system.length < 11_000, `${system.length} chars`);
+  assert.ok(system.length < 12_000, `${system.length} chars`);
 });
 
 test('the parsed place rides in the user prompt outside the fence', () => {

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { Profile } from '@prisma/client';
+import { RELOCATION_PROMPT, isRelocation } from './eligibility';
 import { logger } from './logger';
 import { extractJson } from './text-utils';
 import { getAiRuntime } from './ai-runtime';
@@ -283,7 +284,7 @@ function describeProfile(profile: Profile): string {
 - Acceptable role types (job category, NOT a tech match by themselves): ${list(profile.roleTypes, '(any role type)')}
 - Nice-to-have stack (boost fit_score when present): ${list(profile.stackNiceToHave, '(none specified)')}
 - Auto-reject signals (drastically lower fit_score if these match the role): ${list(profile.stackExclude, '(none)')}
-- Location preferences: ${describeLocation(profile)}
+- Location preferences: ${describeLocation(profile)}${describeEligibility(profile)}
 - ${salaryLine}${notesLine}`;
 }
 
@@ -312,6 +313,12 @@ Each search says where it hunts as codes: ISO countries (PL, DE, US, GB) and gro
 - Hybrid / on-site roles → true only for a search that accepts that arrangement AND lists the office's city, its country, or a group containing it (a listed city adds to the countries, it never narrows them). Never infer remote eligibility from an office address.
 - Several offices or arrangements → judge by the softest one named.
 - When in doubt, default to location_match = false.
+
+ELIGIBILITY (only for a search that says where the candidate lives):
+- Its countries are where it WANTS to work; "lives in" is where it may work today. A posting closed to that country matches only if the posting opens it — relocation, sponsorship, an employer of record, or B2B abroad.
+- "Right to work in X required" / "no visa sponsorship", candidate outside X → false, flag "work-permit-required", or "no-visa-sponsorship" when the search needs sponsorship the posting refuses.
+- "will not relocate": hybrid / on-site outside that country is false. "would relocate": an on-site role offering relocation matches, with sponsorship when the search needs it.
+- Silence is not a refusal: no permit wording keeps the verdict above.
 
 OUTPUT STRICT JSON ONLY (no prose, no code fences, no commentary), matching this schema exactly:
 
@@ -350,9 +357,21 @@ location_match = true ONLY when the role is open to that search's candidate per 
 
 tech_match: lowercase tags that intersect what the role uses with THAT search's stack (required + nice-to-have). Empty array if none match.
 
-red_flags: short kebab-case tags such as "wordpress-only", "onsite-required-wrong-city", "junior-level", "country-locked", "eu-only", "residency-required", "contract-only", "low-pay", "no-salary-listed", "stack-mismatch", "${INJECTION_FLAG}". Empty array if none.
+red_flags: short kebab-case tags such as "wordpress-only", "onsite-required-wrong-city", "junior-level", "country-locked", "eu-only", "residency-required", "work-permit-required", "no-visa-sponsorship", "contract-only", "low-pay", "no-salary-listed", "stack-mismatch", "${INJECTION_FLAG}". Empty array if none.
 
 summary: ONE sentence (max ~25 words) explaining why the posting fits that search or does not.`;
+}
+
+/**
+ * Where the candidate lives and whether they would move (ADR 0033) — said
+ * only when one of them is set, so a search that does not care costs the
+ * prompt nothing. Codes, like the location line.
+ */
+function describeEligibility(profile: Profile): string {
+  const relocation = isRelocation(profile.relocation) ? profile.relocation : 'no';
+  if (!profile.residence && relocation === 'no') return '';
+  const lives = profile.residence ? `lives in: ${profile.residence}` : 'residence not stated';
+  return `\n- Candidate ${lives}; ${RELOCATION_PROMPT[relocation]}`;
 }
 
 /**

--- a/src/eligibility.test.ts
+++ b/src/eligibility.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isCountryCode } from './countries';
+import { isRelocation, parseResidence, placeNames, residenceCovered } from './eligibility';
+
+describe('the relocation vocabulary', () => {
+  it('accepts the three choices and nothing else', () => {
+    assert.equal(isRelocation('no'), true);
+    assert.equal(isRelocation('sponsorship'), true);
+    assert.equal(isRelocation('YES'), false);
+    assert.equal(isRelocation(undefined), false);
+  });
+});
+
+describe('parseResidence', () => {
+  it('takes an ISO-2 code in any case and nothing else', () => {
+    assert.equal(parseResidence('ua', isCountryCode), 'UA');
+    assert.equal(parseResidence(' PL ', isCountryCode), 'PL');
+    assert.equal(parseResidence('', isCountryCode), null);
+    assert.equal(parseResidence('Ukraine', isCountryCode), null);
+    assert.equal(parseResidence('EU', isCountryCode), null);
+    assert.equal(parseResidence(42, isCountryCode), null);
+  });
+});
+
+describe('residenceCovered', () => {
+  const eu = { countries: [], regions: ['EU'] };
+
+  it('reads the posting through the gazetteer: member states, groups, worldwide', () => {
+    assert.equal(residenceCovered(eu, 'PL'), true);
+    assert.equal(residenceCovered(eu, 'UA'), false);
+    assert.equal(residenceCovered({ countries: ['DE', 'PL'], regions: [] }, 'PL'), true);
+    assert.equal(residenceCovered({ countries: ['DE'], regions: [] }, 'UA'), false);
+    assert.equal(residenceCovered({ countries: [], regions: ['EUROPE'] }, 'UA'), true);
+    assert.equal(residenceCovered({ countries: [], regions: ['WORLDWIDE'] }, 'UA'), true);
+    assert.equal(residenceCovered({ countries: ['US'], regions: ['NORTH_AMERICA'] }, 'CA'), true);
+  });
+
+  it('says yes when there is nothing to answer: silence in the posting, or no residence set', () => {
+    assert.equal(residenceCovered({ countries: [], regions: [] }, 'UA'), true);
+    assert.equal(residenceCovered(eu, null), true);
+  });
+});
+
+describe('placeNames', () => {
+  it('spells codes out for a sentence', () => {
+    assert.equal(placeNames(['EU']), 'European Union');
+    assert.equal(placeNames(['PL', 'DE']), 'Poland, Germany');
+    assert.equal(placeNames([]), '');
+  });
+});

--- a/src/eligibility.ts
+++ b/src/eligibility.ts
@@ -1,0 +1,63 @@
+import { countriesOf, groupsOf, placeLabel } from './countries';
+
+/*
+ * "Can I apply from where I live" (stage 4, ADR 0033). A search says where
+ * it HUNTS (countries / regions — a wish) and, since this stage, where the
+ * candidate LIVES (`residence`) and whether they would move (`relocation`).
+ * Pure: the vocabulary, the labels, and the one question the stored columns
+ * can answer on their own — is this posting open to the place the candidate
+ * lives in. Whether a permit, a relocation package or an employer of record
+ * changes that is the model's call: it read the posting, we did not.
+ */
+
+export const RELOCATION_CODES = ['no', 'yes', 'sponsorship'] as const;
+
+export type RelocationCode = (typeof RELOCATION_CODES)[number];
+
+/** What each choice says, in the words the editor and the prompt use. */
+export const RELOCATION_LABEL: Readonly<Record<RelocationCode, string>> = {
+  no: 'I stay where I am',
+  yes: 'I would relocate',
+  sponsorship: 'I would relocate and need visa sponsorship',
+};
+
+/** For the prompt — the same three choices, said to the model. */
+export const RELOCATION_PROMPT: Readonly<Record<RelocationCode, string>> = {
+  no: 'will not relocate',
+  yes: 'would relocate, no sponsorship needed',
+  sponsorship: 'would relocate but needs visa sponsorship',
+};
+
+export function isRelocation(value: unknown): value is RelocationCode {
+  return typeof value === 'string' && (RELOCATION_CODES as readonly string[]).includes(value);
+}
+
+/** The residence a form field carries: an ISO-2 code, or null when unset. */
+export function parseResidence(value: unknown, isCountry: (code: string) => boolean): string | null {
+  if (typeof value !== 'string') return null;
+  const code = value.trim().toUpperCase();
+  return code.length > 0 && isCountry(code) ? code : null;
+}
+
+/**
+ * Is a posting open to the country the candidate lives in? A posting that
+ * names no place at all is open to everyone here — silence is not a refusal,
+ * and the model weighs the wording. WORLDWIDE is likewise open.
+ */
+export function residenceCovered(
+  job: { countries: readonly string[]; regions: readonly string[] },
+  residence: string | null,
+): boolean {
+  if (!residence) return true;
+  if (job.countries.length === 0 && job.regions.length === 0) return true;
+  if (job.regions.includes('WORLDWIDE')) return true;
+  if (job.countries.includes(residence)) return true;
+  if (job.regions.some((r) => countriesOf(r).includes(residence))) return true;
+  // A posting open to a group the residence belongs to (UA ∈ EUROPE, CEE).
+  return groupsOf(residence).some((g) => job.regions.includes(g));
+}
+
+/** "European Union", "Poland, Germany" — the places a posting names, in words. */
+export function placeNames(codes: readonly string[]): string {
+  return codes.map(placeLabel).join(', ');
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -80,6 +80,8 @@ async function bootstrapDefaultProfile(): Promise<void> {
     countries: [],
     regions: [],
     workplace: ['REMOTE'],
+    residence: null,
+    relocation: 'no',
     onsiteCities: [],
     minSalaryUsd: config.MIN_SALARY_USD,
     minFitScore: config.MIN_FIT_SCORE,

--- a/src/jobs/digest-job.ts
+++ b/src/jobs/digest-job.ts
@@ -36,6 +36,8 @@ export async function runDigestJob(): Promise<{ stats: CronStats }> {
     title: j.title,
     companyName: j.company.name,
     location: j.location,
+    countries: j.countries,
+    workplace: j.workplace,
     url: j.url,
     fitScore: j.fitScore ?? 0,
     salaryMin: j.salaryMin,

--- a/src/jobs/location-reason.test.ts
+++ b/src/jobs/location-reason.test.ts
@@ -39,6 +39,31 @@ describe('locationMismatchReason', () => {
     );
   });
 
+  it('explains what the search\'s own list cannot: the candidate does not live there (ADR 0033)', () => {
+    const uaEu = { ...eu, residence: 'UA', relocation: 'no' };
+    assert.equal(
+      locationMismatchReason({ workplace: 'REMOTE', countries: [], regions: ['EU'] }, uaEu),
+      'open to European Union; you live in Ukraine and this search does not relocate',
+    );
+    assert.equal(
+      locationMismatchReason({ workplace: 'HYBRID', countries: ['PL'], regions: [] }, { ...uaEu, relocation: 'sponsorship' }),
+      'office in Poland; you live in Ukraine',
+    );
+    // A search that hunts anywhere still has a residence to answer for.
+    assert.equal(
+      locationMismatchReason({ workplace: 'REMOTE', countries: ['US'], regions: [] }, { countries: [], regions: [], workplace: [], residence: 'UA', relocation: 'no' }),
+      'open to United States; you live in Ukraine and this search does not relocate',
+    );
+  });
+
+  it('says nothing about residence when the posting covers it, or none is set', () => {
+    const uaEu = { ...eu, residence: 'UA', relocation: 'no' };
+    assert.equal(locationMismatchReason({ workplace: 'REMOTE', countries: [], regions: ['EUROPE'] }, uaEu), null);
+    assert.equal(locationMismatchReason({ workplace: 'REMOTE', countries: [], regions: ['WORLDWIDE'] }, uaEu), null);
+    assert.equal(locationMismatchReason({ workplace: 'REMOTE', countries: ['UA', 'PL'], regions: [] }, uaEu), null);
+    assert.equal(locationMismatchReason({ workplace: 'REMOTE', countries: [], regions: ['EU'] }, eu), null);
+  });
+
   it('has nothing to add when the columns agree or say nothing', () => {
     assert.equal(locationMismatchReason({ workplace: 'REMOTE', countries: ['US'], regions: [] }, us), null);
     assert.equal(locationMismatchReason({ workplace: 'REMOTE', countries: ['PL'], regions: [] }, eu), null);

--- a/src/jobs/location-reason.ts
+++ b/src/jobs/location-reason.ts
@@ -1,4 +1,5 @@
 import { placeLabel } from '../countries';
+import { residenceCovered, type RelocationCode } from '../eligibility';
 import { placesOverlap } from '../filter';
 import { WORKPLACE_LABEL, type WorkplaceCode } from '../location';
 
@@ -19,6 +20,9 @@ export interface ReasonProfile {
   countries: string[];
   regions: string[];
   workplace: WorkplaceCode[];
+  /** ADR 0033: where the candidate lives, and whether they would move. */
+  residence?: string | null;
+  relocation?: RelocationCode | string | null;
 }
 
 export function locationMismatchReason(job: ReasonJob, profile: ReasonProfile): string | null {
@@ -32,11 +36,31 @@ export function locationMismatchReason(job: ReasonJob, profile: ReasonProfile): 
 
   const places = names([...job.countries, ...job.regions]);
   if (!places) return hunts ? `no country named; ${huntsIn}` : null;
-  if (!hunts) return null;
-  if (placesOverlap(job, profile)) return null;
-
   const where = job.workplace === 'REMOTE' ? `open to ${places}` : `office in ${places}`;
+
+  // The search's own list first — that is what its owner set. Residence
+  // explains the case the list cannot: the posting is where the search
+  // hunts, and the candidate still may not work from there (ADR 0033).
+  if (!hunts || placesOverlap(job, profile)) return livingReason(where, job, profile);
+
   return `${where}; ${huntsIn}`;
+}
+
+/**
+ * "open to European Union; you live in Ukraine and this search does not
+ * relocate" — the honest sentence for a posting that is where the search
+ * hunts and still closed to the person doing the hunting. Null when the
+ * columns cannot say that: no residence set, or the posting covers it.
+ */
+function livingReason(where: string, job: ReasonJob, profile: ReasonProfile): string | null {
+  const residence = profile.residence ?? null;
+  if (!residence || residenceCovered(job, residence)) return null;
+  const lives = `you live in ${placeLabel(residence)}`;
+  // Whether relocation or sponsorship rescues it is the model's call — it
+  // read the posting. The code only names the setting that made it matter.
+  return profile.relocation === 'no'
+    ? `${where}; ${lives} and this search does not relocate`
+    : `${where}; ${lives}`;
 }
 
 function names(codes: string[]): string {

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -271,6 +271,8 @@ export async function processNormalizedJobs(
           title: created.title,
           companyName,
           location: created.location,
+          countries: created.countries,
+          workplace: created.workplace,
           url: created.url,
           fitScore: created.fitScore ?? finalClassification.fit_score,
           salaryMin: created.salaryMin,

--- a/src/notifier.test.ts
+++ b/src/notifier.test.ts
@@ -4,6 +4,7 @@ import {
   escapeMarkdownV2,
   escapeMarkdownV2Url,
   formatJobMessage,
+  formatPlaceLine,
   formatSalary,
   formatSourceHealthLine,
 } from './notifier';
@@ -191,5 +192,33 @@ describe('formatSourceHealthLine', () => {
       { name: 'X', atsType: 'ASHBY', status: null, streak: 3 },
     ]);
     assert.match(line, /not fetched yet/);
+  });
+});
+
+describe('formatPlaceLine', () => {
+  const base = {
+    title: 't', companyName: 'c', location: '', url: 'u', fitScore: 90,
+    salaryMin: null, salaryMax: null, techMatch: [], redFlags: [], summary: '',
+  };
+
+  it('carries the flags and adds the arrangement the words do not say (ADR 0033)', () => {
+    assert.equal(
+      formatPlaceLine({ ...base, location: 'Hybrid · Berlin, Germany', countries: ['DE'], workplace: 'HYBRID' }),
+      '🇩🇪 Hybrid · Berlin, Germany',
+    );
+    assert.equal(
+      formatPlaceLine({ ...base, location: 'Kyiv, Ukraine', countries: ['UA'], workplace: 'HYBRID' }),
+      '🇺🇦 Kyiv, Ukraine · hybrid',
+    );
+    assert.equal(
+      formatPlaceLine({ ...base, location: 'Remote', countries: ['PL', 'DE'], workplace: 'REMOTE' }),
+      '🇵🇱🇩🇪 Remote',
+    );
+  });
+
+  it('falls back to the arrangement, then to Remote, when the posting names no place', () => {
+    assert.equal(formatPlaceLine({ ...base, location: '', countries: [], workplace: 'ONSITE' }), 'On-site');
+    assert.equal(formatPlaceLine({ ...base, location: '', countries: [], workplace: 'UNKNOWN' }), 'Remote');
+    assert.equal(formatPlaceLine({ ...base, location: 'Anywhere' }), 'Anywhere');
   });
 });

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -1,4 +1,6 @@
 import { logger } from './logger';
+import { flagOf } from './countries';
+import { WORKPLACE_LABEL } from './location';
 import {
   getSettings,
   listActiveTelegramTargets,
@@ -8,6 +10,9 @@ import { prisma } from './db';
 import type { TelegramTarget } from '@prisma/client';
 import { describeStatus } from './fetchers/source-health';
 import type { AlertJob } from './types';
+
+/** Arrangement words a location string may already carry. */
+const WORKPLACE_WORDS = '\\b(remote|hybrid|on-?site|in-office)\\b';
 
 const TELEGRAM_API = 'https://api.telegram.org';
 const TELEGRAM_TIMEOUT_MS = 10_000;
@@ -159,6 +164,21 @@ async function deliverToTarget(
   }
 }
 
+/**
+ * The place line: the posting's own words, the flags of the countries the
+ * stage-1 columns hold, and the arrangement when the words do not already
+ * say it (ADR 0033). "🇩🇪 Remote · Berlin, Germany", "🇺🇦 Kyiv · hybrid".
+ */
+export function formatPlaceLine(job: AlertJob): string {
+  const flags = (job.countries ?? []).map(flagOf).filter((f) => f.length > 0).join('');
+  const workplace = job.workplace && job.workplace !== 'UNKNOWN' ? WORKPLACE_LABEL[job.workplace] : '';
+  const words = job.location.trim();
+  const said = words.length > 0 && new RegExp(WORKPLACE_WORDS, 'i').test(words);
+  const place = words.length > 0 ? words : workplace || 'Remote';
+  const tail = workplace && !said && words.length > 0 ? ` · ${workplace.toLowerCase()}` : '';
+  return `${flags ? `${flags} ` : ''}${place}${tail}`;
+}
+
 /** Pure — exported so the MarkdownV2 escaping can be unit-tested; Telegram
  *  rejects a whole message on a single unescaped special character. */
 export function formatJobMessage(job: AlertJob): string {
@@ -173,9 +193,8 @@ export function formatJobMessage(job: AlertJob): string {
   lines.push(
     `*${escapeMarkdownV2(job.title)}* @ ${escapeMarkdownV2(job.companyName)}`,
   );
-  const loc = job.location || 'Remote';
   lines.push(
-    `📍 ${escapeMarkdownV2(loc)} \\| 💰 ${escapeMarkdownV2(formatSalary(job.salaryMin, job.salaryMax))}`,
+    `📍 ${escapeMarkdownV2(formatPlaceLine(job))} \\| 💰 ${escapeMarkdownV2(formatSalary(job.salaryMin, job.salaryMax))}`,
   );
   if (job.techMatch.length > 0) {
     lines.push(`✅ Tech: ${escapeMarkdownV2(job.techMatch.join(', '))}`);

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -3,6 +3,7 @@ import { prisma } from './db';
 import { logger } from './logger';
 import { MAX_ACTIVE_PROFILES } from './profile-guards';
 import type { WorkplaceCode } from './location';
+import type { RelocationCode } from './eligibility';
 import { ensureSettingsRow, SETTINGS_ID } from './settings';
 import type { PriorityRule } from './priority-rules';
 
@@ -19,6 +20,10 @@ export interface ProfileInput {
   regions: string[];
   /** Arrangements the search accepts; empty = any. */
   workplace: WorkplaceCode[];
+  /** Where the candidate lives now (ISO-2), null = not said (ADR 0033). */
+  residence: string | null;
+  /** Whether they would move for a role: no | yes | sponsorship (ADR 0033). */
+  relocation: RelocationCode;
   onsiteCities: string[];
   minSalaryUsd: number;
   minFitScore: number;
@@ -45,6 +50,8 @@ export function blankProfileInput(): ProfileInput {
     countries: [],
     regions: [],
     workplace: ['REMOTE'],
+    residence: null,
+    relocation: 'no',
     onsiteCities: [],
     minSalaryUsd: 0,
     minFitScore: 70,

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,9 @@ export interface AlertJob {
   title: string;
   companyName: string;
   location: string;
+  /** ADR 0031 columns, so the line can show flags and the arrangement. */
+  countries?: string[];
+  workplace?: WorkplaceCode;
   url: string;
   fitScore: number;
   salaryMin: number | null;

--- a/src/web/pages/jobs-list.tsx
+++ b/src/web/pages/jobs-list.tsx
@@ -51,6 +51,8 @@ export interface JobsListProps {
     q: string;
     sort: string;
     verified: string;
+    /** ADR 0033: "1" = only rows a search of mine can take. */
+    open: string;
     /** Which search the list is narrowed to; null = all of them. */
     profile: number | null;
     /** ADR 0031 facets: place values (codes or "unknown"), workplace values, posted window. */
@@ -233,6 +235,18 @@ export const JobsListPage: FC<JobsListProps> = ({
           >
             Verified
           </a>
+          <a
+            href={buildQuery({ ...filters, open: filters.open ? '' : '1', page: 1 })}
+            aria-current={filters.open ? 'true' : undefined}
+            title="Only roles a search of yours can take from where you live"
+            class={`rounded-md border px-2.5 py-1 text-[13px] transition-colors duration-150 ${
+              filters.open
+                ? 'border-line-strong bg-surface-overlay font-medium text-ink'
+                : 'border-transparent text-ink-muted hover:bg-surface-overlay/70 hover:text-ink'
+            }`}
+          >
+            Open to me
+          </a>
         </nav>
 
         <form method="get" action="/jobs" class="ml-auto flex flex-wrap items-center gap-2">
@@ -242,6 +256,7 @@ export const JobsListPage: FC<JobsListProps> = ({
           <input type="hidden" name="country" value={filters.country.join(',')} />
           <input type="hidden" name="workplace" value={filters.workplace.join(',')} />
           <input type="hidden" name="posted" value={filters.posted} />
+          <input type="hidden" name="open" value={filters.open} />
           <Input
             type="search"
             name="q"

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -8,7 +8,8 @@ import type { FlashMessage } from '../flash';
 import { sourceLabel } from '../source-names';
 import { dotClassFor, MAX_WORK_STAGES } from '../stage-config';
 import { formatPriorityRulesText, parsePriorityRules } from '../../priority-rules';
-import { REGIONS, flagOf, placeLabel } from '../../countries';
+import { COUNTRIES, REGIONS, flagOf, placeLabel } from '../../countries';
+import { RELOCATION_CODES, RELOCATION_LABEL } from '../../eligibility';
 import { PROFILE_WORKPLACES, WORKPLACE_LABEL } from '../../location';
 import { isBlankProfile, MAX_ACTIVE_PROFILES } from '../../profile-guards';
 import { SENIORITY_LEVELS } from '../../resume/profile-draft';
@@ -950,6 +951,13 @@ const ModelPicker: FC<{
     </Select>
   );
 
+/** One line under each relocation choice — editor copy, not vocabulary. */
+const RELOCATION_HINT: Record<string, string> = {
+  no: 'Only roles I can take from where I am.',
+  yes: 'I can move, and I may work there already.',
+  sponsorship: 'A visa or work permit has to come with the job.',
+};
+
 const ProfileEditor: FC<{
   profile: Profile;
   availableTargets: AvailableTarget[];
@@ -1080,6 +1088,36 @@ const ProfileEditor: FC<{
             <PillCheckbox name="regions" value={r.code} checked={profile.regions.includes(r.code)}>
               {r.flag ? `${r.flag} ${r.label}` : r.label}
             </PillCheckbox>
+          ))}
+        </div>
+      </div>
+      <Field
+        label="I live in"
+        hint="Where you are now. Not a place this search hunts — it decides whether a role's work-permit and relocation wording is a problem for you."
+      >
+        <Select name="residence">
+          <option value="" selected={!profile.residence}>
+            Not set
+          </option>
+          {COUNTRIES.map((c) => (
+            <option value={c.code} selected={profile.residence === c.code}>
+              {c.flag} {c.name}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      <div>
+        <Hint>If the role is somewhere you do not live</Hint>
+        <div class="mt-1.5 grid gap-2 sm:grid-cols-3">
+          {RELOCATION_CODES.map((r) => (
+            <Radio
+              name="relocation"
+              value={r}
+              checked={(profile.relocation ?? 'no') === r}
+              title={RELOCATION_LABEL[r]}
+            >
+              {RELOCATION_HINT[r]}
+            </Radio>
           ))}
         </div>
       </div>

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -98,6 +98,11 @@ const ListQuerySchema = z.object({
     .string()
     .optional()
     .transform((v) => (v === '1' ? '1' : '')),
+  // ADR 0033: only rows a search of mine can actually take.
+  open: z
+    .string()
+    .optional()
+    .transform((v) => (v === '1' ? '1' : '')),
   // ADR 0028: narrow the list to one search. Empty = every search.
   profile: z.coerce.number().int().positive().optional().catch(undefined),
   // ADR 0031: the facets. Unknown values are dropped, never rejected.
@@ -126,11 +131,12 @@ jobsRoute.get('/jobs', async (c) => {
     country: c.req.query('country'),
     workplace: c.req.query('workplace'),
     posted: c.req.query('posted'),
+    open: c.req.query('open'),
   });
   if (!parsed.success) {
     return c.text('Invalid query', 400);
   }
-  const { page, status, minFit, q, sort, verified, profile, country, workplace, posted } = parsed.data;
+  const { page, status, minFit, q, sort, verified, profile, country, workplace, posted, open } = parsed.data;
   const now = new Date();
 
   const where: Prisma.JobWhereInput = {};
@@ -140,12 +146,20 @@ jobsRoute.get('/jobs', async (c) => {
   const minFitNum = minFit ? Number(minFit) : NaN;
   // With a search selected both filters read that search's own score, not the
   // best-of — a chip that showed rows another search scored would be a lie.
+  // "Open to me" reads the same per-search verdict (ADR 0033): with a search
+  // selected, that search's; without one, any search that said yes.
+  const openOnly = open === '1' ? { locationMatch: true } : {};
   if (profile) {
     where.scores = {
-      some: { profileId: profile, ...(Number.isNaN(minFitNum) ? {} : { fitScore: { gte: minFitNum } }) },
+      some: {
+        profileId: profile,
+        ...(Number.isNaN(minFitNum) ? {} : { fitScore: { gte: minFitNum } }),
+        ...openOnly,
+      },
     };
-  } else if (!Number.isNaN(minFitNum)) {
-    where.fitScore = { gte: minFitNum };
+  } else {
+    if (!Number.isNaN(minFitNum)) where.fitScore = { gte: minFitNum };
+    if (open === '1') where.scores = { some: { locationMatch: true } };
   }
   if (q.trim().length > 0) {
     where.OR = [
@@ -210,6 +224,7 @@ jobsRoute.get('/jobs', async (c) => {
         q,
         sort,
         verified,
+        open,
         profile: profile ?? null,
         country,
         workplace: workplace.map((w) => w.toLowerCase()),

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -69,7 +69,8 @@ import {
 import { runReclassifyAll } from '../../jobs/reclassify-job';
 import { recordCronRun } from '../../jobs/cron-run';
 import { parseTagList, toStringArray } from '../../text-utils';
-import { isRegionCode, resolveCountries } from '../../countries';
+import { isCountryCode, isRegionCode, resolveCountries } from '../../countries';
+import { isRelocation, parseResidence } from '../../eligibility';
 import { isProfileWorkplace } from '../../location';
 import { suggestSources } from '../../starter-packs/suggest';
 import {
@@ -107,6 +108,9 @@ const ProfileFormSchema = z.object({
   countries: z.union([z.string(), z.array(z.string())]).optional(),
   regions: z.union([z.string(), z.array(z.string())]).optional(),
   workplace: z.union([z.string(), z.array(z.string())]).optional(),
+  // ADR 0033: where the candidate lives, and whether they would move.
+  residence: z.string().optional().default(''),
+  relocation: z.string().optional().default('no'),
   onsiteCities: z.string().optional().default(''),
   minSalaryUsd: z.coerce.number().int().min(0).default(0),
   minFitScore: z.coerce.number().int().min(0).max(100).default(70),
@@ -801,6 +805,8 @@ settingsRoute.post('/settings/profiles/:id/save', async (c) => {
     countries: countries.codes,
     regions: toStringArray(f.regions).filter(isRegionCode),
     workplace: toStringArray(f.workplace).filter(isProfileWorkplace),
+    residence: parseResidence(f.residence, isCountryCode),
+    relocation: isRelocation(f.relocation) ? f.relocation : 'no',
     onsiteCities: parseTagList(f.onsiteCities),
     minSalaryUsd: f.minSalaryUsd,
     minFitScore: f.minFitScore,

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
+import { isRelocation } from '../../eligibility';
 import { CronRunStatus, JobStatus, type Profile } from '@prisma/client';
 import { prisma } from '../../db';
 import { getAiKeys, setAiKey, setFetchingEnabled, setSetupCompleted } from '../../settings';
@@ -378,6 +379,8 @@ function draftCard(
 /** A stored Profile row as the input shape updateProfile takes. */
 function profileInput(p: Profile): ProfileInput {
   return {
+    residence: p.residence,
+    relocation: isRelocation(p.relocation) ? p.relocation : 'no',
     name: p.name,
     stackRequired: p.stackRequired,
     roleTypes: p.roleTypes,


### PR DESCRIPTION
Stage 4 of the country-aware search plan ([docs/country-search-plan.md §5](docs/country-search-plan.md)): **`eligibility` — where you live, and whether you would move.** Follows #128 (Teamtailor, v1.39.0, which closed stage 3d). ADR 0033.

## Analysis note (pre-work §5.0, 2026-09-04)

**Which prompt rules change.** Four of the eight ADR 0032 location lines are written as if the only question were where the search hunts. Residence splits that in two: a place the candidate may WORK FROM (`countries` / `regions` — a wish) and a place they may work from LEGALLY today (`residence` — a fact). What changes: region-locked remote ("EU only" fails a UA-resident search even when it lists EU, unless the posting opens it), on-site and hybrid (a listed city is enough only when the candidate can legally be there, or the posting relocates them and the search accepts that), and the "when in doubt, false" default, which must not fire on a posting that simply says nothing about permits. The stack rules and the shared `location` block are untouched.

**The fixture says the flags must come from the model.** Over the 1 059 stored postings, 115 mention "sponsorship" and only 12 state a policy. Of 24 sampled hits, 7 are real ("authorized to work in the United States without … employer-sponsored work authorization"; "visa sponsorship is not available for this position"; "able to offer visa sponsorship … but do require that someone is based in Spain"), 3 are the ATS application-form question scraped into the description ("Do you now, or will you in the future, require immigration sponsorship … ?"), and 14 are benefits or an org chart ("co-sponsored Multisport card", "employer-sponsored group medical plan", "under the direct sponsorship of the CTO"). A keyword rule would flag more noise than signal, so `work-permit-required` and `no-visa-sponsorship` are model verdicts like every other red flag, and `filter.ts` stays out of it. Other phrase volumes: relocation 12, employer-of-record 2, B2B 1, work-permit wording 10 — the corpus is US-heavy, so stage 3's European sources are what will exercise these rules.

**Salary (the third pre-work question), measured and deferred.** The model already converts silently: the prompt asks for `salary_min_usd` with no rate and no currency field, `Job.salaryMin` is filled on 155 of 1 059 rows, and `Profile.minSalaryUsd` is only a prompt line — no code compares the two. Non-USD postings are 7 % today (€ 39, PLN 29, £ 7) and will grow with solid.jobs (PLN only), DevITjobs (€ / £), Landing.jobs (€) and JobTech (SEK). Kept out of this PR, as §5.1 says; when it lands, prefer conversion constants in code (the model reports the posting's own amount and currency, a table reviewed monthly converts) because that is the only shape where the number can be audited. The alternative, `minSalary` + `salaryCurrency` on the profile, does not remove the conversion — it moves it into the model's head for every comparison. Written down in the plan's §5.0.

## Changes

- **Schema**: `Profile.residence` (ISO-2, nullable) and `Profile.relocation` (`no` | `yes` | `sponsorship`), migration `20260904000000_add_profile_eligibility`.
- **`src/eligibility.ts`** (pure): the vocabulary, the labels the editor and the prompt use, and `residenceCovered(job, residence)` — is this posting's own list of places one the candidate lives in, read through the gazetteer's groups.
- **Prompt**: a per-search line ("Candidate lives in: UA; would relocate but needs visa sponsorship") emitted only when one of the two is set, plus a four-line ELIGIBILITY block sent once, plus the two new red flags. Guard-tested.
- **Job page**: the mismatch sentence learns residence — "open to European Union; you live in Ukraine and this search does not relocate" — the sentence the search's own country list could never produce.
- **`/jobs` "Open to me"**: only rows a search of yours can take, from the same per-search `locationMatch` the fit chips read.
- **Telegram**: the place line carries the country flags and the arrangement (`🇩🇪 Hybrid · Berlin, Germany`, `🇺🇦 Kyiv, Ukraine · hybrid`).
- **Editor**: `/settings` → Profile → Location gains "I live in" (86 countries + "Not set") and three relocation choices.

## Verification

- `npm run lint:types && npm test`: 1503 pass, 0 fail (new: the eligibility vocabulary and `residenceCovered` incl. groups and worldwide; three residence shapes of the mismatch sentence and the three cases where it must stay silent; two prompt guards; the Telegram place line).
- **The plan's definition of done, live** (four crafted postings × two relocation settings, one AI call each, search: lives in UA, hunts PL / DE / EU, remote + hybrid, Berlin on-site allowed):

| Posting | relocation = no | relocation = sponsorship |
|---|---|---|
| Remote · EU only, "cannot sponsor" | ✗ 20 — `no-visa-sponsorship`, `eu-only`, `work-permit-required` | ✗ 18 — `no-visa-sponsorship`, `work-permit-required` |
| Remote · Worldwide, EoR / B2B | ✓ 91 | ✓ 85 |
| Berlin on-site + relocation package + sponsorship | ✗ 28 — `onsite-required`, `relocation-required` | **✓ 85** |
| Berlin on-site, "no visa sponsorship" | ✗ 10 — `work-permit-required`, `no-visa-sponsorship` | **✗ 15** — `no-visa-sponsorship`, `work-permit-required` |

  Both §5.2 bullets hold: "Remote · EU only" is a mismatch for a UA resident while "Remote · Worldwide" matches, and the Berlin role flips on the relocation setting, refused by name when the posting says no sponsorship.
- **Dashboard smoke** (Docker, both images rebuilt, live DB, backup at `~/applypack-backups/applypack-2026-09-04-before-eligibility.sql`): `init.ts` applied the migration and all three searches read `residence = NULL, relocation = no`, so no verdict moved; the editor saved `UA` + `sponsorship` on the test search; "Open to me" narrows 1 059 rows to 109 and marks itself selected; a job page renders the by-search reasons unchanged where the search's own list already explains the mismatch. The test search was reverted afterwards.
- Prompt budget: the guard now measures the worst case a user pays — eight searches that all state a residence — and allows 12 000 characters (11 003 today, of which ~790 is the rules block).

## Follow-ups

- Salary in EUR / PLN / GBP: its own PR, per §5.1 and §6.7, with the recommendation above.
- The classifier answered `relocation-required` as a free tag in one verdict; if it recurs, add it to the red-flag list in the prompt so the vocabulary stays closed.
- Stage 3e (France Travail, Adzuna) still waits on the robots-versus-licence decision (§6.4).

## Release notes (draft, v1.40.0)

**Where you live, and whether you would move.** A search now says "I live in" and picks one of three: I stay where I am, I would relocate, I would relocate and need visa sponsorship. The classifier reads both — a role open only to places you cannot work from matches only if the posting itself opens it (relocation, sponsorship, an employer of record, a contract abroad) — and flags `work-permit-required` or `no-visa-sponsorship` when it does not. Jobs gains "Open to me", the job page says why a role is closed to you, and Telegram alerts show the country flags and the arrangement. Searches created before this keep working unchanged until you say where you live. Schema: `Profile.residence`, `Profile.relocation`.

After merge:
```
git tag -a v1.40.0 -m "Eligibility: residence and relocation" <merge-sha> && git push origin v1.40.0
```
