### PR TITLE
docs: tailoring loop analysis + integration plan (TASKS §18)

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1504,3 +1504,206 @@ presets `hour / day / week` only — enough? (3) Is the change-watch rung
 wanted at all, or is "refused / not supported" the more honest answer for
 sites with no machine-readable data? (4) ADR 0034 states "no headless
 browser" as policy — confirm before stage A so the question is closed.
+
+---
+
+## 18. Tailoring loop: apply, copy, save, export (analysis 2026-09-03, nothing built)
+
+Owner's ask: after a resume-vs-posting comparison, let the user take the
+AI's edit suggestions in a few clicks (apply, add missing keywords, reorder)
+or copy them comfortably and edit by hand, then save the tailored resume as
+a real file; check whether the linkedin-radar "resume regeneration" service
+is worth reusing; make sure nothing ApplyPack writes gets a resume flagged
+as "AI-generated"; use libraries where they exist; handle every user's own
+template. Analysis: [tailoring-loop-plan.md](./tailoring-loop-plan.md).
+Build guide, file by file, with the session model and effort per stage:
+[tailoring-loop-integration.md](./tailoring-loop-integration.md).
+
+### 18.1 Facts established (don't re-derive)
+
+- `/jobs/:id/target` already has the editor, the live score, the
+  quote-to-editor jump, the draft in localStorage and Save as vN (a `.md`
+  text version). Missing: copying a proposal, applying one, adding a
+  keyword to the text, a file after Save. §5.10 (.docx export) and §5.15
+  (AI-tailored resume) were closed with reopen triggers; this ask is the
+  trigger, in a narrower form: the user picks each edit, the model only
+  proposes wording, the file keeps the user's design.
+- The stored suggestion shape is `actions[] {section, where, what, why,
+  priority, quote}`; 16 of the 18 actions on the two stored full analyses
+  (matches 59, 68) carry the proposal as a quoted string inside `what`.
+  Removals carry the exact quote to delete; the card does not show it.
+- Live corpus: resume 1 is the only `.docx` (89 paragraphs, 527 runs, 31 of
+  65 non-empty paragraphs fragmented into 4+ runs, one 1×2 skills table,
+  2 OMML objects, 100 tabs, junk third-party template properties in
+  `core.xml`, mime stored as `application/octet-stream`); resumes 4
+  (scratch), 5 and 8 are PDFs from macOS Quartz. Our own writers
+  (`pdf-write.ts`, `docx-write.ts`) emit no `/Info` and no `docProps`.
+- The linkedin-radar "service" is the `job-apply` Claude Code skill: two
+  rulebooks + nine stdlib-Python scripts that patch one person's .docx in
+  place (run-mapped replacement, byte-identical style parts, text round
+  trip, hygiene, metadata cleaning) and render the PDF through Pages / Word
+  on macOS. Take the gates and the idea; the code is tuned to one template
+  and one Mac.
+- No major ATS detects AI authorship (Jobscan, Enhancv, 2026). What is
+  flagged: hidden white text (Greenhouse: ~1% of ~300 M resumes in H1 2025),
+  unparseable layout. Library fingerprints in metadata (`python-docx`,
+  `pdf-lib`, `docx` "Un-named", pdfkit "PDFKit") are visible to a human
+  opening File → Properties, not a rejection rule. linkedin-radar's
+  rulebook claim about "vendor AI-content classifiers since late 2025" is
+  unsupported.
+- No Node library replaces arbitrary text inside an existing .docx with
+  formatting intact (`docx.patchDocument` wants `{{placeholders}}`;
+  docxtemplater's search-and-replace is a paid module). Generation has
+  libraries: `docx` (dolanmiu), `pdfkit`, Typst via WASM; `@xmldom/xmldom`
+  + `jszip` for the patcher; LibreOffice (~240 MB image) only as an
+  optional profile. OpenResume's parser is AGPL. JSON Resume is the model.
+- Templates are three populations: flow `.docx` (patch fully), structural
+  `.docx` with tables / text boxes / columns (patch partly), PDF-only
+  (nothing to patch). A deterministic check at upload sorts them.
+- Page review (live, 800 px and 375 px): clicking a suggestion focuses the
+  editor and scrolls the page away from the proposal; the wording is buried
+  in "Reword as: "…"" sentences; cards are clickable `<li>` elements; the
+  selection is invisible; chips only navigate. Hierarchy 7, consistency 8,
+  accessibility 5, polish 6.
+
+### 18.2 Decisions
+
+Copy and Locate as separate controls (Locate never moves the page); every
+card shows Now / Proposed; a Markdown change sheet ("Copy all suggestions",
+"Copy my changes") ships first as the universal manual path; Apply, Remove,
+Add to Skills, Undo are client-side text operations; the model returns
+`replacement` / `insert_after` and `fact-check.ts` decides at persist time
+what is applicable (blocked proposals become questions); keyword additions
+stay deterministic (`add` and confirmed terms only); Save patches the
+user's `.docx` in place when the template check allows it, else a text
+version with the reason; the patcher is in-house over xmldom + jszip,
+generation uses `docx` + pdfkit, JSON Resume is the structured model; the
+metadata policy binds every writer (no tool name, no hidden text); for
+PDF-only and structural files the product offers a clean single-column
+re-render in the user's typography, labelled as such; no external service.
+
+### 18.3 Session model and effort per stage
+
+| Stage | Session model | Effort |
+|---|---|---|
+| Pre-work notes, `code-review-expert` passes | Fable 5.1 | high |
+| 1 `target-copy-locate` | Opus 5 (`/fast` for markup) | medium |
+| 2 `target-apply-edits` | Opus 5 | high |
+| 3 `suggestion-replacements` | Fable 5.1 | high |
+| 4 `docx-patch` | Fable 5.1 for the patcher, check and fixtures; Opus 5 for wiring | max / medium |
+| 5 `resume-render` | Opus 5 for libraries and pages; Fable 5.1 for the `structure` prompt | high |
+
+Product engine unchanged: the resume role stays `claude-opus-5` (ADR 0029
+bench); re-run `bench:resume` after stages 3 and 5.
+
+### 18.4 Implementation order (five branches, each its own PR; tags from stage 3 on)
+
+**Stage 1 — `target-copy-locate` (no schema, no prompt; ~1 session)**
+- [ ] **Analyse first:** read the page and card sources; pull every stored
+      `actions[].what` and write the proposal extractor against the real
+      shapes; one 375 px screenshot of the Suggestions tab in the note.
+- [ ] `add proposal extractor` — `target.mjs:proposalOf` + tests.
+- [ ] `add line diff` — `public/line-diff.mjs:diffLines` + tests.
+- [ ] `add change sheet` — `changeSheet` / `formatChangeSheet` (Markdown);
+      "Copy all suggestions", "Copy my changes".
+- [ ] `add copy and locate` — `copy.mjs:wireCopy` (clipboard + fallback,
+      aria-live "Copied"); Locate outlines the span (`.located`), scrolls
+      the editor only, `focus({ preventScroll: true })` on wide screens;
+      "Couldn't find this text" inline instead of the pulse.
+- [ ] `restructure suggestion cards` — `SuggestionCard` with Now / Proposed,
+      `<button>` controls, removal quote shown, badge inline; Copy also on
+      `/jobs/:id`.
+- [ ] `fix narrow layout` — editor first and collapsed at ≤ 1023 px, keyword
+      table behind a disclosure, "show matched" toggle into the editor header.
+- [ ] `document copy path` — CLAUDE.md rows, SPEC, CHANGELOG + bump.
+
+**Stage 2 — `target-apply-edits` (no schema, no prompt; ~1 session)**
+- [ ] **Analyse first:** read `keyword-overrides.ts` and `facts.ts`; count
+      quotes `locateQuote` finds and multi-line removal quotes.
+- [ ] `add text operations` — `applyReplacement`, `removeSpan` (contact line
+      protected), `insertIntoSkills`, `moveLineToBlockTop` + tests.
+- [ ] `add apply state` — Apply / Edit & apply / Skip / Remove / Undo;
+      `target-edits:<matchId>` in localStorage beside the draft.
+- [ ] `add keyword insert` — "Add to Skills" on `add` and confirmed chips;
+      `cannot_claim` never gets a button.
+- [ ] `document apply` — CLAUDE.md rows, SPEC, CHANGELOG + bump.
+
+**Stage 3 — `suggestion-replacements` (PROMPT_VERSION 7, ADR 0035; ~1 session)**
+- [ ] **Analyse first:** read `prompts.ts`, `match.ts`, `suggestions.ts`,
+      `cover-letter.ts` (the `factCheck` call), `prompts.test.ts`; run
+      `bench:resume --mode full` before the change and keep the file.
+- [ ] `add replacement fields` — `replacement`, `insert_after` in
+      `MatchSchema`; `RULE_BULLET_STYLE` shared with the review's example
+      rule; `OUTPUT_ACTIONS`; `PROMPT_VERSION = 7`.
+- [ ] `add replacement gate` — `replacement-gate.ts:gateActions` (plain
+      punctuation, `factCheck`, KEEP WANTED KEYWORDS in code); wired before
+      `createMatch` and `updateMatchSuggestions`.
+- [ ] `test both variants` — guard tests: rule present in full, fast and
+      suggestions prompts; a reply without the fields parses; the gate
+      blocks an invented figure and keeps a real one.
+- [ ] `write adr 0035` — "suggestions carry replacement text; the fact gate
+      decides what is applicable"; bench after-table in the PR; CHANGELOG +
+      bump + tag.
+
+**Stage 4 — `docx-patch` (deps xmldom + jszip, ADR 0036; ~2 sessions)**
+- [ ] **Analyse first:** prove xmldom fidelity on resume 1's `document.xml`
+      (DOM for `document.xml`, raw bytes for every other part); build the
+      three fixtures (`flow-fragmented`, `structural-table-layout`,
+      `flow-simple`); run the parser-disagreement check by hand.
+- [ ] `add template check` — `docx-structure.ts:docxStructure` (kind, lines,
+      counts, notes) + tests; shown on `/resumes/:id` and above the editor.
+- [ ] `expose document blocks` — `docx-text.ts:walkDocument` with a parity
+      test against the old text output on every fixture.
+- [ ] `share line diff` — `resume/line-diff.ts` bridging to the `.mjs`.
+- [ ] `add docx patcher` — `docx-patch.ts:patchDocx` (change / delete /
+      insert, tabbed headers, cell text, hygiene on new text, gates) +
+      `docx-props.ts` + tests.
+- [ ] `save patched versions` — `POST /resumes/:id/draft` branches on
+      `.docx` + check; `replaceResumeFile` with the patched bytes; text
+      fallback with the reason; "Save as a tailored copy" (owner decides the
+      default); Download reflects the new file; export report line.
+- [ ] `fix document properties` — the opt-in POST; current values shown.
+- [ ] `write adr 0036` — supersedes ADR 0010's text-only consequence;
+      CLAUDE.md rows; CHANGELOG + bump + tag; screenshots of the patched
+      file in Word, Pages, LibreOffice in the PR.
+
+**Stage 5 — `resume-render` (deps docx + pdfkit + one OFL font, ADR 0037; ~2 sessions)**
+- [ ] **Analyse first:** render one JSON Resume sample through `docx` +
+      pdfkit and through Typst; compare output, size, producer strings
+      (owner question 3); pick the bundled font family.
+- [ ] `add json resume model` — `json-resume.ts` (zod subset).
+- [ ] `add scan structure` — `structure` block in `SCAN_SYSTEM` +
+      `ScanSchema`; `structure-anchor.ts` verbatim guard;
+      `Resume.structure Json?` with a hand-written migration;
+      `structure-from-text.ts` fallback.
+- [ ] `add style inference` — `style-infer.ts` from docx styles / pdf.js
+      fonts + tests.
+- [ ] `add clean renderers` — `render/clean-docx.ts`, `render/clean-pdf.ts`
+      (metadata per library, Cyrillic-capable font, fonts copied in the
+      Dockerfile).
+- [ ] `add render page` — `/resumes/:id/render`: knobs prefilled, structure
+      editable, "what the ATS sees" preview, download or save as a new
+      resume; links from `/resumes/:id` and the target page for PDF-only and
+      structural files.
+- [ ] `write adr 0037` — JSON Resume as the model, the dependencies, the
+      font, the label; CHANGELOG + bump + tag.
+
+**Optional — LibreOffice profile.** Only if the owner reports the "export
+the PDF from Word or Pages" step as friction after stage 4.
+
+**Verification (all stages).** Pure modules unit-tested next to the file;
+`npm run lint:types && npm test` every commit; `docker compose build web`
+and a curl of every touched route; screenshots at 1200 / 768 / 375 with
+keyboard walks; stage 3 benched before and after; stage 4's patched file
+opened in Word, Pages and LibreOffice; stage 5's outputs round-tripped
+through our own extractors and `parse-warnings`; `code-review-expert` over
+`git diff main...HEAD` before every PR.
+
+**Decisions for the owner.** (1) Tailored edits save as a copy per posting
+(recommended) or as a version of the master? (2) Fix junk document
+properties on click (recommended) or on the first patched save? (3) pdfkit
+(recommended) or Typst for stage 5? (4) Is "export the PDF from Word or
+Pages" acceptable for v1, or is the LibreOffice profile required? (5)
+Tables in the patcher's v1: cell text edits or refuse? (6) Reordering:
+"make this the first bullet" only, or free line moves? (7) Ship stages 1
+and 2 as one branch or two?

--- a/docs/tailoring-loop-integration.md
+++ b/docs/tailoring-loop-integration.md
@@ -1,0 +1,738 @@
+# The tailoring loop: integration guide
+
+> How to build what [tailoring-loop-plan.md](./tailoring-loop-plan.md)
+> decided, in this codebase, file by file. Written 2026-09-03 before any
+> code; the backlog ticks are [TASKS.md §18](./TASKS.md). One stage = one
+> branch = one PR (+ an annotated tag when it changes runtime behaviour,
+> `release-discipline`). Before a stage: read CLAUDE.md "File rules", the
+> `testing-gate`, `commit-discipline`, `accessible-interactions` and
+> `adr-writer` skills, then the stage's pre-work checklist here. Facts in
+> the plan expire; the pre-work note at the top of each PR says what changed.
+
+---
+
+## 0. Sessions: which model, which effort
+
+Two different things are called "model" in this repo. The **session model**
+is the Claude Code model that writes the code. The **product engine** is
+what ApplyPack calls at runtime (`/settings` → AI engine; the resume role
+defaults to `claude-opus-5` per the ADR 0029 bench). Changing one never
+touches the other.
+
+| Stage | Session model | Effort | Why |
+|---|---|---|---|
+| Pre-work analysis notes (every stage) | Fable 5.1 | high | the note decides scope; a wrong assumption here costs the whole branch |
+| 1 `target-copy-locate` | Opus 5 | medium; `/fast` for the markup | UI markup, DOM wiring, two pure functions with tests |
+| 2 `target-apply-edits` | Opus 5 | high | text operations have edge cases (quotes spanning lines, separators, the contact line) |
+| 3 `suggestion-replacements` | Fable 5.1 | high | prompt rules plus guard tests (the gotcha 8/11 class of work) and the persist-time gate |
+| 4 `docx-patch` | Fable 5.1 for `docx-patch.ts`, `docx-structure.ts` and the fixtures; Opus 5 for routes and pages | max for the patcher, medium for the wiring | the patcher is the one piece with no library behind it and a byte-level correctness bar |
+| 5 `resume-render` | Opus 5 for the library wiring and pages; Fable 5.1 for the `structure` prompt block and its anchoring | high | new dependencies, fonts, two renderers, one prompt change |
+| `code-review-expert` pass before each PR | Fable 5.1 | high | mandatory pre-merge gate |
+| ADRs 0035–0037, CLAUDE.md rows, CHANGELOG | Opus 5 | medium | mechanical |
+
+Product engine: no change. The resume role stays Opus 5 (the ADR 0029 bench
+measured Sonnet slower on the CLI engine at lower keyword-frame stability);
+the new `replacement` field and the scan's `structure` block run on the same
+role. Re-run `npm run bench:resume` after stage 3 and stage 5 and paste the
+table into the PR.
+
+---
+
+## 1. Map of the change
+
+| File | Stage 1 | Stage 2 | Stage 3 | Stage 4 | Stage 5 |
+|---|---|---|---|---|---|
+| `src/web/public/target.mjs` | `proposalOf`, `changeSheet`, `formatChangeSheet` | `applyReplacement`, `removeSpan`, `insertIntoSkills`, `moveLineToBlockTop` | reads `replacement` | | |
+| `src/web/public/line-diff.mjs` (new) | `diffLines` | | | reused server-side | |
+| `src/web/public/copy.mjs` (new) | `wireCopy` | | | | |
+| `src/web/public/target-page.mjs` | Copy, Locate, `.located`, change sheet | Apply / Remove / Add / Undo, edit state | Apply enabled by `replacement` | Download button state | |
+| `src/web/pages/resume-match-card.tsx` | `SuggestionCard` (Now / Proposed), removal quote, buttons | states | | | |
+| `src/web/pages/target.tsx` | CSS, narrow order, toggle move, sheet buttons | | | template verdict line, Download | "Clean version" link |
+| `src/web/pages/job-detail.tsx` | loads `copy.mjs` | | | | |
+| `src/web/target.test.ts` | tests | tests | | | |
+| `src/resume/prompts.ts` | | | `replacement`, `insert_after`, `RULE_BULLET_STYLE`, `PROMPT_VERSION 7` | | `structure` block in `SCAN_SYSTEM` + `ScanSchema` |
+| `src/resume/replacement-gate.ts` (new) | | | `gateActions` | | |
+| `src/resume/match.ts`, `suggestions.ts` | | | call the gate before persist | | |
+| `src/resume/prompts.test.ts` | | | guard tests for both variants | | structure guard |
+| `src/resume/docx-structure.ts` (new) | | | | template check | reads styles for inference |
+| `src/resume/docx-text.ts` | | | | `walkDocument` + parity test | |
+| `src/resume/docx-patch.ts` (new) | | | | the patcher | |
+| `src/resume/docx-props.ts` (new) | | | | read / fix properties | |
+| `src/resume/line-diff.ts` (new) | | | | server wrapper over the `.mjs` | |
+| `src/resume/store.ts` | | | | `replaceResumeFile` reused for the patched version | `structure` column |
+| `src/web/routes/resumes.tsx` | | | | branch in `POST /resumes/:id/draft`; `structure` in `GET /resumes/:id` | `/resumes/:id/render` |
+| `src/web/routes/jobs.tsx` | | | | verdict for the target page | |
+| `src/web/pages/resume-detail.tsx` | | | | "Template check" card | knob view link |
+| `src/resume/json-resume.ts` (new) | | | | | zod model |
+| `src/resume/structure-anchor.ts` (new) | | | | | verbatim guard |
+| `src/resume/style-infer.ts` (new) | | | | | typography from docx / pdf |
+| `src/resume/render/clean-docx.ts`, `render/clean-pdf.ts` (new) | | | | | the two renderers |
+| `src/web/pages/resume-render.tsx` (new) | | | | | knobs + preview |
+| `prisma/schema.prisma` + migration | | | | | `Resume.structure Json?` |
+| `Dockerfile` | | | | | copy `src/resume/fonts` |
+| `package.json` | | | | `@xmldom/xmldom`, `jszip` | `docx`, `pdfkit`, `@types/pdfkit` |
+| `docs/adr/0035…0037` | | | 0035 | 0036 | 0037 |
+| CLAUDE.md, SPEC.md, CHANGELOG.md, README | rows + bump | rows + bump | rows + bump | rows + bump | rows + bump |
+
+Stages 1 and 2 need no schema and no prompt change. Stage 3 bumps
+`PROMPT_VERSION`. Stage 4 adds two pure-JS dependencies and no migration.
+Stage 5 adds two dependencies, one font, one column.
+
+---
+
+## 2. Stage 1: `target-copy-locate`
+
+The page becomes comfortable for the manual path: copy any proposal, locate
+its target without losing the card, carry the whole list out as text.
+
+### 2.1 Pre-work (before the branch)
+
+- [ ] Read `pages/target.tsx`, `public/target-page.mjs`, `public/target.mjs`,
+      `pages/resume-match-card.tsx` (`ActionsBlock`, `RemovalsBlock`,
+      `MatchReport`), `pages/job-detail.tsx` (how the match card is mounted),
+      `src/web/ui.tsx` (`Button`, `Badge`, `Hint`).
+- [ ] Pull every stored `actions[].what` (`select jsonb_array_elements(actions)->>'what' from resume_match`)
+      and write the proposal extractor against the real shapes: `Reword as: "…"`,
+      `Rewrite as: "…"`, `Change title to "…"`, `Open with: "…"`, `Add: "…"`,
+      `Add a … grouping: "…"`, and the no-quote conditionals. Record the hit
+      rate in the note (16 of 18 on 2026-09-03).
+- [ ] Decide the narrow-screen order with one screenshot of the current tab
+      at 375 px in the note.
+
+### 2.2 Pure functions
+
+`src/web/public/target.mjs` (dependency-free ES module, tested from
+`src/web/target.test.ts` via `import()`):
+
+```js
+/** The wording an action proposes, or null when `what` is an instruction with no quoted text. */
+export function proposalOf(action) → { text: string, verb: string } | null
+```
+Rules: prefer `action.replacement` when present (stage 3); else the longest
+double-quoted span in `what` (straight or curly quotes, folded); the `verb`
+is the text before the first quote with trailing colon and "as/to/with"
+stripped ("Reword", "Change title", "Add"). A quoted span under 12
+characters is not a proposal (it is a term mention).
+
+`src/web/public/line-diff.mjs` (new, pure):
+
+```js
+/** Line diff of two texts: [{ op: 'keep'|'change'|'delete'|'insert', a?: {i, text}, b?: {i, text} }]. */
+export function diffLines(before, after)
+```
+LCS over lines normalised by trim + whitespace collapse; a delete
+immediately followed by an insert pairs into `change`. Blank lines are kept
+as lines (paragraph gaps matter to the patcher later). Bound: 2 000 lines
+per side, O(n·m) is fine at resume size.
+
+`src/web/public/target.mjs`:
+
+```js
+/** Markdown change sheet: before editing (proposals) or after (the diff). */
+export function changeSheet({ actions, removals, analysedText, editedText })
+  → { entries: [{ section, where, now, next, why, kind: 'proposal'|'removal'|'edit' }] }
+export function formatChangeSheet(sheet) → string   // Markdown, one block per entry
+```
+"Copy all suggestions" uses the proposals; "Copy my changes" uses
+`diffLines(analysedText, editedText)` and ignores unchanged lines.
+
+Tests (`src/web/target.test.ts`): the extractor against eight real shapes
+plus the two conditionals; the diff on keep / change / delete / insert /
+moved line (a move shows as delete + insert, documented); the sheet on an
+edited fixture; Markdown output stable (snapshot string in the test).
+
+### 2.3 DOM wiring (`target-page.mjs`)
+
+- **Copy**: `navigator.clipboard.writeText(text)`; on rejection fall back to
+  a hidden textarea + `document.execCommand('copy')`; the button text turns
+  to "Copied" for 2 s and an `aria-live="polite"` region says "Copied to
+  clipboard". `src/web/public/copy.mjs` exports `wireCopy(root)` that
+  delegates clicks on `[data-copy]` buttons; the target page and the job
+  page both import it, so Copy works on `/jobs/:id` as well.
+- **Locate**: `locateQuote(editor.value, quote)`; on a hit add
+  `.located` to the matching backdrop span (render marks it via a new span
+  class in `resumeSpans`, or wrap after render), set the editor's own
+  `scrollTop` so the span sits in the upper third, call
+  `editor.focus({ preventScroll: true })` only when
+  `matchMedia('(min-width: 1024px)')` matches. The page scroll position
+  does not change; assert this in the manual walk. On a miss set the card's
+  status line to "Couldn't find this text in the editor, it may already be
+  edited" and drop the `flash-target` animation.
+- Remove the `[data-quote]` click handler on list items; the buttons carry
+  `data-quote` and `data-proposal` instead.
+- "Copy all suggestions" and "Copy my changes" at the top of the Suggestions
+  pane; the second is disabled while the editor equals the analysed text.
+
+### 2.4 Markup
+
+`pages/resume-match-card.tsx`: a `SuggestionCard` component used by
+`ActionsBlock` (on both pages) with this anatomy: label row (priority badge
+inline with the section and `where`), **Now** block (the quote, monospace
+off, 14 px), **Proposed** block (the proposal text, with the Copy button on
+the right), "serves: <why>" as a small line, then the button row (Copy,
+Locate; Apply and friends arrive in stage 2 behind a prop). `RemovalsBlock`
+gains the quote, dimmed and struck through, and a Locate button.
+`interactive` replaces the `jumpable` prop and is true only on the target
+page; Copy is always rendered.
+
+`pages/target.tsx`: CSS for `.located` (2 px accent outline, fade 2 s,
+`@media (prefers-reduced-motion: reduce)` disables the fade); on
+`max-width: 1023px` the `.pane-resume` card comes first in the Suggestions
+view with the editor at 40 vh and an "Expand editor" button that toggles
+70 vh; the "show matched highlights" checkbox moves into the editor card
+header; the keyword table folds into a `<details>` on narrow screens.
+
+Copy text (DESIGN.md voice): "Copy", "Copied", "Locate", "Couldn't find this
+text in the editor, it may already be edited", "Copy all suggestions", "Copy
+my changes".
+
+### 2.5 Accessibility
+
+Buttons are `<button type="button">` from the `Button` primitive, size sm;
+focus ring from the layout tokens; the aria-live region exists once per
+page; the Locate outline is not the only signal (the card also says the
+line number). Keyboard walk: Tab reaches every Copy and Locate in order,
+Enter activates, Escape closes nothing new.
+
+### 2.6 Verification (testing-gate: dashboard page + pure logic)
+
+- `npm run lint:types && npm test` (new tests included).
+- `docker compose build web && docker compose up -d web`; curl `/jobs/:id`
+  and `/jobs/:id/target?match=…` for 200.
+- Screenshots at 1200, 768, 375 of a card in its three states; the page
+  scroll position before and after Locate at 800 px (the bug in the plan).
+- Browser console: 0 errors; clipboard tested in the app's browser pane and
+  in Safari (permission prompt behaviour differs).
+- `code-review-expert` over `git diff main...HEAD`.
+
+### 2.7 Docs and release
+
+CLAUDE.md "Where to look": rows for `proposalOf`, `diffLines`, `copy.mjs`;
+"how does the user…" rows: "Copy a suggested wording", "Take the change
+list into Word". SPEC.md targeted-view paragraph. CHANGELOG + minor bump
+(next minor at PR time). Release notes draft in the PR body.
+
+### 2.8 Acceptance
+
+A user on a phone opens Suggestions, copies a proposal in one tap, pastes
+it into Google Docs, comes back and the card is still on screen. On
+desktop, Locate outlines the target without moving the page. "Copy all
+suggestions" pastes as readable Markdown.
+
+---
+
+## 3. Stage 2: `target-apply-edits`
+
+Apply, Remove, Add to Skills, Undo, as text operations on the editor.
+
+### 3.1 Pre-work
+
+- [ ] Read `keyword-overrides.ts` (`effectiveKeywords`, `addKeyword` status
+      rules) and `facts.ts` (confirmed / denied), because Add to Skills must
+      obey them.
+- [ ] Count, on the stored matches, how many actions have a quote the
+      editor finds (`locateQuote`) and how many removals span more than one
+      line; the note records both.
+
+### 3.2 Pure functions (`target.mjs`)
+
+```js
+export function applyReplacement(text, quote, replacement) → { text, span } | { error: 'not-found' }
+export function removeSpan(text, quote) → { text, span } | { error: 'not-found' | 'protected' }
+export function insertIntoSkills(text, term, where) → { text, span } | { error: 'no-skills-line' }
+export function moveLineToBlockTop(text, quote) → { text, span } | { error: 'not-found' | 'not-a-bullet' }
+```
+Rules:
+- `applyReplacement` locates through `locateQuote`, replaces exactly that
+  span, keeps the surrounding line's leading bullet marker, and returns the
+  new span for `.located`.
+- `removeSpan` removes the span; when the quote equals a whole line the line
+  goes with its newline; when the line matches `EMAIL_RE` or a phone run
+  (import the patterns from `parse-warnings.ts` by copying the two regexes
+  into the module with a comment, the browser module cannot import TS) the
+  result is `protected`.
+- `insertIntoSkills` finds the target line: the line containing the
+  `where` hint's key word ("Programming", "Frameworks", "Others"), else the
+  first non-heading line under a heading matching /skills/i, else error.
+  The separator is inferred from the line (", " / " | " / " · "); the term
+  goes at the end; a term already present (via `findTerm`) is a no-op.
+- `moveLineToBlockTop` finds the quoted line, walks up while lines start
+  with `- ` to the block start, moves the line there.
+
+Tests: each function on a fixture resume text, including the protected
+line, a quote with curly apostrophes, a two-line removal quote (join with a
+space before locating), a skills line with pipes.
+
+### 3.3 DOM wiring and state
+
+- Buttons: Apply (when `proposalOf` returns text), Edit & apply (a
+  textarea inline in the card prefilled with the proposal; Save applies),
+  Skip, Remove, Add to Skills on chips, Undo on applied and skipped cards.
+- State per match in localStorage `target-edits:<matchId>` =
+  `{ applied: { [key]: previousText }, skipped: [key] }` where `key` is
+  `section|where|quote` hashed with the same short hash the routes use
+  (copy the function; keep it tiny). Undo restores `previousText` when the
+  editor still equals the post-apply text; otherwise it says "the text moved
+  on, undo by hand" and stays disabled.
+- "Reset edits" and "Discard" clear the state with the draft.
+- Chips: `add` status and `ask_user` with a confirmed `CandidateFact` get
+  "Add to Skills"; `ask_user` without an answer keeps the confirm flow first;
+  `cannot_claim` chips render without a button and say why on hover and in
+  the line under the chips on touch.
+
+### 3.4 Verification
+
+Unit tests above; keyboard walk (every button reachable, Undo announces
+through the live region); screenshots of applied / skipped / undone; the
+dirty bar reacts; Re-check with AI still posts the edited text; a reload
+restores draft and state together.
+
+### 3.5 Docs and release
+
+CLAUDE.md rows for the four operations and the state key; SPEC; CHANGELOG +
+minor bump. No ADR: no contract changed.
+
+---
+
+## 4. Stage 3: `suggestion-replacements`
+
+The model returns applicable wording; the fact gate decides what is
+applicable.
+
+### 4.1 Pre-work
+
+- [ ] Read `prompts.ts` (`RULE_ACTIONS`, `RULE_REMOVALS`, `OUTPUT_ACTIONS`,
+      `REVIEW_SYSTEM`'s example / ask rules), `match.ts` (where the parsed
+      result meets `createMatch`), `suggestions.ts`, `cover-letter.ts` (how
+      it calls `factCheck` and what sources it passes), `fact-check.ts`
+      (the `factCheck` signature and verdict shape), `prompts.test.ts`
+      (the guard-test pattern for both variants),
+      `prompt-fence-registry.test.ts`.
+- [ ] Run `npm run bench:resume -- --mode full --out before.json` on the
+      current prompt and keep the file for the after-table.
+
+### 4.2 Schema and rules (`prompts.ts`)
+
+```ts
+actions: z.array(z.object({
+  section, where, what, why, priority,
+  quote: nullableText,
+  replacement: nullableText,   // the exact new text for the quoted span
+  insert_after: nullableText,  // verbatim anchor line for an addition
+}))
+```
+- Extract the bullet-style rules from `RULE_ACTIONS` into
+  `RULE_BULLET_STYLE` and reuse the same string in `REVIEW_SYSTEM`'s
+  example rule, so one wording rule governs both surfaces.
+- `RULE_ACTIONS` gains: "When the edit changes existing text, put the
+  complete new text in `replacement`, ready to paste in place of `quote`;
+  for an addition put the line it follows in `insert_after` and the new
+  text in `replacement`; `what` says what changes in one clause." The
+  NO TREADMILL and quantification rules stay word for word.
+- `OUTPUT_ACTIONS` lists the two fields. `SuggestionsSchema` picks them up
+  through `MatchSchema.pick`.
+- `PROMPT_VERSION = 7`, one bump; stored v6 rows keep working through
+  `proposalOf`'s quoted-span fallback.
+
+### 4.3 The gate (`src/resume/replacement-gate.ts`, pure)
+
+```ts
+export interface GateSources { resumeText: string; confirmedFacts: {term, note}[]; deniedTerms: string[]; keywords: MatchKeyword[] }
+export function gateActions(actions: MatchAction[], sources: GateSources): { actions: MatchAction[]; blocked: number; warned: number }
+```
+For every action with a `replacement`: `toPlainPunctuation` first; then
+`factCheck(replacement, [resumeText, ...confirmedFactLines])` exactly as
+`cover-letter.ts` calls it; `block` → `replacement` becomes null,
+`why` gains " · needs a real number: <first blocked claim>"; `warn` →
+kept, `note`-style suffix on `why`. Then KEEP WANTED KEYWORDS in code: if
+the quote contains a keyword whose status is `present` or `add` and the
+replacement does not (via the keyword matcher's `findTerm`), drop the
+replacement the same way. Log counts.
+
+Wire it in `match.ts` after `parseMatchResponse` and before `createMatch`,
+and in `suggestions.ts` before `updateMatchSuggestions`, with the sources
+loaded where `listFacts()` already is.
+
+### 4.4 UI
+
+Apply appears only when `replacement` is present after the gate; a blocked
+card shows the question and Edit & apply. The removal path is unchanged.
+
+### 4.5 Guard tests (`prompts.test.ts`)
+
+Both variants and the suggestions prompt contain the replacement rule; the
+zod schema accepts a reply without the new fields; the gate blocks an
+invented "40%" and keeps a figure present in the resume; the KEEP WANTED
+KEYWORDS check drops a replacement that loses "Docker".
+
+### 4.6 Verification
+
+`bench:resume` after-table (parse failures 0, reply size delta, status
+agreement); one live full analysis and one Get suggestions on a stored
+resume; count blocked replacements and paste the numbers in the PR;
+`prompt-fence-registry.test.ts` green (no new call site).
+
+### 4.7 ADR 0035 and release
+
+"Suggestions carry replacement text; the fact gate decides what is
+applicable." Context: TASKS §5.15's closure and its reopen trigger, the
+16/18 measurement. Decision: the two fields, the gate at persist time,
+blocked proposals shown as questions, keyword additions deterministic.
+Consequences: more output tokens on the full report (measured), Apply on
+one click. CHANGELOG + minor bump + tag.
+
+---
+
+## 5. Stage 4: `docx-patch`
+
+Save returns the user's own .docx with the edited strings, when the file
+allows it; the template check tells the user beforehand.
+
+### 5.1 Pre-work
+
+- [ ] Read `docx-text.ts` end to end, `zip.ts`, `zip-write.ts`,
+      `docx-text.test.ts` fixtures, `store.ts` (`replaceResumeFile`,
+      `saveResumeTextVersion`, `getResumeOriginal`), `routes/resumes.tsx`
+      (`POST /resumes/:id/draft` and its run), `pages/resume-detail.tsx`
+      (where parse warnings render), `web/upload.ts`.
+- [ ] Prove `@xmldom/xmldom` fidelity in a throwaway script: parse resume
+      1's `document.xml`, serialise unchanged, compare text nodes and
+      attribute order; decide "DOM for document.xml, raw bytes for every
+      other part" (the expected outcome) and write it in the note.
+- [ ] Build the structural twin fixture: take resume 1's XML, replace every
+      text node with neutral prose of the same length, keep runs, tabs, the
+      1×2 table, numbering and the OMML objects; commit it under
+      `src/resume/fixtures/flow-fragmented.docx`. Add two more:
+      `structural-table-layout.docx` (two-column table layout, a text box,
+      contact in the header) built with the `docx` library from stage 5 or
+      by hand in Word, and `flow-simple.docx` (paragraphs only).
+- [ ] Run the parser-disagreement test by hand: `docx-text` vs
+      `libreoffice --convert-to txt` on the three fixtures; note the
+      differences (tabs, table rows, list markers).
+
+### 5.2 Dependencies
+
+`jszip` (container: list, read, write with the original compression
+settings) and `@xmldom/xmldom` (DOM). Pin exact versions; they are pure JS,
+so the Dockerfile stays as it is. ADR 0036 records both.
+
+### 5.3 Template check (`src/resume/docx-structure.ts`, pure)
+
+```ts
+export interface DocxStructure {
+  kind: 'flow' | 'structural' | 'unsupported';
+  lines: { total: number; editable: number };
+  tables: number; textBoxes: number; drawings: number; columns: number;
+  headerChars: number; footerChars: number; math: number;
+  hiddenRuns: number; whiteRuns: number; tinyRuns: number;
+  notes: string[];   // plain sentences for the card
+}
+export function docxStructure(bytes: Buffer): DocxStructure
+```
+`kind` is `flow` when tables + text boxes + columns are 0 and the header /
+footer carry no text; `structural` otherwise; `unsupported` when
+`document.xml` is missing or the document has more text in text boxes than
+in the body. `lines.editable` counts rendered lines whose block is a
+paragraph or a table cell (stage v1 policy: cell text edits allowed; owner
+question 5). `notes` are the sentences the card shows ("2 formula objects:
+some parsers cannot read them", "Contact details live in the header: ATS
+parsers and this editor do not see them").
+
+Runs at upload (`web/upload.ts` after `extractResumeText`, .docx only) and
+the result is not stored: it is recomputed from `original` on
+`GET /resumes/:id` (43 KB, sub-millisecond) and on the target page. Tests:
+the three fixtures give the three kinds; hidden / white / tiny runs are
+counted from a hand-made XML string.
+
+### 5.4 `docx-text.ts` refactor
+
+Add `walkDocument(doc: Document) → Block[]` with
+`Block = { kind: 'heading'|'bullet'|'body'|'cell'|'tabbed', node: Element, lines: string[] }`
+and make `documentXmlToText` a thin fold over it (`lines.join('\n')` per
+block, same blank-line rules). The parity test asserts old and new output
+are identical on every existing fixture plus the three new ones. Keep the
+regex reader as the fallback for the text path if xmldom throws on a file
+(some producers emit invalid XML); log which path ran.
+
+### 5.5 Line diff on the server
+
+`src/resume/line-diff.ts` imports the browser module the way
+`keyword-matcher.ts` already bridges to `target.mjs`, so the change sheet
+and the patcher share one `diffLines`.
+
+### 5.6 The patcher (`src/resume/docx-patch.ts`, pure)
+
+```ts
+export interface PatchReport { changed: number; removed: number; added: number; skipped: { line: string; reason: string }[] }
+export type PatchResult =
+  | { ok: true; docx: Buffer; report: PatchReport; text: string }
+  | { ok: false; reason: string; report?: PatchReport };
+export function patchDocx(original: Buffer, analysedText: string, editedText: string, opts?: { fixProperties?: { title: string; author: string } }): PatchResult
+```
+Algorithm:
+1. `jszip.loadAsync(original)`; read `word/document.xml`; parse with xmldom.
+2. `walkDocument` → blocks; `analysedText` must equal the fold of the
+   blocks (normalised); if not, return `ok: false, reason: 'analysed text
+   does not match this file'` (the user edited a different version).
+3. `diffLines(analysedText, editedText)`; map each `a` line index to its
+   block through a running counter over `block.lines`.
+4. Apply ops in reverse document order (so indices stay valid):
+   - `change` on a paragraph block: concatenate its `w:t` text nodes; find
+     the old line text; write the new text into the first affected `w:t`
+     (set `xml:space="preserve"`), empty the rest of the span, keep partial
+     runs' outside parts. A `tabbed` block splits the line on ` | ` and
+     patches each side within its tab-delimited run group. A `cell` block
+     patches the cell paragraph the same way.
+   - `delete`: remove the paragraph node; refuse when the block is a
+     `tabbed` header or a `cell` (skipped with reason).
+   - `insert`: clone the previous block's paragraph node deep, replace its
+     runs with one run carrying the previous run's `rPr` and the new text;
+     a bullet after a bullet keeps `numPr`. Refuse inserts inside tables in v1.
+   - Hygiene on every inserted / changed string: `toPlainPunctuation`
+     applied to the *new* text only; the original's characters stay.
+5. Serialise `document.xml`; refresh `dcterms:modified` in
+   `docProps/core.xml` (`docx-props.ts`); apply `fixProperties` when given
+   (title, `dc:creator`, `cp:lastModifiedBy`; nothing else).
+6. Rebuild the zip with every other entry copied byte for byte
+   (`jszip` keeps them when only two files are replaced).
+7. Gates, in order; any failure returns `ok: false` with the reason:
+   `docxToText(docx)` equals `editedText` after the editor's normalisation;
+   counts of `m:oMath`, `w:drawing`, `txbxContent` unchanged; no new
+   hidden characters; `report.skipped` is empty or the caller allowed
+   partial patches (v1: empty required).
+
+`docx-props.ts` (pure): `readProps(bytes) → { title, creator, lastModifiedBy, modified, application }`,
+`withProps(bytes, patch) → bytes` touching only `docProps/core.xml`; test
+that `word/*` is byte-identical afterwards.
+
+Tests (`docx-patch.test.ts`): change a fragmented bullet; change both
+halves of a tabbed header; delete a bullet; insert a bullet after a bullet
+(numbering kept); refuse a delete of a header; refuse an edit when the
+analysed text mismatches; round trip on all fixtures; properties fix leaves
+`word/*` untouched; a curly quote in new text becomes straight.
+
+### 5.7 Store and routes
+
+- `POST /resumes/:id/draft` (`routes/resumes.tsx`): inside the existing
+  run, before `saveResumeTextVersion`: load `getResumeOriginal(id)`; if the
+  filename ends with `.docx` (the stored mime is unreliable: resume 1 says
+  `application/octet-stream`) and `docxStructure(original).kind !== 'unsupported'`,
+  call `patchDocx(original, analysedText, text)` where `analysedText` is the
+  match's `resumeText` the editor started from (post it as a hidden field
+  `baseText`, or the match id and read it back). On `ok`, call
+  `replaceResumeFile(id, { sourceFilename: `${slug}-v${n}.docx`, mimeType: DOCX_MIME, original: docx, text })`;
+  on `ok: false`, fall back to the text version and put the reason in the
+  flash ("Saved as v5 (text). The .docx could not be patched: <reason>.").
+  The run's subtitle names which one happened.
+- "Save as a tailored copy": a second submit value on the same form creates
+  a new `Resume` row (`createResume` with the patched or text file, name
+  `${resume.name} · ${job.companyName}`) instead of bumping the master;
+  owner question 1 decides the default.
+- `GET /resumes/:id` passes `structure` (or null for non-docx) to
+  `ResumeDetailPage`; `GET /jobs/:id/target` passes the one-line verdict.
+- `GET /resumes/:id/download` is unchanged: it serves the current file,
+  which is now the patched one after a patched save.
+
+### 5.8 UI
+
+- `/resumes/:id`: a "Template check" card next to "What the ATS sees":
+  kind as a badge (Editable in place / Partly editable / Text only), the
+  lines line, the notes, and "Fix document properties" (a POST that calls
+  `withProps`, shown only when `readProps` finds a creator or title that is
+  not the candidate; the current values are printed on the button's card).
+- Target page: above the editor, "This file: editable in place, 61 of 78
+  lines" or "This file is a PDF: Save keeps a text version; upload the .docx
+  it was printed from to get a styled file back." After a patched save the
+  flash carries "Download .docx" and the export report line.
+- Copy: never say "AI"; say what happened and why.
+
+### 5.9 Verification
+
+Unit tests above; round trip on resume 1 (real file, by hand); open the
+patched output in Word, Pages and LibreOffice and compare with the original
+side by side (screenshots in the PR); `docker compose build web` and the
+draft flow end to end; the parser-disagreement check on the output; the
+`Fix document properties` POST verified with `readProps` before and after.
+
+### 5.10 ADR 0036 and release
+
+"Save patches the user's .docx in place; text-only versions are the
+fallback." Supersedes the "text-only versions" consequence of ADR 0010.
+Records the dependencies, the DOM-for-document.xml decision, the gates, the
+v1 table policy, the metadata policy. CHANGELOG + minor bump + tag. CLAUDE.md
+rows: template check, patcher, properties, the `.docx`-only rule.
+
+---
+
+## 6. Stage 5: `resume-render`
+
+A clean single-column .docx and .pdf in the user's typography, for files
+that cannot be patched.
+
+### 6.1 Pre-work
+
+- [ ] Read `scan.ts`, `SCAN_SYSTEM`, `ScanSchema`, `saveResumeScan`,
+      `keyword-anchor.ts` (the verbatim guard to imitate), `pdf-text.ts`
+      (how the pdf.js proxy is opened and destroyed), `Dockerfile` (how
+      `src/web/public` is copied).
+- [ ] Render one JSON Resume sample through `docx` + pdfkit and through
+      Typst (`basic-resume` or `jsume`) in a throwaway script; compare
+      output, dependency size and the producer strings; the note decides
+      the PDF engine (owner question 3).
+- [ ] Pick the bundled font: one OFL family with Latin + Cyrillic coverage
+      in regular and bold (Source Sans 3 or Liberation Sans); record the
+      licence file path.
+
+### 6.2 Model (`src/resume/json-resume.ts`)
+
+A zod schema for the subset ApplyPack renders: `basics` (name, label,
+email, phone, url, summary, location, profiles), `work[]` (name, position,
+location, startDate, endDate, summary, highlights[]), `education[]`,
+`skills[]` (name, keywords[]), `languages[]`, `certificates[]`,
+`projects[]`. Export the type and `readStructure(json)` for the column.
+
+### 6.3 The scan's `structure` block
+
+`SCAN_SYSTEM` gains a `"structure"` field in the output shape with the
+schema above and one rule: every `highlights[]` entry, every `summary` and
+every `basics` string is copied character for character from the resume.
+`src/resume/structure-anchor.ts` (pure) checks it: a string that is not a
+verbatim span (after `normalise`) of the resume text is dropped and logged;
+a work entry that loses all highlights is kept with an issue line.
+Migration `add_resume_structure`: `Resume.structure Json?`, hand-written,
+`npx prisma format`. `saveResumeScan` writes it. Guard test in
+`prompts.test.ts`: the rule text is present; a reply without `structure`
+still parses.
+
+Deterministic fallback (`structure-from-text.ts`): headings from `## `,
+roles from `Company | Location` + `Title | Dates` pairs, bullets from `- `;
+used when the scan has not run or dropped everything.
+
+### 6.4 Style inference (`src/resume/style-infer.ts`, pure)
+
+```ts
+export interface InferredStyle { fontFamily: string | null; bodyPt: number | null; namePt: number | null; headingPt: number | null; accentHex: string | null; marginsIn: number | null; nameCentered: boolean | null; source: 'docx' | 'pdf' | 'none' }
+export function inferFromDocx(bytes: Buffer): InferredStyle
+export async function inferFromPdf(bytes: Buffer): Promise<InferredStyle>
+```
+docx: `styles.xml` docDefaults + Normal + Heading styles for fonts and
+sizes, `w:color` on heading runs for the accent, `w:pgMar` for margins,
+`w:jc center` on the first paragraph. pdf: `page.getTextContent()` items
+with `styles[fontName].fontFamily` and the transform's scale; body size is
+the mode, name size the maximum on page 1; no colour. Map the family to the
+bundled list (Arial / Helvetica / Calibri → the sans face; Georgia / Times
+→ a serif face if bundled, else the sans face) and keep the original name
+for the label ("Your resume uses Calibri; the closest bundled face is
+Source Sans 3").
+
+### 6.5 Renderers
+
+`src/resume/render/clean-docx.ts`: `renderDocx(resume: JsonResume, knobs: RenderKnobs) → Buffer` with the `docx` library: one section, margins from knobs, `styles.default.document.run` font + size, headings as bold paragraphs with spacing, bullets through a single numbering definition, `creator` / `lastModifiedBy` / `title` from `basics`. No tables, no text boxes, no headers.
+
+`src/resume/render/clean-pdf.ts`: `renderPdf(resume, knobs) → Promise<Buffer>` with pdfkit: `new PDFDocument({ size: knobs.page, margins, info: { Title, Author, Producer: '', Creator: '' } })`, the bundled TTF registered for regular and bold, `doc.text` with `width` for wrapping, bullets through `doc.list` or a manual "• " with hanging indent, page breaks automatic.
+
+`RenderKnobs`: `{ fontFamily, bodyPt, accentHex | null, marginsIn, sectionOrder, dateFormat, nameCentered, page: 'LETTER' | 'A4' }`, defaults from `InferredStyle`, then the user's edits (stored in `AppSettings` JSON as `renderKnobs` per resume id, or in the form only; owner decides).
+
+### 6.6 Routes and page
+
+`GET /resumes/:id/render`: the knob form prefilled, the parsed structure
+(editable text areas per section for the mis-split case), a plain-text
+preview of "what the ATS sees" produced by rendering to docx and running
+`docxToText` on it (sub-second). `POST /resumes/:id/render` with
+`format=docx|pdf` downloads; `save=1` creates a new Resume row from the
+.docx so the loop continues on it. The target page and `/resumes/:id`
+link to it for PDF-only and structural files: "Clean version in your
+typeface".
+
+### 6.7 Dockerfile
+
+Copy `src/resume/fonts/` into the runtime image beside `src/web/public`
+(same COPY pattern); the licence file ships with the fonts.
+
+### 6.8 Verification
+
+Unit: renderers produce parseable files (round trip through `docxToText`
+and `pdfToText`), the anchoring guard, the inference on the three fixtures
+and on a pdf fixture. Live: render the three stored resumes, open the
+outputs in Word, Pages, Preview and LibreOffice, check Cyrillic in a name,
+run `parse-warnings` on the outputs; `bench:resume` unaffected (the scan
+prompt is not benched; run one scan and inspect the structure).
+
+### 6.9 ADR 0037 and release
+
+"Resumes render from JSON Resume through `docx` and pdfkit; metadata per
+library." Records the dependencies, the font, the WinAnsi limitation and
+its fix, the Typst comparison result, the honest label. CHANGELOG + minor
+bump + tag.
+
+---
+
+## 7. Optional: the LibreOffice profile
+
+Only if owner question 4 says the Word export step hurts. A compose service
+`pdf` on a Debian-slim LibreOffice image, `profiles: [pdf]`, no ports; the
+web container calls it through a shared volume and `docker compose exec`
+is not available from inside a container, so the conversion runs as a tiny
+HTTP shim in that image (one POST, returns the PDF) or through a watched
+folder. Producer "LibreOffice"; the metadata is then stamped with pdf-lib
+or left as is. Decide when needed; do not build ahead.
+
+---
+
+## 8. Cross-cutting rules
+
+- **Names and copy.** "Copy", "Locate", "Apply", "Edit & apply", "Skip",
+  "Remove", "Add to Skills", "Undo", "Save as vN (.docx)", "Save as a
+  tailored copy", "Clean version in your typeface", "Fix document
+  properties". Never "AI" in a file, never "regenerate" for a patch.
+- **No-JS.** Copy, Locate, Apply are JavaScript by nature; Save, Download,
+  Fix properties and the render form are plain forms.
+- **localStorage keys.** `target-draft:<matchId>` (exists),
+  `target-edits:<matchId>` (stage 2). Both cleared by Discard.
+- **Runs.** Patched saves and renders ride the existing run registry; no
+  new registry.
+- **Logging.** One `logger.info` per patched save with the report counts;
+  one per render with format and size; gate counts in stage 3.
+- **Security.** Uploaded .docx files are user-owned bytes; `jszip` reads
+  them with a cap (`MAX_UPLOAD_MB` already bounds the file; add an
+  uncompressed-size cap of 50 MB against zip bombs). No external fetch
+  anywhere in these stages.
+- **Performance.** Template check and patch: milliseconds on a 43 KB file;
+  render: under a second. Anything slower is a bug, not a run.
+- **Docs per stage.** CLAUDE.md rows in both tables, SPEC.md, README feature
+  list, CHANGELOG + bump, the ADR named for the stage, TASKS §18 ticks.
+
+---
+
+## 9. Risks and where each one is retired
+
+| Risk | Retired by |
+|---|---|
+| The proposal extractor misreads a `what` | stage 1 tests on the real shapes; stage 3 makes the field explicit |
+| A replacement invents a number | stage 3 gate; the question fallback |
+| xmldom changes untouched XML | stage 4 pre-work fidelity proof; raw bytes for every part but `document.xml` |
+| A patched file opens differently in Word and Pages | stage 4 verification opens both; the twin fixture keeps tabbed headers and the 1×2 table |
+| The template check calls a flow file structural | fixtures for the three kinds; the verdict says what it counted |
+| pdfkit tofu on Cyrillic | the bundled OFL face; a test renders a Cyrillic name |
+| The `structure` block rewrites a bullet | the anchoring guard drops unanchored strings |
+| Users expect "my template" from the re-render | the label and the preview; the plan's §5 wording in the UI |
+| Dependency drift | exact pins; the ADRs list versions; `npm audit` in the PR body |
+
+---
+
+## 10. Release notes drafts
+
+- **Stage 1.** Suggestions you can take with you: every proposed wording
+  has a Copy button, Locate shows the line without moving the page, and
+  "Copy all suggestions" / "Copy my changes" give you the edit list for
+  Word, Canva or Google Docs.
+- **Stage 2.** Apply a suggestion, remove a line, add a missing keyword to
+  Skills, undo any of it; nothing is saved until you save.
+- **Stage 3.** The analysis now proposes the exact wording and the fact
+  checker decides what is safe to apply; a proposal that needs a number you
+  have not given becomes a question.
+- **Stage 4.** Save returns your own .docx with the edits in place when the
+  file allows it; the resume page tells you beforehand what is editable in
+  place, and can fix template junk in the document properties.
+- **Stage 5.** A clean single-column version of any resume in your own
+  typeface, as .docx and .pdf, for files that cannot be patched.

--- a/docs/tailoring-loop-plan.md
+++ b/docs/tailoring-loop-plan.md
@@ -1,0 +1,455 @@
+# The tailoring loop: apply, copy, save, export (plan)
+
+> Analysis 2026-09-03, nothing built. Answers four questions the owner asked
+> about `/target` → `/jobs/:id/target`: can the user apply the AI's edit
+> suggestions with a click and save the result as a file; is the
+> linkedin-radar "resume regeneration service" worth reusing; do ATS block
+> "AI-generated" files; and how should the page serve someone who edits by
+> hand, with every user on a different template. Backlog ticks live in
+> [TASKS.md §18](./TASKS.md); the file-by-file build guide is
+> [tailoring-loop-integration.md](./tailoring-loop-integration.md). Pairs with
+> [ADR 0010](./adr/0010-two-scores-live-keywords-vs-ai-match.md),
+> [ADR 0012](./adr/0012-deterministic-match-score.md),
+> [ADR 0020](./adr/0020-fact-gate-blocks-fabrication-not-imprecision.md),
+> [ADR 0029](./adr/0029-quick-check-and-lazy-suggestions.md),
+> [ADR 0030](./adr/0030-resume-strength-review.md), the
+> [resume-match UX audit](./archive/applypack-resume-match-ux-refactor.md)
+> and [resume-ats-blueprint.md §29–30](./resume-ats-blueprint.md).
+> The published report this plan condenses: «The Tailoring Loop»
+> (claude.ai artifact 3715b171-b31e-4911-af4e-126caa75cc5b).
+
+**Ground rules for everything below**
+
+- **Analyse before every stage, in writing.** Each stage in the integration
+  guide opens with a pre-work checklist; its result is a 10–20 line analysis
+  note at the top of the PR body (what the plan assumed, what differs today,
+  which simpler alternative lost and why).
+- **The user's own file first.** A tailored resume is the user's document
+  with edited strings, never a re-typeset copy, wherever the file allows it.
+  When it does not, the page says so before the user starts.
+- **The fact gate stays in code.** Wording the model proposes enters the
+  resume only after `fact-check.ts` has read it (ADR 0020). A proposal the
+  gate blocks is shown as a question, never as an Apply button.
+- **Libraries where a library exists.** `docx`, `pdfkit`, `@xmldom/xmldom`
+  and `jszip` do their jobs; the one piece no library does (replacing text
+  inside an arbitrary existing .docx with its formatting intact) stays
+  in-house and small.
+- **No hidden text, no tool name in a file, no external service.** The
+  metadata policy in §2 binds every writer; the resume never leaves the box.
+- **Facts expire.** Every count and library fact below was observed on
+  2026-09-03. Re-verify at implementation time.
+
+---
+
+## 0. Facts established (don't re-derive)
+
+### 0.1 What `/jobs/:id/target` does today
+
+| Capability | State | Where |
+|---|---|---|
+| Plain-text editor with live highlights | shipped | `pages/target.tsx`, `public/target-page.mjs` |
+| Live score while typing, same formula as the AI score | shipped | `public/score.mjs`, parity test vs `score.ts` (ADR 0012) |
+| Click a suggestion → its quoted text is selected in the editor | shipped | `locateQuote` in `target.mjs`; audit §6.1/6.2 |
+| Missing-keyword chips jump to the section the AI named | shipped | `jumpToSection` |
+| Draft survives reloads; Re-check with AI; Save as vN | shipped | localStorage per match; `POST /resumes/:id/draft` |
+| Copy the proposed wording | **missing** | the wording sits inside an instruction sentence in a clickable list item; no Copy anywhere |
+| Apply a suggestion to the text | **missing** | the audit specified `[Apply] [Edit] [Skip]`; only the jump shipped |
+| Add a missing keyword into the text | **missing** | chips only navigate |
+| A file after Save | text only | Save writes a `.md` version; Download returns the original upload, never the edit (ADR 0010: "there is no .docx to update") |
+| `.docx` export | closed 2026-09-01 | TASKS §5.10: a plaintext dump loses the design; format-preserving patching is "big-ticket XML surgery"; reopen trigger: the paste workflow hurting |
+| AI-written tailored resume | closed 2026-09-01 | TASKS §5.15: auto-rewriting reopens the hallucination surface; reopen trigger: manual tailoring too slow |
+
+This request is the reopen trigger for both closed items, in a narrower
+form than either: the user picks each edit, the model only proposes wording,
+and the file keeps the user's design.
+
+### 0.2 The suggestion contract
+
+| Field | Shape | Applicable as-is? |
+|---|---|---|
+| `actions[]` | `section · where · what · why · priority · quote\|null` | partly. `quote` is verbatim (the editor finds it), `what` is prose: "Reword as: "…"", "Change title to "…"", "Add: "…"". Measured on the two stored full analyses (matches 59 and 68): **16 of 18 actions carry the proposal as a quoted string inside `what`**; the two that do not are conditional ("if accurate, add RabbitMQ…"). No `replacement` field exists. |
+| `removals[]` | `section · where · what · why · quote` | yes. The quote is the text to delete (5–182 characters on match 59); two prompt rules protect the contact line and wanted keywords. The card does not show the quote. |
+| `keywords[]` | `term · requirement · status present\|add\|ask_user\|cannot_claim · where · aliases` | yes, deterministically. `add` = evidenced but unwritten; `ask_user` has a confirm flow; `cannot_claim` must never get a button. |
+| `review.advice[]` | `… example\|null · ask\|null · quote` | the precedent (ADR 0030): a rewrite built only from facts in the resume, or a question for the missing number. Exactly the contract the actions need. |
+
+### 0.3 Building blocks already in the tree
+
+| Module | What it does | Reused for |
+|---|---|---|
+| `resume/zip.ts`, `zip-write.ts` | read one zip entry; write a deterministic STORED zip | the letter writers keep them; the patcher uses `jszip` (§4) |
+| `resume/docx-text.ts` | WordprocessingML → text: one line per paragraph, `- ` for list items, `## ` for headings, table rows as `cell \| cell`, tabs as ` \| ` | the paragraph ↔ editor-line map; the round-trip gate; the template check |
+| `resume/docx-write.ts`, `pdf-write.ts` | letter → minimal .docx (no docProps) / PDF 1.4 Helvetica-only (no /Info) | stay for letters; resumes go through libraries |
+| `resume/fact-check.ts` | pure fabrication gate: pass / warn / block over numbers, denied terms, employers (ADR 0020) | every replacement the model proposes |
+| `prompts.ts:toPlainPunctuation` | NFKC, dashes, curly quotes, NBSP, zero-width, emoji → plain keyboard text | the hygiene gate on inserted text |
+| `resume/parse-warnings.ts` | deterministic "what the ATS sees" checks over the text | the export report; gains a structural sibling for .docx (§5) |
+| `target.mjs:locateQuote` | exact, then whitespace/punctuation-insensitive match of a quote in the text | Locate and Apply; the "couldn't find it" fallback |
+| `resume/pdf-text.ts` (unpdf) | PDF text via pdf.js; the same proxy exposes per-item font names and sizes | typography inference for PDF-only users (§5) |
+| `web/target-runs.ts`, `draft-stash.ts` | in-memory run registry and one-shot draft hand-off | patched saves ride the existing draft run |
+
+### 0.4 The live corpus (port 5433, read-only)
+
+| id | Resume | ver | Stored file | bytes | chars | Patchable in place? |
+|---|---|---|---|---|---|---|
+| 1 | Senior Backend PHP | 4 | `.docx` (mime stored as `application/octet-stream`) | 43 440 | 6 004 | yes |
+| 4 | scratch row (hidden, /target) | 19 | `.pdf` | 122 856 | 5 975 | no |
+| 5 | PHP/JS/React | 1 | `.pdf` | 122 631 | 5 908 | no |
+| 8 | with photo | 1 | `.pdf`, 1 image | 269 098 | 6 338 | no |
+
+Two of three visible resumes are PDFs printed from macOS. A docx patcher
+alone covers a third of today's corpus; the product has to ask for the .docx
+source when it wants to return a styled file.
+
+**Resume 1, the one .docx, measured:** 89 paragraphs, 527 runs, 31 of 65
+non-empty paragraphs split into more than three runs (Word fragmentation:
+string replacement must map across runs); 24 numbered bullets; one table
+(KEY SKILLS as a single row with two cells, every label stacked in the left
+cell); 2 Office Math objects; 100 literal tabs aligning company/location and
+title/dates; 2 hyperlinks; 2 non-breaking spaces; no text boxes, drawings,
+headers or footers; Arial throughout. `docx-text` renders it as 78 lines:
+four section headings, 24 bullets, role headers as `Company | Location`
+lines, the skills table as one glued label line plus one value line.
+
+Its `docProps/core.xml` still carries a third-party template's junk: a
+street address as the title, a stranger's first name as the creator, "a
+draft of … Resume Template" as the description; `app.xml` says Microsoft
+Office Word 16. This is the defect linkedin-radar's `clean_docx_metadata.py`
+exists for, live in the database today.
+
+The three PDFs carry `/Producer (macOS Version 26.3.1 … Quartz PDFContext)`,
+no Creator, no Author, no Title, no XMP: a Pages or Preview export, and the
+most "human" fingerprint a PDF can have.
+
+**ApplyPack's own exports carry nothing.** `pdf-write.ts` emits no `/Info`
+dictionary; `docx-write.ts` emits no `docProps` part.
+
+---
+
+## 1. The linkedin-radar `job-apply` skill, checked
+
+What the request calls "the service that regenerates PDFs" is
+`.claude/skills/job-apply/` in `~/main/linkedin-radar`: a `SKILL.md`
+pipeline, two rulebooks (`ats-rules.md`, `us-resume-format.md`), a ghost-job
+checklist and nine stdlib-Python scripts. Last used 2026-08-02 (six rows in
+its applications log). The pipeline, in its own order:
+
+1. Verify the posting is real (job-verifier subagent).
+2. Pick a master from six markdown masters, each naming its styled source .docx.
+3. Write the analysis first: recruiter appeal + ATS keyword map (present / add / cannot claim).
+4. Tailor per the analysis only: title, summary, skills order, top-2 roles' bullets, stack lines; older roles verbatim.
+5. `patch_resume_docx.py`: paragraph-level text replacement mapped back onto fragmented runs; styles / numbering / settings byte-identical.
+6. `set_skills_table.py`, `fix_role_header_tabs.py`, `tighten_layout.py`, `replace_math_with_text.py`, `insert_role_block.py`, `delete_paragraphs.py`: structural repairs of one specific template.
+7. `clean_docx_metadata.py`: rewrite core.xml / app.xml only; `word/*` byte-identical.
+8. `check_text_hygiene.py`: every run printable ASCII plus the template's two separators; NBSP, soft hyphen, zero-width and curly quotes fail the build.
+9. ATS gates: extracted text equals the markdown; every P1 keyword present or listed as "missing, no evidence"; exactly 2 pages; human voice.
+10. `resume.pdf`: Word render preferred, Pages export via `osascript` as fallback, PDFKit stamps Title/Author. macOS only.
+
+| Piece | Generic? | Take it? |
+|---|---|---|
+| Run-mapped paragraph replacement | yes, any .docx | the idea; rewritten over a DOM in TS |
+| Byte-identical style parts gate | yes | port |
+| Extracted-text round-trip gate | yes | port; the extractor exists |
+| Hygiene gate | yes | port, over new text only |
+| Metadata cleaning | yes | port as an opt-in "fix document properties" |
+| Skills-table rebuild, role-header tables, layout tightening, the page-2 break | no: hard-coded labels, colours, twips, a company name that must start page 2 | leave; a generic patcher must not restyle |
+| Math-to-text flattening | yes | later: a warning first |
+| Word / Pages PDF render | no: AppleScript | impossible in Docker; LibreOffice is the container equivalent (§4) |
+| Rulebooks | mostly | already absorbed into `prompts.ts`; one claim does not hold up (§2) |
+
+House rule: other `~/main` projects are studied for logic and implemented
+independently. Here the rule has a second reason: the Python is regex over
+XML tuned to one file.
+
+---
+
+## 2. The "AI-marked file" question, answered
+
+| Claim | Status | Sources say |
+|---|---|---|
+| ATS reject AI-written resumes | myth | Jobscan (25 US recruiters) and Enhancv (ten largest systems) found no authorship feature in any major ATS in 2026; Workday scores fit, Greenhouse's 2025 AI suite has no authorship filter, Lever's AI is sourcing. Vendors avoid it because false positives on human text would be catastrophic. [S1, S2] |
+| A "generated" PDF or DOCX carries a mark | half true | the mark is the library's: python-docx writes creator `python-docx` [S5], pdf-lib names itself in Producer [S6], `docx` writes creator "Un-named" [S17], pdfkit writes Producer and Creator "PDFKit" [S18]; ChatGPT's sandbox uses python-docx and ReportLab [S7]. Parsers do not reject on those fields; a recruiter opening File → Properties reads them. [S7, S8] |
+| Hidden or white keywords are detected | fact | Greenhouse: about 1% of ~300 million resumes in H1 2025 carried white-text messages [S3]; 2026 guides report Workday's 2025 "content integrity check" and iCIMS data on flagged resumes [S4]. No vendor-primary source for the Workday check; treat the mechanism as reported, the risk as real. |
+| Formatting breaks the parse | fact, the real risk | single-column .docx 97.4% of seeded fields vs two-column PDF 71.2% in one 2026 test; DOCX parses at least as well as PDF on Workday, Taleo and iCIMS, equally on Greenhouse. [S9, S10] |
+| Text-level AI detectors on the prose | human-side risk | some recruiters run GPTZero-class tools on the text. Keep the candidate's own phrasing; the prompt rules already enforce that. |
+
+One rulebook claim does not hold up: linkedin-radar's `ats-rules.md` says
+"since late 2025 major ATS vendors ship AI-content classifiers … 77% of
+employers scan for AI-generated content". No 2026 source supports
+vendor-side classifiers; the 77% is survey talk about recruiters. Keep the
+human-voice rule, drop the vendor claim if the rulebook is ever ported.
+
+**So the generation method is not the risk. Three things are:** hidden text
+(this design writes only visible text and refuses zero-width / NBSP / soft
+hyphen in inserted text); layout the parser cannot walk (patching changes no
+layout; re-rendering is single-column by construction); metadata that names
+a tool (policy below).
+
+### Metadata policy for every file ApplyPack writes
+
+| File | Do | Never |
+|---|---|---|
+| Patched .docx | keep the user's `core.xml` creator and `app.xml`; refresh `dcterms:modified`; offer a one-click "fix document properties" (title = resume name, creator / lastModifiedBy = candidate) when the file carries template junk | write "ApplyPack", a model name or "AI" anywhere; touch `word/*` when only properties change |
+| Generated .docx (`docx` library) | pass `creator`, `lastModifiedBy`, `title` from the resume so "Un-named" never ships | invent an Application value; an empty field is honest, a spoofed "Microsoft Office Word" is not |
+| Generated .pdf (pdfkit or Typst) | write `/Title` and `/Author` from the resume; set pdfkit `info.Producer` and `info.Creator` to empty; check what Typst leaves in `/Producer` before choosing it | spoof a Word or Quartz producer string |
+| Any file | plain visible text only; the export report lists what was checked | white text, tiny fonts, keyword blocks, injected instructions for screeners |
+
+---
+
+## 3. Where the file comes from
+
+| Option | Keeps the user's design | Covers | Hallucination surface | Effort / deps | Verdict |
+|---|---|---|---|---|---|
+| A · text version only (today) | n/a | everything | none | 0 | the status quo the request rejects |
+| A′ · change sheet: the edits as a copyable list | n/a, the user applies them in their own tool | everything, Canva and Google Docs included | none | small; pure line diff + Copy | **build first**; the universal manual path |
+| B · re-render from a structured model into a clean template | typography yes, layout no | every original, once parsed | parsing errors, not fabrication | medium with libraries: `docx` + pdfkit, JSON Resume as the model | the offer for PDF-only users, labelled "clean version in your typeface" |
+| C · patch the user's .docx in place | yes, byte-identical styles | flow .docx fully; structural .docx partly; PDF users upload the .docx source | none added; the text is what the user accepted | medium: ~250 lines over xmldom; no new runtime | **recommended** |
+| D · recreate the user's own layout automatically | promises what it cannot keep | — | — | a layout engine; endless | no; §5 says what "like theirs" can mean |
+| E · external tailoring service or API | none preserve it | — | theirs | the resume leaves the box | no; contrary to "your data in your own Postgres" |
+
+**Decision.** A′ and C, then B for everyone C cannot serve, with a clear
+label. DOCX is the primary deliverable: ATS parse it best, and the user's
+own Word or Pages turns it into the most natural PDF there is.
+
+Commercial tools (Jobscan Power Edit, Teal, Rezi, Kickresume, Enhancv) all
+show the resume as plain text or in their own builder, accept or reject per
+suggestion with a live match rate, and export their own rendering; none
+preserves the original file [S11, S12]. Open-source builders (Reactive
+Resume, OpenResume, RenderCV, JSON Resume) replace the file too [S13, S14].
+The UX pattern is worth copying; the file model is not.
+
+---
+
+## 4. Libraries, not hand-rolled writers
+
+| Job | Library | Licence · size | Metadata it writes by default | Verdict |
+|---|---|---|---|---|
+| Generate a .docx from a structured resume | [`docx`](https://github.com/dolanmiu/docx) (dolanmiu) 9.7.x: paragraphs, numbering, tables, styles, fonts by name | MIT · pure JS, a few deps (jszip among them) | `dc:creator` "Un-named" unless `creator` is set [S17] | **adopt** for resumes |
+| Change text inside an existing .docx, formatting intact | `docx.patchDocument` replaces `{{placeholders}}` only [S19]; docxtemplater core is tags only, its search-and-replace lives in the paid Meta module [S20]; python-docx has a run-level API with the same fragmentation problem and needs a Python runtime | — | — | **no fit**; the patcher stays in-house |
+| Walk and edit WordprocessingML safely | [`@xmldom/xmldom`](https://www.npmjs.com/package/@xmldom/xmldom) (DOM) + `jszip` for the container | MIT · small | none | **adopt for the patcher**; prove untouched-part fidelity in the first test |
+| Generate a PDF from a structured resume | [`pdfkit`](https://pdfkit.org/): text layout, wrapping, bold/italic by font, TTF embedding; pdfmake sits on top with a declarative layout | MIT · ~2 MB with fontkit | Producer and Creator "PDFKit", overridable via `info` [S18] | **adopt pdfkit**; the standard 14 fonts are WinAnsi only, so a Ukrainian name needs one embedded OFL face (about 1 MB per face) |
+| Typeset PDF with real typography | Typst via [`@myriaddreamin/typst-ts-node-compiler`](https://www.npmjs.com/package/@myriaddreamin/typst-ts-node-compiler) (WASM, no sidecar); Typst Universe has `basic-resume`, `simple-technical-resume`, `jsume` (takes JSON Resume) [S21] | Apache-2.0 · tens of MB plus fonts you supply | a Typst producer string; check whether it can be blanked | alternative to pdfkit; decide in stage 5 by rendering the same JSON Resume both ways |
+| .docx → .pdf with Word-like fidelity | LibreOffice headless as a compose service | MPL · about 240 MB as a Debian-slim image [S22] | Producer "LibreOffice x.y" | optional profile, only if "export the PDF from Word yourself" hurts |
+| HTML → PDF | Puppeteer / Playwright with Chromium | the Alpine Chrome image alone is 423 MB compressed [S14] | Producer "Skia/PDF" | no |
+| Low-level PDF editing | pdf-lib | MIT | Producer names itself [S6] | not needed |
+| Parse a resume into a structure | OpenResume's parser is AGPL-3.0 [S23]; resume-parsing APIs send the file out | AGPL | — | no; the AI scan already reads the resume and gains a `structure` block (§5) |
+| The structured model itself | [JSON Resume](https://jsonresume.org/schema): an open schema with a DOCX renderer (`jsonresume-docx`) and Typst templates written against it [S24, S21] | open standard | — | **adopt as the model** |
+
+What this changes against the first draft of this plan: stage 5 renders
+JSON Resume through `docx` and pdfkit instead of extending `pdf-write.ts`;
+the patcher gets a DOM; the in-house letter writers stay because they work
+and carry no fingerprint; one ADR records the dependencies and the metadata
+rule per library.
+
+---
+
+## 5. Every user has a different template
+
+"Users have different templates" hides three situations.
+
+| The file the user has | How common | In-place patch | What the user gets |
+|---|---|---|---|
+| Flow-based .docx | the "Simple / Traditional / Chronological" template family; anything written top to bottom [S25] | full | the styled file back, every edited line in place |
+| Structural .docx: tables for layout, text boxes, sidebars, two columns, contact in the header | most of Word's own gallery and most "ATS-friendly" downloads, which real parsers read badly too [S25] | partial: table-cell text yes; text boxes, headers and footers no (the extractor never showed them, so the editor never had them) | the file back with the patchable lines changed, the change sheet for the rest, a warning that text-box content is invisible to ATS parsers as well |
+| PDF only: Canva, Pages, Google Docs export, a designer's file | two of the three resumes in the live database | none | the change sheet, and the offer of a clean single-column re-render in their typography |
+
+**The check that sorts a file into a row is deterministic and cheap:**
+counts of `w:tbl`, `txbxContent`, `w:drawing`, `w:cols`, header and footer
+text, `m:oMath`, hidden runs (`w:vanish`), white-on-white runs
+(`w:color FFFFFF`), tiny sizes (`w:sz` under 12). It is the DOCX half of the
+blueprint's parseability analyser (§29.2) that `parse-warnings.ts` never
+got. It runs at upload, so `/resumes/:id` can say "In-place editing: 61 of
+78 lines. The skills table is editable; the header block is not", and the
+target page repeats the one-line verdict above the editor.
+
+**"Analyse their template and make one like it", honestly.** Inferable and
+reproducible: typeface family and sizes for name, headings and body (from
+`styles.xml` in a .docx; from pdf.js font names and transforms in a PDF,
+which unpdf exposes); accent colour (docx only; pdf.js text content carries
+no fill colour); margins; section order and headings; date format; bullet
+glyph; whether the name is centred. Not reproducible and not to be promised:
+two-column and sidebar layouts, icons, skill bars, photos, decorative rules,
+exact line breaks and pagination. Those are the ATS-hostile parts anyway.
+
+So the third path is **style inference → a handful of knobs → preview →
+export**: the inferred values pre-fill the knobs (font, size, colour,
+margins, section order), the user adjusts nothing or one thing, the preview
+shows "how it looks" and "what the ATS sees", the export goes through
+`docx` and pdfkit. The button says "Clean version in your typeface", never
+"Your template". A user who wants their exact Canva design keeps Canva and
+the change sheet beside it. "Tell users to configure everything" fails for
+the same reason a template language would: the daily user will not learn
+it; the knobs are the whole configuration surface.
+
+**Getting the structure for the re-render.** The scan prompt gains a
+`structure` block shaped as JSON Resume (`basics`, `work[]`, `education[]`,
+`skills[]`); `docx-text`'s headings, bullets and `Company | Location` lines
+give a deterministic fallback. Every string in the structure must be a
+verbatim span of the resume text, checked in code the way keyword terms are
+anchored today, so the model cannot rewrite a bullet on the way through.
+The user sees the parsed structure once, in the knob view, and fixes a
+mis-split role there.
+
+**Verification, whichever path produced the file:** run the app's own
+extractor on the output and compare with the editor text; show "what the
+ATS sees" of the exported file; run `parse-warnings` plus the structural
+check on the output; once, by hand, the blueprint's parser-disagreement test
+(our extractor against `libreoffice --convert-to txt`) on the real files.
+
+---
+
+## 6. The page today, reviewed
+
+Reviewed live on 2026-09-03: `/jobs/1393/target?match=59` (full analysis,
+10 edits, 8 removals, 26 keywords) in the desktop app's browser pane at
+800 px and 375 px, plus the source of `target.tsx`, `target-page.mjs` and
+`resume-match-card.tsx`. Format per the `ui-review` skill.
+
+**Overall impression.** The decision layer above the tabs (score, verdict
+sentence, breakdown chips, gates, confirm questions) reads in one pass and
+matches the product. The Suggestions tab explains every edit well and helps
+with none of them; on anything narrower than a wide desktop its one
+interaction moves the user away from the advice.
+
+**First-screen verdict.** Desktop: 66 of 100, moderate, primary stack 2/2,
+ten edits and eight removals one click away. 375 px: the ring, the number
+and the verdict land first; "Re-upload resume" is the only visible button,
+so the first screen says "upload something" to a user who came to edit; the
+Suggestions tab sits below the fold and, once opened, puts every card and
+the whole keyword table above an editor the user reaches after four screens.
+
+**Critical**
+
+1. *Clicking a card takes the user away from the proposal.* The handler
+   calls `select()`, which focuses the textarea; the browser scrolls the
+   focused control into view. At 800 px and below the editor sits under the
+   whole advice column, so the screen jumps past the card (observed live);
+   on a wide desktop focus leaves the card. Nothing on the page copies the
+   proposal. Fix: split the click into **Copy** (clipboard, "Copied" inline)
+   and **Locate** (outline the span in the backdrop, scroll the editor's own
+   `scrollTop`, `focus({ preventScroll: true })` on wide screens only).
+2. *The wording is buried in an instruction sentence.* "Reword as: "…"" is
+   one 14 px paragraph; copying the quoted part means precise selection
+   inside a line, a fight with selection handles on a phone. Fix: each card
+   renders **Now** (the quote) and **Proposed** (the quoted string parsed
+   out of `what` today, the `replacement` field after prompt v7) as two
+   blocks with Copy on Proposed; the leading verb becomes the label.
+   Removals show their quote under **Remove**.
+3. *The cards are not keyboard-reachable.* A list item with a click handler
+   has no role, no focus state, no key handling; the only hint is a `title`
+   tooltip touch screens never show (`accessible-interactions`). Fix: real
+   `<button>` elements from the `Button` primitive; the list item stops
+   being clickable.
+
+**High impact**
+
+4. *The selection is invisible.* The textarea text is transparent and its
+   `::selection` is a 25% tint under the backdrop marks; the located title
+   line showed only its green "matched" mark. Fix: a `.located` class on the
+   backdrop span (2 px accent outline, 2 s fade, reduced-motion aware) and
+   "line N" on the card; on a miss the card says "Couldn't find this text in
+   the editor, it may already be edited" instead of the 1.2 s pulse.
+5. *Advice and editor cannot be seen together on a phone.* With Copy on
+   every card the manual path no longer needs the editor. For the Apply
+   path: on narrow screens the editor card comes first, collapsed to about
+   40 vh with "Expand"; the keyword table folds behind a disclosure.
+6. *Chips navigate and do nothing else.* Fix: a chip's click inserts the
+   term into the skills line for `add` and confirmed terms (stage 2); until
+   then a Copy affordance and the weight / count shown as a line under the
+   chips on touch.
+7. *There is no way to take the work out of the page.* A user editing in
+   Word, Canva or Google Docs needs the edit list beside their document.
+   Fix: a **change sheet**: "Copy all suggestions" (Markdown: section, Now,
+   Proposed, why) and, after edits, "Copy my changes" from a line diff of
+   analysed against edited text (Now → New). Pure functions; the same diff
+   later feeds the .docx patcher.
+
+**Polish.** The 64 px priority column holds one word; "why:" in 12 px faint
+ink names the posting requirement, which is the reason to accept the edit:
+badge inline with the section label, the requirement as a small pill under
+Proposed. "show matched highlights" lives on the tab row far from the panes
+and wraps as an orphan at 375 px: move it into the editor header. The
+primary button says "Re-upload" on a page whose task is editing: once Apply
+exists, "Save as vN (.docx)" in the dirty bar is the primary and Re-upload
+moves into the menu. Removal cards hide the quote they point at in a data
+attribute: show it dimmed and struck through.
+
+**Quick wins.** Copy per action with the quoted span extracted by one
+regex; `focus({ preventScroll: true })` and editor-internal scrolling;
+`<button>` semantics on cards and chips; the removal quote on the card;
+"Couldn't find this text" as inline copy; the toggle moved.
+
+**Score.** Hierarchy 7, consistency 8, accessibility 5, polish 6.
+
+---
+
+## 7. Decisions this plan makes
+
+1. Copy and Locate are separate controls; Locate never moves the page.
+2. Every action card shows Now and Proposed; the proposal is a first-class
+   string (parsed from `what` until prompt v7 adds `replacement`).
+3. The change sheet is the universal manual path and ships before Apply.
+4. Apply, Remove, Add to Skills, Undo are client-side text operations over
+   the plain-text editor; nothing is saved until Save.
+5. The model returns `replacement` and `insert_after`; `fact-check.ts`
+   decides at persist time whether a proposal is applicable; blocked
+   proposals become questions.
+6. Keyword additions are deterministic; only `add` and confirmed
+   `ask_user` terms get a button; `cannot_claim` never does.
+7. Save patches the user's .docx in place when the template check allows
+   it; every other case saves a text version and says why.
+8. The patcher is in-house over `@xmldom/xmldom` + `jszip`; generation uses
+   `docx` and `pdfkit`; JSON Resume is the structured model; no external
+   service; LibreOffice only as an optional profile.
+9. The metadata policy in §2 binds every writer; no hidden text, ever.
+10. For PDF-only and structural files the product offers a clean
+    single-column re-render in the user's typography, labelled as such.
+11. A tailored edit saves as a copy per posting by default (owner to
+    confirm, §8).
+
+---
+
+## 8. Open questions for the owner
+
+1. **Copy or version** when saving a tailored edit? Recommendation: a
+   tailored copy per posting, the master untouched.
+2. **Fix junk document properties** on the first patched save, or only on
+   click? Recommendation: on click, with the current values shown.
+3. **PDF engine for stage 5:** pdfkit (small, plain output) or Typst through
+   WASM (typeset, heavier)? Recommendation: pdfkit first.
+4. **PDF from a patched .docx:** accept "export it from Word or Pages" as the
+   v1 answer, or is the LibreOffice profile a launch requirement?
+5. **Tables in v1 of the patcher:** cell text edits only, or refuse tables
+   until v2?
+6. **Reordering scope:** "Make this the first bullet" only, or free ↑ ↓ on
+   any line?
+7. **Stage order:** stages 1 and 2 could ship as one branch; separate keeps
+   the page fixes releasable in a day.
+
+---
+
+## 9. Sources
+
+- S1 [Jobscan, "Can ATS Detect AI Resumes in 2026?"](https://www.jobscan.co/blog/can-ats-detect-ai-resume/)
+- S2 [Enhancv, "Does ATS Detect AI Resumes? We Researched the Top 10 Systems"](https://enhancv.com/blog/ats-detect-ai-resume/)
+- S3 [AI and You, on Greenhouse's white-text disclosure](https://aiandyou.org/news/recruiters_say_hiding_ai-friendly_white_text_in_your_resume_is_not_going_to_work_these_new_hires_say_otherwise/)
+- S4 [The Interview Guys](https://blog.theinterviewguys.com/job-seekers-are-hiding-secret-text-in-their-resumes/), [Hiration](https://www.hiration.com/blog/white-text-resume-hack/), [Resume Optimizer Pro](https://resumeoptimizerpro.com/blog/ats-friendly-resume-tips) on hidden-text detection (secondary sources)
+- S5 [python-docx, Core Document Properties](https://python-docx.readthedocs.io/en/latest/dev/analysis/features/coreprops.html)
+- S6 [pdf-lib issue #1571](https://github.com/Hopding/pdf-lib/issues/1571)
+- S7 [DEV, "From Prompts to Real Files"](https://dev.to/imaginex/your-llm-can-write-files-now-4c6e)
+- S8 [SanitiDOC, "Does Your DOCX Reveal It Was Written by AI?"](https://sanitidoc.com/blog/ai-metadata.html)
+- S9 [ATS Verification, "PDF vs Word Resume for ATS (2026)"](https://atsverification.com/blog/pdf-vs-word-for-ats/)
+- S10 [scale.jobs, "PDF vs Word: which format ATS reads correctly"](https://scale.jobs/blog/pdf-vs-word-resume-format-ats-reads-correctly)
+- S11 [Jobscan Power Edit](https://www.jobscan.co/power-edit), [One-Click Optimize](https://www.jobscan.co/one-click-optimize)
+- S12 [Jobscan vs Teal (2026)](https://www.jobscan.co/blog/jobscan-vs-teal/)
+- S13 [DEV, "5 Open-Source Resume Builders (2026)"](https://dev.to/srbhr/5-open-source-resume-builders-thatll-help-get-you-hired-in-2026-1b92); [Reactive Resume](https://github.com/amruthpillai/reactive-resume); [OpenResume](https://www.open-resume.com/)
+- S14 [RenderCV](https://rendercv.com/); [Typst, "Automated PDF Generation"](https://typst.app/blog/2025/automated-generation/); [zenika/alpine-chrome](https://hub.docker.com/r/zenika/alpine-chrome)
+- S15 [dolanmiu/docx](https://github.com/dolanmiu/docx)
+- S16 [docxtemplater](https://github.com/open-xml-templating/docxtemplater)
+- S17 [dolanmiu/docx discussion #2584](https://github.com/dolanmiu/docx/discussions/2584) (default creator "Un-named")
+- S18 [PDFKit, Getting Started](https://pdfkit.org/docs/getting_started.html) (`info` defaults and overrides)
+- S19 [docx, patchDocument](https://docx.js.org/api/functions/patchDocument.html); [issue #2855](https://github.com/dolanmiu/docx/issues/2855)
+- S20 [docxtemplater Meta module](https://docxtemplater.com/modules/meta/)
+- S21 [jsume](https://typst.app/universe/package/jsume/), [basic-resume](https://typst.app/universe/package/basic-resume/), [typst-jsonresume-cv](https://github.com/fruggiero/typst-jsonresume-cv), [@myriaddreamin/typst-ts-node-compiler](https://www.npmjs.com/package/@myriaddreamin/typst-ts-node-compiler)
+- S22 [docx-pdf-converter-libreoffice](https://hub.docker.com/r/beladevos/docx-pdf-converter-libreoffice); [OneUptime, LibreOffice in Docker](https://oneuptime.com/blog/post/2026-02-08-how-to-run-libreoffice-in-docker-for-document-conversion/view)
+- S23 [OpenResume](https://github.com/xitanggg/open-resume) (AGPL-3.0)
+- S24 [jsonresume-docx](https://github.com/panasenco/jsonresume-docx); [JSON Resume projects](https://jsonresume.org/projects)
+- S25 [Resume Optimizer Pro, "Microsoft Word Resume Templates: Which Ones Are ATS-Safe"](https://resumeoptimizerpro.com/blog/microsoft-word-resume-template); [ATS Verification, "Resume Templates That Pass ATS in 2026"](https://atsverification.com/blog/resume-templates-that-pass-ats-2026/)


### PR DESCRIPTION
Analysis only, nothing built. Three documents:

- `docs/tailoring-loop-plan.md` — the analysis: what `/jobs/:id/target` already does, the suggestion contract as stored, the live corpus measured, the linkedin-radar `job-apply` skill checked, the "AI-marked file" question answered with sources, the file options, the library survey, the three template populations, the live page review, decisions and open questions.
- `docs/tailoring-loop-integration.md` — the build guide, file by file, stage by stage: pure functions with signatures, DOM wiring, markup, schema and prompt changes, the docx patcher's algorithm and gates, dependencies with their metadata defaults, verification per `testing-gate`, ADRs to write, release notes drafts, and the session model + effort per stage.
- `docs/TASKS.md` §18 — facts, decisions, the model/effort table, the five-stage checklist, the owner's decisions.

## Analysis note

- The request is the reopen trigger for TASKS §5.10 and §5.15, in a narrower form than either: the user picks each edit, the model only proposes wording, the file keeps the user's design.
- 16 of the 18 stored actions already carry the proposal as a quoted string inside `what`; stage 1 can ship Copy without a prompt change.
- No major ATS detects AI authorship (Jobscan, Enhancv, 2026); hidden white text and unparseable layout are what gets flagged; library fingerprints in metadata are a human-side embarrassment, not a rejection rule. One claim in linkedin-radar's rulebook ("vendor AI-content classifiers since late 2025") is unsupported.
- No Node library replaces arbitrary text inside an existing .docx with formatting intact; the patcher stays in-house over `@xmldom/xmldom` + `jszip`. Generation uses `docx` and `pdfkit`; JSON Resume is the model; OpenResume's parser is AGPL and out.
- Only one of three visible resumes is a .docx; the other two are macOS PDFs. The template check at upload sorts files into flow / structural / unsupported before the user edits.
- Live page review at 800 px and 375 px: clicking a card focuses the editor and scrolls the page away from the proposal; cards are clickable `<li>` elements; the selection is invisible. Stage 1 fixes those.

## Review

Docs-only PR: `code-review-expert` not run; prose checked against `stop-slop` (no em dashes in body text, active voice), every relative link and referenced source path verified to exist. No version bump, no tag (precedent: #109).

## Owner decisions before stage 1

Listed in `docs/TASKS.md` §18.4 "Decisions for the owner" (copy vs version, properties fix on click, pdfkit vs Typst, LibreOffice profile, tables in the patcher v1, reordering scope, stages 1+2 as one branch or two).
