### PR TITLE
One run, one wording for the suggestions call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.47.1] — 2026-09-04
+
+### Fixed
+- **/target no longer names a step it never runs.** When a full analysis is
+  asked of a posting whose quick check is already stored, only the suggestions
+  call is needed — but the progress page still advertised the comparison step
+  and then flipped straight to done. It now writes the suggestions itself, on
+  one progress page instead of two chained ones, and says so
+  (thanks [@harshvardhan60792](https://github.com/harshvardhan60792), [#138](https://github.com/applypack/applypack/pull/138)).
+- Pressing "Get suggestions" on that comparison while /target is already
+  writing them joins the run in flight instead of calling the model a second
+  time — the guarantee [#76](https://github.com/applypack/applypack/issues/76)
+  exists for. A run can now answer to more than one name.
+- The flash that follows a suggestions call has one wording again, in one
+  place, and the /target path says why the score did not move.
+
 ## [1.47.0] — 2026-09-04
 
 ### Added
@@ -1867,6 +1883,31 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.47.1]: https://github.com/applypack/applypack/compare/v1.47.0...v1.47.1
+[1.47.0]: https://github.com/applypack/applypack/compare/v1.46.0...v1.47.0
+[1.46.0]: https://github.com/applypack/applypack/compare/v1.45.0...v1.46.0
+[1.45.0]: https://github.com/applypack/applypack/compare/v1.44.0...v1.45.0
+[1.44.0]: https://github.com/applypack/applypack/compare/v1.43.0...v1.44.0
+[1.43.0]: https://github.com/applypack/applypack/compare/v1.42.0...v1.43.0
+[1.42.0]: https://github.com/applypack/applypack/compare/v1.41.0...v1.42.0
+[1.41.0]: https://github.com/applypack/applypack/compare/v1.40.0...v1.41.0
+[1.40.0]: https://github.com/applypack/applypack/compare/v1.39.0...v1.40.0
+[1.39.0]: https://github.com/applypack/applypack/compare/v1.38.0...v1.39.0
+[1.38.0]: https://github.com/applypack/applypack/compare/v1.37.0...v1.38.0
+[1.37.0]: https://github.com/applypack/applypack/compare/v1.36.0...v1.37.0
+[1.36.0]: https://github.com/applypack/applypack/compare/v1.35.0...v1.36.0
+[1.35.0]: https://github.com/applypack/applypack/compare/v1.34.0...v1.35.0
+[1.34.0]: https://github.com/applypack/applypack/compare/v1.33.0...v1.34.0
+[1.33.0]: https://github.com/applypack/applypack/compare/v1.32.0...v1.33.0
+[1.32.0]: https://github.com/applypack/applypack/compare/v1.31.0...v1.32.0
+[1.31.0]: https://github.com/applypack/applypack/compare/v1.30.0...v1.31.0
+[1.30.0]: https://github.com/applypack/applypack/compare/v1.29.0...v1.30.0
+[1.29.0]: https://github.com/applypack/applypack/compare/v1.28.0...v1.29.0
+[1.28.0]: https://github.com/applypack/applypack/compare/v1.27.0...v1.28.0
+[1.27.0]: https://github.com/applypack/applypack/compare/v1.26.0...v1.27.0
+[1.26.0]: https://github.com/applypack/applypack/compare/v1.25.0...v1.26.0
+[1.25.0]: https://github.com/applypack/applypack/compare/v1.24.0...v1.25.0
+[1.24.0]: https://github.com/applypack/applypack/compare/v1.23.4...v1.24.0
 [1.23.4]: https://github.com/applypack/applypack/compare/v1.23.3...v1.23.4
 [1.23.3]: https://github.com/applypack/applypack/compare/v1.23.2...v1.23.3
 [1.23.2]: https://github.com/applypack/applypack/compare/v1.23.1...v1.23.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.47.0",
+      "version": "1.47.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/resume/match-reuse.test.ts
+++ b/src/resume/match-reuse.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readPromptVersion, reuseDecision, reuseNotice, suggestNotice, type StoredMatch } from './match-reuse';
+import { readPromptVersion, reuseDecision, reuseNotice, suggestionsFlash, type StoredMatch } from './match-reuse';
 
 const TEXT = 'Nazar Boyko\nSenior Software Engineer\n## SKILLS\nPHP, Laravel, React';
 const full: StoredMatch = { resumeText: TEXT, promptVersion: 5, mode: 'full' };
@@ -45,9 +45,19 @@ test('reuseNotice names the age and says the model was not called', () => {
   assert.match(notice, /not called again/);
 });
 
-test('suggestNotice keeps the verdicts and never claims the model stayed idle', () => {
-  const notice = suggestNotice('3m ago');
-  assert.match(notice, /3m ago/);
-  assert.match(notice, /verdicts and score/);
-  assert.doesNotMatch(notice, /not called/);
+test('suggestionsFlash counts what was written and never claims the model stayed idle', () => {
+  const flash = suggestionsFlash({ actions: 4, removals: 2 });
+  assert.match(flash, /4 edits/);
+  assert.match(flash, /2 removals/);
+  assert.match(flash, /score is unchanged/);
+  assert.doesNotMatch(flash, /not called/);
+});
+
+// The "suggest" decision is the one path where the user asked for a full
+// analysis and gets a score that did not move — it has to say why.
+test('suggestionsFlash explains the kept verdicts when a stored quick check was reused', () => {
+  const flash = suggestionsFlash({ actions: 1, removals: 0 }, '3m ago');
+  assert.match(flash, /3m ago/);
+  assert.match(flash, /verdicts and score stand/);
+  assert.match(flash, /1 edits, 0 removals/);
 });

--- a/src/resume/match-reuse.ts
+++ b/src/resume/match-reuse.ts
@@ -47,7 +47,19 @@ export function reuseNotice(when: string): string {
   return `Unchanged since the last analysis (${when}) — showing that result; the resume model was not called again.`;
 }
 
-/** The flash for the "suggest" decision: the verdicts stand, only the suggestions are being written. */
-export function suggestNotice(when: string): string {
-  return `The quick check from ${when} judged this exact text — keeping its verdicts and score, and writing the suggestions now.`;
+/** What the user is told when the suggestions call could not answer. */
+export const SUGGESTIONS_FAILED =
+  'The suggestions call failed — the quick check is still there. See the web logs.';
+
+/**
+ * The flash a finished suggestions call leaves. `reusedFrom` is the stored
+ * quick check's age, given only by the "suggest" decision — there the user
+ * asked for a full analysis and needs to know why the score did not move.
+ * Pressing "Get suggestions" on a comparison already knows that.
+ */
+export function suggestionsFlash(counts: { actions: number; removals: number }, reusedFrom?: string): string {
+  const kept = reusedFrom
+    ? `The quick check from ${reusedFrom} judged this exact text, so its verdicts and score stand. `
+    : '';
+  return `${kept}Suggestions added — ${counts.actions} edits, ${counts.removals} removals; the score is unchanged.`;
 }

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -7,7 +7,7 @@ import { createManualJob, ManualJobSchema, MAX_FIELD_CHARS, MIN_DESCRIPTION_CHAR
 import { extractPostingFacts, fallbackTitle } from '../../jobs/posting-extract';
 import { findReusableMatch, matchResumeToJob } from '../../resume/match';
 import { parseMatchMode } from '../../resume/match-mode';
-import { reuseNotice } from '../../resume/match-reuse';
+import { reuseNotice, SUGGESTIONS_FAILED, suggestionsFlash } from '../../resume/match-reuse';
 import { readActions, readRemovals } from '../../resume/prompts';
 import {
   deleteCoverLettersForResume,
@@ -18,13 +18,14 @@ import {
   upsertScratchResume,
 } from '../../resume/store';
 import { suggestForMatch } from '../../resume/suggestions';
+import { suggestionsKey } from '../suggestions-run';
 import { draftStash } from '../draft-stash';
 import { decideInstantCheck, instantCheckNotice } from '../instant-check';
 import { TargetStartPage } from '../pages/target-start';
 import { TargetRunPage } from '../pages/target-run';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
-import { claimRun, getRun, matchStep, startRun, updateRun, type RunStep } from '../target-runs';
+import { alsoClaims, claimRun, getRun, matchStep, startRun, updateRun, type RunStep } from '../target-runs';
 import {
   MAX_RESUME_NAME_CHARS,
   nameFromFilename,
@@ -209,7 +210,10 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
     // 2. The same text against the same posting is already answered — a
     //    double submit or a re-paste shows the stored analysis instead. A
     //    full analysis asked of a stored quick check needs only the
-    //    suggestions call, which gets its own run.
+    //    suggestions call, which this run makes itself: one progress page,
+    //    not two chained ones. It answers to the suggestions key as well,
+    //    so pressing "Get suggestions" on that comparison meanwhile joins
+    //    this run instead of calling the model a second time (issue #76).
     const reused = await findReusableMatch(job.id, resume.id, resume.text, f.mode);
     if (reused?.decision === 'reuse') {
       updateRun(run.id, {
@@ -221,22 +225,23 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
       return;
     }
     if (reused) {
+      alsoClaims(run.id, suggestionsKey(reused.row.id));
       updateRun(run.id, {
         steps: needExtract ? ['extract', 'suggestions'] : ['suggestions'],
         stage: 'suggestions',
       });
       const row = await suggestForMatch(reused.row, jobInput);
       if (!row) {
-        updateRun(run.id, {
-          stage: 'error',
-          error: 'The suggestions call failed — the quick check is still there. See the web logs.',
-        });
+        updateRun(run.id, { stage: 'error', error: SUGGESTIONS_FAILED });
         return;
       }
       updateRun(run.id, {
         stage: 'done',
         resultUrl: `/jobs/${job.id}/target?match=${reused.row.id}`,
-        flash: `Suggestions added — ${readActions(row.actions).length} edits, ${readRemovals(row.removals).length} removals; the score is unchanged.`,
+        flash: suggestionsFlash(
+          { actions: readActions(row.actions).length, removals: readRemovals(row.removals).length },
+          formatRelative(reused.row.createdAt),
+        ),
       });
       return;
     }

--- a/src/web/suggestions-run.ts
+++ b/src/web/suggestions-run.ts
@@ -4,16 +4,16 @@ import { readActions, readRemovals, type MatchJobInput } from '../resume/prompts
 import { suggestForMatch } from '../resume/suggestions';
 import { claimRun, startRun, updateRun } from './target-runs';
 
-/**
- * The lazy second call as a progress-page run (ADR 0029): "Get suggestions"
- * on a quick check, and the answer to a full analysis asked of a text whose
- * quick check is already stored. Returns the run URL to redirect to.
- */
 /** The name the suggestions work for one comparison is claimed under (issue #76). */
 export function suggestionsKey(matchId: number): string {
   return `suggestions:${matchId}`;
 }
 
+/**
+ * The lazy second call as a progress-page run (ADR 0029): "Get suggestions"
+ * on a quick check, and the answer to a full analysis asked of a text whose
+ * quick check is already stored. Returns the run URL to redirect to.
+ */
 export function startSuggestionsRun(input: {
   match: ResumeMatch;
   job: MatchJobInput & { id: number };

--- a/src/web/suggestions-run.ts
+++ b/src/web/suggestions-run.ts
@@ -1,4 +1,5 @@
 import type { ResumeMatch } from '@prisma/client';
+import { SUGGESTIONS_FAILED, suggestionsFlash } from '../resume/match-reuse';
 import { readActions, readRemovals, type MatchJobInput } from '../resume/prompts';
 import { suggestForMatch } from '../resume/suggestions';
 import { claimRun, startRun, updateRun } from './target-runs';
@@ -8,6 +9,11 @@ import { claimRun, startRun, updateRun } from './target-runs';
  * on a quick check, and the answer to a full analysis asked of a text whose
  * quick check is already stored. Returns the run URL to redirect to.
  */
+/** The name the suggestions work for one comparison is claimed under (issue #76). */
+export function suggestionsKey(matchId: number): string {
+  return `suggestions:${matchId}`;
+}
+
 export function startSuggestionsRun(input: {
   match: ResumeMatch;
   job: MatchJobInput & { id: number };
@@ -17,7 +23,7 @@ export function startSuggestionsRun(input: {
   const { match, job } = input;
   // One comparison can only be completed once: a second "Get suggestions" —
   // another tab, a reload — joins the call in flight (issue #76).
-  const { run, joined } = claimRun(`suggestions:${match.id}`, {
+  const { run, joined } = claimRun(suggestionsKey(match.id), {
     steps: ['suggestions'],
     jobTitle: job.title,
     resumeName: input.resumeName,
@@ -34,9 +40,9 @@ export function startSuggestionsRun(input: {
         ? {
             stage: 'done',
             resultUrl: input.resultUrl,
-            flash: `Suggestions added — ${readActions(row.actions).length} edits, ${readRemovals(row.removals).length} removals; the score is unchanged.`,
+            flash: suggestionsFlash({ actions: readActions(row.actions).length, removals: readRemovals(row.removals).length }),
           }
-        : { stage: 'error', error: 'The suggestions call failed — the quick check is still there. See the web logs.' },
+        : { stage: 'error', error: SUGGESTIONS_FAILED },
     );
   });
   return `/target/runs/${run.id}`;

--- a/src/web/target-runs.test.ts
+++ b/src/web/target-runs.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { claimRun, findLiveRun, getRun, startRun, updateRun } from './target-runs';
+import { alsoClaims, claimRun, findLiveRun, getRun, startRun, updateRun } from './target-runs';
 
 /*
  * Issue #76 — server-side idempotency for the POSTs that start AI runs. Every
@@ -83,4 +83,42 @@ test('the work runs once: the second claim must not start a second chain', async
   await new Promise((r) => setImmediate(r));
   assert.equal(calls, 1);
   assert.equal(findLiveRun(key), null);
+});
+
+/*
+ * One run, two names (issue #88 follow-up). /target's suggest path makes the
+ * suggestions call itself, so the run started as "this posting and this
+ * resume" is also the run doing "the suggestions for this comparison" — and a
+ * request arriving under the second name must join it, not pay again.
+ */
+test('a run answers to a name it picked up mid-flight', () => {
+  const stamp = Math.random();
+  const first = claim(`target:1:full:${stamp}`);
+  alsoClaims(first.run.id, `suggestions:${stamp}`);
+
+  const second = claim(`suggestions:${stamp}`);
+  assert.equal(second.joined, true);
+  assert.equal(second.run.id, first.run.id);
+  // …and the name it started with still finds it.
+  assert.equal(findLiveRun(`target:1:full:${stamp}`)?.id, first.run.id);
+});
+
+test('the second name stops working when the run finishes, like the first', () => {
+  const stamp = Math.random();
+  const first = claim(`target:2:full:${stamp}`);
+  alsoClaims(first.run.id, `suggestions:${stamp}`);
+  updateRun(first.run.id, { stage: 'done' });
+
+  assert.equal(findLiveRun(`suggestions:${stamp}`), null);
+  assert.equal(claim(`suggestions:${stamp}`).joined, false);
+});
+
+test('picking up a name twice, or on a run that is gone, changes nothing', () => {
+  const stamp = Math.random();
+  const first = claim(`target:3:full:${stamp}`);
+  alsoClaims(first.run.id, `suggestions:${stamp}`);
+  alsoClaims(first.run.id, `suggestions:${stamp}`);
+  alsoClaims('no-such-run', `suggestions:${stamp}`);
+
+  assert.deepEqual(getRun(first.run.id)?.keys, [`target:3:full:${stamp}`, `suggestions:${stamp}`]);
 });

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -142,7 +142,8 @@ export function alsoClaims(id: string, key: string): void {
   logger.info({ runId: id, key }, 'run: also answering to another name');
 }
 
-export function updateRun(id: string, patch: Partial<Omit<TargetRun, 'id'>>): void {
+/** `keys` is not patchable: a run's names are claimed, never overwritten. */
+export function updateRun(id: string, patch: Partial<Omit<TargetRun, 'id' | 'keys'>>): void {
   const run = runs.get(id);
   if (!run) return;
   if (patch.stage && patch.stage !== run.stage) {

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -55,8 +55,14 @@ export interface TargetRun {
   /** Done with a stored analysis, not a fresh one — the flash warns and offers "Re-run anyway". */
   reused?: boolean;
   error?: string;
-  /** What this run is working on — a second POST for the same thing joins it (issue #76). */
-  key?: string;
+  /**
+   * What this run is working on — a second POST for the same thing joins it
+   * (issue #76). More than one name, because one run can answer requests that
+   * arrive under different names: /target's suggest path is both "this
+   * posting and this resume" and "the suggestions for this comparison", and a
+   * request under either must join it rather than call the model again.
+   */
+  keys: string[];
 }
 
 const RUN_TTL_MS = 30 * 60_000;
@@ -65,11 +71,12 @@ const runs = new Map<string, TargetRun>();
 /** Registers a run. Private: every start goes through `claimRun`, which is what makes a second POST join instead of duplicate. */
 function createRun(
   fields: Pick<TargetRun, 'steps' | 'jobTitle' | 'resumeName'> &
-    Partial<Pick<TargetRun, 'jobId' | 'backUrl' | 'backLabel' | 'heading' | 'subtitle' | 'key'>>,
+    Partial<Pick<TargetRun, 'jobId' | 'backUrl' | 'backLabel' | 'heading' | 'subtitle'>>,
 ): TargetRun {
   prune();
   const run: TargetRun = {
     id: randomUUID(),
+    keys: [],
     stage: fields.steps[0] ?? 'match',
     startedAt: Date.now(),
     stageAt: Date.now(),
@@ -110,15 +117,29 @@ export function claimRun(
     logger.info({ runId: live.id, key }, 'run: joined a run already in flight');
     return { run: live, joined: true };
   }
-  return { run: createRun({ ...fields, key }), joined: false };
+  const run = createRun(fields);
+  run.keys.push(key);
+  return { run, joined: false };
 }
 
-/** The unfinished run for `key`, if one is in flight. */
+/** The unfinished run answering to `key`, if one is in flight. */
 export function findLiveRun(key: string): TargetRun | null {
   for (const run of runs.values()) {
-    if (run.key === key && run.stage !== 'done' && run.stage !== 'error') return run;
+    if (run.keys.includes(key) && run.stage !== 'done' && run.stage !== 'error') return run;
   }
   return null;
+}
+
+/**
+ * Gives a run another name to be found by, once it turns out to be doing work
+ * a different request would ask for. Idempotent, and a no-op on a run that has
+ * gone: only a live run is worth joining.
+ */
+export function alsoClaims(id: string, key: string): void {
+  const run = runs.get(id);
+  if (!run || run.keys.includes(key)) return;
+  run.keys.push(key);
+  logger.info({ runId: id, key }, 'run: also answering to another name');
 }
 
 export function updateRun(id: string, patch: Partial<Omit<TargetRun, 'id'>>): void {


### PR DESCRIPTION
Follow-up to [#138](https://github.com/applypack/applypack/pull/138), which fixed [#88](https://github.com/applypack/applypack/issues/88) and is already merged. That change was right in substance — I reviewed it and ran the gate on it locally, since the fork's CI had not run — but it left four things behind. This is those four, plus the version bump and changelog entry a runtime fix needs.

## What #138 changed, and what it cost

`/target`'s suggest path — a full analysis asked of a posting whose quick check is already stored — used to hand off to `startSuggestionsRun`, a second progress page chained after the first. #138 makes the target run write the suggestions itself. That is better: one page, one redirect, and the run stops advertising a comparison step it never runs.

The cost was the claim key. `startSuggestionsRun` claims `suggestions:${match.id}` so that a second "Get suggestions" — another tab, a reload — joins the call in flight instead of paying for it twice ([#76](https://github.com/applypack/applypack/issues/76)). The inline call is claimed only under the target key, so `/target` and the "Get suggestions" button on the same comparison could both reach the model.

## What this does

- **A run can answer to more than one name.** `TargetRun.key` becomes `keys: string[]` and `alsoClaims(id, key)` adds one mid-flight; `findLiveRun` checks membership. The suggest path picks up `suggestions:${match.id}` the moment it decides to make that call, so a request under either name joins it. That is the honest description of what the run is doing — it really is both "this posting and this resume" and "the suggestions for this comparison" — and it needed no new mechanism, just a set where there was a scalar.
  - `updateRun` can no longer patch `keys` (`Omit<TargetRun, 'id' | 'keys'>`): a run's names are claimed, never overwritten.
- **One wording for the suggestions outcome, in one place.** #138 copied the done flash and the error string out of `suggestions-run.ts`. Both now live in the pure `resume/match-reuse.ts` as `suggestionsFlash()` and `SUGGESTIONS_FAILED`, and both call sites use them.
- **`suggestNotice` is gone.** It became dead code with a live unit test the moment the inline path stopped using it. What it said was worth keeping, though — on the suggest path the user asked for a full analysis and gets a score that did not move, so the flash has to say why. `suggestionsFlash(counts, reusedFrom?)` carries that sentence when the caller has a stored check to name, and omits it when the user pressed "Get suggestions" and already knows.
- **The comment above the reuse block said the suggestions call "gets its own run".** It has not since #138. It now says what actually happens and why the second key is there.

## Also here: the changelog compare links

Not related to #138 — I found it during the parity check before tagging v1.46.0. The compare-link list at the bottom of `CHANGELOG.md` stopped at `[1.23.4]` while tags ran to `v1.47.0`: **23 missing links**. Backfilled, plus `1.47.1`. Every version heading now has a link and every link has a heading (68 each) — it is a separate commit, so it is easy to read past.

## Verification

`npm run lint:types` + `npm test` green — **1626 tests**, 5 new:

- three in `target-runs.test.ts` for the second name: a request under it joins the live run; it stops working when the run finishes, exactly as the first name does; and picking up a name twice, or on a run that has gone, changes nothing. Each fails against `key: string`.
- two in `match-reuse.test.ts` replacing the `suggestNotice` test: the flash counts what was written and never claims the model stayed idle, and it explains the kept verdicts when a stored quick check was reused.

No schema change, no migration, no image rebuild needed beyond the usual.

## Review

`code-review-expert` over `git diff main...HEAD`. No P0/P1 survived. Two fixed while writing it: `suggestionsKey` had been wedged between `startSuggestionsRun`'s docstring and the function, orphaning the docstring; and `updateRun` could still overwrite `keys`, which is now structurally impossible.

### Follow-ups (P3, not in this PR)

- A "Get suggestions" request that joins the target run inherits that run's `backUrl` (`/target`, "Back to Target") rather than "Back to the comparison". Only visible on the error page.
- The run's stage lingers on `extract` during `createManualJob` and `findReusableMatch`, so those DB reads are attributed to the extract step's timing on the progress page. #138 moved the advance below the reuse decision deliberately — showing `match` there would be its own small lie — but neither placement is quite honest; a step that means "working out what to do" would be.

## Tag

```
git tag -a v1.47.1 -m "One run, one wording for the suggestions call" && git push origin v1.47.1
```
