### PR TITLE
phase-18a: copy a suggestion, locate it, take the list with you

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -220,6 +220,7 @@ src/
     facts.ts                   ← apply CandidateFacts / cross-resume hints to keywords, pure
     fact-check.ts              ← deterministic fabrication gate for generated prose (ADR 0020), pure
     diff.ts                    ← version delta from two matches (gained/lost, components), pure
+    change-sheet.ts            ← the wording a suggestion proposes + the whole list as Markdown, pure
     parse-warnings.ts          ← ATS parseability checks over extracted text, pure
     pick.ts                    ← preselect: profile link first, then skill-tag overlap, pure
     store.ts                   ← Resume / ResumeMatch / CandidateFact / CoverLetter CRUD (Prisma)
@@ -291,7 +292,10 @@ src/
     profile-from-resume.ts    ← "create a search from this resume": blank-base draft + inactive create
     public/target.mjs         ← browser keyword matcher (pure ES module, node-tested)
     public/score.mjs          ← browser mirror of resume/score.ts (parity-tested, ADR 0012)
-    public/cover-letter.mjs   ← copy-to-clipboard for the letter card (import-smoke-tested)
+    public/cover-letter.mjs   ← autosave + fact-check status for the letter card (import-smoke-tested)
+    public/copy.mjs           ← copy-to-clipboard for every page (delegated, execCommand fallback, aria-live)
+    public/line-diff.mjs      ← LCS line diff of the analysed text vs the editor (pure, node-tested)
+    public/change-sheet.mjs   ← "Copy my changes" as Markdown over line-diff.mjs (pure, node-tested)
     public/board.mjs          ← /applications drag-and-drop over POST /jobs/:id/stage (planMove tested)
     public/fetch-run.mjs      ← activity lines for the fetch-now progress page (pure; target-run.mjs polls)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.51.0] — 2026-09-04
+
+### Added
+- **Every suggestion now shows what your resume says now and what to make it
+  say.** A comparison used to bury the proposed wording inside a sentence
+  (*Reword as: "…"*) and hide the removal quotes entirely — it told you to
+  delete something it would not show you. Each card is now a **Now** block and
+  a **Proposed** block with the wording on its own, and removals show the text
+  to cut, struck through.
+- **Copy** on every card puts just the proposed wording on the clipboard — on
+  `/jobs/:id` as well as the targeted view — so the manual path is one press
+  instead of a careful drag through a sentence.
+- **Locate** outlines the target text in the editor and scrolls **the editor**
+  to it. The page does not move, so the card you were reading is still in front
+  of you. It also prints the line number, and says *"Couldn't find this text in
+  the editor, it may already be edited"* when the text has already changed.
+- **Copy all suggestions** and **Copy my changes** hand over the whole list as
+  Markdown — the first from the AI's suggestions, the second as a diff of your
+  own edits. This is the universal path: it needs no Apply button, and it
+  pastes into whatever your resume actually lives in.
+
+### Fixed
+- **The targeted view no longer scrolls sideways on a phone.** At 375 px the
+  suggestions pane was 499 px wide and dragged the page with it: the keyword
+  table's `overflow-x-auto` wrapper had nothing bounding it, because a grid
+  item defaults to `min-width: auto` and is sized by its widest content.
+- On a narrow screen the editor now comes first in the Suggestions view and
+  starts at 40 vh (**expand editor** makes it tall), and the keyword table
+  starts folded — it is by far the longest block on the page.
+
+### Notes
+- The proposal extractor was written against the **209 stored actions**, not
+  against the plan's assumption. Straight single quotes outnumber double ones
+  **131 to 45** and curly quotes never occur, so the double-quote-only rule the
+  guide specified would have found a wording in 22 % of them; reading both, with
+  an apostrophe guard, finds one in **80 %**. The 42 it declines were read by
+  hand: 33 are instructions with no wording in them, 8 quote a term rather than
+  a sentence, 1 quotes the current text.
+- Cover-letter Copy now shares one clipboard module with the new buttons
+  instead of its own copy of the same fallback.
+
 ## [1.50.0] — 2026-09-04
 
 ### Added
@@ -2015,6 +2056,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.51.0]: https://github.com/applypack/applypack/compare/v1.50.0...v1.51.0
 [1.50.0]: https://github.com/applypack/applypack/compare/v1.49.0...v1.50.0
 [1.49.0]: https://github.com/applypack/applypack/compare/v1.48.0...v1.49.0
 [1.48.0]: https://github.com/applypack/applypack/compare/v1.47.2...v1.48.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,8 @@
   (ADR 0012), `facts.ts`, `diff.ts`, `parse-warnings.ts`, `match-mode.ts`,
   `match-reuse.ts`, `bench-report.ts`,
   `profile-draft.ts` (ADR 0015), `fact-check.ts` (ADR 0020),
-  `keyword-overrides.ts`, `keyword-frame.ts`, `review-score.ts` (ADR 0030)
+  `keyword-overrides.ts`, `keyword-frame.ts`, `review-score.ts` (ADR 0030),
+  `change-sheet.ts`
   are pure (tested);
   `scan.ts` / `match.ts` / `suggestions.ts` / `review.ts` / `cover-letter.ts`
   call the AI provider (the letter is gated by `fact-check.ts` and generates from stored
@@ -272,6 +273,9 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Letting a call use web search (API server tools / CLI WebSearch) | `AiRequest.webTools` in `src/ai-provider.ts`, args in `ai-provider-parse.ts:buildClaudeCodeArgs` |
 | Classify one stored job (Re-classify button, pasted jobs) | `src/jobs/classify-existing.ts` |
 | Live keyword score + highlights in the browser | `src/web/public/target.mjs` (served at `/static/`, tested from `src/web/target.test.ts`) |
+| The wording a suggestion proposes, pulled out of its `what` sentence | `src/resume/change-sheet.ts:proposalOf` (pure) — reads `'…'` and `"…"`, guards the apostrophe, takes the span after a `to`/`with` connective, refuses a run under 12 chars; `suggestionSheet` renders the whole list as the Markdown behind "Copy all suggestions" |
+| What the user changed in the editor, as Markdown ("Copy my changes") | `src/web/public/line-diff.mjs:diffLines` (LCS over normalised lines; a delete/insert pair becomes a `change` only when 30 % of the wording survives) + `public/change-sheet.mjs:formatEditSheet` |
+| Copy-to-clipboard anywhere in the dashboard | `src/web/public/copy.mjs:wireCopy` — delegates `[data-copy]` (literal text) and `[data-copy-target]` (an element's value), falls back to `execCommand`, announces in one `aria-live` region it creates itself |
 | The targeted-resume page (editor, tabs, score ring) | `src/web/pages/target.tsx` (`TARGET_JS` wires the DOM) |
 | Each cron's once-script (manual trigger) | `src/scripts/{fetch,digest,cleanup,stale,hn,discovery}-once.ts` |
 
@@ -322,6 +326,8 @@ When the question is **"how does the user toggle / configure X?"**:
 | Ask how strong a resume is on its own (no posting) | `/resumes/:id` → "Resume strength" → Run strength review (one AI call, ~1 min; nothing runs on its own). Scores show in the `/resumes` Strength column |
 | Compare a resume with a posting | `/jobs/:id` → "Resume match" card — **Compare** = quick check (keywords, gates, score), **Full analysis** = also the edit suggestions (ADR 0029) |
 | Get the edit suggestions for a quick check | the comparison → "Get suggestions" (second call, reuses the stored verdicts, score unchanged) |
+| Copy a suggested wording, or find it in the editor | the comparison on `/jobs/:id` or `/jobs/:id/target` → each card's **Copy** (the proposed wording alone) and **Locate** (outlines it in the editor and scrolls the editor — never the page) |
+| Take the whole change list into Word / Docs / a mail | the comparison → **Copy all suggestions** (the AI's list) or, on the targeted view, **Copy my changes** (a diff of your own edits, live once you type). Both are Markdown and need no Apply |
 | Re-level, ignore or add a keyword by hand | the keyword table on `/jobs/:id` or `/jobs/:id/target` → the "Wants it" select, `ignore` / `reset`, and "Add a keyword" (instant re-score, no AI call; the edit sticks to the posting across re-runs) |
 | Throw away a keyword list the model got wrong | the keyword table → "Rebuild keywords" (one run with the stored frame withheld; your own keyword edits survive it, the new score is not comparable with the old) |
 | Paste a posting the fetchers don't see | `/jobs` → "+ Paste a job" (`/jobs/new`) |

--- a/SPEC.md
+++ b/SPEC.md
@@ -354,6 +354,17 @@ default) and renders both panes' highlights from the match's `keywords`
 `draft = true`; `resumeText` snapshots the judged text on every match.
 "Save as vN" turns the draft into a `.md` resume version.
 
+Each suggestion is a card showing **Now** (the resume's own words) and
+**Proposed** (the wording the model quoted inside its `what` sentence, pulled
+out by `resume/change-sheet.ts:proposalOf`), with **Copy** for that wording and
+**Locate**, which outlines it in the editor and scrolls the editor only — the
+page never moves. Removals show the text to cut rather than describing it.
+The whole list travels as Markdown: **Copy all suggestions** is rendered
+server-side, so it also works on `/jobs/:id`, and **Copy my changes** diffs the
+analysed text against the editor in the browser (`public/line-diff.mjs`). This
+manual path is complete on its own — nothing has to be applied for it to be
+useful.
+
 The loop: edit the resume → "Upload a new version" on `/resumes/:id`
 (`Resume.version` +1, re-scan) → Compare again. `ResumeMatch.resumeVersion`
 records which version scored; the card shows the delta vs the previous run.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1658,24 +1658,33 @@ bench); re-run `bench:resume` after stages 3 and 5.
 
 ### 18.4 Implementation order (five branches, each its own PR; tags from stage 3 on)
 
-**Stage 1 — `target-copy-locate` (no schema, no prompt; ~1 session)**
-- [ ] **Analyse first:** read the page and card sources; pull every stored
+**Stage 1 — `target-copy-locate` — SHIPPED v1.51.0 (no schema, no prompt)**
+- [x] **Analyse first:** read the page and card sources; pull every stored
       `actions[].what` and write the proposal extractor against the real
       shapes; one 375 px screenshot of the Suggestions tab in the note.
-- [ ] `add proposal extractor` — `target.mjs:proposalOf` + tests.
-- [ ] `add line diff` — `public/line-diff.mjs:diffLines` + tests.
-- [ ] `add change sheet` — `changeSheet` / `formatChangeSheet` (Markdown);
-      "Copy all suggestions", "Copy my changes".
-- [ ] `add copy and locate` — `copy.mjs:wireCopy` (clipboard + fallback,
+- [x] `add proposal extractor` — `resume/change-sheet.ts:proposalOf` + tests
+      (NOT `target.mjs`: the card renders it server-side, and `target.mjs` is a
+      byte copy in the landing demo — a new import there 404s on applypack.dev).
+      Measured 167/209 on the live corpus; single quotes are 131 of them.
+- [x] `add line diff` — `public/line-diff.mjs:diffLines` + tests.
+- [x] `add change sheet` — two, not one: `resume/change-sheet.ts:suggestionSheet`
+      is rendered server-side into the button ("Copy all suggestions" therefore
+      works on `/jobs/:id`, which carries no editor), `public/change-sheet.mjs:formatEditSheet`
+      builds "Copy my changes" from the live editor.
+- [x] `add copy and locate` — `copy.mjs:wireCopy` (clipboard + fallback,
       aria-live "Copied"); Locate outlines the span (`.located`), scrolls
       the editor only, `focus({ preventScroll: true })` on wide screens;
       "Couldn't find this text" inline instead of the pulse.
-- [ ] `restructure suggestion cards` — `SuggestionCard` with Now / Proposed,
+- [x] `restructure suggestion cards` — `SuggestionCard` with Now / Proposed,
       `<button>` controls, removal quote shown, badge inline; Copy also on
       `/jobs/:id`.
-- [ ] `fix narrow layout` — editor first and collapsed at ≤ 1023 px, keyword
-      table behind a disclosure, "show matched" toggle into the editor header.
-- [ ] `document copy path` — CLAUDE.md rows, SPEC, CHANGELOG + bump.
+- [x] `fix narrow layout` — editor first and collapsed at ≤ 1023 px, keyword
+      table behind a disclosure, and `#panes > * { min-width: 0 }`: the real
+      bug was a grid track widened to 499 px by the keyword table inside a
+      375 px column. The "show matched" toggle stayed where it is — the editor
+      card is `display:none` in the job-only view, which would take the job
+      pane's own control with it.
+- [x] `document copy path` — CLAUDE.md rows, SPEC, CHANGELOG + bump.
 
 **Stage 2 — `target-apply-edits` (no schema, no prompt; ~1 session)**
 - [ ] **Analyse first:** read `keyword-overrides.ts` and `facts.ts`; count

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.50.0",
+      "version": "1.51.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/resume/change-sheet.test.ts
+++ b/src/resume/change-sheet.test.ts
@@ -1,0 +1,192 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { proposalOf, suggestionSheet } from './change-sheet';
+import type { MatchAction, MatchRemoval } from './prompts';
+
+const action = (what: string, over: Partial<MatchAction> = {}): MatchAction => ({
+  section: 'summary',
+  where: 'PROFESSIONAL SUMMARY',
+  what,
+  why: 'matches the posting',
+  priority: 'high',
+  quote: null,
+  ...over,
+});
+
+/*
+ * Every shape below is a verbatim `actions[].what` from the live database
+ * (209 rows, 2026-09-04). Single quotes outnumber double quotes 131 to 45 and
+ * curly quotes never occur, so the straight single quote — which is also the
+ * apostrophe — carries most of the corpus.
+ */
+test('proposalOf reads the eight quoting shapes the model actually writes', () => {
+  const cases: [string, string, string | null][] = [
+    [
+      `Rewrite as: "Back end developer with 10+ years building PHP and Laravel web applications."`,
+      'Back end developer with 10+ years building PHP and Laravel web applications.',
+      'Rewrite',
+    ],
+    [
+      `Reword: 'Led code reviews and design guidance for the engineering team, raising code quality 20%.'`,
+      'Led code reviews and design guidance for the engineering team, raising code quality 20%.',
+      'Reword',
+    ],
+    [`Change to "Senior Backend Engineer"`, 'Senior Backend Engineer', 'Change'],
+    [
+      `Add: 'Converts business needs into technical specifications and resolves software bugs.'`,
+      'Converts business needs into technical specifications and resolves software bugs.',
+      'Add',
+    ],
+    [
+      `Reorder to 'React.js, Vue.js, Node.js, Laravel, Symfony' so React appears early.`,
+      'React.js, Vue.js, Node.js, Laravel, Symfony',
+      'Reorder',
+    ],
+    [`Change title to "Senior Full-Stack PHP Engineer"`, 'Senior Full-Stack PHP Engineer', 'Change title'],
+    [
+      `Lead with: 'Built and ran 10+ PHP/Laravel microservices on AWS with Elasticsearch.'`,
+      'Built and ran 10+ PHP/Laravel microservices on AWS with Elasticsearch.',
+      'Lead',
+    ],
+    [
+      `Rewrite so the stack is in the bullet, not just the footer: 'Built and owned PHP 8 services.'`,
+      'Built and owned PHP 8 services.',
+      // The lead is a sentence, not a label — the card falls back to "Proposed".
+      null,
+    ],
+  ];
+  for (const [what, text, verb] of cases) {
+    const got = proposalOf(action(what));
+    assert.deepEqual(got, { text, verb }, what);
+  }
+});
+
+test('proposalOf takes the wording after a swap connective, not the one before it', () => {
+  // Both spans are 19 characters: without the connective rule this is a coin toss.
+  assert.equal(
+    proposalOf(action(`Change 'Windsurf (Opus 4.6)' to just 'Windsurf and Claude' with no version number.`))?.text,
+    'Windsurf and Claude',
+  );
+  assert.equal(
+    proposalOf(
+      action(
+        `Replace 'Senior Software Engineer' with 'Senior Full-Stack PHP & Vue Developer | Laravel · TypeScript · AWS'`,
+      ),
+    )?.text,
+    'Senior Full-Stack PHP & Vue Developer | Laravel · TypeScript · AWS',
+  );
+});
+
+test('proposalOf refuses a quote that is the current wording, not a new one', () => {
+  // The only false positive the plain "longest span" rule produced on the corpus.
+  assert.equal(
+    proposalOf(
+      action(
+        `Replace 'Reduced the complexity of the system, cutting costs by hundreds of thousands of dollars annually' with a specific version: name the system and a concrete figure.`,
+      ),
+    ),
+    null,
+  );
+});
+
+test('proposalOf treats a short quoted run as a term mention', () => {
+  assert.equal(proposalOf(action(`Delete the stray '|' character sitting on its own line.`)), null);
+  assert.equal(proposalOf(action(`Spell it "Node.js" instead of "Node" and move it to the front.`)), null);
+  assert.equal(proposalOf(action(`Add "RabbitMQ" and "nginx" beside Kafka if confirmed`)), null);
+});
+
+test('proposalOf does not read an apostrophe as a quote', () => {
+  assert.equal(
+    proposalOf(action(`Surface PostgreSQL and Google Cloud wording consistently with the posting's terms.`)),
+    null,
+  );
+  assert.equal(
+    proposalOf(action(`State plainly that you're applying for the Vue & PHP track, not Angular & PHP.`)),
+    null,
+  );
+  // An apostrophe INSIDE the proposal must not close it early.
+  assert.equal(
+    proposalOf(action(`Reword: 'Owned the client's payment platform end to end, at 99.9% uptime.'`))?.text,
+    "Owned the client's payment platform end to end, at 99.9% uptime.",
+  );
+});
+
+test('proposalOf returns instructions without a wording as null', () => {
+  for (const what of [
+    'Cut to 4 bullets: keep architecture, payment platform, notification/TypeScript.',
+    'Add a number: users covered, services integrated, or login failure reduction.',
+    'Move the backend architecture bullet to first position',
+  ]) {
+    assert.equal(proposalOf(action(what)), null, what);
+  }
+});
+
+test('proposalOf prefers the model’s own replacement field over parsing', () => {
+  const withField = { ...action(`Reword: 'the parsed one, which is long enough'`), replacement: '  the field one  ' };
+  assert.deepEqual(proposalOf(withField), { text: 'the field one', verb: 'Replace' });
+  // An empty field falls back to the sentence rather than blanking the card.
+  assert.equal(proposalOf({ ...withField, replacement: '   ' })?.text, 'the parsed one, which is long enough');
+});
+
+test('proposalOf folds curly quotes so a re-styled reply still parses', () => {
+  assert.equal(
+    proposalOf(action('Rewrite as: “Senior backend engineer building Node.js services.”'))?.text,
+    'Senior backend engineer building Node.js services.',
+  );
+});
+
+const removal = (over: Partial<MatchRemoval> = {}): MatchRemoval => ({
+  section: 'experience',
+  where: 'OGD, bullet 3',
+  what: 'Drop the SEO bullet.',
+  why: 'unrelated to the posting',
+  quote: 'Improved SEO rankings for marketing pages.',
+  ...over,
+});
+
+test('suggestionSheet is Markdown with Now, Proposed and why for every entry', () => {
+  const sheet = suggestionSheet(
+    { jobTitle: 'Back end Developer', companyName: 'Acme', resumeName: 'Nazar CV' },
+    [
+      action(`Change to "Back end Developer | Senior PHP Engineer".`, {
+        section: 'title',
+        where: 'Headline under name',
+        quote: 'Senior Backend Software Engineer',
+        why: 'Mirrors the posting title for ATS title match.',
+      }),
+    ],
+    [removal()],
+  );
+  assert.match(sheet, /^# Resume changes — Back end Developer at Acme$/m);
+  assert.match(sheet, /^Resume: Nazar CV$/m);
+  assert.match(sheet, /^## What to change \(1\)$/m);
+  assert.match(sheet, /^### 1\. Headline under name — title$/m);
+  assert.match(sheet, /^\*\*Now:\*\*$/m);
+  assert.match(sheet, /^> Senior Backend Software Engineer$/m);
+  assert.match(sheet, /^\*\*Change:\*\*$/m);
+  assert.match(sheet, /^> Back end Developer \| Senior PHP Engineer$/m);
+  assert.match(sheet, /^_Why: Mirrors the posting title for ATS title match\._$/m);
+  assert.match(sheet, /^## What to remove \(1\)$/m);
+  assert.match(sheet, /^### 1\. OGD, bullet 3 — experience \(remove\)$/m);
+  // A removal proposes nothing; only its quote is shown.
+  assert.equal(sheet.includes('**Proposed:**'), false);
+  assert.match(sheet, /^> Improved SEO rankings for marketing pages\.$/m);
+  assert.equal(sheet.includes('\n\n\n'), false, 'no triple blank lines');
+  assert.ok(sheet.endsWith('\n'));
+});
+
+test('suggestionSheet quotes every line of a multi-line removal', () => {
+  const sheet = suggestionSheet(
+    { jobTitle: 'X', companyName: 'Y', resumeName: 'Z' },
+    [],
+    [removal({ quote: 'First line of the block\nSecond line of the block' })],
+  );
+  assert.match(sheet, /^> First line of the block$/m);
+  assert.match(sheet, /^> Second line of the block$/m);
+});
+
+test('suggestionSheet says so when there is nothing to carry out', () => {
+  const sheet = suggestionSheet({ jobTitle: 'X', companyName: 'Y', resumeName: 'Z' }, [], []);
+  assert.match(sheet, /No edits suggested\./);
+  assert.equal(sheet.includes('## What to change'), false);
+});

--- a/src/resume/change-sheet.ts
+++ b/src/resume/change-sheet.ts
@@ -1,0 +1,174 @@
+/*
+ * The manual path out of a comparison: the wording a suggestion proposes, and
+ * the whole suggestion list as Markdown the user can paste into Word, Google
+ * Docs or a mail. Pure — no I/O, no DOM. The card renders `proposalOf` as its
+ * "Proposed" block and `suggestionSheet` into the Copy button's payload, so
+ * the sheet needs no JavaScript to work.
+ *
+ * The model writes the proposal inside the `what` sentence rather than in a
+ * field of its own (a field arrives in stage 3 as `replacement`, and is
+ * preferred here the day it does). Every rule below was measured against the
+ * 209 stored actions — see the branch's pre-work note.
+ */
+
+import type { MatchAction, MatchRemoval } from './prompts';
+
+/**
+ * Shorter quoted runs are term mentions, not wordings: the corpus quotes
+ * `'|'`, `"Node"`, `"nginx"` and `'CloudWath'` to name them, never to propose
+ * them. It costs one real proposal in 209 (`Reduce to 'Austin, TX'`).
+ */
+const MIN_PROPOSAL = 12;
+/** A label, not a sentence: anything longer is the instruction, which the card already shows. */
+const MAX_VERB = 24;
+
+/** "Change 'A' to 'B'": the wording AFTER the connective is the proposal, the one before it is today's text. */
+const SWAP = /\s(?:with|to|instead of)\s/gi;
+const REPLACE_OPENER = /^(?:replace|change|swap)\b/i;
+const WORDLIKE = /[A-Za-z0-9]/;
+
+/** Curly quotes to straight, tabs to spaces — one character for one, so indexes still line up. */
+function fold(text: string): string {
+  return text.replace(/[‘’]/g, "'").replace(/[“”]/g, '"').replace(/[\t ]/g, ' ');
+}
+
+interface Span {
+  start: number;
+  end: number;
+  text: string;
+}
+
+/**
+ * Runs of `text` between two `quote` characters. A straight single quote is
+ * also an apostrophe, so an opener may not follow a word character
+ * (`posting's`) and a closer flanked by word characters is skipped as
+ * word-internal (`you're`).
+ */
+function quotedSpans(text: string, quote: string): Span[] {
+  const spans: Span[] = [];
+  const apostrophe = quote === "'";
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== quote) continue;
+    if (apostrophe && WORDLIKE.test(text[i - 1] ?? '')) continue;
+    let close = text.indexOf(quote, i + 1);
+    while (
+      close !== -1 &&
+      apostrophe &&
+      WORDLIKE.test(text[close - 1] ?? '') &&
+      WORDLIKE.test(text[close + 1] ?? '')
+    ) {
+      close = text.indexOf(quote, close + 1);
+    }
+    if (close === -1) break;
+    spans.push({ start: i + 1, end: close, text: text.slice(i + 1, close) });
+    i = close;
+  }
+  return spans;
+}
+
+export interface Proposal {
+  /** The wording itself — what Copy puts on the clipboard. */
+  text: string;
+  /** How the model introduced it ("Rewrite", "Add", "Change"), or null when the lead was a sentence. */
+  verb: string | null;
+}
+
+/**
+ * The wording an action proposes, or null when `what` is an instruction with
+ * no quoted wording in it ("Cut to four bullets", "Add a number").
+ */
+export function proposalOf(action: Pick<MatchAction, 'what'> & { replacement?: unknown }): Proposal | null {
+  // Stage 3 gives the model a field of its own; when it is there, nothing is parsed.
+  if (typeof action.replacement === 'string' && action.replacement.trim()) {
+    return { text: action.replacement.trim(), verb: 'Replace' };
+  }
+  const what = fold(action.what ?? '');
+  const all = [...quotedSpans(what, '"'), ...quotedSpans(what, "'")].sort((a, b) => a.start - b.start);
+  let candidates = all.filter((s) => s.text.trim().length >= MIN_PROPOSAL);
+  const first = all[0];
+  const firstCandidate = candidates[0];
+  if (!first || !firstCandidate) return null;
+
+  const connectives = [...what.matchAll(SWAP)].map((m) => m.index);
+  const cut = connectives.filter(
+    (i) => candidates.some((s) => s.end <= i) && candidates.some((s) => s.start > i),
+  ).at(-1);
+  if (cut !== undefined) {
+    candidates = candidates.filter((s) => s.start > cut);
+  } else if (
+    REPLACE_OPENER.test(what.trimStart()) &&
+    connectives.some((i) => i >= firstCandidate.end && i <= firstCandidate.end + 2)
+  ) {
+    // "Replace 'the old line' with a specific version: …" — the quote is today's text.
+    return null;
+  }
+
+  const [best] = candidates.sort((a, b) => b.text.trim().length - a.text.trim().length || b.start - a.start);
+  if (!best) return null;
+  const lead = what
+    .slice(0, first.start - 1)
+    .replace(/[:,\s]+$/, '')
+    .replace(/\s+(?:as|to|with|into|like)$/i, '')
+    .trim();
+  return {
+    text: best.text.trim(),
+    verb: lead && lead.length <= MAX_VERB && !lead.includes('.') ? lead : null,
+  };
+}
+
+export interface SheetHeading {
+  jobTitle: string;
+  companyName: string;
+  resumeName: string;
+}
+
+function block(lines: (string | null)[]): string {
+  return lines.filter((l): l is string => l !== null).join('\n');
+}
+
+/** One entry: what the resume says now, what to make it say, and why. */
+function entry(
+  index: number,
+  item: { section: string; where: string; what: string; why: string; quote?: string | null },
+  proposal: Proposal | null,
+  removal: boolean,
+): string {
+  return block([
+    `### ${index}. ${item.where} — ${item.section}${removal ? ' (remove)' : ''}`,
+    '',
+    item.what,
+    item.quote ? '' : null,
+    item.quote ? `**Now:**\n\n> ${item.quote.split('\n').join('\n> ')}` : null,
+    proposal ? '' : null,
+    proposal ? `**${proposal.verb ?? 'Proposed'}:**\n\n> ${proposal.text.split('\n').join('\n> ')}` : null,
+    '',
+    `_Why: ${item.why}_`,
+  ]);
+}
+
+/**
+ * The whole suggestion list as Markdown — the universal manual path. Nothing
+ * here is applied for the user; it is the list they take to whatever editor
+ * their resume actually lives in.
+ */
+export function suggestionSheet(
+  heading: SheetHeading,
+  actions: MatchAction[],
+  removals: MatchRemoval[],
+): string {
+  const parts: string[] = [
+    `# Resume changes — ${heading.jobTitle} at ${heading.companyName}`,
+    '',
+    `Resume: ${heading.resumeName}`,
+  ];
+  if (actions.length > 0) {
+    parts.push('', `## What to change (${actions.length})`, '');
+    actions.forEach((a, i) => parts.push(entry(i + 1, a, proposalOf(a), false), ''));
+  }
+  if (removals.length > 0) {
+    parts.push('', `## What to remove (${removals.length})`, '');
+    removals.forEach((r, i) => parts.push(entry(i + 1, r, null, true), ''));
+  }
+  if (actions.length === 0 && removals.length === 0) parts.push('', 'No edits suggested.');
+  return parts.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+}

--- a/src/web/change-sheet.test.ts
+++ b/src/web/change-sheet.test.ts
@@ -119,6 +119,16 @@ test('copy module loads without a DOM and exposes the clipboard helpers', async 
   }
 });
 
+test('wireCopy listens once per root, so a page that boots it twice copies once', async () => {
+  const { wireCopy } = (await copy) as { wireCopy: (root: unknown) => void };
+  // /jobs/:id boots this module itself and again through the cover-letter card.
+  let listeners = 0;
+  const root = { addEventListener: () => listeners++ };
+  wireCopy(root);
+  wireCopy(root);
+  assert.equal(listeners, 1);
+});
+
 test('copyToClipboard refuses empty text rather than clearing the clipboard', async () => {
   const { copyToClipboard } = (await copy) as { copyToClipboard: (t: string) => Promise<boolean> };
   assert.equal(await copyToClipboard(''), false);

--- a/src/web/change-sheet.test.ts
+++ b/src/web/change-sheet.test.ts
@@ -1,0 +1,125 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Both modules ship to the browser as static ES modules; node loads them the same way.
+// @ts-expect-error — plain JS with no declaration file; the shape is asserted below.
+const lineDiff = import('./public/line-diff.mjs') as Promise<{
+  diffLines: (
+    before: string,
+    after: string,
+  ) => { op: 'keep' | 'change' | 'delete' | 'insert'; a?: { i: number; text: string }; b?: { i: number; text: string } }[];
+}>;
+
+// @ts-expect-error — plain JS with no declaration file.
+const sheet = import('./public/change-sheet.mjs') as Promise<{
+  formatEditSheet: (
+    heading: { jobTitle: string; companyName: string; resumeName: string },
+    before: string,
+    after: string,
+  ) => string | null;
+}>;
+
+// @ts-expect-error — plain JS with no declaration file.
+const copy = import('./public/copy.mjs') as Promise<Record<string, unknown>>;
+
+const ops = (d: { op: string }[]) => d.map((x) => x.op);
+
+test('diffLines reports an unchanged text as all keeps', async () => {
+  const { diffLines } = await lineDiff;
+  const text = 'Summary\n\nBuilt payment systems.\nLed code review.';
+  assert.deepEqual(ops(diffLines(text, text)), ['keep', 'keep', 'keep', 'keep']);
+});
+
+test('diffLines pairs a delete followed by an insert into one change', async () => {
+  const { diffLines } = await lineDiff;
+  const d = diffLines('Alpha\nBravo\nCharlie', 'Alpha\nBravo reworded\nCharlie');
+  assert.deepEqual(ops(d), ['keep', 'change', 'keep']);
+  assert.equal(d[1]!.a?.text, 'Bravo');
+  assert.equal(d[1]!.b?.text, 'Bravo reworded');
+  assert.equal(d[1]!.a?.i, 1, 'line indexes are 0-based on each side');
+  assert.equal(d[1]!.b?.i, 1);
+});
+
+test('diffLines separates a pure insert from a pure delete', async () => {
+  const { diffLines } = await lineDiff;
+  assert.deepEqual(ops(diffLines('Alpha\nCharlie', 'Alpha\nBravo\nCharlie')), ['keep', 'insert', 'keep']);
+  assert.deepEqual(ops(diffLines('Alpha\nBravo\nCharlie', 'Alpha\nCharlie')), ['keep', 'delete', 'keep']);
+});
+
+test('diffLines reads a moved line as one delete and one insert, not a change', async () => {
+  const { diffLines } = await lineDiff;
+  // Documented behaviour, not an accident: nothing here tracks identity across a move.
+  const d = diffLines('- first\n- second\n- third', '- second\n- third\n- first');
+  assert.deepEqual(ops(d), ['delete', 'keep', 'keep', 'insert']);
+  assert.equal(d[0]!.a?.text, '- first');
+  assert.equal(d[3]!.b?.text, '- first');
+});
+
+test('diffLines ignores re-indentation and doubled spaces but keeps the original text', async () => {
+  const { diffLines } = await lineDiff;
+  const d = diffLines('  Built  payment systems.', 'Built payment systems.');
+  assert.deepEqual(ops(d), ['keep']);
+  assert.equal(d[0]!.a?.text, '  Built  payment systems.', 'the op carries what is on screen');
+});
+
+test('diffLines treats a lost blank line as a change to the document', async () => {
+  const { diffLines } = await lineDiff;
+  assert.deepEqual(ops(diffLines('Alpha\n\nBravo', 'Alpha\nBravo')), ['keep', 'delete', 'keep']);
+});
+
+test('diffLines handles an empty side', async () => {
+  const { diffLines } = await lineDiff;
+  // An empty text is still one (blank) line, so it shows up as such on either side.
+  assert.deepEqual(ops(diffLines('', 'Alpha')), ['delete', 'insert'], 'nothing in common is not a rewrite');
+  assert.deepEqual(ops(diffLines('Alpha\nBravo', '')), ['delete', 'delete', 'insert']);
+});
+
+const HEADING = { jobTitle: 'Back end Developer', companyName: 'Acme', resumeName: 'Nazar CV v3' };
+
+test('formatEditSheet returns null when nothing was edited', async () => {
+  const { formatEditSheet } = await sheet;
+  assert.equal(formatEditSheet(HEADING, 'Alpha\nBravo', 'Alpha\nBravo'), null);
+  assert.equal(formatEditSheet(HEADING, 'Alpha\nBravo', ' Alpha \nBravo'), null, 'whitespace alone is not an edit');
+});
+
+test('formatEditSheet writes Was/Now for a rework and names added and removed lines', async () => {
+  const { formatEditSheet } = await sheet;
+  const md = formatEditSheet(
+    HEADING,
+    'Senior Backend Engineer\nBuilt payment systems.\nDrop me.',
+    'Senior Backend Engineer\nBuilt PHP/Laravel payment systems at 99.9% uptime.\nBrand new line.',
+  );
+  assert.ok(md);
+  assert.match(md!, /^# My resume edits — Back end Developer at Acme$/m);
+  assert.match(md!, /^Resume: Nazar CV v3$/m);
+  assert.match(md!, /1 reworded, 1 added, 1 removed/);
+  assert.match(md!, /A line moved elsewhere reads as one removed and one added\./);
+  assert.match(md!, /^### 1\. Reworded — line 2$/m);
+  assert.match(md!, /^\*\*Was:\*\*$/m);
+  assert.match(md!, /^> Built payment systems\.$/m);
+  assert.match(md!, /^\*\*Now:\*\*$/m);
+  assert.match(md!, /^> Built PHP\/Laravel payment systems at 99\.9% uptime\.$/m);
+  assert.match(md!, /^### 2\. Removed — line 3$/m);
+  assert.match(md!, /^> Drop me\.$/m);
+  assert.match(md!, /^### 3\. Added — line 3$/m);
+  assert.match(md!, /^> Brand new line\.$/m);
+  assert.equal(md!.includes('\n\n\n'), false, 'no triple blank lines');
+});
+
+test('formatEditSheet names a blank line instead of quoting nothing', async () => {
+  const { formatEditSheet } = await sheet;
+  const md = formatEditSheet(HEADING, 'Alpha\n\nBravo', 'Alpha\nBravo');
+  assert.match(md!, /^> \(blank line\)$/m);
+});
+
+test('copy module loads without a DOM and exposes the clipboard helpers', async () => {
+  const mod = await copy;
+  for (const name of ['wireCopy', 'copyToClipboard', 'flashCopied', 'copyFrom', 'announce']) {
+    assert.equal(typeof mod[name], 'function', name);
+  }
+});
+
+test('copyToClipboard refuses empty text rather than clearing the clipboard', async () => {
+  const { copyToClipboard } = (await copy) as { copyToClipboard: (t: string) => Promise<boolean> };
+  assert.equal(await copyToClipboard(''), false);
+});

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -320,8 +320,16 @@ export const JobDetailPage: FC<JobDetailProps> = ({
         </Card>
       </div>
     </div>
+    {/* Copy on the suggestion cards and the change sheet; the card itself is
+        server-rendered, so this is all the JavaScript this page needs. */}
+    <script type="module" dangerouslySetInnerHTML={{ __html: COPY_BOOT }} />
   </Layout>
 );
+
+const COPY_BOOT = `
+import { wireCopy } from '/static/copy.mjs';
+wireCopy(document);
+`;
 
 /**
  * What each running search made of this posting. Hidden while only one search

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -97,8 +97,13 @@ const HARD_VIEW: Record<MatchHardRequirement['status'], { label: string; tone: T
 };
 
 const SUBHEAD = 'mb-2 text-[13px] font-medium text-ink-muted';
-/** The Now / Proposed captions: quiet enough to read as labels, not as content. */
-const LABEL = 'text-[11px] font-semibold uppercase tracking-wide text-ink-faint';
+/**
+ * The Now / Proposed captions. Micro step (12px/500) — the ramp's floor — and
+ * no uppercase tracking: DESIGN.md says nothing in this app is ever set that
+ * way, and the caption is a real word the model chose ("Rewrite", "Add"), not
+ * a category shouting at the reader.
+ */
+const LABEL = 'text-xs font-medium text-ink-faint';
 
 export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
   jobId,

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -576,11 +576,15 @@ const SuggestionCard: FC<{
             Copy
           </Button>
           {interactive && item.quote && (
-            <Button type="button" variant="ghost" size="sm" data-locate={item.quote}>
-              Locate
-            </Button>
+            <>
+              <Button type="button" variant="ghost" size="sm" data-locate={item.quote}>
+                Locate
+              </Button>
+              {/* Only where Locate exists: an empty live region on every card of
+                  every page is noise a screen reader has to carry. */}
+              <span class="text-xs text-ink-faint" data-locate-status role="status"></span>
+            </>
           )}
-          <span class="text-xs text-ink-faint" data-locate-status role="status"></span>
         </div>
       </div>
     </li>

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource hono/jsx */
-import type { FC } from 'hono/jsx';
+import type { Child, FC } from 'hono/jsx';
 import {
   ActionForm,
   Badge,
@@ -30,6 +30,7 @@ import {
   type MatchKeyword,
 } from '../../resume/prompts';
 import { freshFrame, freshFrameNotice } from '../../resume/keyword-frame';
+import { proposalOf, suggestionSheet, type Proposal } from '../../resume/change-sheet';
 import { readMatchMode, type MatchMode } from '../../resume/match-mode';
 import type { CountedKeyword } from '../../resume/keyword-matcher';
 import { effectiveRequirement, isIgnored } from '../../resume/keyword-overrides';
@@ -48,6 +49,8 @@ export interface ResumeMatchCardProps {
   selected: MatchWithResume | null;
   /** The selected comparison's keywords, ordered and counted by the matcher. */
   selectedKeywords: CountedKeyword[];
+  /** Names the change sheet the Copy button hands over. */
+  job: { title: string; companyName: string };
 }
 
 const PRIORITY_TONE: Record<MatchAction['priority'], Tone> = {
@@ -94,6 +97,8 @@ const HARD_VIEW: Record<MatchHardRequirement['status'], { label: string; tone: T
 };
 
 const SUBHEAD = 'mb-2 text-[13px] font-medium text-ink-muted';
+/** The Now / Proposed captions: quiet enough to read as labels, not as content. */
+const LABEL = 'text-[11px] font-semibold uppercase tracking-wide text-ink-faint';
 
 export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
   jobId,
@@ -103,6 +108,7 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
   matches,
   selected,
   selectedKeywords,
+  job,
 }) => (
   <div id="resume-match">
     <Card>
@@ -161,6 +167,7 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
           previous={previousFor(selected, matches)}
           keywords={selectedKeywords}
           factsBack={`/jobs/${jobId}?match=${selected.id}#resume-match`}
+          job={job}
         />
       )}
 
@@ -325,7 +332,9 @@ export const MatchReport: FC<{
   keywords: CountedKeyword[];
   /** Where the ask_user confirm/deny and keyword-override forms return to. */
   factsBack: string;
-}> = ({ match, previous, keywords, factsBack }) => {
+  /** Names the change sheet the Copy button hands over. */
+  job: { title: string; companyName: string };
+}> = ({ match, previous, keywords, factsBack, job }) => {
   const bd = readBreakdown(match.breakdown);
   // A re-extracted frame counts different terms, so the older number is not a
   // baseline for this one (keyword-frame.ts). DeltaBox says so in words.
@@ -371,6 +380,15 @@ export const MatchReport: FC<{
         <SuggestionsPrompt matchId={match.id} jobId={match.jobId} />
       ) : (
         <>
+          <div class="flex flex-wrap items-center gap-2">
+            <ChangeSheetButton
+              job={job}
+              resumeName={match.resume.name}
+              actions={readActions(match.actions)}
+              removals={readRemovals(match.removals)}
+            />
+            <Hint class="!mt-0">as Markdown, for the document your resume really lives in</Hint>
+          </div>
           <ActionsBlock actions={readActions(match.actions)} />
           <RemovalsBlock removals={readRemovals(match.removals)} />
         </>
@@ -506,10 +524,73 @@ export const MatchSignals: FC<{ match: MatchWithResume }> = ({ match }) => (
   </>
 );
 
-/** "What to change" — jumpable on the targeted view (click selects the quote). */
-export const ActionsBlock: FC<{ actions: MatchAction[]; jumpable?: boolean }> = ({
+/**
+ * One suggestion: what the resume says now, the wording proposed for it, and
+ * the two controls that make the manual path bearable. Copy is always there —
+ * a proposal you cannot get onto the clipboard is a proposal you retype.
+ * Locate only exists where there is an editor to scroll (`interactive`), and
+ * it never moves the page.
+ */
+const SuggestionCard: FC<{
+  item: { section: string; where: string; what: string; why: string; quote?: string | null };
+  badge: Child;
+  /** The wording to copy, when the model quoted one inside `what`. */
+  proposal: Proposal | null;
+  /** True on the targeted view, where an editor exists to locate the quote in. */
+  interactive: boolean;
+  /** A removal shows its quote struck through: this is the text to delete. */
+  strike?: boolean;
+  /** Priority badges are one word, section badges are up to four syllables. */
+  badgeWidth?: string;
+}> = ({ item, badge, proposal, interactive, strike = false, badgeWidth = 'w-16' }) => {
+  const copyable = proposal?.text ?? item.quote ?? item.what;
+  return (
+    <li class="flex flex-col gap-1 p-3 sm:flex-row sm:gap-3">
+      <div class={`${badgeWidth} shrink-0`}>{badge}</div>
+      <div class="min-w-0 flex-1 text-sm">
+        <div class="font-medium text-ink">{item.where}</div>
+        <div class="mt-0.5 leading-6 text-ink">{item.what}</div>
+        {item.quote && (
+          <div class="mt-2">
+            <div class={LABEL}>Now</div>
+            <p
+              class={`mt-0.5 whitespace-pre-wrap break-words border-l-2 border-line-strong pl-2 leading-6 text-ink-muted ${
+                strike ? 'line-through decoration-danger/60' : ''
+              }`}
+            >
+              {item.quote}
+            </p>
+          </div>
+        )}
+        {proposal && (
+          <div class="mt-2">
+            <div class={LABEL}>{proposal.verb ?? 'Proposed'}</div>
+            <p class="mt-0.5 whitespace-pre-wrap break-words border-l-2 border-accent/50 pl-2 leading-6 text-ink">
+              {proposal.text}
+            </p>
+          </div>
+        )}
+        <div class="mt-1 text-xs leading-5 text-ink-faint">why: {item.why}</div>
+        <div class="mt-2 flex flex-wrap items-center gap-2">
+          <Button type="button" variant="secondary" size="sm" data-copy={copyable}>
+            Copy
+          </Button>
+          {interactive && item.quote && (
+            <Button type="button" variant="ghost" size="sm" data-locate={item.quote}>
+              Locate
+            </Button>
+          )}
+          <span class="text-xs text-ink-faint" data-locate-status role="status"></span>
+        </div>
+      </div>
+    </li>
+  );
+};
+
+/** "What to change" — one card per edit, with Copy and (on the targeted view) Locate. */
+export const ActionsBlock: FC<{ actions: MatchAction[]; interactive?: boolean }> = ({
   actions,
-  jumpable = false,
+  interactive = false,
 }) => {
   const sections = ACTION_SECTIONS.filter((s) => actions.some((a) => a.section === s));
   return (
@@ -526,26 +607,12 @@ export const ActionsBlock: FC<{ actions: MatchAction[]; jumpable?: boolean }> = 
                 {actions
                   .filter((a) => a.section === section)
                   .map((a) => (
-                    <li
-                      class={`flex flex-col gap-1 p-3 sm:flex-row sm:gap-3 ${
-                        jumpable && a.quote
-                          ? 'cursor-pointer transition-colors duration-150 hover:bg-surface-overlay/50'
-                          : ''
-                      }`}
-                      data-quote={jumpable && a.quote ? a.quote : undefined}
-                      title={
-                        jumpable && a.quote ? 'Click to select this text in the editor' : undefined
-                      }
-                    >
-                      <div class="w-16 shrink-0">
-                        <Badge tone={PRIORITY_TONE[a.priority]}>{a.priority}</Badge>
-                      </div>
-                      <div class="min-w-0 text-sm">
-                        <div class="font-medium text-ink">{a.where}</div>
-                        <div class="mt-0.5 leading-6 text-ink">{a.what}</div>
-                        <div class="mt-0.5 text-xs leading-5 text-ink-faint">why: {a.why}</div>
-                      </div>
-                    </li>
+                    <SuggestionCard
+                      item={a}
+                      badge={<Badge tone={PRIORITY_TONE[a.priority]}>{a.priority}</Badge>}
+                      proposal={proposalOf(a)}
+                      interactive={interactive}
+                    />
                   ))}
               </ol>
             </div>
@@ -556,37 +623,53 @@ export const ActionsBlock: FC<{ actions: MatchAction[]; jumpable?: boolean }> = 
   );
 };
 
-/** "What to remove" — same jumpable behavior as ActionsBlock. */
-export const RemovalsBlock: FC<{ removals: ReturnType<typeof readRemovals>; jumpable?: boolean }> = ({
-  removals,
-  jumpable = false,
-}) =>
+/** "What to remove" — the same card, showing the text to cut rather than hiding it. */
+export const RemovalsBlock: FC<{
+  removals: ReturnType<typeof readRemovals>;
+  interactive?: boolean;
+}> = ({ removals, interactive = false }) =>
   removals.length === 0 ? null : (
     <div>
       <div class={SUBHEAD}>What to remove — {removals.length} items</div>
       <ul class="divide-y divide-line rounded-md border border-line">
         {removals.map((r) => (
-          <li
-            class={`flex flex-col gap-1 p-3 sm:flex-row sm:gap-3 ${
-              jumpable && r.quote
-                ? 'cursor-pointer transition-colors duration-150 hover:bg-surface-overlay/50'
-                : ''
-            }`}
-            data-quote={jumpable && r.quote ? r.quote : undefined}
-            title={jumpable && r.quote ? 'Click to select this text in the editor' : undefined}
-          >
-            <div class="w-24 shrink-0">
-              <Badge tone="neutral">{r.section}</Badge>
-            </div>
-            <div class="min-w-0 text-sm">
-              <div class="font-medium text-ink">{r.where}</div>
-              <div class="mt-0.5 leading-6 text-ink">{r.what}</div>
-              <div class="mt-0.5 text-xs leading-5 text-ink-faint">why: {r.why}</div>
-            </div>
-          </li>
+          <SuggestionCard
+            item={r}
+            badge={<Badge tone="neutral">{r.section}</Badge>}
+            proposal={null}
+            interactive={interactive}
+            strike
+            badgeWidth="w-24"
+          />
         ))}
       </ul>
     </div>
+  );
+
+/**
+ * The whole list as Markdown, on the clipboard in one press. The payload is
+ * rendered here rather than built in the browser, so it works on this page
+ * too — which carries no editor and no JSON blob.
+ */
+export const ChangeSheetButton: FC<{
+  job: { title: string; companyName: string };
+  resumeName: string;
+  actions: MatchAction[];
+  removals: ReturnType<typeof readRemovals>;
+}> = ({ job, resumeName, actions, removals }) =>
+  actions.length === 0 && removals.length === 0 ? null : (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      data-copy={suggestionSheet(
+        { jobTitle: job.title, companyName: job.companyName, resumeName },
+        actions,
+        removals,
+      )}
+    >
+      Copy all suggestions
+    </Button>
   );
 
 /**

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -12,6 +12,7 @@ import { readMatchMode } from '../../resume/match-mode';
 import { readBreakdown } from '../../resume/score';
 import {
   ActionsBlock,
+  ChangeSheetButton,
   ConfirmFacts,
   DeltaBox,
   HardRequirementsDigest,
@@ -140,6 +141,8 @@ export const TargetPage: FC<TargetPageProps> = ({
     scoring: breakdown
       ? { alignment: breakdown.alignment, redFlagCount: match.redFlags.length, penalty: breakdown.penalty }
       : null,
+    // Heads "Copy my changes"; the suggestion sheet is rendered server-side.
+    sheet: { jobTitle: job.title, companyName: job.companyName, resumeName: resume.name },
   };
   return (
     <Layout title={`Resume match · ${job.title}`} active="jobs">
@@ -502,6 +505,14 @@ export const TargetPage: FC<TargetPageProps> = ({
               <span><mark class="edit-remove rounded px-1">remove</mark></span>
               <button
                 type="button"
+                id="expand-editor"
+                class="cursor-pointer text-ink-muted underline-offset-2 transition-colors duration-150 hover:text-ink hover:underline lg:hidden"
+                aria-expanded="false"
+              >
+                expand editor
+              </button>
+              <button
+                type="button"
                 id="reset-edits"
                 class="cursor-pointer text-ink-muted underline-offset-2 transition-colors duration-150 hover:text-ink hover:underline"
               >
@@ -521,8 +532,8 @@ export const TargetPage: FC<TargetPageProps> = ({
           </div>
           <Hint class="mt-2">
             {resume.ephemeral
-              ? 'Plain text — what an ATS parser sees. Edits stay in this browser tab until you re-check. Click a suggestion to select the text it targets.'
-              : 'Plain text — what an ATS parser sees. Edits stay in this browser tab until you re-check or Save. Click a suggestion to select the text it targets.'}
+              ? 'Plain text — what an ATS parser sees. Edits stay in this browser tab until you re-check. Locate on a suggestion outlines the text it targets.'
+              : 'Plain text — what an ATS parser sees. Edits stay in this browser tab until you re-check or Save. Locate on a suggestion outlines the text it targets.'}
           </Hint>
         </Card>
 
@@ -534,11 +545,35 @@ export const TargetPage: FC<TargetPageProps> = ({
                 <SuggestionsPrompt matchId={match.id} jobId={job.id} next="target" />
               ) : (
                 <>
-                  <ActionsBlock actions={actions} jumpable />
-                  <RemovalsBlock removals={removals} jumpable />
+                  <div>
+                    <div class="flex flex-wrap items-center gap-2">
+                      <ChangeSheetButton
+                        job={{ title: job.title, companyName: job.companyName }}
+                        resumeName={resume.name}
+                        actions={actions}
+                        removals={removals}
+                      />
+                      <Button type="button" variant="secondary" size="sm" id="copy-edits" disabled>
+                        Copy my changes
+                      </Button>
+                    </div>
+                    <Hint class="mt-1.5">
+                      Markdown, for the document your resume really lives in. The second one is the
+                      diff of your own edits and turns on once you change the text.
+                    </Hint>
+                  </div>
+                  <ActionsBlock actions={actions} interactive />
+                  <RemovalsBlock removals={removals} interactive />
                 </>
               )}
               <MatchSignals match={match} />
+              {/* Wide screens open it on boot (target-page.mjs); narrow ones keep
+                  it shut, because it is the longest block on the page by far. */}
+              <details class="kw-fold">
+                <summary class="cursor-pointer text-[13px] font-medium text-ink-muted">
+                  Keyword coverage — {keywords.length} terms
+                </summary>
+                <div class="mt-3">
               <KeywordTable
                 keywords={keywords}
                 edit={
@@ -550,6 +585,8 @@ export const TargetPage: FC<TargetPageProps> = ({
                 // screen — the same call Re-check makes, minus the stored frame.
                 rebuild={{ jobId: job.id, resumeId: resume.id, mode: fast ? 'fast' : 'full', formId: 'reanalyze-form' }}
               />
+                </div>
+              </details>
             </div>
           </Card>
         </div>
@@ -657,6 +694,10 @@ const TARGET_CSS = `
   #backdrop { color: rgb(var(--ink)); pointer-events: none; overflow: hidden; }
   #editor { background: transparent; color: transparent; caret-color: rgb(var(--ink)); border: 0; outline: none; resize: none; }
   #editor::selection { background: rgb(var(--accent) / 0.25); }
+  /* A grid item defaults to min-width:auto, so it is sized by its widest
+     content — which made the keyword table's own overflow-x-auto wrapper
+     497px wide inside a 375px column and pushed the page sideways. */
+  #panes > * { min-width: 0; }
   #panes[data-view="job"] .pane-resume, #panes[data-view="job"] .pane-changes,
   #panes[data-view="both"] .pane-changes,
   #panes[data-view="changes"] .pane-job { display: none; }
@@ -666,6 +707,24 @@ const TARGET_CSS = `
   #panes[data-view="changes"] .pane-changes { order: -1; }
   @media (min-width: 1024px) {
     #panes[data-view="changes"] .pane-resume { position: sticky; top: 0.75rem; align-self: start; }
+  }
+  /* Locate: the outline says "here", and it fades on its own so it never
+     becomes permanent furniture. It is never the ONLY signal — the card
+     prints the line number beside the button. */
+  .located { outline: 2px solid rgb(var(--accent) / 0.9); outline-offset: 1px; border-radius: 3px; animation: located-fade 2s ease-out forwards; }
+  @keyframes located-fade { from { background: rgb(var(--accent) / 0.3); } to { background: transparent; } }
+  @media (prefers-reduced-motion: reduce) {
+    .located { animation: none; }
+  }
+  .kw-fold > summary::-webkit-details-marker { display: none; }
+  .kw-fold > summary::before { content: '▸ '; }
+  .kw-fold[open] > summary::before { content: '▾ '; }
+  @media (max-width: 1023px) {
+    /* The editor is what the user is here to change, so it comes first and
+       starts short; the advice column below it is the long read. */
+    #panes[data-view="changes"] .pane-changes { order: 0; }
+    #panes .editor { height: 40vh; }
+    #panes.editor-tall .editor { height: 75vh; }
   }
   .chip { cursor: pointer; }
   .runs-toggle::-webkit-details-marker { display: none; }

--- a/src/web/public/change-sheet.mjs
+++ b/src/web/public/change-sheet.mjs
@@ -1,0 +1,58 @@
+/*
+ * "Copy my changes" — the edits the user made in the editor, as Markdown they
+ * can paste into a mail or hand to whoever owns the real document. The other
+ * half of the manual path ("Copy all suggestions") is rendered on the server
+ * from src/resume/change-sheet.ts, because it needs no live text and must work
+ * on /jobs/:id too.
+ *
+ * Dependency-free ES module, no DOM — unit-tested from src/web/target.test.ts.
+ */
+
+import { diffLines } from './line-diff.mjs';
+
+/** A blank line has no content to quote; the sheet names it instead. */
+const BLANK = '(blank line)';
+
+function quote(text) {
+  const body = text.trim();
+  return body ? `> ${body}` : `> ${BLANK}`;
+}
+
+/**
+ * The diff between the analysed text and the edited one, as Markdown. Returns
+ * null when nothing changed, so the caller can keep the button disabled rather
+ * than copy an empty sheet.
+ */
+export function formatEditSheet({ jobTitle, companyName, resumeName }, before, after) {
+  const ops = diffLines(before, after).filter((d) => d.op !== 'keep');
+  if (ops.length === 0) return null;
+
+  const counts = { change: 0, insert: 0, delete: 0 };
+  for (const d of ops) counts[d.op]++;
+  const summary = [
+    counts.change ? `${counts.change} reworded` : null,
+    counts.insert ? `${counts.insert} added` : null,
+    counts.delete ? `${counts.delete} removed` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  const lines = [
+    `# My resume edits — ${jobTitle} at ${companyName}`,
+    '',
+    `Resume: ${resumeName}`,
+    `Lines: ${summary}. A line moved elsewhere reads as one removed and one added.`,
+    '',
+  ];
+  ops.forEach((d, n) => {
+    // Line numbers are 1-based for a human reading them beside their own document.
+    if (d.op === 'change') {
+      lines.push(`### ${n + 1}. Reworded — line ${d.a.i + 1}`, '', '**Was:**', '', quote(d.a.text), '', '**Now:**', '', quote(d.b.text), '');
+    } else if (d.op === 'insert') {
+      lines.push(`### ${n + 1}. Added — line ${d.b.i + 1}`, '', quote(d.b.text), '');
+    } else {
+      lines.push(`### ${n + 1}. Removed — line ${d.a.i + 1}`, '', quote(d.a.text), '');
+    }
+  });
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+}

--- a/src/web/public/copy.mjs
+++ b/src/web/public/copy.mjs
@@ -1,0 +1,92 @@
+/*
+ * Copy-to-clipboard, shared by every page that offers one. Dependency-free ES
+ * module served as-is; the page imports wireCopy() once and every
+ * `[data-copy]` (literal text) and `[data-copy-target]` (an element's value)
+ * button works from then on.
+ *
+ * Two things it does that a bare navigator.clipboard call does not: it falls
+ * back to a hidden textarea + execCommand where the Clipboard API is refused
+ * (Safari without a user-gesture chain, an insecure origin), and it announces
+ * the result in a polite live region, because a button that only changes its
+ * own label says nothing to a screen reader.
+ */
+
+const RESET_MS = 2000;
+const LIVE_ID = 'copy-live';
+
+/** The one live region per page, created on first use so no page has to carry the markup. */
+function liveRegion() {
+  let el = document.getElementById(LIVE_ID);
+  if (!el) {
+    el = document.createElement('div');
+    el.id = LIVE_ID;
+    el.setAttribute('aria-live', 'polite');
+    // Off-screen rather than hidden: display:none is not announced.
+    el.style.cssText = 'position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap';
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+export function announce(message) {
+  liveRegion().textContent = message;
+}
+
+/** Put `text` on the clipboard. Resolves to whether it landed. */
+export async function copyToClipboard(text) {
+  if (!text) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // execCommand needs a selection in the document, so borrow one off-screen.
+    const area = document.createElement('textarea');
+    area.value = text;
+    area.setAttribute('readonly', '');
+    area.style.cssText = 'position:fixed;top:-1000px;left:-1000px;opacity:0';
+    document.body.appendChild(area);
+    area.select();
+    let ok = false;
+    try {
+      ok = typeof document.execCommand === 'function' && document.execCommand('copy');
+    } catch {
+      ok = false;
+    }
+    area.remove();
+    return ok;
+  }
+}
+
+/** Say it on the button and in the live region, then put the button back. */
+export function flashCopied(button, ok) {
+  const original = button.dataset.copyLabel ?? button.textContent;
+  button.dataset.copyLabel = original;
+  button.textContent = ok ? 'Copied' : 'Copy failed';
+  announce(ok ? 'Copied to clipboard' : 'Could not copy — select the text and copy it by hand');
+  clearTimeout(Number(button.dataset.copyTimer));
+  button.dataset.copyTimer = String(
+    setTimeout(() => {
+      button.textContent = original;
+    }, RESET_MS),
+  );
+}
+
+/** Copy `text` and report it on `button` — for buttons whose payload is built at click time. */
+export async function copyFrom(button, text) {
+  flashCopied(button, await copyToClipboard(text));
+}
+
+/**
+ * Delegate clicks inside `root`: `[data-copy]` copies the attribute's own text,
+ * `[data-copy-target]` copies the value of the element with that id. Delegation
+ * rather than per-button listeners, so markup rendered after boot works too.
+ */
+export function wireCopy(root = document) {
+  root.addEventListener('click', (event) => {
+    const button = event.target.closest?.('[data-copy], [data-copy-target]');
+    if (!button || !root.contains(button)) return;
+    const source = button.dataset.copyTarget ? document.getElementById(button.dataset.copyTarget) : null;
+    const text = button.dataset.copyTarget ? (source?.value ?? source?.textContent ?? '') : button.dataset.copy;
+    copyFrom(button, text ?? '');
+  });
+}

--- a/src/web/public/copy.mjs
+++ b/src/web/public/copy.mjs
@@ -13,6 +13,11 @@
 
 const RESET_MS = 2000;
 const LIVE_ID = 'copy-live';
+/**
+ * Roots already listening. /jobs/:id boots this module itself AND through the
+ * cover-letter card, so without this every click there would copy twice.
+ */
+const wired = new WeakSet();
 
 /** The one live region per page, created on first use so no page has to carry the markup. */
 function liveRegion() {
@@ -82,6 +87,8 @@ export async function copyFrom(button, text) {
  * rather than per-button listeners, so markup rendered after boot works too.
  */
 export function wireCopy(root = document) {
+  if (wired.has(root)) return;
+  wired.add(root);
   root.addEventListener('click', (event) => {
     const button = event.target.closest?.('[data-copy], [data-copy-target]');
     if (!button || !root.contains(button)) return;

--- a/src/web/public/cover-letter.mjs
+++ b/src/web/public/cover-letter.mjs
@@ -3,12 +3,13 @@
  * card boots init(). Progressive: without JS the Save button is visible and
  * the plain form POST still works, so nothing here is load-bearing.
  *   - the letter autosaves while you type (debounced), the button hides;
- *   - Copy puts the current text on the clipboard.
+ *   - Copy puts the current text on the clipboard (shared with ./copy.mjs).
  * statusFor and nextDelay are pure — unit-tested from src/web/cover-letter.test.ts.
  */
 
+import { wireCopy } from './copy.mjs';
+
 const SAVE_DEBOUNCE_MS = 900;
-const COPY_RESET_MS = 1500;
 
 /** What the status line says for a given save state. */
 export function statusFor(state, verdict) {
@@ -33,29 +34,6 @@ export function statusFor(state, verdict) {
 /** Retry backoff after a failed autosave; capped so it never sleeps forever. */
 export function nextDelay(attempt) {
   return Math.min(SAVE_DEBOUNCE_MS * 2 ** attempt, 15_000);
-}
-
-function wireCopy() {
-  for (const btn of document.querySelectorAll('[data-copy-target]')) {
-    btn.addEventListener('click', async () => {
-      const el = document.getElementById(btn.dataset.copyTarget);
-      if (!el) return;
-      let ok = true;
-      try {
-        await navigator.clipboard.writeText(el.value);
-      } catch {
-        el.select();
-        ok = typeof document.execCommand === 'function' && document.execCommand('copy');
-      }
-      const original = btn.textContent;
-      btn.textContent = ok ? 'Copied' : 'Copy failed';
-      btn.disabled = true;
-      setTimeout(() => {
-        btn.textContent = original;
-        btn.disabled = false;
-      }, COPY_RESET_MS);
-    });
-  }
 }
 
 function wireAutosave() {
@@ -135,6 +113,6 @@ function wireAutosave() {
 }
 
 export function init() {
-  wireCopy();
+  wireCopy(document);
   wireAutosave();
 }

--- a/src/web/public/line-diff.mjs
+++ b/src/web/public/line-diff.mjs
@@ -1,0 +1,133 @@
+/*
+ * Line diff for the targeted-resume page: what the user actually changed
+ * between the text the AI analysed and the text in the editor. Dependency-free
+ * ES module, no DOM — served as-is and unit-tested from src/web/target.test.ts.
+ *
+ * Lines are compared on a normalised key (trimmed, whitespace collapsed, curly
+ * quotes folded) so a re-indent or a double space is not an edit, but every op
+ * carries the ORIGINAL text — the change sheet quotes what is on screen, not
+ * the key it matched on. Blank lines are lines: a lost paragraph gap is a real
+ * change to a resume, and the .docx patcher in a later stage needs them.
+ */
+
+/** Above this a resume is not a resume; the LCS table is O(n·m) and this keeps it small. */
+const MAX_LINES = 2000;
+
+/**
+ * How much of two lines' wording has to survive for one to be a rewrite of the
+ * other rather than a deletion next to an unrelated addition. Measured as
+ * shared words over all words: "Built payment systems." → "Built PHP/Laravel
+ * payment systems at 99.9% uptime." is 0.43, "Drop me." → the same line is 0.
+ */
+const REWRITE_OVERLAP = 0.3;
+
+function key(line) {
+  return line
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function split(text) {
+  return String(text ?? '')
+    .split('\n')
+    .slice(0, MAX_LINES);
+}
+
+function words(line) {
+  return new Set(
+    key(line)
+      .toLowerCase()
+      .split(/[^\p{L}\p{N}]+/u)
+      .filter(Boolean),
+  );
+}
+
+/** Shared words over all words — 1 for identical wording, 0 for two lines with nothing in common. */
+function overlap(a, b) {
+  const left = words(a);
+  const right = words(b);
+  if (left.size === 0 || right.size === 0) return 0;
+  let shared = 0;
+  for (const w of left) if (right.has(w)) shared++;
+  return shared / (left.size + right.size - shared);
+}
+
+/**
+ * Longest common subsequence of the two line-key arrays, as a table of lengths.
+ * Rows are built one at a time; only the full table is needed to walk back.
+ */
+function lcsTable(a, b) {
+  const table = Array.from({ length: a.length + 1 }, () => new Uint32Array(b.length + 1));
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      table[i][j] = a[i] === b[j] ? table[i + 1][j + 1] + 1 : Math.max(table[i + 1][j], table[i][j + 1]);
+    }
+  }
+  return table;
+}
+
+/**
+ * before, after → [{ op, a?, b? }] where op is 'keep' | 'change' | 'delete' |
+ * 'insert', `a` is { i, text } in the before text and `b` the same in the
+ * after text (both 0-based line indexes).
+ *
+ * A delete immediately followed by an insert is one 'change' — that is how a
+ * reworded bullet reads to a person. A line MOVED elsewhere has no pairing
+ * partner, so it comes out as a delete and an insert; the sheet says as much
+ * rather than pretending to track it.
+ */
+export function diffLines(before, after) {
+  const aLines = split(before);
+  const bLines = split(after);
+  const aKeys = aLines.map(key);
+  const bKeys = bLines.map(key);
+  const table = lcsTable(aKeys, bKeys);
+
+  const raw = [];
+  let i = 0;
+  let j = 0;
+  while (i < aLines.length && j < bLines.length) {
+    if (aKeys[i] === bKeys[j]) {
+      raw.push({ op: 'keep', a: { i, text: aLines[i] }, b: { i: j, text: bLines[j] } });
+      i++;
+      j++;
+    } else if (table[i + 1][j] >= table[i][j + 1]) {
+      raw.push({ op: 'delete', a: { i, text: aLines[i] } });
+      i++;
+    } else {
+      raw.push({ op: 'insert', b: { i: j, text: bLines[j] } });
+      j++;
+    }
+  }
+  for (; i < aLines.length; i++) raw.push({ op: 'delete', a: { i, text: aLines[i] } });
+  for (; j < bLines.length; j++) raw.push({ op: 'insert', b: { i: j, text: bLines[j] } });
+
+  // A block of edits arrives as every delete then every insert. Zip them in
+  // order — pairing the LAST delete with the FIRST insert, which is what a
+  // naive "insert after delete" rule does, attributes each rewrite to the
+  // wrong line. A pair only becomes a 'change' when the wording survived.
+  const out = [];
+  for (let k = 0; k < raw.length; ) {
+    if (raw[k].op !== 'delete') {
+      out.push(raw[k++]);
+      continue;
+    }
+    let d = k;
+    while (d < raw.length && raw[d].op === 'delete') d++;
+    let ins = d;
+    while (ins < raw.length && raw[ins].op === 'insert') ins++;
+    const deletes = raw.slice(k, d);
+    const inserts = raw.slice(d, ins);
+    const paired = Math.min(deletes.length, inserts.length);
+    let n = 0;
+    for (; n < paired; n++) {
+      if (overlap(deletes[n].a.text, inserts[n].b.text) < REWRITE_OVERLAP) break;
+      out.push({ op: 'change', a: deletes[n].a, b: inserts[n].b });
+    }
+    out.push(...deletes.slice(n), ...inserts.slice(n));
+    k = ins;
+  }
+  return out;
+}

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -181,6 +181,8 @@ export function init(data) {
 
   function resetEdits() {
     editor.value = data.resumeText;
+    // The outline was an offset into the text being discarded.
+    located = null;
     render();
   }
 

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -16,6 +16,8 @@ import {
   wantsLabel,
 } from './target.mjs';
 import { computeScore, entriesFromLive } from './score.mjs';
+import { formatEditSheet } from './change-sheet.mjs';
+import { wireCopy, copyFrom } from './copy.mjs';
 
 // Full literal class names — the Tailwind CDN JIT only generates what it can
 // see verbatim in the document, composed strings would come out unstyled.
@@ -54,6 +56,9 @@ export function init(data) {
   const barDelta = document.getElementById('bar-delta');
   const panes = document.getElementById('panes');
   const storageKey = 'target-draft:' + data.matchId;
+  // The span Locate is pointing at, or null. Cleared on every edit, because an
+  // offset into text the user has since changed points at the wrong words.
+  let located = null;
 
   function load() {
     try { return localStorage.getItem(storageKey); } catch { return null; }
@@ -104,7 +109,15 @@ export function init(data) {
       + (missing.length ? ' · missing: ' + missingNames + (missing.length > 3 ? ' +' + (missing.length - 3) : '') : '')
       + capNote + maxNote;
 
-    backdrop.innerHTML = highlightHtml(text, resumeSpans(data.keywords, data.actions, data.removals, text)) + '\n';
+    const spans = resumeSpans(data.keywords, data.actions, data.removals, text);
+    if (located) {
+      // The quote usually already carries an edit mark; add the outline to that
+      // span rather than pushing a rival one, which highlightHtml would drop.
+      const same = spans.find((s) => s.start === located.start && s.end === located.end);
+      if (same) same.cls += ' located';
+      else spans.push({ ...located, cls: 'located' });
+    }
+    backdrop.innerHTML = highlightHtml(text, spans) + '\n';
     jd.innerHTML = highlightHtml(data.jobText, jobSpans(data.keywords, data.jobText, scored));
 
     chips.innerHTML = '';
@@ -133,6 +146,9 @@ export function init(data) {
     const saveText = document.getElementById('save-text');
     if (saveText) saveText.value = text;
     document.getElementById('reanalyze-text').value = dirty ? text : '';
+    // Nothing to carry out until the text differs from what the AI judged.
+    const copyEdits = document.getElementById('copy-edits');
+    if (copyEdits) copyEdits.disabled = !dirty;
     store(text);
   }
 
@@ -149,15 +165,18 @@ export function init(data) {
     }
   }
 
-  function select(start, end) {
-    editor.focus();
-    editor.setSelectionRange(start, end);
-    // Scroll the caret into view: estimate the line's offset from the top.
-    const before = editor.value.slice(0, start);
-    const lineIndex = before.split('\n').length - 1;
+  /** Scroll THE EDITOR so the offset sits in its upper third. The page never moves. */
+  function scrollEditorTo(start) {
+    const lineIndex = editor.value.slice(0, start).split('\n').length - 1;
     const lineHeight = parseFloat(getComputedStyle(editor).lineHeight) || 22;
     editor.scrollTop = Math.max(0, lineIndex * lineHeight - editor.clientHeight / 3);
     backdrop.scrollTop = editor.scrollTop;
+  }
+
+  function select(start, end) {
+    editor.focus();
+    editor.setSelectionRange(start, end);
+    scrollEditorTo(start);
   }
 
   function resetEdits() {
@@ -166,7 +185,11 @@ export function init(data) {
   }
 
   let timer = null;
-  editor.addEventListener('input', () => { clearTimeout(timer); timer = setTimeout(render, 120); });
+  editor.addEventListener('input', () => {
+    located = null;
+    clearTimeout(timer);
+    timer = setTimeout(render, 120);
+  });
   editor.addEventListener('scroll', () => { backdrop.scrollTop = editor.scrollTop; backdrop.scrollLeft = editor.scrollLeft; });
   document.getElementById('show-matched').addEventListener('change', (e) => {
     panes.classList.toggle('show-matched', e.target.checked);
@@ -206,14 +229,57 @@ export function init(data) {
     }
   });
 
-  // The editor sits beside the suggestions, so a click selects in place — no tab switch.
-  for (const item of document.querySelectorAll('[data-quote]')) {
-    item.addEventListener('click', () => {
-      const loc = locateQuote(editor.value, item.dataset.quote);
-      if (!loc) { item.classList.add('flash-target'); setTimeout(() => item.classList.remove('flash-target'), 1200); return; }
-      select(loc.start, loc.end);
+  // Copy works the same on every page; Locate only exists where this editor does.
+  wireCopy(document);
+
+  // Locate: outline the quote in the editor and scroll THE EDITOR to it. The
+  // page does not move — losing the card you just read was the whole complaint.
+  for (const button of document.querySelectorAll('[data-locate]')) {
+    const status = button.parentElement?.querySelector('[data-locate-status]');
+    button.addEventListener('click', () => {
+      const loc = locateQuote(editor.value, button.dataset.locate);
+      if (!loc) {
+        located = null;
+        render();
+        if (status) status.textContent = "Couldn't find this text in the editor, it may already be edited";
+        return;
+      }
+      located = loc;
+      render();
+      const line = editor.value.slice(0, loc.start).split('\n').length;
+      // The outline is not the only signal: the line number is readable and announced.
+      if (status) status.textContent = 'Line ' + line;
+      scrollEditorTo(loc.start);
+      // Focus moves the caret, which on a phone opens the keyboard over the text.
+      if (window.matchMedia('(min-width: 1024px)').matches) {
+        editor.focus({ preventScroll: true });
+        editor.setSelectionRange(loc.start, loc.end);
+      }
     });
   }
+
+  // "Copy my changes": the diff of the analysed text against what is on screen.
+  const copyEdits = document.getElementById('copy-edits');
+  if (copyEdits) {
+    copyEdits.addEventListener('click', () => {
+      const sheet = formatEditSheet(data.sheet, data.resumeText, editor.value);
+      if (sheet) copyFrom(copyEdits, sheet);
+    });
+  }
+
+  const expand = document.getElementById('expand-editor');
+  if (expand) {
+    expand.addEventListener('click', () => {
+      const tall = panes.classList.toggle('editor-tall');
+      expand.textContent = tall ? 'shrink editor' : 'expand editor';
+      expand.setAttribute('aria-expanded', String(tall));
+    });
+  }
+
+  // The keyword table is the longest block on the page; on a phone it starts
+  // folded, on a desktop it is simply open. Media queries cannot set `open`.
+  const fold = document.querySelector('details.kw-fold');
+  if (fold) fold.open = window.matchMedia('(min-width: 1024px)').matches;
 
   // An instant check hands over its parsed upload: it becomes this tab's draft
   // in place of whatever the tab held, and lives in localStorage from here on.

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -385,6 +385,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
         matches,
         selected,
         selectedKeywords,
+        job: { title: job.title, companyName: job.company.name },
       }}
       coverLetters={{
         jobId: id,


### PR DESCRIPTION
Stage 1 of [TASKS §18](docs/TASKS.md) — the tailoring loop. The comparison
becomes usable by hand: copy any proposed wording, find it in the editor
without losing the card, or carry the whole list out as Markdown. Nothing is
applied for the user; that is stage 2.

Stages 2–5 are untouched.

---

## Pre-work note (measured 2026-09-04, live DB, before any code)

### The proposal corpus is bigger and quoted differently than the plan assumed

`select jsonb_array_elements(actions)->>'what' from resume_match` — **209 actions**
across 20 comparisons (the plan measured 18 across two), plus **154 removals**.

| quote character in `what` | actions |
|---|---|
| straight single `'` (U+0027) | 131 |
| straight double `"` (U+0022) | 45 |
| none at all | 33 |
| curly `‘’ “”` | **0** |

The integration guide specifies "the longest double-quoted span … (straight or
curly quotes)". Against the live corpus that finds a proposal in **45 of 209
(22 %)**. Single quotes are the model's habit, curly quotes never occur. The
extractor is therefore written for `'` **and** `"`, with curly folded in for
safety, and the apostrophe problem is handled explicitly: `'` opens a span only
when the preceding character is not a letter or digit, and a closing `'`
flanked by letters on both sides is treated as word-internal (`posting's`,
`you're`, `I'm`) and skipped.

### Measured hit rate: 167 of 209 (80 %)

Rules, each one paid for by a case in the corpus:

- **12-character floor.** Rejects `'|'`, `"Node"`, `"nginx"`, `'CloudWath'` —
  term mentions, not wordings. Costs one genuine short proposal
  (`Reduce to 'Austin, TX'`); saves seven false ones.
- **Longest span wins**, ties broken by the later one.
- **Swap connective.** `Change 'A' to 'B'` / `Replace 'A' with 'B'`: when a
  ` to `/` with `/` instead of ` sits between two candidate spans, only spans
  after it are considered. Without it `Change 'Windsurf (Opus 4.6)' to just
  'Windsurf and Claude'` is a 19-vs-19 tie decided by luck.
- **Replace-with-prose returns null.** `Replace 'Reduced the complexity of the
  system…' with a specific version: name the system, the PHP/Laravel work…` —
  the only quoted text is the CURRENT wording. This was the single false
  positive the plain "longest span" rule produced, and it is the one row where
  the two prototypes disagree.

All 42 rejections were read by hand: 33 have no quote character (they are
genuine instructions — "Cut to 4 bullets", "Add a number"), 8 are term
mentions under the floor, 1 is the replace-with-prose case. **No rejection
hides a proposal.**

A rule the guide suggested and the data killed: suppressing spans equal to the
action's own `quote`. It fires **0 times in 209** — `quote` is empty on every
two-part replace — so it is not written.

`verb` (the label above the Proposed block) is the text before the *first*
quote, kept only when it is ≤ 24 chars and contains no full stop: 110 of 167
get one (`Rewrite` 20, `Reword` 19, `Add` 18, `Change` 16, `Lead` 5 …), the
other 57 fall back to the plain label "Proposed".

### Removals: the quote is there, and 12 of them span lines

154 removals, **113 carry a quote** (5–212 chars), **12 span more than one
line**. The card currently renders `what`/`why`/`where` and hides the quote —
so the user is told to delete something the card will not show them. Owner
decision 2 fixes this.

### The 375 px screenshot found a real overflow bug

At 375 px the Suggestions pane is **499 px wide inside a 375 px column** and
`<main>` scrolls horizontally (515 px). Cause, measured in the page: the
keyword table's `overflow-x-auto` wrapper is itself 497 px, because the grid
item `.pane-changes` has the default `min-width: auto` and is sized by its
content instead of its track. `overflow-x-auto` cannot clip what nothing
bounds. One class — `min-w-0` on the grid items — is the fix; the disclosure
the owner asked for shortens the page but is not what was breaking it.

### Deviations from the integration guide, and why

1. **`proposalOf` / the change sheet do not go in `target.mjs`.**
   `site/public/demo/target.mjs` is a byte copy enforced by
   `src/web/site-vendor.test.ts`, and the landing demo imports it in the
   browser. A new `import './line-diff.mjs'` inside it would 404 on
   applypack.dev and take the demo's live score down with it. Stage 1
   therefore leaves `target.mjs` untouched and adds three new modules.
2. **Two change sheets, not one.** "Copy all suggestions" is a pure function of
   data the server already has, so it is rendered server-side into the
   button's `data-copy` and works with the clipboard handler alone — on
   `/jobs/:id` too, which has no JSON blob. "Copy my changes" needs the live
   editor, so it is built in the browser from `diffLines`. Two shapes, two
   places, no mirrored implementation to keep in parity.
3. **"show matched highlights" stays where it is.** The guide moves it into the
   editor card header; in `data-view="job"` that card is `display:none`, which
   would remove the only control over the job pane's own matched marks.

---

## What shipped

| File | What |
|---|---|
| `src/resume/change-sheet.ts` **new** | `proposalOf` (the wording inside a `what` sentence) and `suggestionSheet` (the whole list as Markdown). Pure, 11 tests. |
| `src/web/public/line-diff.mjs` **new** | `diffLines` — LCS over normalised lines; a delete/insert pair becomes a `change` only when 30 % of the wording survives. |
| `src/web/public/change-sheet.mjs` **new** | `formatEditSheet` — "Copy my changes" from the live editor. |
| `src/web/public/copy.mjs` **new** | `wireCopy` for the whole dashboard: delegated, `execCommand` fallback, one `aria-live` region. `cover-letter.mjs` now imports it instead of carrying its own copy. |
| `pages/resume-match-card.tsx` | `SuggestionCard` — Now / Proposed / why / Copy / Locate; removals show their quote struck through; `ChangeSheetButton`. `jumpable` → `interactive`. |
| `pages/target.tsx` | `.located` CSS, narrow-screen order and heights, the two sheet buttons, the keyword disclosure. |
| `pages/job-detail.tsx` | boots `copy.mjs` — Copy works on `/jobs/:id` too. |
| `public/target-page.mjs` | Locate, the outline, the expand toggle, the fold, "Copy my changes". |

The click-anywhere-on-the-`<li>` handler is gone: the controls are
`<button type="button">`, so keyboard users reach them and a click on the
quote no longer means something invisible.

## Verified on the branch build

`docker compose build web && docker compose up -d web`, then walked it myself.

- `npm run lint:types` clean; `npm test` **1831 passing** (24 new).
- **Locate does not move the page** — the requirement the plan called out.
  Measured at 1280 px: page scroll 515 before, 515 after; editor scroll
  0 → 462; one span outlined; the card says *Line 31*.
- **Copy** on a card puts the extracted wording on the clipboard
  (`Back end Developer | Senior PHP / Laravel / Vue Engineer`), not the whole
  sentence. Button says *Copied*, live region says *Copied to clipboard*.
- **Copy all suggestions** hands over 5 602 characters of Markdown, built from
  8 real actions and 6 real removals — identical payload on `/jobs/:id`, which
  has 15 Copy buttons and 0 Locate buttons, exactly as intended.
- **Copy my changes** is disabled on a clean load and, after one reword and
  one inserted line, produces `1 reworded, 1 added` with Was/Now blocks.
- **375 px**: `main.scrollWidth === main.clientWidth` (was 515 vs 375). Editor
  first, 325 px collapsed → 609 px expanded, keyword table folded.
- Accessibility: 27 Copy/Locate buttons, **0 of them `type="submit"`**; tab
  order inside a card is Copy → Locate; one `aria-live` region per page;
  `prefers-reduced-motion` disables the outline fade.
- Console: **0 errors** on both pages.
- Escaping: the 5 766-character `data-copy` attribute holds **0 raw `"`** and
  **0 raw `<`** — hono/jsx encodes them, so AI text in an attribute cannot
  break out.

## code-review-expert pass (`git diff main...HEAD`)

Three findings, all fixed in this branch:

- **P1 — `/jobs/:id` booted `copy.mjs` twice** (its own boot script and the
  cover-letter card), so one click on the letter's Copy fired two delegated
  handlers. `wireCopy` now records its roots in a module-level `WeakSet`;
  regression test added, and re-measured on job 937 (which has letters):
  one click, one clipboard write.
- **P2 — Discard left the Locate outline** pointing into text that had just
  been thrown away. `resetEdits` clears it.
- **P2 — an empty `role="status"` region on every card of every page.** It now
  renders only beside a Locate button, so `/jobs/:id` carries none.

No P0. No follow-ups outstanding.

## Screenshots

Attached in the conversation: the Suggestions view at 1280 px with the outline
live in the editor, the removals showing the text to cut, and the 375 px view
with the editor first and no sideways scroll.

## Tag

```
git tag -a v1.51.0 -m "Copy a suggestion, find it in your resume, take the list with you" && git push origin v1.51.0
```

§18.4 says "tags from stage 3 on", but the stage-1 checklist asks for a
CHANGELOG entry and a bump, and this changes what the user sees — so the bump
to **1.51.0** is in this PR and the tag is yours to run or skip at merge.
