### PR TITLE
fixed: the Compare page's scratch resume can be saved as a new resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.54.1] — 2026-09-04
+
+### Fixed
+- **A one-off check from the Compare page could not be saved at all.** The
+  scratch resume `/target` uploads to has no versions by design, so the
+  targeted view hid every Save — while the line above the editor promised a
+  text version. It now offers one button, **Save as a new resume**, which
+  keeps the edited text as a resume of its own on `/resumes` (named after the
+  company), and the line above the editor says so. A scratch resume is never
+  bumped in place, whatever the form sends.
+
 ## [1.54.0] — 2026-09-04
 
 ### Added
@@ -2175,6 +2186,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.54.1]: https://github.com/applypack/applypack/compare/v1.54.0...v1.54.1
 [1.54.0]: https://github.com/applypack/applypack/compare/v1.53.0...v1.54.0
 [1.53.0]: https://github.com/applypack/applypack/compare/v1.52.0...v1.53.0
 [1.52.0]: https://github.com/applypack/applypack/compare/v1.51.0...v1.52.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.54.0",
+      "version": "1.54.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -380,13 +380,15 @@ export const TargetPage: FC<TargetPageProps> = ({
                     Full analysis with suggestions
                   </Button>
                 </form>
-                {!resume.ephemeral && (
-                  <form
-                    method="post"
-                    action={`/resumes/${resume.id}/draft`}
-                    id="save-form"
-                    onsubmit={SUBMIT_ONCE}
-                  >
+                {/* The Compare page's scratch resume has no versions, so it saves one
+                    way only: as a resume of its own (issue: a pasted posting, an
+                    uploaded resume, an hour of edits and nowhere to put them). */}
+                <form
+                  method="post"
+                  action={`/resumes/${resume.id}/draft`}
+                  id="save-form"
+                  onsubmit={SUBMIT_ONCE}
+                >
                     <input type="hidden" name="text" id="save-text" value="" />
                     <input type="hidden" name="jobId" value={job.id} />
                     {/* The text the edits started from: the patcher diffs against it (ADR 0038). */}
@@ -400,10 +402,15 @@ export const TargetPage: FC<TargetPageProps> = ({
                       onclick="this.form.elements.as.value='copy'"
                       data-save-button
                       disabled
-                      title="Enabled once you edit the text — saves a new resume beside this one, named after the company, and leaves this one as it is; a .docx is patched in place when its layout allows (~1 min)"
+                      title={
+                        resume.ephemeral
+                          ? 'Enabled once you edit the text — keeps this one-off check as a resume of its own, named after the company, on /resumes (~1 min)'
+                          : 'Enabled once you edit the text — saves a new resume beside this one, named after the company, and leaves this one as it is; a .docx is patched in place when its layout allows (~1 min)'
+                      }
                     >
-                      Save as a tailored copy
+                      {resume.ephemeral ? 'Save as a new resume' : 'Save as a tailored copy'}
                     </Button>
+                    {!resume.ephemeral && (
                     <Button
                       variant="secondary"
                       class="mt-2 w-full"
@@ -415,8 +422,8 @@ export const TargetPage: FC<TargetPageProps> = ({
                     >
                       Save as v{resume.version + 1}
                     </Button>
+                    )}
                   </form>
-                )}
               </div>
             </details>
             </div>
@@ -634,11 +641,17 @@ export const TargetPage: FC<TargetPageProps> = ({
             <Button variant="violet" size="sm" form="reanalyze-form">
               Re-check with AI
             </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              form="save-form"
+              onclick="document.getElementById('save-form').elements.as.value='copy'"
+              title={resume.ephemeral ? 'Keeps this one-off check as a resume of its own on /resumes' : 'A new resume beside this one, named after the company; this one stays as it is'}
+            >
+              {resume.ephemeral ? 'Save as a new resume' : 'Save as a tailored copy'}
+            </Button>
             {!resume.ephemeral && (
               <>
-                <Button variant="primary" size="sm" form="save-form" onclick="document.getElementById('save-form').elements.as.value='copy'" title="A new resume beside this one, named after the company; this one stays as it is">
-                  Save as a tailored copy
-                </Button>
                 <Button
                   variant="secondary"
                   size="sm"

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -783,7 +783,8 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
   }
   const resume = await getResume(match.resumeId);
   if (!resume) return c.text('Not found', 404);
-  const fileVerdict = await describeResumeFile(resume);
+  // The scratch resume from /target has no versions: its one save is a resume of its own.
+  const fileVerdict = (resume.hidden ? 'This is a one-off check from the Compare page — Save keeps it as a resume of its own. ' : '') + (await describeResumeFile(resume));
   // An instant check arrives with its parsed upload — taken once; from then on the browser holds it.
   const draftKey = c.req.query('draft');
   const draftText = draftTextForPage(draftKey ? draftStash.take(draftKey) : null, match.id);

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -170,7 +170,8 @@ resumesRoute.get('/resumes/:id/download', async (c) => {
 resumesRoute.post('/resumes/:id/draft', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
-  if (!(await getResume(id))) return c.text('Not found', 404);
+  const current = await getResume(id);
+  if (!current) return c.text('Not found', 404);
   const form = await c.req.parseBody();
   const text = typeof form.text === 'string' ? form.text.replace(/\r\n/g, '\n').trim() : '';
   if (text.length < MIN_DRAFT_CHARS) {
@@ -180,7 +181,8 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
   // it a .docx cannot be patched (the diff would be against nothing) and the
   // save is a text version, as before ADR 0038.
   const baseText = typeof form.baseText === 'string' ? form.baseText.replace(/\r\n/g, '\n').trim() : '';
-  const asCopy = form.as === 'copy';
+  // The /target scratch resume has no versions of its own: it is only ever saved as a new resume.
+  const asCopy = form.as === 'copy' || current.hidden;
   const jobId = Number(form.jobId);
   const job = Number.isFinite(jobId)
     ? await prisma.job.findUnique({ where: { id: jobId }, include: { company: { select: { name: true } } } })


### PR DESCRIPTION
A follow-up fix to v1.54.0, found by the owner on
`/jobs/1473/target?match=73`: a posting pasted by hand, a resume uploaded on the
Compare page, an hour of edits — and no Save anywhere.

## Cause

The Compare page's uploads land on the hidden **scratch resume** (one row,
replaced in place, no versions — by design). The targeted view treated it as
`ephemeral` and rendered **no save form at all**, while the line stage 4 put
above the editor promised *"Save keeps a text version"*. The backend path
already worked: `POST /resumes/:id/draft` does not refuse a hidden row and
`saveEdited(asCopy)` creates an ordinary resume.

## Fix

- The scratch resume gets one button, **Save as a new resume** — the existing
  copy path — on the card and in the unsaved-changes bar. "Save as vN" stays
  hidden for it: a scratch row has no versions.
- The line above the editor says what it is: *"This is a one-off check from
  the Compare page — Save keeps it as a resume of its own."* followed by the
  file sentence.
- The draft route forces the copy for a hidden row, whatever the form sends —
  a scratch row is never bumped in place.
- CHANGELOG `1.54.1`, patch bump.

## Verified on the branch build

- `npm run lint:types` clean; `npm test` 1899 passing.
- On the owner's page (match 73, scratch resume 4, a PDF): the card shows
  only **Save as a new resume**, the bar shows Discard · Re-check with AI ·
  Save as a new resume, the verdict line reads as above.
- Edited one line, pressed the button → web log `resume: created` → **resume
  11 "Nazar Boyko Senior Full Stack Engineer Resume · foreUP Golf"**, visible,
  v1, a text version (the source is a PDF); **scratch resume 4 untouched**
  (still hidden, still v20).

Note for the owner: resumes **10** ("Senior Backend PHP · Imgix", the stage-4
walk) and **11** (this walk) are my test artefacts in the live database —
delete them from `/resumes` if you do not want them.

## Tag

```
git tag -a v1.54.1 -m "The Compare page's scratch resume can be saved as a new resume" && git push origin v1.54.1
```
