### PR TITLE
Comparisons no longer fail on the default resume model (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.55.1] — 2026-09-04
+
+### Fixed
+- **Comparisons no longer fail on the default resume model.** `max_tokens`
+  on the Messages API counts the model's thinking, and Claude Opus 5 thinks
+  by default: one full comparison measured 6 078 thinking tokens inside the
+  8 000-token budget, the JSON was cut off mid-string, and with three or more
+  resumes stored every comparison failed in both modes (#159). The Anthropic
+  path now adds 8 000 tokens of headroom to every answer budget, the way the
+  OpenAI path already did for its reasoning models.
+- **A cut-off reply is reported as cut off, not as "no JSON object in
+  reply".** The provider reads `stop_reason` and refuses an incomplete or
+  declined reply with the reason, and a reply that stopped inside the JSON
+  is not retried — the identical call stops in the identical place, which
+  cost two full-price calls per attempt.
+- **The "other resumes mention" hints are filtered to the posting.** With
+  four resumes stored the list ran to 122 fenced lines on every comparison;
+  a skill the posting never names cannot become one of its keywords, so only
+  the ones it names (aliases included) go into the prompt.
+
+### Notes
+- The five resume calls and the ghost-job check share one parse-and-retry
+  wrapper (`src/ai-json.ts`) instead of five copies of the same loop.
+- Every reply's `stop_reason` and `usage` are logged at debug level.
+
 ## [1.55.0] — 2026-09-04
 
 ### Added
@@ -2241,6 +2266,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.55.1]: https://github.com/applypack/applypack/compare/v1.55.0...v1.55.1
 [1.55.0]: https://github.com/applypack/applypack/compare/v1.54.1...v1.55.0
 [1.54.1]: https://github.com/applypack/applypack/compare/v1.54.0...v1.54.1
 [1.54.0]: https://github.com/applypack/applypack/compare/v1.53.0...v1.54.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Fence markers, the untrusted directive, the forged-marker sanitiser | `src/prompt-fence.ts` (pure, ADR 0022); guard `src/prompt-fence-registry.test.ts` |
 | Which AI engines run (priority chain + per-engine models, auto-failover) | `src/ai-runtime.ts:getAiRuntime().complete({role})` + pure chain merge in `src/ai-engine.ts` (ADR 0013/0014); UI on `/settings` → "AI engine" tab |
 | Adding a new AI backend | `src/ai-provider.ts` (`CliProvider` spec or fetch class) + `AI_PROVIDER_IDS`/labels/options in `src/ai-engine.ts` + probe in `src/ai-runtime.ts` + `AI_KEY_ENV_VARS` in `src/ai-keys.ts` if it takes a key |
+| Why a `max_tokens` budget is the ANSWER's size (thinking headroom), and why a cut-off reply is not retried | `src/ai-provider-parse.ts:anthropicMaxTokens` (pure, gotcha 16) + the `stop_reason` branch in `ai-provider.ts`; `src/ai-json.ts:askForJson` is the one parse-and-retry loop every resume call and the ghost-job check go through, and `text-utils.ts:jsonFailure` tells "cut off" from "not JSON" |
 | Per-engine API keys (DB-first, `.env` fallback, masking) | `src/ai-keys.ts` (pure, ADR 0027) + `settings.ts:getAiKeys/setAiKey`; resolved in `ai-runtime.ts`, spent as `AiRequest.apiKey` |
 | How users set up each engine (local + Docker) | `docs/ai-engines.md` |
 | AI usage counters (runs per engine × role) | `AppSettings.aiUsage` — incremented in `ai-runtime.ts:recordUsage`, 7-day summary on `/settings` AI tab, 60-day trim in `cleanup-job.ts` |
@@ -544,6 +545,27 @@ different ETags. Its `Vary: Accept-Encoding, Origin` and a 304 on a lucky
 pair of requests make it look like a revalidating source; it is not. A
 vendor that "supports ETag" is not the same as a vendor whose feed is stable
 enough for it to fire.
+
+### 16. `max_tokens` counts the thinking, and the default resume model thinks
+
+Found on a fresh install with four resumes (#159, 2026-09-04): every
+comparison failed in both modes, and the log said *"no JSON object in
+reply"* about a reply that was 96 % a JSON object. `stop_reason` was
+`max_tokens` — 6 078 of the 8 000 output tokens had gone to thinking and
+the JSON was cut off mid-string. Claude Opus 5 (the `CLAUDE_MODEL_RESUME`
+default) thinks by default, `max_tokens` includes the thinking, and every
+budget in `prompts.ts` was sized against a non-thinking answer. It surfaced
+with the fourth resume because the prompt grew (122 "other resume" hints),
+and the thinking grew with it.
+
+Three rules, all in code now:
+- A budget constant is the ANSWER's size. `anthropicMaxTokens` adds the
+  headroom on the Anthropic path, as the OpenAI path already did for gpt-5 /
+  o-series; the sum stays under the SDK's non-streaming ceiling (~21 300).
+- The provider reads `stop_reason`: `max_tokens` and `refusal` are failures
+  with a reason, never text handed to a parser.
+- A reply that stopped inside the JSON is not retried (`ai-json.ts`) — the
+  identical call stops in the identical place, so the retry was pure cost.
 
 ### 12. stripHtml: decode entities FIRST, and never re-run it on its own output
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.55.0",
+  "version": "1.55.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.55.0",
+      "version": "1.55.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.55.0",
+  "version": "1.55.1",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/ai-json.test.ts
+++ b/src/ai-json.test.ts
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { askForJson } from './ai-json';
+import type { AiCallRequest, AiCallResult } from './ai-runtime';
+import { extractJson, jsonFailure, type ParseResult } from './text-utils';
+
+const REQ: AiCallRequest = { system: 's', user: 'u', maxTokens: 100, label: 'test', role: 'resume' };
+
+/** A runtime that answers from a script; null means "no engine answered". */
+function runtime(replies: (string | null)[]) {
+  const calls: AiCallRequest[] = [];
+  return {
+    calls,
+    complete: async (req: AiCallRequest): Promise<AiCallResult | null> => {
+      calls.push(req);
+      const text = replies[calls.length - 1] ?? null;
+      return text === null ? null : { text, providerId: 'anthropic_api', model: 'm', viaFallback: calls.length > 1 };
+    },
+  };
+}
+
+const parse = (text: string): ParseResult<{ n: number }> => {
+  const json = extractJson(text) as { n?: unknown } | null;
+  if (json === null) return jsonFailure(text);
+  return typeof json.n === 'number' ? { ok: true, data: { n: json.n } } : { ok: false, error: 'no n' };
+};
+
+test('askForJson returns the parsed reply with the engine marker', async () => {
+  const ai = runtime(['{"n":1}']);
+  const answer = await askForJson(ai, REQ, parse);
+  assert.deepEqual(answer?.data, { n: 1 });
+  assert.equal(answer?.model, 'm');
+  assert.equal(answer?.attempt, 0);
+  assert.equal(answer?.chars, 7);
+  assert.equal(ai.calls.length, 1);
+});
+
+test('askForJson retries once when the reply did not fit the schema, and names a fallback engine', async () => {
+  const ai = runtime(['{"x":1}', '{"n":2}']);
+  const answer = await askForJson(ai, REQ, parse);
+  assert.deepEqual(answer?.data, { n: 2 });
+  assert.equal(answer?.attempt, 1);
+  assert.equal(answer?.model, 'm · fallback');
+  assert.equal(ai.calls.length, 2);
+});
+
+test('askForJson gives up after the second bad reply', async () => {
+  const ai = runtime(['{"x":1}', 'not even json']);
+  assert.equal(await askForJson(ai, REQ, parse), null);
+  assert.equal(ai.calls.length, 2);
+});
+
+test('askForJson does not retry a reply cut off inside the JSON', async () => {
+  const ai = runtime(['{"n": {"deep": 1', '{"n":3}']);
+  assert.equal(await askForJson(ai, REQ, parse), null);
+  assert.equal(ai.calls.length, 1);
+});
+
+test('askForJson returns null when no engine answered', async () => {
+  const ai = runtime([null]);
+  assert.equal(await askForJson(ai, REQ, parse), null);
+  assert.equal(ai.calls.length, 1);
+});

--- a/src/ai-json.ts
+++ b/src/ai-json.ts
@@ -1,0 +1,53 @@
+import { logger } from './logger';
+import type { AiCallRequest, AiRuntime } from './ai-runtime';
+import type { ParseResult } from './text-utils';
+
+// A reply that does not parse gets ONE more try — the model's output varies
+// between calls, a second one usually fits the schema.
+const PARSE_ATTEMPTS = 2;
+
+export interface JsonAnswer<T> {
+  data: T;
+  /** Engine marker for the stored row: the model, plus " · fallback" when chain #1 did not answer. */
+  model: string;
+  chars: number;
+  attempt: number;
+  ms: number;
+}
+
+/**
+ * One AI call whose reply is JSON: complete, parse, retry once on a reply
+ * that did not parse. Null when no engine answered or both replies failed.
+ *
+ * A reply cut off inside the JSON is not retried: the budget ran out, not
+ * the dice, and the identical call would be cut off identically — that was
+ * two full-price calls per attempt before #159.
+ */
+export async function askForJson<T>(
+  ai: Pick<AiRuntime, 'complete'>,
+  req: AiCallRequest,
+  parse: (text: string) => ParseResult<T>,
+  context: Record<string, unknown> = {},
+): Promise<JsonAnswer<T> | null> {
+  for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
+    const started = Date.now();
+    const out = await ai.complete(req);
+    if (out === null) return null;
+    const parsed = parse(out.text);
+    if (parsed.ok) {
+      return {
+        data: parsed.data,
+        model: (out.model || out.providerId) + (out.viaFallback ? ' · fallback' : ''),
+        chars: out.text.length,
+        attempt,
+        ms: Date.now() - started,
+      };
+    }
+    logger.warn(
+      { ...context, label: req.label, attempt, error: parsed.error, raw: out.text.slice(0, 500) },
+      'ai: reply did not parse',
+    );
+    if (parsed.cutOff) return null;
+  }
+  return null;
+}

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -1,6 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  ANTHROPIC_THINKING_HEADROOM_TOKENS,
+  anthropicMaxTokens,
   buildClaudeCodeArgs,
   buildCliEnv,
   buildCodexCliArgs,
@@ -12,6 +14,7 @@ import {
   parseGeminiCliOutput,
   parseOpenAiChatResponse,
 } from './ai-provider-parse';
+import { SCAN_MAX_TOKENS } from './resume/prompts';
 
 const ok = (result: string) =>
   JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result });
@@ -247,4 +250,16 @@ test('describeAiFailure caps a runaway stderr dump', () => {
 
 test('describeAiFailure never renders an empty message', () => {
   assert.equal(describeAiFailure('   \n  '), 'no reason reported');
+});
+
+test('anthropicMaxTokens adds the thinking headroom to the answer budget', () => {
+  assert.equal(anthropicMaxTokens(8_000), 8_000 + ANTHROPIC_THINKING_HEADROOM_TOKENS);
+});
+
+test('the largest answer budget keeps its full headroom under the SDK non-streaming cap', () => {
+  assert.equal(anthropicMaxTokens(SCAN_MAX_TOKENS), SCAN_MAX_TOKENS + ANTHROPIC_THINKING_HEADROOM_TOKENS);
+});
+
+test('anthropicMaxTokens never asks for more than a non-streaming request may carry', () => {
+  assert.ok(anthropicMaxTokens(100_000) <= 21_333);
 });

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -31,6 +31,22 @@ const MAX_FAILURE_REASON = 200;
 const KEY_SHAPED = /\b(?:sk-[A-Za-z0-9._-]{8,}|AIza[A-Za-z0-9._-]{10,})\b/g;
 
 /**
+ * `max_tokens` on the Messages API counts the thinking too, and the current
+ * Claude models think by default — one comparison measured 6 078 thinking
+ * tokens inside an 8 000 budget, and the JSON was cut off mid-string (#159).
+ * The callers' budgets size the ANSWER; this adds the room the thinking
+ * takes. A ceiling, not a spend: a model that does not think stops where it
+ * always did. The cap is the SDK's own — above ~21 300 tokens a non-streaming
+ * request is refused outright (10 minutes at 128k tokens/hour).
+ */
+export const ANTHROPIC_THINKING_HEADROOM_TOKENS = 8_000;
+const ANTHROPIC_NONSTREAMING_MAX_TOKENS = 21_000;
+
+export function anthropicMaxTokens(answerTokens: number): number {
+  return Math.min(answerTokens + ANTHROPIC_THINKING_HEADROOM_TOKENS, ANTHROPIC_NONSTREAMING_MAX_TOKENS);
+}
+
+/**
  * One-line, browser-safe rendering of a provider failure: masks credentials,
  * collapses whitespace and caps the length. ADR 0027 keeps keys out of the
  * browser, and that must not depend on what a CLI happened to print.

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -6,6 +6,7 @@ import { config } from './config';
 import { logger } from './logger';
 import { sleep } from './http';
 import {
+  anthropicMaxTokens,
   buildClaudeCodeArgs,
   buildCliEnv,
   buildCodexCliArgs,
@@ -158,14 +159,26 @@ class AnthropicApiProvider implements AiProvider {
     for (let resumes = 0; ; resumes++) {
       const resp = await client.messages.create({
         model: req.model ?? config.CLAUDE_MODEL,
-        max_tokens: req.maxTokens,
+        max_tokens: anthropicMaxTokens(req.maxTokens),
         system: [{ type: 'text', text: req.system, cache_control: { type: 'ephemeral' } }],
         messages,
         tools,
       });
+      logger.debug({ label: req.label, stop: resp.stop_reason, usage: resp.usage }, 'ai: reply');
       if (resp.stop_reason === 'pause_turn' && resumes < MAX_PAUSE_TURN_RESUMES) {
         messages.push({ role: 'assistant', content: resp.content });
         continue;
+      }
+      // An incomplete reply is a failure, not an answer: every caller parses
+      // JSON, and a cut-off one used to come back as "no JSON object" (#159).
+      if (resp.stop_reason === 'max_tokens') {
+        const { output_tokens, output_tokens_details } = resp.usage;
+        throw new Error(
+          `reply cut off at ${output_tokens} output tokens (${output_tokens_details?.thinking_tokens ?? 0} of them thinking)`,
+        );
+      }
+      if (resp.stop_reason === 'refusal') {
+        throw new Error(`the model declined this request (${resp.stop_details?.category ?? 'no category given'})`);
       }
       return resp.content
         .filter((b): b is Anthropic.TextBlock => b.type === 'text')

--- a/src/prompt-fence-registry.test.ts
+++ b/src/prompt-fence-registry.test.ts
@@ -40,6 +40,7 @@ const PROMPT_MODULES: Record<string, Record<string, unknown>> = {
 const KNOWN_CALL_SITES: Record<string, string> = {
   'ai-provider.ts': 'the seam itself',
   'ai-runtime.ts': 'the chain that drives the seam',
+  'ai-json.ts': 'the parse-and-retry wrapper over the seam — its callers bring the prompt',
   'classifier.ts': 'buildClassifyPrompt',
   'classifier-prefilter.ts': 'buildPrefilterPrompt',
   'jobs/posting-extract.ts': 'buildExtractPrompt',
@@ -205,7 +206,7 @@ test('every exported prompt builder has a fence case', () => {
 });
 
 test('every AI call site is a known one', () => {
-  const callers = walkSrc().filter((f) => readFileSync(join(SRC, f), 'utf8').includes('.complete('));
+  const callers = walkSrc().filter((f) => /\.complete\(|askForJson\(/.test(readFileSync(join(SRC, f), 'utf8')));
   const unknown = callers.filter((f) => !(f in KNOWN_CALL_SITES));
   assert.deepEqual(
     unknown,

--- a/src/resume/cover-letter.ts
+++ b/src/resume/cover-letter.ts
@@ -1,6 +1,7 @@
 import type { CoverLetter } from '@prisma/client';
 import { logger } from '../logger';
-import { getAiRuntime, type AiRuntime } from '../ai-runtime';
+import { getAiRuntime } from '../ai-runtime';
+import { askForJson } from '../ai-json';
 import {
   buildCoverPrompt,
   COVER_MAX_TOKENS,
@@ -13,10 +14,8 @@ import {
   toPlainPunctuation,
   type CoverAngles,
   type CoverContext,
-  type CoverResult,
   type CoverTone,
   type MatchJobInput,
-  type Prompt,
 } from './prompts';
 import { factCheck } from './fact-check';
 import {
@@ -27,7 +26,6 @@ import {
 } from './store';
 
 const COVER_TIMEOUT_MS = 3 * 60_000;
-const PARSE_ATTEMPTS = 2;
 const MATCH_ALIGNED_MAX = 12;
 const MATCH_GAPS_MAX = 6;
 
@@ -74,11 +72,16 @@ export async function generateCoverLetter(
   let regenerated = false;
   let prompt = buildCoverPrompt(resume.text, job, context);
   for (;;) {
-    const answer = await askOnce(ai, prompt, job.id);
+    const answer = await askForJson(
+      ai,
+      { ...prompt, maxTokens: COVER_MAX_TOKENS, label: 'cover-letter', role: 'cover', timeoutMs: COVER_TIMEOUT_MS },
+      parseCoverResponse,
+      { jobId: job.id },
+    );
     if (!answer) return { kind: 'failed' };
     // Deterministic plain-punctuation pass BEFORE the gate, so what is
     // checked is exactly what gets stored and copied (F8.1).
-    const letter = toPlainPunctuation(answer.parsed.letter);
+    const letter = toPlainPunctuation(answer.data.letter);
     const gate = factCheck({
       text: letter,
       sources,
@@ -117,8 +120,8 @@ export async function generateCoverLetter(
       text: letter,
       model: answer.model,
       promptVersion: COVER_PROMPT_VERSION,
-      keywordsUsed: answer.parsed.keywords_used,
-      gapsAcknowledged: answer.parsed.gaps_acknowledged,
+      keywordsUsed: answer.data.keywords_used,
+      gapsAcknowledged: answer.data.gaps_acknowledged,
       usedVerification: companySnapshot !== null,
       gateVerdict: gate.verdict,
       gateNotes: notes,
@@ -138,35 +141,6 @@ export async function generateCoverLetter(
     );
     return { kind: 'ok', row };
   }
-}
-
-/** One provider call with the match.ts parse-retry pattern. */
-async function askOnce(
-  ai: AiRuntime,
-  prompt: Prompt,
-  jobId: number,
-): Promise<{ parsed: CoverResult; model: string } | null> {
-  for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const out = await ai.complete({
-      ...prompt,
-      maxTokens: COVER_MAX_TOKENS,
-      label: 'cover-letter',
-      role: 'cover',
-      timeoutMs: COVER_TIMEOUT_MS,
-    });
-    if (out === null) return null;
-    const parsed = parseCoverResponse(out.text);
-    if (parsed.ok) {
-      // Same marker as the match card: the user sees when a fallback engine
-      // (not chain #1) wrote this letter.
-      return { parsed: parsed.data, model: (out.model || out.providerId) + (out.viaFallback ? ' · fallback' : '') };
-    }
-    logger.warn(
-      { jobId, attempt, error: parsed.error, raw: out.text.slice(0, 300) },
-      'cover: reply did not match schema',
-    );
-  }
-  return null;
 }
 
 /** The match row boiled down to what a letter needs: what to feature, what to concede. */

--- a/src/resume/keyword-anchor.test.ts
+++ b/src/resume/keyword-anchor.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { anchorKeywords } from './keyword-anchor';
+import { anchorKeywords, elsewhereForPosting } from './keyword-anchor';
 import { loadKeywordMatcher } from './keyword-matcher';
 import type { MatchKeyword } from './prompts';
 
@@ -55,4 +55,15 @@ test('anchorKeywords leaves a row unanchored when its phrase is another row alre
   const matcher = await loadKeywordMatcher();
   const r = anchorKeywords([keyword('unit tests'), keyword('Testing (unit tests)')], POSTING, matcher);
   assert.deepEqual(r.keywords.map((k) => [k.term, k.unanchored ?? false]), [['unit tests', false], ['Testing (unit tests)', true]]);
+});
+
+test('elsewhereForPosting keeps only the other-resume skills the posting names, aliases included', async () => {
+  const matcher = await loadKeywordMatcher();
+  const skills = [
+    { skill: 'php', resumeName: 'A' },
+    { skill: 'golang', resumeName: 'A' },
+    { skill: 'kubernetes', resumeName: 'B' },
+    { skill: 'react', resumeName: 'B' },
+  ];
+  assert.deepEqual(elsewhereForPosting(skills, POSTING, matcher).map((s) => s.skill), ['php', 'golang']);
 });

--- a/src/resume/keyword-anchor.ts
+++ b/src/resume/keyword-anchor.ts
@@ -1,4 +1,5 @@
 import { canonicalTerm } from './facts';
+import { aliasesFor } from './keyword-aliases';
 import type { KeywordMatcher } from './keyword-matcher';
 import type { MatchKeyword } from './prompts';
 
@@ -58,4 +59,18 @@ function longestVerbatimPhrase(term: string, posting: string, matcher: KeywordMa
     }
   }
   return null;
+}
+
+/**
+ * The other-resume hints this posting can use. A skill the posting never
+ * names cannot become one of its keywords, and with four resumes stored the
+ * full list ran to 122 fenced lines on every call (#159). annotateElsewhere
+ * still reads the whole list — it annotates terms the model returned.
+ */
+export function elsewhereForPosting<S extends { skill: string }>(
+  otherSkills: S[],
+  posting: string,
+  matcher: Pick<KeywordMatcher, 'findTerm'>,
+): S[] {
+  return otherSkills.filter((s) => matcher.findTerm(posting, s.skill, aliasesFor(s.skill)).length > 0);
 }

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -16,7 +16,7 @@ import { annotateElsewhere, applyFacts } from './facts';
 import { gateActions } from './replacement-gate';
 import { withTableAliases } from './keyword-aliases';
 import { carryOverrides, effectiveKeywords } from './keyword-overrides';
-import { anchorKeywords } from './keyword-anchor';
+import { anchorKeywords, elsewhereForPosting } from './keyword-anchor';
 import { planKeywordFrame } from './keyword-frame';
 import { loadKeywordMatcher } from './keyword-matcher';
 import { readMatchMode, type MatchMode } from './match-mode';
@@ -76,7 +76,7 @@ export async function matchResumeToJob(
   const context: MatchContext = {
     confirmedFacts: facts.filter((f) => f.status === 'confirmed').map((f) => ({ term: f.term, note: f.note })),
     deniedTerms: facts.filter((f) => f.status === 'denied').map((f) => f.term),
-    otherResumeSkills: otherSkills,
+    otherResumeSkills: elsewhereForPosting(otherSkills, posting, matcher),
     // The previous run's keyword frame keeps terms/levels stable across
     // versions, so a better resume shows up as a better number. Terms the user
     // ignored are left out of it — asking for them back would be noise.
@@ -148,6 +148,7 @@ export async function matchResumeToJob(
       readded: carry.readded,
       frame: frame.reason,
       promptVersion: PROMPT_VERSION,
+      elsewhere: context.otherResumeSkills?.length,
       chars: answer.chars,
       ms: answer.ms,
     },

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -1,6 +1,7 @@
 import type { ResumeMatch } from '@prisma/client';
 import { logger } from '../logger';
 import { getAiRuntime } from '../ai-runtime';
+import { askForJson } from '../ai-json';
 import {
   buildMatchPrompt,
   MATCH_FAST_MAX_TOKENS,
@@ -32,7 +33,6 @@ import {
 const PREVIOUS_KEYWORDS_MAX = 40;
 
 const MATCH_TIMEOUT_MS = 5 * 60_000;
-const PARSE_ATTEMPTS = 2;
 
 /**
  * One resume-vs-posting comparison, persisted as a ResumeMatch row. `resume.text`
@@ -72,6 +72,7 @@ export async function matchResumeToJob(
     PROMPT_VERSION,
     opts.rebuild ?? false,
   );
+  const posting = `${job.title}\n${job.description}`;
   const context: MatchContext = {
     confirmedFacts: facts.filter((f) => f.status === 'confirmed').map((f) => ({ term: f.term, note: f.note })),
     deniedTerms: facts.filter((f) => f.status === 'denied').map((f) => f.term),
@@ -85,91 +86,74 @@ export async function matchResumeToJob(
           .map((k) => ({ term: k.term, priority: k.priority, requirement: k.requirement, primary: k.primary }))
       : undefined,
   };
-  const prompt = buildMatchPrompt(resume.text, job, mode, context);
-  const ai = await getAiRuntime();
-  for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const started = Date.now();
-    const out = await ai.complete({
-      ...prompt,
+  const answer = await askForJson(
+    await getAiRuntime(),
+    {
+      ...buildMatchPrompt(resume.text, job, mode, context),
       maxTokens: mode === 'fast' ? MATCH_FAST_MAX_TOKENS : MATCH_MAX_TOKENS,
       label: mode === 'fast' ? 'resume-match-fast' : 'resume-match',
       role: 'resume',
       timeoutMs: MATCH_TIMEOUT_MS,
-    });
-    if (out === null) return null;
+    },
+    parseMatchResponse,
+    { jobId: job.id, resumeId: resume.id },
+  );
+  if (!answer) return null;
+  const reply = answer.data;
+  // Deterministic guarantees on top of the model's judgment: the alias
+  // table joins the model's spellings, every term is anchored to the
+  // posting (or flagged), stored facts always win, and unclaimable terms
+  // point at the resume that has them.
+  const anchor = anchorKeywords(reply.keywords.map(withTableAliases), posting, matcher);
+  const carry = carryOverrides(anchor.keywords, storedKeywords, { resumeText: resume.text, posting, matcher });
+  const withFacts = applyFacts(carry.keywords, facts).keywords;
+  const keywords = annotateElsewhere(withFacts, otherSkills);
+  // What may be applied with one press is decided here, in code, against
+  // the resume, the posting and the facts — never by the model (ADR 0037).
+  const gate = gateActions(reply.actions, { resumeText: resume.text, posting, facts, keywords, matcher });
+  // The row stores what the user sees; the score reads what they decided:
+  // their levels, without the terms they ignored (§5).
+  const breakdown = scoreMatch(effectiveKeywords(keywords), reply.alignment, reply.red_flags.length);
+  const row = await createMatch({
+    jobId: job.id,
+    resumeId: resume.id,
+    resumeVersion: resume.version,
+    resumeText: resume.text,
+    draft: opts.draft ?? false,
     // The marker surfaces on the match card's meta line — the user can see
     // that a fallback engine (not chain #1) produced this analysis.
-    const model = (out.model || out.providerId) + (out.viaFallback ? ' · fallback' : '');
-    const parsed = parseMatchResponse(out.text);
-    if (parsed.ok) {
-      // Deterministic guarantees on top of the model's judgment: the alias
-      // table joins the model's spellings, every term is anchored to the
-      // posting (or flagged), stored facts always win, and unclaimable terms
-      // point at the resume that has them.
-      const posting = `${job.title}\n${job.description}`;
-      const anchor = anchorKeywords(parsed.data.keywords.map(withTableAliases), posting, matcher);
-      const carry = carryOverrides(anchor.keywords, storedKeywords, {
-        resumeText: resume.text,
-        posting,
-        matcher,
-      });
-      const withFacts = applyFacts(carry.keywords, facts).keywords;
-      const keywords = annotateElsewhere(withFacts, otherSkills);
-      // What may be applied with one press is decided here, in code, against
-      // the resume, the posting and the facts — never by the model (ADR 0037).
-      const gate = gateActions(parsed.data.actions, { resumeText: resume.text, posting, facts, keywords, matcher });
-      // The row stores what the user sees; the score reads what they decided:
-      // their levels, without the terms they ignored (§5).
-      const breakdown = scoreMatch(
-        effectiveKeywords(keywords),
-        parsed.data.alignment,
-        parsed.data.red_flags.length,
-      );
-      const row = await createMatch({
-        jobId: job.id,
-        resumeId: resume.id,
-        resumeVersion: resume.version,
-        resumeText: resume.text,
-        draft: opts.draft ?? false,
-        model,
-        result: { ...parsed.data, keywords, actions: gate.actions },
-        breakdown,
-        promptVersion: PROMPT_VERSION,
-        mode,
-        frame: frame.reason,
-      });
-      logger.info(
-        {
-          matchId: row.id,
-          jobId: job.id,
-          resumeId: resume.id,
-          version: resume.version,
-          draft: row.draft,
-          mode,
-          score: row.matchScore,
-          replacementsBlocked: gate.blocked,
-          replacementsWarned: gate.warned,
-          cap: breakdown.cap,
-          keywords: keywords.length,
-          anchored: anchor.anchored,
-          unanchored: anchor.unanchored,
-          overrides: carry.carried,
-          readded: carry.readded,
-          frame: frame.reason,
-          promptVersion: PROMPT_VERSION,
-          chars: out.text.length,
-          ms: Date.now() - started,
-        },
-        'resume: matched',
-      );
-      return row;
-    }
-    logger.warn(
-      { jobId: job.id, resumeId: resume.id, attempt, error: parsed.error, raw: out.text.slice(0, 500) },
-      'resume: match reply did not match schema',
-    );
-  }
-  return null;
+    model: answer.model,
+    result: { ...reply, keywords, actions: gate.actions },
+    breakdown,
+    promptVersion: PROMPT_VERSION,
+    mode,
+    frame: frame.reason,
+  });
+  logger.info(
+    {
+      matchId: row.id,
+      jobId: job.id,
+      resumeId: resume.id,
+      version: resume.version,
+      draft: row.draft,
+      mode,
+      score: row.matchScore,
+      replacementsBlocked: gate.blocked,
+      replacementsWarned: gate.warned,
+      cap: breakdown.cap,
+      keywords: keywords.length,
+      anchored: anchor.anchored,
+      unanchored: anchor.unanchored,
+      overrides: carry.carried,
+      readded: carry.readded,
+      frame: frame.reason,
+      promptVersion: PROMPT_VERSION,
+      chars: answer.chars,
+      ms: answer.ms,
+    },
+    'resume: matched',
+  );
+  return row;
 }
 
 /**

--- a/src/resume/prompts.ts
+++ b/src/resume/prompts.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { extractJson } from '../text-utils';
+import { extractJson, jsonFailure, type ParseResult } from '../text-utils';
 import {
   ALIGNMENT_GRADES,
   KEYWORD_STATUSES,
@@ -726,8 +726,6 @@ export function buildSuggestionsPrompt(
   };
 }
 
-export type ParseResult<T> = { ok: true; data: T } | { ok: false; error: string };
-
 export function parseScanResponse(text: string): ParseResult<ResumeScan> {
   return parseWith(ScanSchema, text);
 }
@@ -973,7 +971,7 @@ export function coverGateSources(
 
 function parseWith<T>(schema: z.ZodType<T, z.ZodTypeDef, unknown>, text: string): ParseResult<T> {
   const json = extractJson(text);
-  if (json === null) return { ok: false, error: 'no JSON object in reply' };
+  if (json === null) return jsonFailure(text);
   const parsed = schema.safeParse(json);
   if (!parsed.success) {
     return { ok: false, error: JSON.stringify(parsed.error.flatten().fieldErrors) };

--- a/src/resume/review.ts
+++ b/src/resume/review.ts
@@ -1,6 +1,7 @@
 import type { ResumeReview } from '@prisma/client';
 import { logger } from '../logger';
 import { getAiRuntime } from '../ai-runtime';
+import { askForJson } from '../ai-json';
 import { answerLines, readAnswers } from './answers';
 import { parseWarnings } from './parse-warnings';
 import {
@@ -13,7 +14,6 @@ import { scoreReview } from './review-score';
 import { createReview } from './store';
 
 const REVIEW_TIMEOUT_MS = 5 * 60_000;
-const PARSE_ATTEMPTS = 2;
 
 /**
  * One strength review of one resume, judged on its own — no posting, no
@@ -39,54 +39,42 @@ export async function reviewResume(resume: {
     roleTypes: resume.roleTypes,
     answers: answerLines(answers),
   });
-  const ai = await getAiRuntime();
-  for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const started = Date.now();
-    const out = await ai.complete({
-      ...prompt,
-      maxTokens: REVIEW_MAX_TOKENS,
-      label: 'resume-review',
-      role: 'resume',
-      timeoutMs: REVIEW_TIMEOUT_MS,
-    });
-    if (out === null) return null;
-    const parsed = parseReviewResponse(out.text);
-    if (parsed.ok) {
-      const breakdown = scoreReview(parsed.data.grades);
-      const row = await createReview({
-        resumeId: resume.id,
-        resumeVersion: resume.version,
-        // The marker surfaces on the card: the user can see which engine judged them.
-        model: (out.model || out.providerId) + (out.viaFallback ? ' · fallback' : ''),
-        result: parsed.data,
-        breakdown,
-        promptVersion: REVIEW_PROMPT_VERSION,
-      });
-      logger.info(
-        {
-          reviewId: row.id,
-          resumeId: resume.id,
-          version: resume.version,
-          score: row.reviewScore,
-          raw: breakdown.rawPts,
-          cap: breakdown.cap,
-          weak: breakdown.weakCount,
-          missing: breakdown.missing.length,
-          advice: parsed.data.advice.length,
-          asks: parsed.data.advice.filter((a) => a.ask !== null).length,
-          // The point of the loop: answered figures should make asks go down.
-          answersUsed: answers.length,
-          chars: out.text.length,
-          ms: Date.now() - started,
-        },
-        'resume: reviewed',
-      );
-      return row;
-    }
-    logger.warn(
-      { resumeId: resume.id, attempt, error: parsed.error, raw: out.text.slice(0, 500) },
-      'resume: review reply did not match schema',
-    );
-  }
-  return null;
+  const answer = await askForJson(
+    await getAiRuntime(),
+    { ...prompt, maxTokens: REVIEW_MAX_TOKENS, label: 'resume-review', role: 'resume', timeoutMs: REVIEW_TIMEOUT_MS },
+    parseReviewResponse,
+    { resumeId: resume.id },
+  );
+  if (!answer) return null;
+  const review = answer.data;
+  const breakdown = scoreReview(review.grades);
+  const row = await createReview({
+    resumeId: resume.id,
+    resumeVersion: resume.version,
+    // The marker surfaces on the card: the user can see which engine judged them.
+    model: answer.model,
+    result: review,
+    breakdown,
+    promptVersion: REVIEW_PROMPT_VERSION,
+  });
+  logger.info(
+    {
+      reviewId: row.id,
+      resumeId: resume.id,
+      version: resume.version,
+      score: row.reviewScore,
+      raw: breakdown.rawPts,
+      cap: breakdown.cap,
+      weak: breakdown.weakCount,
+      missing: breakdown.missing.length,
+      advice: review.advice.length,
+      asks: review.advice.filter((a) => a.ask !== null).length,
+      // The point of the loop: answered figures should make asks go down.
+      answersUsed: answers.length,
+      chars: answer.chars,
+      ms: answer.ms,
+    },
+    'resume: reviewed',
+  );
+  return row;
 }

--- a/src/resume/scan.ts
+++ b/src/resume/scan.ts
@@ -1,46 +1,29 @@
 import { logger } from '../logger';
 import { getAiRuntime } from '../ai-runtime';
+import { askForJson } from '../ai-json';
 import { buildScanPrompt, parseScanResponse, SCAN_MAX_TOKENS, type ResumeScan } from './prompts';
 import type { JsonResume } from './json-resume';
 import { anchorStructure, structureIsUsable } from './structure-anchor';
 import { saveResumeScan } from './store';
 
 const SCAN_TIMEOUT_MS = 5 * 60_000;
-const PARSE_ATTEMPTS = 2;
 
 /** Extracts the structured profile of a resume and stores it. Null on AI failure. */
 export async function scanResume(resume: { id: number; text: string }): Promise<ResumeScan | null> {
-  const prompt = buildScanPrompt(resume.text);
-  const ai = await getAiRuntime();
-  for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const started = Date.now();
-    const out = await ai.complete({
-      ...prompt,
-      maxTokens: SCAN_MAX_TOKENS,
-      label: 'resume-scan',
-      role: 'resume',
-      timeoutMs: SCAN_TIMEOUT_MS,
-    });
-    if (out === null) return null;
-    const parsed = parseScanResponse(out.text);
-    if (parsed.ok) {
-      const structure = guardStructure(resume, parsed.data);
-      await saveResumeScan(resume.id, parsed.data, structure);
-      logger.info(
-        {
-          id: resume.id,
-          skills: parsed.data.skills.length,
-          issues: parsed.data.issues.length,
-          attempt,
-          ms: Date.now() - started,
-        },
-        'resume: scanned',
-      );
-      return parsed.data;
-    }
-    logger.warn({ id: resume.id, attempt, error: parsed.error, raw: out.text.slice(0, 500) }, 'resume: scan reply did not match schema');
-  }
-  return null;
+  const answer = await askForJson(
+    await getAiRuntime(),
+    { ...buildScanPrompt(resume.text), maxTokens: SCAN_MAX_TOKENS, label: 'resume-scan', role: 'resume', timeoutMs: SCAN_TIMEOUT_MS },
+    parseScanResponse,
+    { id: resume.id },
+  );
+  if (!answer) return null;
+  const scan = answer.data;
+  await saveResumeScan(resume.id, scan, guardStructure(resume, scan));
+  logger.info(
+    { id: resume.id, skills: scan.skills.length, issues: scan.issues.length, attempt: answer.attempt, ms: answer.ms },
+    'resume: scanned',
+  );
+  return scan;
 }
 
 /**

--- a/src/resume/suggestions.ts
+++ b/src/resume/suggestions.ts
@@ -1,6 +1,7 @@
 import type { ResumeMatch } from '@prisma/client';
 import { logger } from '../logger';
 import { getAiRuntime } from '../ai-runtime';
+import { askForJson } from '../ai-json';
 import {
   buildSuggestionsPrompt,
   parseSuggestionsResponse,
@@ -16,7 +17,6 @@ import { gateActions } from './replacement-gate';
 import { listFacts, updateMatchSuggestions } from './store';
 
 const SUGGESTIONS_TIMEOUT_MS = 5 * 60_000;
-const PARSE_ATTEMPTS = 2;
 
 /**
  * The lazy second half of a quick check (ADR 0029): the stored verdicts —
@@ -35,53 +35,43 @@ export async function suggestForMatch(match: ResumeMatch, job: MatchJobInput): P
     confirmedFacts: facts.filter((f) => f.status === 'confirmed').map((f) => ({ term: f.term, note: f.note })),
     deniedTerms: facts.filter((f) => f.status === 'denied').map((f) => f.term),
   });
-  const ai = await getAiRuntime();
-  for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const started = Date.now();
-    const out = await ai.complete({
-      ...prompt,
-      maxTokens: SUGGESTIONS_MAX_TOKENS,
-      label: 'resume-suggestions',
-      role: 'resume',
-      timeoutMs: SUGGESTIONS_TIMEOUT_MS,
-    });
-    if (out === null) return null;
-    const parsed = parseSuggestionsResponse(out.text);
+  const answer = await askForJson(
+    await getAiRuntime(),
+    { ...prompt, maxTokens: SUGGESTIONS_MAX_TOKENS, label: 'resume-suggestions', role: 'resume', timeoutMs: SUGGESTIONS_TIMEOUT_MS },
     // Every array defaults to empty, so "{}" parses — but a reply with nothing
     // in it would flip the row to "full" and lock the button out for good.
-    if (parsed.ok && !isEmpty(parsed.data)) {
-      // The same gate the full report runs before it stores (ADR 0037).
-      const gate = gateActions(parsed.data.actions, {
-        resumeText: match.resumeText,
-        posting: `${job.title}\n${job.description}`,
-        facts,
-        keywords: readKeywords(match.keywords),
-        matcher: await loadKeywordMatcher(),
-      });
-      const row = await updateMatchSuggestions(match.id, { ...parsed.data, actions: gate.actions });
-      logger.info(
-        {
-          matchId: match.id,
-          jobId: match.jobId,
-          resumeId: match.resumeId,
-          actions: parsed.data.actions.length,
-          removals: parsed.data.removals.length,
-          replacementsBlocked: gate.blocked,
-          replacementsWarned: gate.warned,
-          model: out.model || out.providerId,
-          chars: out.text.length,
-          ms: Date.now() - started,
-        },
-        'resume: suggestions added',
-      );
-      return row;
-    }
-    logger.warn(
-      { matchId: match.id, attempt, error: parsed.ok ? 'empty reply' : parsed.error, raw: out.text.slice(0, 500) },
-      'resume: suggestions reply unusable',
-    );
-  }
-  return null;
+    (text) => {
+      const parsed = parseSuggestionsResponse(text);
+      return parsed.ok && isEmpty(parsed.data) ? { ok: false, error: 'empty reply' } : parsed;
+    },
+    { matchId: match.id },
+  );
+  if (!answer) return null;
+  // The same gate the full report runs before it stores (ADR 0037).
+  const gate = gateActions(answer.data.actions, {
+    resumeText: match.resumeText,
+    posting: `${job.title}\n${job.description}`,
+    facts,
+    keywords: readKeywords(match.keywords),
+    matcher: await loadKeywordMatcher(),
+  });
+  const row = await updateMatchSuggestions(match.id, { ...answer.data, actions: gate.actions });
+  logger.info(
+    {
+      matchId: match.id,
+      jobId: match.jobId,
+      resumeId: match.resumeId,
+      actions: answer.data.actions.length,
+      removals: answer.data.removals.length,
+      replacementsBlocked: gate.blocked,
+      replacementsWarned: gate.warned,
+      model: answer.model,
+      chars: answer.chars,
+      ms: answer.ms,
+    },
+    'resume: suggestions added',
+  );
+  return row;
 }
 
 function isEmpty(s: MatchSuggestions): boolean {

--- a/src/text-utils.test.ts
+++ b/src/text-utils.test.ts
@@ -8,6 +8,7 @@ import {
   decideStageStrategy,
   extractAtsToken,
   extractJson,
+  jsonFailure,
   maskToken,
   parseTagList,
   toStringArray,
@@ -399,4 +400,22 @@ describe('url and text keys', () => {
   assert.equal(feedItemKey('n/a', '!!!'), null);
   });
 
+});
+
+describe('jsonFailure', () => {
+  it('names a reply with no JSON at all', () => {
+    assert.deepEqual(jsonFailure('Sorry, I cannot help with that.'), { ok: false, error: 'no JSON object in reply' });
+  });
+
+  it('tells a reply cut off inside the JSON from one that is not JSON', () => {
+    const cut = jsonFailure('{"keywords": [{"term": "Laravel", "replacement": "Frameworks: Laravel 10, Sym');
+    assert.equal(cut.cutOff, true);
+    assert.match(cut.error, /cut off/);
+  });
+
+  it('calls balanced braces that still do not parse malformed, not cut off', () => {
+    const bad = jsonFailure('{"a": 1, "b": }');
+    assert.equal(bad.cutOff, undefined);
+    assert.equal(bad.error, 'malformed JSON in reply');
+  });
 });

--- a/src/text-utils.ts
+++ b/src/text-utils.ts
@@ -138,6 +138,27 @@ export function extractJson(text: string): unknown | null {
   }
 }
 
+export interface ParseFailure {
+  ok: false;
+  error: string;
+  /** The reply stopped inside the JSON — the same call would stop the same way, so it is not retried. */
+  cutOff?: boolean;
+}
+export type ParseResult<T> = { ok: true; data: T } | ParseFailure;
+
+/**
+ * Why extractJson returned null. A reply cut off inside the JSON used to be
+ * reported as "no JSON object" about text that was 96% a JSON object (#159);
+ * unbalanced braces tell the two apart well enough.
+ */
+export function jsonFailure(text: string): ParseFailure {
+  if (!text.includes('{')) return { ok: false, error: 'no JSON object in reply' };
+  const open = text.split('{').length;
+  const close = text.split('}').length;
+  if (open > close) return { ok: false, error: 'reply cut off inside the JSON', cutOff: true };
+  return { ok: false, error: 'malformed JSON in reply' };
+}
+
 /**
  * Maps a classifier mode to the stage-1 decision. Trivial but explicit so
  * we can unit-test the toggle semantics in isolation from the API client.

--- a/src/verification/prompts.ts
+++ b/src/verification/prompts.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { extractJson } from '../text-utils';
+import { extractJson, jsonFailure, type ParseResult } from '../text-utils';
 import { fence, untrustedDirective } from '../prompt-fence';
 
 /*
@@ -121,11 +121,9 @@ export function buildVerifyPrompt(job: VerifyJobInput): { system: string; user: 
   };
 }
 
-export type ParseResult<T> = { ok: true; data: T } | { ok: false; error: string };
-
 export function parseVerifyResponse(text: string): ParseResult<VerificationResult> {
   const json = extractJson(text);
-  if (json === null) return { ok: false, error: 'no JSON object in reply' };
+  if (json === null) return jsonFailure(text);
   const parsed = VerificationSchema.safeParse(json);
   if (!parsed.success) return { ok: false, error: JSON.stringify(parsed.error.flatten().fieldErrors) };
   return { ok: true, data: parsed.data };

--- a/src/verification/verify.ts
+++ b/src/verification/verify.ts
@@ -2,12 +2,12 @@ import type { JobVerification, Prisma } from '@prisma/client';
 import { prisma } from '../db';
 import { logger } from '../logger';
 import { getAiRuntime } from '../ai-runtime';
+import { askForJson } from '../ai-json';
 import { buildVerifyPrompt, parseVerifyResponse, VERIFY_MAX_TOKENS, type VerifyJobInput } from './prompts';
 import { runLivenessLadder, type LivenessJobInput, type LivenessResult } from './liveness';
 
 // Web research through the CLI can take several minutes.
 const VERIFY_TIMEOUT_MS = 10 * 60_000;
-const PARSE_ATTEMPTS = 2;
 
 /** Rungs 1-2 of the ladder (ADR 0016): free checks, verdict stored on the Job row. */
 export async function checkLiveness(job: LivenessJobInput & { id: number }): Promise<LivenessResult> {
@@ -22,40 +22,29 @@ export async function checkLiveness(job: LivenessJobInput & { id: number }): Pro
 
 /** Runs the ghost-job check with web tools and stores the verdict. Null on AI failure. */
 export async function verifyJob(job: VerifyJobInput & { id: number }): Promise<JobVerification | null> {
-  const prompt = buildVerifyPrompt(job);
-  const ai = await getAiRuntime();
-  for (let attempt = 0; attempt < PARSE_ATTEMPTS; attempt++) {
-    const out = await ai.complete({
-      ...prompt,
-      maxTokens: VERIFY_MAX_TOKENS,
-      label: 'job-verify',
-      role: 'resume',
-      timeoutMs: VERIFY_TIMEOUT_MS,
-      webTools: true,
-    });
-    if (out === null) return null;
-    const parsed = parseVerifyResponse(out.text);
-    if (parsed.ok) {
-      const r = parsed.data;
-      const row = await prisma.jobVerification.create({
-        data: {
-          jobId: job.id,
-          model: (out.model || out.providerId) + (out.viaFallback ? ' · fallback' : ''),
-          verdict: r.verdict,
-          recommendation: r.recommendation,
-          confidence: r.confidence,
-          summary: r.summary,
-          evidence: r.evidence as Prisma.InputJsonValue,
-          redFlags: r.red_flags,
-          companySnapshot: r.company_snapshot,
-        },
-      });
-      logger.info({ jobId: job.id, verdict: r.verdict, recommendation: r.recommendation }, 'verify: done');
-      return row;
-    }
-    logger.warn({ jobId: job.id, attempt, error: parsed.error, raw: out.text.slice(0, 500) }, 'verify: reply did not match schema');
-  }
-  return null;
+  const answer = await askForJson(
+    await getAiRuntime(),
+    { ...buildVerifyPrompt(job), maxTokens: VERIFY_MAX_TOKENS, label: 'job-verify', role: 'resume', timeoutMs: VERIFY_TIMEOUT_MS, webTools: true },
+    parseVerifyResponse,
+    { jobId: job.id },
+  );
+  if (!answer) return null;
+  const r = answer.data;
+  const row = await prisma.jobVerification.create({
+    data: {
+      jobId: job.id,
+      model: answer.model,
+      verdict: r.verdict,
+      recommendation: r.recommendation,
+      confidence: r.confidence,
+      summary: r.summary,
+      evidence: r.evidence as Prisma.InputJsonValue,
+      redFlags: r.red_flags,
+      companySnapshot: r.company_snapshot,
+    },
+  });
+  logger.info({ jobId: job.id, verdict: r.verdict, recommendation: r.recommendation }, 'verify: done');
+  return row;
 }
 
 export async function listVerificationsForJob(jobId: number): Promise<JobVerification[]> {


### PR DESCRIPTION
Closes #159.

## What

- `max_tokens` on the Messages API counts the thinking, and Claude Opus 5 (the `CLAUDE_MODEL_RESUME` default) thinks by default. Every answer budget was sized against a non-thinking reply, so a full comparison with a few resumes stored was cut off mid-JSON. The Anthropic path now adds `ANTHROPIC_THINKING_HEADROOM_TOKENS` (8 000) to every answer budget — the mirror of `OPENAI_REASONING_HEADROOM_TOKENS` — capped under the SDK's non-streaming ceiling (~21 300 tokens).
- The provider reads `stop_reason`: `max_tokens` and `refusal` are a failure with a reason ("reply cut off at 8000 output tokens (6078 of them thinking)") instead of text handed to a parser. `stop_reason` and `usage` are logged at debug level on every reply.
- `text-utils.ts:jsonFailure` tells "reply cut off inside the JSON" from "no JSON object in reply"; `ParseResult` lives there now (one definition instead of two).
- `src/ai-json.ts:askForJson` is the one parse-and-retry loop — the five resume calls and the ghost-job check go through it (five copies of the same loop deleted), and a reply cut off inside the JSON is not retried: the identical call stops in the identical place, which cost two full-price calls per attempt.
- `keyword-anchor.ts:elsewhereForPosting`: the "other resumes mention" hints are filtered to the skills the posting names (aliases included). With four resumes stored, 122 fenced lines went into every comparison prompt.
- CLAUDE.md: gotcha 16 and a "where to look" row; CHANGELOG 1.55.1; version bump.

## Verification

- `npm run lint:types` + `npm test`: 1980 tests, 0 failures (new: `jsonFailure` ×3, `anthropicMaxTokens` ×3, `askForJson` ×5, `elsewhereForPosting` ×1; the fence-registry guard now also scans for `askForJson(`).
- Live on `claude-opus-5` with four resumes in the database — the four comparisons from the issue, all of which failed on v1.55.0, plus one quick check:

| comparison | mode | stop | output tokens | of them thinking | old budget | result |
|---|---|---|---|---|---|---|
| job 646 × resume 2 | full | end_turn | 8 535 | 3 079 | 8 000 | stored #4 · score 70 · 30 keywords · 9 actions |
| job 114 × resume 3 | full | end_turn | 9 289 | 4 666 | 8 000 | parsed · 29 keywords · 8 actions |
| job 646 × resume 3 | full | end_turn | 11 518 | 6 010 | 8 000 | parsed · 30 keywords · 7 actions |
| job 618 × resume 4 | full | end_turn | 9 826 | 5 696 | 8 000 | parsed · 23 keywords · 6 actions |
| job 646 × resume 2 | fast | end_turn | 5 168 | 2 381 | 4 000 | parsed · 28 keywords |

Every one of the five replies is longer than its old budget — even the one with the least thinking would have been cut off. The other-resume hints went 122 → 28, 114 → 5, 114 → 25, 110 → 2. The first row ran through `matchResumeToJob` and stored its row; the dashboard's engine was switched to `claude_code` mid-run, so the other four were run against the provider directly with the same prompt builder and parser (no rows stored).
- A side measurement: `cache_read_input_tokens` = 4 749 on the repeated calls — on Opus 5 the system prompt does get cached (512-token floor), unlike the Haiku classifier (gotcha 3).

## Follow-ups (P2, from the pre-merge review)

- The OpenAI path still hands a `finish_reason: "length"` reply to the parser; the parser now names it as cut off, but the provider could refuse it earlier, as the Anthropic path does. The CLI paths carry no truncation signal at all.
- `jsonFailure` counts braces without parsing strings — a complete reply whose string values contain an unbalanced `{` would be called cut off and not retried. Not seen in practice.
- `output_config.effort` per role is the next cost lever: the thinking is 30–50 % of every reply above. Not touched here because it changes the model's behaviour, and the bench should measure it first.

## Release notes

### What's new
- Comparisons work again on the default resume model: the Anthropic path gives every reply room for the model's thinking, and a reply that runs out of room is reported as cut off instead of being retried at full price.
- The "other resumes mention" hints are filtered to the posting.

### Schema
- no schema changes

### Verification
- 1980 tests; five live comparisons on claude-opus-5 with four resumes stored, all complete (table in the PR).

### References
- #159 · CLAUDE.md gotcha 16

Tag after merge: `git tag -a v1.55.1 -m "Comparisons no longer fail on the default resume model" <merge-sha>`
