### PR TITLE
The wizard links its resume; fill-from-resume caps nice-to-have (#158, #157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.55.2] — 2026-09-04
+
+### Fixed
+- **The wizard's search now hunts with the resume it was built from.** Step 3
+  filled the primary search from the uploaded resume and left
+  `Profile.resumeId` empty, so every Compare afterwards guessed the resume
+  by skill overlap — right by luck with one resume, a coin toss with three
+  (#158). The apply step links it, as filling from a resume on Settings
+  already did.
+- **"Fill from a resume" no longer drafts an 86-chip nice-to-have list.**
+  Every skill the scan found went into the list the classifier is told to
+  raise the score for — `git`, `jira`, `agile`, `scrum` included — and cost
+  717 characters of prompt per search on every classification (#157). The
+  draft keeps the first 20 skills after the required stack, drops universal
+  tooling, and says so above the chips. Measured on the four stored resumes:
+  86 → 20, 19 → 19, 15 → 14, 19 → 18.
+
 ## [1.55.1] — 2026-09-04
 
 ### Fixed
@@ -2266,6 +2283,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.55.2]: https://github.com/applypack/applypack/compare/v1.55.1...v1.55.2
 [1.55.1]: https://github.com/applypack/applypack/compare/v1.55.0...v1.55.1
 [1.55.0]: https://github.com/applypack/applypack/compare/v1.54.1...v1.55.0
 [1.54.1]: https://github.com/applypack/applypack/compare/v1.54.0...v1.54.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.55.1",
+  "version": "1.55.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.55.1",
+      "version": "1.55.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.55.1",
+  "version": "1.55.2",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/resume/profile-draft.test.ts
+++ b/src/resume/profile-draft.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildProfileDraft, type ProfileForDraft, type ScanForDraft } from './profile-draft';
+import { buildProfileDraft, NICE_TO_HAVE_MAX, type ProfileForDraft, type ScanForDraft } from './profile-draft';
 
 const PROFILE: ProfileForDraft = {
   name: 'PHP hunt',
@@ -86,4 +86,22 @@ test('a blank base takes everything the scan speaks for — the new-profile case
     seniority: ['senior'],
   });
   assert.equal(d.warnings.length, 0);
+});
+
+test('universal tooling never becomes a scored preference', () => {
+  const d = buildProfileDraft(PROFILE, {
+    ...SCAN,
+    skills: ['php', 'laravel', 'git', 'GitHub', 'jira', 'agile', 'scrum', 'kanban', 'ci/cd', 'redis'],
+  });
+  assert.deepEqual(d.changes.stackNiceToHave, ['redis']);
+  assert.equal(d.warnings.length, 0);
+});
+
+test('the drafted nice-to-have list is capped, and the draft says so', () => {
+  const skills = Array.from({ length: 90 }, (_, i) => `tool-${i}`);
+  const d = buildProfileDraft({ ...PROFILE, stackRequired: [] }, { ...SCAN, skills, primarySkills: ['tool-0', 'tool-1'] });
+  assert.equal(d.changes.stackNiceToHave?.length, NICE_TO_HAVE_MAX);
+  assert.equal(d.changes.stackNiceToHave?.[0], 'tool-2');
+  assert.equal(d.warnings.length, 1);
+  assert.match(d.warnings[0] ?? '', /90 skills/);
 });

--- a/src/resume/profile-draft.ts
+++ b/src/resume/profile-draft.ts
@@ -34,6 +34,18 @@ export interface ProfileDraft {
 /** Only a freshly created profile gets renamed from the resume headline. */
 const DEFAULT_PROFILE_NAMES = ['New profile', 'My profile'];
 
+/**
+ * The classifier is told to raise the score for every nice-to-have term, and
+ * the draft is reviewed as chips (ADR 0015): a scan of 90 skills produced an
+ * 86-chip list nobody checks and 717 characters of prompt per search (#157).
+ */
+export const NICE_TO_HAVE_MAX = 20;
+/** Tooling every software posting can be assumed to involve — a boost for it is noise, not preference. */
+const UNIVERSAL_TOOLING = new Set([
+  'git', 'github', 'gitlab', 'bitbucket', 'svn', 'mercurial',
+  'jira', 'confluence', 'agile', 'scrum', 'kanban', 'ci/cd', 'rest', 'restful',
+]);
+
 export function buildProfileDraft(current: ProfileForDraft, scan: ScanForDraft): ProfileDraft {
   const changes: Partial<ProfileForDraft> = {};
   const changed: string[] = [];
@@ -50,7 +62,13 @@ export function buildProfileDraft(current: ProfileForDraft, scan: ScanForDraft):
 
   const required = changes.stackRequired ?? current.stackRequired;
   if (scan.skills.length > 0) {
-    const nice = withoutTags(scan.skills, required);
+    const candidates = withoutTags(scan.skills, required).filter((s) => !UNIVERSAL_TOOLING.has(norm(s)));
+    const nice = candidates.slice(0, NICE_TO_HAVE_MAX);
+    if (candidates.length > nice.length) {
+      warnings.push(
+        `the scan names ${scan.skills.length} skills — the nice-to-have list keeps the first ${NICE_TO_HAVE_MAX}, add any other by hand`,
+      );
+    }
     if (!sameTags(nice, current.stackNiceToHave)) {
       changes.stackNiceToHave = nice;
       changed.push('nice-to-have stack');

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -236,12 +236,15 @@ welcomeRoute.post('/welcome/profile/apply', async (c) => {
   if (!profile) return flashRedirect(PROFILE_STEP, 'err', 'No primary search — create one in Settings → Profile.');
   if (!resume || !resume.scannedAt) return flashRedirect(PROFILE_STEP, 'err', 'That resume has not been read yet.');
   const draft = buildProfileDraft(profile, scanFields(resume));
-  await updateProfile(profile.id, { ...profileInput(profile), ...draft.changes });
+  // The search is built from this resume, so it hunts with it (#158) — the
+  // same link the settings route proposes when it fills from a resume.
+  await updateProfile(profile.id, { ...profileInput(profile), ...draft.changes, resumeId: resume.id });
+  const changed = profile.resumeId === resume.id ? draft.changed : [...draft.changed, 'resume for this search'];
   return flashRedirect(
     MATCHES_STEP,
     'ok',
-    draft.changed.length > 0
-      ? `Profile filled from "${resume.name}" — ${draft.changed.join(', ')}. Adjust it any time in Settings → Profile.`
+    changed.length > 0
+      ? `Profile filled from "${resume.name}" — ${changed.join(', ')}. Adjust it any time in Settings → Profile.`
       : `Profile already matched "${resume.name}".`,
   );
 });


### PR DESCRIPTION
Closes #158. Closes #157.

Stacked on #163 (`thinking-headroom`) — merge that first; GitHub retargets this one to `main` on its own.

## What

- `/welcome/profile/apply` writes `Profile.resumeId`: the search built from a resume hunts with it (#158), the same link the Settings fill-from-resume route already proposed. The flash names it ("resume for this search").
- `buildProfileDraft` caps the drafted nice-to-have list at `NICE_TO_HAVE_MAX` (20) after the required stack, drops universal tooling (git, github, gitlab, bitbucket, svn, mercurial, jira, confluence, agile, scrum, kanban, ci/cd, rest, restful) and adds the warning line the draft cards already render when the list was cut (#157).
- CHANGELOG 1.55.2, version bump.

## Verification

- `npm run lint:types` + `npm test`: 1982 tests, 0 failures (2 new).
- Draft lengths on the four stored resumes (a host script over the stored scans, no AI call): 86 → 20 (with the warning), 19 → 19, 15 → 14, 19 → 18.
- The route, on a copy of the live database (`pg_dump | psql` into `scratch`, the dashboard built from this branch on :4748): `POST /welcome/profile/apply resumeId=1` → 303 to `/welcome?step=matches`; `profile.resumeId` NULL → 1, nice-to-have 86 → 20, required stack unchanged; `/jobs/646` then preselects that resume with four resumes present ("your search hunts with this"). The live database was not touched — its profile 1 still has `resumeId = NULL` and 86 nice-to-have terms, i.e. the shipped bug.
- Not run: a before/after re-classification of a posting sample — the fix is to the draft, and the live profile is the user's to update.

## Notes

- The PM-resume half of #157 (`stackRequired = ['sql']` capping every product posting) stays with #154, as the issue itself suggests.
- #70 was closed separately: the transaction with `SELECT … FOR UPDATE` has been on main since v1.20.0.

## Release notes

### What's new
- The search the wizard builds from a resume now hunts with that resume.
- "Fill from a resume" drafts a nice-to-have list of at most 20 terms, without git/jira/agile-style tooling, and says when it cut the list.

### Schema
- no schema changes

### Verification
- 1982 tests; the route exercised on a copy of the live database; draft lengths measured on the four stored resumes.

### References
- #158 · #157

Tag after merge: `git tag -a v1.55.2 -m "The wizard links its resume; fill-from-resume caps nice-to-have" <merge-sha>`
