### PR TITLE
Save & re-check waits for the match only; the CLI stops thinking on tool-free calls (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.59.1] — 2026-09-05
+
+### Fixed
+- **Save & re-check no longer waits six minutes on the Claude Code CLI.**
+  Three causes, all measured (#168). `claude -p` turns extended thinking on,
+  and on "copy this resume into JSON" Haiku 4.5 spent 18 924 thinking tokens
+  for a 3 500-token answer — 227 s where the same call takes 34 s with the
+  budget at zero, same structure quality: every tool-free call on the CLI
+  now runs with `MAX_THINKING_TOKENS=0` (the verify call keeps the default;
+  it reasons over search results). The Save route waited for a scan the
+  comparison never reads — it runs in the background now, as the re-upload
+  route's has since 1.14.0, and the flash says the headline and skills
+  refresh behind it. And every reply logs one line with the model, the API
+  time, the output tokens and the thinking tokens on both the CLI and the API
+  path, so a slow call, a throttled call and a thinking call stop looking
+  alike. The run page's step copy states bands instead of "about half a
+  minute" for every engine.
+
+### Notes
+- `docs/ai-engines.md`'s 2026-08-31 table blamed prompt size for Haiku's
+  146 s on the CLI; it was this thinking budget running into the 180 s
+  timeout. Corrected.
+
 ## [1.59.0] — 2026-09-05
 
 ### Changed
@@ -2414,6 +2437,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.59.1]: https://github.com/applypack/applypack/compare/v1.59.0...v1.59.1
 [1.59.0]: https://github.com/applypack/applypack/compare/v1.58.0...v1.59.0
 [1.58.0]: https://github.com/applypack/applypack/compare/v1.57.3...v1.58.0
 [1.57.3]: https://github.com/applypack/applypack/compare/v1.57.2...v1.57.3

--- a/docs/ai-engines.md
+++ b/docs/ai-engines.md
@@ -180,7 +180,7 @@ works on macOS too.)
   failed` lists the chain that was tried. Jobs are retried on the next
   cron tick; nothing is lost.
 
-## Measured: Haiku through the Claude Code CLI cannot hold the cover-letter prompt
+## Measured: the Claude Code CLI thinks before it answers — and Haiku thinks a lot
 
 Benchmarked 2026-08-31 on one job + one resume, cover-letter role only:
 
@@ -193,14 +193,31 @@ Benchmarked 2026-08-31 on one job + one resume, cover-letter role only:
 | claude_code | haiku-4.5 | 146 s / timeout | unreliable |
 | claude_code | `haiku` alias | 2 x 180 s timeout | **failed, no letter** |
 
-The CLI is killed by our own 180 s per-attempt timeout (`code: 143,
-killed: true`), and the alias behaves the same as the dated id, so this is
-not a model-id problem. The classifier runs haiku through the same CLI all
-day without trouble — the difference is prompt size: the letter sends ~10 KB
-of system prompt plus the whole resume, the classifier sends a fraction of
-that.
+The 2026-08-31 reading of this table — "the difference is prompt size" — was
+wrong, and #168 measured the real cause on 2026-09-05 with the resume-scan
+prompt (6.2 KB system + 5.8 KB user), one call at a time:
 
-**Practical rule:** for the cover-letter role pick opus or sonnet on
-`claude_code`, or use `anthropic_api` (fastest of all). Leaving the Cover
-letter slot empty is safe — it inherits the resume model, which is opus by
-default.
+| Lane | Wall | Output tokens | of which thinking |
+|---|---:|---:|---:|
+| claude_code + haiku-4.5, CLI defaults | **227 s** | 22 515 | **18 924** |
+| claude_code + haiku-4.5, `MAX_THINKING_TOKENS=0` | **34 s** | 3 512 | 0 |
+| claude_code + opus-5, CLI defaults | 69 s | 6 975 | 2 020 |
+| anthropic_api + haiku-4.5 | 41 s | 4 106 | 0 |
+
+Every lane generates at ~100 tokens/s; `claude -p` turns extended thinking
+on, and on "copy this resume into JSON" Haiku spends ~19 000 tokens thinking
+for a 3 500-token answer. The 146 s / timeout row above was the same thing
+running into our own 180 s per-attempt timeout.
+
+**What the app does now (v1.59.1):** every tool-free call on `claude_code`
+runs the child with `MAX_THINKING_TOKENS=0` (`src/ai-provider-parse.ts:
+cliThinkingCap`); the verify call keeps the CLI's default, because it
+reasons over search results. One `ai: reply` line per call names the model,
+the API time, the output tokens and the thinking tokens on both the CLI and
+the API path, so a slow call, a throttled call and a thinking call no longer
+look alike in `docker compose logs web`.
+
+**Practical rule:** Opus or Sonnet still judge resumes better than Haiku;
+pick them for the resume and cover-letter roles on `claude_code`, or use
+`anthropic_api` (fastest of all). Leaving the Cover letter slot empty is
+safe — it inherits the resume model, which is opus by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.59.0",
+      "version": "1.59.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -8,6 +8,8 @@ import {
   buildCodexCliArgs,
   buildGeminiCliArgs,
   CLI_PROVIDER_ENV_KEYS,
+  CLI_THINKING_CAP_ENV,
+  cliThinkingCap,
   describeAiFailure,
   parseClaudeCodeOutput,
   parseCodexCliOutput,
@@ -262,4 +264,23 @@ test('the largest answer budget keeps its full headroom under the SDK non-stream
 
 test('anthropicMaxTokens never asks for more than a non-streaming request may carry', () => {
   assert.ok(anthropicMaxTokens(100_000) <= 21_333);
+});
+
+test('the CLI reply keeps what the call spent — API time, output and thinking tokens, turns (#168)', () => {
+  const raw = JSON.stringify({
+    type: 'result', subtype: 'success', is_error: false, result: '{}',
+    duration_api_ms: 33_812, num_turns: 1,
+    usage: { output_tokens: 3_512, output_tokens_details: { thinking_tokens: 0 } },
+  });
+  assert.deepEqual(parseClaudeCodeOutput(raw).usage, { apiMs: 33_812, outputTokens: 3_512, thinkingTokens: 0, turns: 1 });
+  assert.deepEqual(parseClaudeCodeOutput(ok('{}')).usage, { apiMs: undefined, outputTokens: undefined, thinkingTokens: undefined, turns: undefined });
+});
+
+test('tool-free CLI calls get the thinking cap; the verify call keeps the CLI default', () => {
+  assert.deepEqual(cliThinkingCap(false), { MAX_THINKING_TOKENS: '0' });
+  assert.deepEqual(cliThinkingCap(undefined), { MAX_THINKING_TOKENS: '0' });
+  assert.deepEqual(cliThinkingCap(true), {});
+  assert.ok(CLI_PROVIDER_ENV_KEYS.claude_code?.includes(CLI_THINKING_CAP_ENV), 'the allowlist must let the cap through');
+  const env = buildCliEnv(CLI_PROVIDER_ENV_KEYS.claude_code ?? [], { PATH: '/bin', ...cliThinkingCap(false) });
+  assert.equal(env.MAX_THINKING_TOKENS, '0');
 });

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -13,13 +13,30 @@ const ClaudeCodeResultSchema = z.object({
   is_error: z.boolean(),
   result: z.string().optional(),
   api_error_status: z.number().nullable().optional(),
+  duration_api_ms: z.number().optional(),
+  num_turns: z.number().optional(),
+  usage: z
+    .object({
+      output_tokens: z.number().optional(),
+      output_tokens_details: z.object({ thinking_tokens: z.number().optional() }).optional(),
+    })
+    .optional(),
 });
+
+/** What one CLI call spent — logged per call, so a slow call, a throttled call and a thinking call stop looking alike (#168). */
+export interface CliUsage {
+  apiMs?: number;
+  outputTokens?: number;
+  thinkingTokens?: number;
+  turns?: number;
+}
 
 export interface CliOutcome {
   text: string | null;
   /** True for 429 / overloaded / quota — the caller may retry later. */
   rateLimited: boolean;
   error: string | null;
+  usage?: CliUsage;
 }
 
 const RATE_LIMIT_STATUS = 429;
@@ -82,7 +99,17 @@ export function parseClaudeCodeOutput(raw: string): CliOutcome {
       r.api_error_status === RATE_LIMIT_STATUS || RATE_LIMIT_PATTERN.test(message);
     return { text: null, rateLimited, error: `claude-code: ${message}` };
   }
-  return { text: r.result ?? '', rateLimited: false, error: null };
+  return {
+    text: r.result ?? '',
+    rateLimited: false,
+    error: null,
+    usage: {
+      apiMs: r.duration_api_ms,
+      outputTokens: r.usage?.output_tokens,
+      thinkingTokens: r.usage?.output_tokens_details?.thinking_tokens,
+      turns: r.num_turns,
+    },
+  };
 }
 
 /**
@@ -97,8 +124,21 @@ const CLI_BASE_ENV_KEYS = [
   'PATH', 'HOME', 'SHELL', 'TERM', 'USER', 'LOGNAME', 'TMPDIR', 'LANG', 'LC_ALL', 'TZ',
 ] as const;
 
+/**
+ * `claude -p` turns extended thinking on, and on "copy this resume into JSON"
+ * Haiku 4.5 spent ~19 000 thinking tokens for a 3 500-token answer — 227 s
+ * where the same call answers in 34 s with the budget at zero, same structure
+ * quality (#168). Every tool-free call gets the cap; the verify call keeps
+ * the CLI's default, it reasons over search results.
+ */
+export const CLI_THINKING_CAP_ENV = 'MAX_THINKING_TOKENS';
+
+export function cliThinkingCap(webTools: boolean | undefined): Record<string, string> {
+  return webTools ? {} : { [CLI_THINKING_CAP_ENV]: '0' };
+}
+
 export const CLI_PROVIDER_ENV_KEYS: Partial<Record<AiProviderId, readonly string[]>> = {
-  claude_code: ['CLAUDE_CODE_OAUTH_TOKEN', 'CLAUDE_CONFIG_DIR'],
+  claude_code: ['CLAUDE_CODE_OAUTH_TOKEN', 'CLAUDE_CONFIG_DIR', CLI_THINKING_CAP_ENV],
   gemini_cli: [
     'GEMINI_API_KEY',
     'GOOGLE_GENAI_USE_VERTEXAI',

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -12,6 +12,7 @@ import {
   buildCodexCliArgs,
   buildGeminiCliArgs,
   CLI_PROVIDER_ENV_KEYS,
+  cliThinkingCap,
   describeAiFailure,
   parseClaudeCodeOutput,
   parseCodexCliOutput,
@@ -164,7 +165,19 @@ class AnthropicApiProvider implements AiProvider {
         messages,
         tools,
       });
-      logger.debug({ label: req.label, stop: resp.stop_reason, usage: resp.usage }, 'ai: reply');
+      logger.info(
+        {
+          label: req.label,
+          provider: this.name,
+          model: resp.model,
+          stop: resp.stop_reason,
+          inputTokens: resp.usage.input_tokens,
+          cacheRead: resp.usage.cache_read_input_tokens,
+          outputTokens: resp.usage.output_tokens,
+          thinkingTokens: resp.usage.output_tokens_details?.thinking_tokens,
+        },
+        'ai: reply',
+      );
       if (resp.stop_reason === 'pause_turn' && resumes < MAX_PAUSE_TURN_RESUMES) {
         messages.push({ role: 'assistant', content: resp.content });
         continue;
@@ -271,6 +284,8 @@ interface CliSpec {
   keyEnv?: string;
   /** Working directory — set to keep the CLI away from workspace context. */
   cwd?: string;
+  /** This CLI reads MAX_THINKING_TOKENS: tool-free calls get it capped (#168). */
+  thinkingCap?: boolean;
 }
 
 /** Headless-CLI backend: spawn, parse JSON stdout, one retry on rate limit. */
@@ -308,7 +323,10 @@ class CliProvider implements AiProvider {
         return null;
       }
       const out = this.spec.parse(stdout);
-      if (out.text !== null) return out.text;
+      if (out.text !== null) {
+        logger.info({ label: req.label, provider: this.name, model: req.model, ...out.usage }, 'ai: reply');
+        return out.text;
+      }
       if (out.rateLimited && attempt < MAX_ATTEMPTS - 1) {
         logger.warn({ label: req.label, provider: this.name }, 'ai: cli rate-limited, retrying');
         await sleep(RATE_LIMIT_RETRY_DELAY_MS);
@@ -330,9 +348,12 @@ class CliProvider implements AiProvider {
    * variable in the child env, still filtered by the buildCliEnv allowlist.
    */
   private envSource(req: AiRequest): NodeJS.ProcessEnv {
-    const { keyEnv } = this.spec;
-    if (!keyEnv || !req.apiKey) return process.env;
-    return { ...process.env, [keyEnv]: req.apiKey };
+    const { keyEnv, thinkingCap } = this.spec;
+    return {
+      ...process.env,
+      ...(keyEnv && req.apiKey ? { [keyEnv]: req.apiKey } : {}),
+      ...(thinkingCap ? cliThinkingCap(req.webTools) : {}),
+    };
   }
 }
 
@@ -358,6 +379,7 @@ export function getAiProviderById(id: AiProviderId): AiProvider {
         defaultModel: config.CLAUDE_MODEL,
         envKeys: CLI_PROVIDER_ENV_KEYS.claude_code ?? [],
         keyEnv: AI_KEY_ENV_VARS.claude_code,
+        thinkingCap: true,
       });
       break;
     case 'gemini_cli':

--- a/src/resume/scan.ts
+++ b/src/resume/scan.ts
@@ -20,7 +20,7 @@ export async function scanResume(resume: { id: number; text: string }): Promise<
   const scan = answer.data;
   await saveResumeScan(resume.id, scan, guardStructure(resume, scan));
   logger.info(
-    { id: resume.id, skills: scan.skills.length, issues: scan.issues.length, attempt: answer.attempt, ms: answer.ms },
+    { id: resume.id, skills: scan.skills.length, issues: scan.issues.length, attempt: answer.attempt, chars: answer.chars, ms: answer.ms },
     'resume: scanned',
   );
   return scan;

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -18,11 +18,11 @@ const STEP_VIEW: Record<RunStep, StepView> = {
     // Also reached by a plain re-scan and a first upload, where there is no
     // "new version" to speak of.
     label: 'Read the resume',
-    detail: 'headline, skills, ATS issues — about half a minute',
+    detail: 'headline, skills, ATS issues, the resume as a shape — half a minute to a minute',
   },
   keywords: {
     label: 'Quick AI check',
-    detail: 'the resume model judges every keyword, the gates and the score — no edit suggestions — about half a minute on Opus',
+    detail: 'the resume model judges every keyword, the gates and the score — no edit suggestions — half a minute to a minute',
   },
   match: {
     label: 'Full AI analysis',

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -3,7 +3,7 @@ import { Hono, type Context } from 'hono';
 import { logger } from '../../logger';
 import type { ResumeReview } from '@prisma/client';
 import { reviewResume } from '../../resume/review';
-import { scanResume } from '../../resume/scan';
+import { scanInBackground, scanResume } from '../../resume/scan';
 import type { ResumeScan } from '../../resume/prompts';
 import { matchResumeToJob } from '../../resume/match';
 import { prisma } from '../../db';
@@ -193,7 +193,7 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
   // a duplicate version behind whatever the run registry then did. Keyed on
   // the text, because that is what the user submitted (issue #76).
   const { run, joined } = claimRun(`draft:${id}:${hashShortId(text)}:${job?.id ?? ''}:${asCopy ? 'copy' : 'version'}`, {
-    steps: job ? ['scan', 'keywords'] : ['scan'],
+    steps: job ? ['keywords'] : ['scan'],
     jobTitle: job?.title ?? '',
     resumeName: '',
     jobId: job?.id,
@@ -213,16 +213,19 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
     const saved = asCopy ? `Saved as a new resume "${resume.name}" (${note})` : `Saved as v${resume.version} (${note})`;
     updateRun(run.id, {
       resumeName: resume.name,
-      subtitle: `${saved}.${job ? ' Reading it, then scoring it against the posting.' : ''}`,
+      subtitle: `${saved}.${job ? ' Scoring it against the posting.' : ''}`,
     });
-    const scan = await scanResume(resume);
     if (!job) {
+      const scan = await scanResume(resume);
       updateRun(run.id, scan
         ? { stage: 'done', resultUrl: `/resumes/${resume.id}`, flash: `${saved}.` }
         : { stage: 'error', error: `${saved}, but the scan failed — try "Scan".` });
       return;
     }
-    updateRun(run.id, { stage: 'keywords' });
+    // The match reads the text, never the scan (target-plan §3.1 item 2), so
+    // the scan runs behind it as the re-upload route's does — it was 63 % of
+    // a six-minute wait on a CLI engine (#168).
+    scanInBackground(resume);
     const match = await matchResumeToJob(resume, {
       id: job.id,
       title: job.title,
@@ -234,7 +237,7 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
       ? {
           stage: 'done',
           resultUrl: `/jobs/${job.id}/target?match=${match.id}`,
-          flash: `${saved} and checked: AI match ${match.matchScore}/100.`,
+          flash: `${saved} and checked: AI match ${match.matchScore}/100. The headline and skills refresh in the background.`,
         }
       : {
           stage: 'error',


### PR DESCRIPTION
Closes #168.

Off `main` at v1.59.0 — the first PR of the second sweep. A fix to shipped behaviour: **v1.59.1**.

## What — the three causes, in the order the issue weighed them

- **A. The CLI's thinking budget.** `cliThinkingCap` (pure, `src/ai-provider-parse.ts`) puts `MAX_THINKING_TOKENS=0` into the `claude_code` child's env for every tool-free call; the verify call keeps the CLI's default — it reasons over search results. The variable is on the env allowlist, so an operator's own value passes through for the tool call.
- **C. Log what the call did.** `ClaudeCodeResultSchema` keeps `duration_api_ms`, `num_turns`, `usage.output_tokens` and `usage.output_tokens_details.thinking_tokens`; `CliOutcome.usage` carries them and the CLI provider logs one `ai: reply` line per call (label, provider, model, apiMs, outputTokens, thinkingTokens, turns). The API path's debug line from #159 is now the same info line (model, stop, input/cache/output/thinking tokens). `resume: scanned` logs `chars`.
- **B. The Save route no longer waits for a scan the match never reads.** `POST /resumes/:id/draft` with a job runs `scanInBackground(resume)` and goes straight to the quick check — the run has one step, and the flash says the headline and skills refresh behind it. A Save with no job keeps the awaited scan (it is the only step).
- **D, the honest half.** The run page's step copy states bands ("half a minute to a minute") instead of "about half a minute" for every engine; `docs/ai-engines.md`'s 2026-08-31 section — which blamed prompt size for Haiku's 146 s on the CLI — is rewritten with the measured cause and the cap.
- Not built: **E** (a cheaper `structure`) — its own stage with a prompt bump, as the issue said; and the Settings hint of D, because with A the Haiku lane is no longer slow, and the Resume-model field already says "judgment calls".
- CHANGELOG 1.59.1, version bump.

## Verification

- `npm run lint:types` + `npm test`: 1996 tests, 0 failures (new: the CLI reply's usage fields; the cap on tool-free calls, none on the verify call, the allowlist lets it through).
- **The scan through `claude_code` + Haiku 4.5 with the cap**, host CLI 2.1.223, resume 6's text: `ai: reply … apiMs: 40963 outputTokens: 3968 turns: 1`, the reply parsed (structure anchored). Against the issue's uncapped measurement of the same prompt (22 515 output tokens, 18 924 thinking, 227 s) that is the 34–41 s lane. This CLI version reports no `output_tokens_details`, so `thinkingTokens` is absent in the line rather than 0; the output-token count says the thinking is gone.
- **Save & re-check on a copy of the live database** (resume 6 edited by one line, vs job 2094, the engine as configured — `claude_code` + the `.env` Haiku): the run took **33 s** end to end (the issue measured 366 s on the same pair), one step (`keywords`), flash *"Saved as v2 (text version) and checked: AI match 100/100. The headline and skills refresh in the background."*; the background scan landed 12 s later (`ai: reply … apiMs: 39908 outputTokens: 3934`, `resume: scanned … chars: 13167`). The quick check itself: `apiMs: 28212 outputTokens: 2679`.
- The live containers were not touched; the copy was dropped afterwards.

## Release notes

### What's new
- Save & re-check waits for the comparison only (about half a minute on a CLI engine, where it was six minutes); the resume's headline and skills refresh in the background.
- The Claude Code CLI no longer spends its thinking budget on tool-free calls; every AI reply logs one line with its model, time and token counts.

### Schema
- no schema changes

### Verification
- 1996 tests; the scan and the Save & re-check run measured live on a copy of the live database.

### References
- #168 · #159 · ADR 0039 · docs/target-plan.md §3.1 item 2

Tag after merge: `git tag -a v1.59.1 -m "Save & re-check waits for the match only; the CLI stops thinking on tool-free calls" <merge-sha>`
