### PR TITLE
Verify: Haiku on the API path, the reason on failure, a progress page (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.59.1] — 2026-09-05
+
+### Fixed
+- **Save & re-check no longer waits six minutes on the Claude Code CLI.**
+  Three causes, all measured (#168). `claude -p` turns extended thinking on,
+  and on "copy this resume into JSON" Haiku 4.5 spent 18 924 thinking tokens
+  for a 3 500-token answer — 227 s where the same call takes 34 s with the
+  budget at zero, same structure quality: every tool-free call on the CLI
+  now runs with `MAX_THINKING_TOKENS=0` (the verify call keeps the default;
+  it reasons over search results). The Save route waited for a scan the
+  comparison never reads — it runs in the background now, as the re-upload
+  route's has since 1.14.0, and the flash says the headline and skills
+  refresh behind it. And every reply logs one line with the model, the API
+  time, the output tokens and the thinking tokens on both the CLI and the API
+  path, so a slow call, a throttled call and a thinking call stop looking
+  alike. The run page's step copy states bands instead of "about half a
+  minute" for every engine.
+
+### Notes
+- `docs/ai-engines.md`'s 2026-08-31 table blamed prompt size for Haiku's
+  146 s on the CLI; it was this thinking budget running into the 180 s
+  timeout. Corrected.
+
 ## [1.59.0] — 2026-09-05
 
 ### Changed
@@ -2414,6 +2437,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.59.1]: https://github.com/applypack/applypack/compare/v1.59.0...v1.59.1
 [1.59.0]: https://github.com/applypack/applypack/compare/v1.58.0...v1.59.0
 [1.58.0]: https://github.com/applypack/applypack/compare/v1.57.3...v1.58.0
 [1.57.3]: https://github.com/applypack/applypack/compare/v1.57.2...v1.57.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.59.2] — 2026-09-05
+
+### Fixed
+- **Verify works on the API path with Haiku 4.5.** The web-search and
+  web-fetch tools of 2026-02-09 filter their results through code execution,
+  which needs programmatic tool calling — Opus 4.6+ and Sonnet 4.6+ have it,
+  Haiku 4.5 does not and answered 400 to every verify request (#161). On
+  models without it the same tools are declared with direct calls only, the
+  API's own escape hatch.
+- **A failed verify says why.** The provider's one-line reason (keys masked)
+  reaches the run page — *"Verification failed: 'claude-haiku-4-5-20251001'
+  does not support programmatic tool calling …"* — instead of "see the web
+  logs".
+
+### Changed
+- **Verify runs on a progress page.** The free rungs (the company's board
+  API, the posting page) are a step whose answer appears under it within
+  seconds — *"the posting page renders normally (rung 2, no AI spent)"* —
+  and the research step names the seven checks it runs as it runs them;
+  closing the tab loses nothing, a second click joins the run, and the job
+  page's card says "Checking… — open the progress page" while it is in
+  flight instead of offering a second button (#161). A pasted posting with
+  no URL says so up front (`no_url`) instead of "the stored URL is not
+  safely fetchable", and its Verify goes straight to the research.
+
 ## [1.59.1] — 2026-09-05
 
 ### Fixed
@@ -2437,6 +2462,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.59.2]: https://github.com/applypack/applypack/compare/v1.59.1...v1.59.2
 [1.59.1]: https://github.com/applypack/applypack/compare/v1.59.0...v1.59.1
 [1.59.0]: https://github.com/applypack/applypack/compare/v1.58.0...v1.59.0
 [1.58.0]: https://github.com/applypack/applypack/compare/v1.57.3...v1.58.0

--- a/docs/ai-engines.md
+++ b/docs/ai-engines.md
@@ -180,7 +180,7 @@ works on macOS too.)
   failed` lists the chain that was tried. Jobs are retried on the next
   cron tick; nothing is lost.
 
-## Measured: Haiku through the Claude Code CLI cannot hold the cover-letter prompt
+## Measured: the Claude Code CLI thinks before it answers — and Haiku thinks a lot
 
 Benchmarked 2026-08-31 on one job + one resume, cover-letter role only:
 
@@ -193,14 +193,31 @@ Benchmarked 2026-08-31 on one job + one resume, cover-letter role only:
 | claude_code | haiku-4.5 | 146 s / timeout | unreliable |
 | claude_code | `haiku` alias | 2 x 180 s timeout | **failed, no letter** |
 
-The CLI is killed by our own 180 s per-attempt timeout (`code: 143,
-killed: true`), and the alias behaves the same as the dated id, so this is
-not a model-id problem. The classifier runs haiku through the same CLI all
-day without trouble — the difference is prompt size: the letter sends ~10 KB
-of system prompt plus the whole resume, the classifier sends a fraction of
-that.
+The 2026-08-31 reading of this table — "the difference is prompt size" — was
+wrong, and #168 measured the real cause on 2026-09-05 with the resume-scan
+prompt (6.2 KB system + 5.8 KB user), one call at a time:
 
-**Practical rule:** for the cover-letter role pick opus or sonnet on
-`claude_code`, or use `anthropic_api` (fastest of all). Leaving the Cover
-letter slot empty is safe — it inherits the resume model, which is opus by
-default.
+| Lane | Wall | Output tokens | of which thinking |
+|---|---:|---:|---:|
+| claude_code + haiku-4.5, CLI defaults | **227 s** | 22 515 | **18 924** |
+| claude_code + haiku-4.5, `MAX_THINKING_TOKENS=0` | **34 s** | 3 512 | 0 |
+| claude_code + opus-5, CLI defaults | 69 s | 6 975 | 2 020 |
+| anthropic_api + haiku-4.5 | 41 s | 4 106 | 0 |
+
+Every lane generates at ~100 tokens/s; `claude -p` turns extended thinking
+on, and on "copy this resume into JSON" Haiku spends ~19 000 tokens thinking
+for a 3 500-token answer. The 146 s / timeout row above was the same thing
+running into our own 180 s per-attempt timeout.
+
+**What the app does now (v1.59.1):** every tool-free call on `claude_code`
+runs the child with `MAX_THINKING_TOKENS=0` (`src/ai-provider-parse.ts:
+cliThinkingCap`); the verify call keeps the CLI's default, because it
+reasons over search results. One `ai: reply` line per call names the model,
+the API time, the output tokens and the thinking tokens on both the CLI and
+the API path, so a slow call, a throttled call and a thinking call no longer
+look alike in `docker compose logs web`.
+
+**Practical rule:** Opus or Sonnet still judge resumes better than Haiku;
+pick them for the resume and cover-letter roles on `claude_code`, or use
+`anthropic_api` (fastest of all). Leaving the Cover letter slot empty is
+safe — it inherits the resume model, which is opus by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.59.1",
+  "version": "1.59.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.59.1",
+      "version": "1.59.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.59.0",
+      "version": "1.59.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.59.1",
+  "version": "1.59.2",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -8,6 +8,8 @@ import {
   buildCodexCliArgs,
   buildGeminiCliArgs,
   CLI_PROVIDER_ENV_KEYS,
+  CLI_THINKING_CAP_ENV,
+  cliThinkingCap,
   describeAiFailure,
   parseClaudeCodeOutput,
   parseCodexCliOutput,
@@ -262,4 +264,23 @@ test('the largest answer budget keeps its full headroom under the SDK non-stream
 
 test('anthropicMaxTokens never asks for more than a non-streaming request may carry', () => {
   assert.ok(anthropicMaxTokens(100_000) <= 21_333);
+});
+
+test('the CLI reply keeps what the call spent — API time, output and thinking tokens, turns (#168)', () => {
+  const raw = JSON.stringify({
+    type: 'result', subtype: 'success', is_error: false, result: '{}',
+    duration_api_ms: 33_812, num_turns: 1,
+    usage: { output_tokens: 3_512, output_tokens_details: { thinking_tokens: 0 } },
+  });
+  assert.deepEqual(parseClaudeCodeOutput(raw).usage, { apiMs: 33_812, outputTokens: 3_512, thinkingTokens: 0, turns: 1 });
+  assert.deepEqual(parseClaudeCodeOutput(ok('{}')).usage, { apiMs: undefined, outputTokens: undefined, thinkingTokens: undefined, turns: undefined });
+});
+
+test('tool-free CLI calls get the thinking cap; the verify call keeps the CLI default', () => {
+  assert.deepEqual(cliThinkingCap(false), { MAX_THINKING_TOKENS: '0' });
+  assert.deepEqual(cliThinkingCap(undefined), { MAX_THINKING_TOKENS: '0' });
+  assert.deepEqual(cliThinkingCap(true), {});
+  assert.ok(CLI_PROVIDER_ENV_KEYS.claude_code?.includes(CLI_THINKING_CAP_ENV), 'the allowlist must let the cap through');
+  const env = buildCliEnv(CLI_PROVIDER_ENV_KEYS.claude_code ?? [], { PATH: '/bin', ...cliThinkingCap(false) });
+  assert.equal(env.MAX_THINKING_TOKENS, '0');
 });

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -12,6 +12,7 @@ import {
   cliThinkingCap,
   describeAiFailure,
   parseClaudeCodeOutput,
+  webToolsDirectOnly,
   parseCodexCliOutput,
   parseGeminiCliOutput,
   parseOpenAiChatResponse,
@@ -283,4 +284,13 @@ test('tool-free CLI calls get the thinking cap; the verify call keeps the CLI de
   assert.ok(CLI_PROVIDER_ENV_KEYS.claude_code?.includes(CLI_THINKING_CAP_ENV), 'the allowlist must let the cap through');
   const env = buildCliEnv(CLI_PROVIDER_ENV_KEYS.claude_code ?? [], { PATH: '/bin', ...cliThinkingCap(false) });
   assert.equal(env.MAX_THINKING_TOKENS, '0');
+});
+
+test('the web tools filter through code execution only where the model can call tools programmatically (#161)', () => {
+  for (const m of ['claude-opus-5', 'claude-opus-4-6', 'claude-opus-4-8', 'claude-sonnet-5', 'claude-sonnet-4-6', 'claude-fable-5-1']) {
+    assert.equal(webToolsDirectOnly(m), false, m);
+  }
+  for (const m of ['claude-haiku-4-5-20251001', 'claude-haiku-4-5', 'claude-opus-4-1-20250805', 'claude-sonnet-4-5', 'gpt-5-mini']) {
+    assert.equal(webToolsDirectOnly(m), true, m);
+  }
 });

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -68,6 +68,19 @@ export function anthropicMaxTokens(answerTokens: number): number {
  * collapses whitespace and caps the length. ADR 0027 keeps keys out of the
  * browser, and that must not depend on what a CLI happened to print.
  */
+/**
+ * The 2026-02-09 web tools filter their results through code execution, and
+ * that needs programmatic tool calling — Opus 4.6+, Sonnet 4.6+ and their
+ * successors. Haiku 4.5 (and anything older) answered 400 to the same request
+ * (#161); the API's own escape hatch is to allow direct calls only, which is
+ * the same tools without the filtering.
+ */
+const PROGRAMMATIC_TOOL_MODEL = /^claude-(opus-(4-[6-9]|5)|sonnet-(4-[6-9]|5)|fable|mythos)\b/;
+
+export function webToolsDirectOnly(model: string): boolean {
+  return !PROGRAMMATIC_TOOL_MODEL.test(model);
+}
+
 export function describeAiFailure(reason: string): string {
   const oneLine = reason.replace(/\s+/g, ' ').trim();
   if (oneLine.length === 0) return 'no reason reported';

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -13,13 +13,30 @@ const ClaudeCodeResultSchema = z.object({
   is_error: z.boolean(),
   result: z.string().optional(),
   api_error_status: z.number().nullable().optional(),
+  duration_api_ms: z.number().optional(),
+  num_turns: z.number().optional(),
+  usage: z
+    .object({
+      output_tokens: z.number().optional(),
+      output_tokens_details: z.object({ thinking_tokens: z.number().optional() }).optional(),
+    })
+    .optional(),
 });
+
+/** What one CLI call spent — logged per call, so a slow call, a throttled call and a thinking call stop looking alike (#168). */
+export interface CliUsage {
+  apiMs?: number;
+  outputTokens?: number;
+  thinkingTokens?: number;
+  turns?: number;
+}
 
 export interface CliOutcome {
   text: string | null;
   /** True for 429 / overloaded / quota — the caller may retry later. */
   rateLimited: boolean;
   error: string | null;
+  usage?: CliUsage;
 }
 
 const RATE_LIMIT_STATUS = 429;
@@ -82,7 +99,17 @@ export function parseClaudeCodeOutput(raw: string): CliOutcome {
       r.api_error_status === RATE_LIMIT_STATUS || RATE_LIMIT_PATTERN.test(message);
     return { text: null, rateLimited, error: `claude-code: ${message}` };
   }
-  return { text: r.result ?? '', rateLimited: false, error: null };
+  return {
+    text: r.result ?? '',
+    rateLimited: false,
+    error: null,
+    usage: {
+      apiMs: r.duration_api_ms,
+      outputTokens: r.usage?.output_tokens,
+      thinkingTokens: r.usage?.output_tokens_details?.thinking_tokens,
+      turns: r.num_turns,
+    },
+  };
 }
 
 /**
@@ -97,8 +124,21 @@ const CLI_BASE_ENV_KEYS = [
   'PATH', 'HOME', 'SHELL', 'TERM', 'USER', 'LOGNAME', 'TMPDIR', 'LANG', 'LC_ALL', 'TZ',
 ] as const;
 
+/**
+ * `claude -p` turns extended thinking on, and on "copy this resume into JSON"
+ * Haiku 4.5 spent ~19 000 thinking tokens for a 3 500-token answer — 227 s
+ * where the same call answers in 34 s with the budget at zero, same structure
+ * quality (#168). Every tool-free call gets the cap; the verify call keeps
+ * the CLI's default, it reasons over search results.
+ */
+export const CLI_THINKING_CAP_ENV = 'MAX_THINKING_TOKENS';
+
+export function cliThinkingCap(webTools: boolean | undefined): Record<string, string> {
+  return webTools ? {} : { [CLI_THINKING_CAP_ENV]: '0' };
+}
+
 export const CLI_PROVIDER_ENV_KEYS: Partial<Record<AiProviderId, readonly string[]>> = {
-  claude_code: ['CLAUDE_CODE_OAUTH_TOKEN', 'CLAUDE_CONFIG_DIR'],
+  claude_code: ['CLAUDE_CODE_OAUTH_TOKEN', 'CLAUDE_CONFIG_DIR', CLI_THINKING_CAP_ENV],
   gemini_cli: [
     'GEMINI_API_KEY',
     'GOOGLE_GENAI_USE_VERTEXAI',

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -12,6 +12,7 @@ import {
   buildCodexCliArgs,
   buildGeminiCliArgs,
   CLI_PROVIDER_ENV_KEYS,
+  cliThinkingCap,
   describeAiFailure,
   parseClaudeCodeOutput,
   parseCodexCliOutput,
@@ -164,7 +165,19 @@ class AnthropicApiProvider implements AiProvider {
         messages,
         tools,
       });
-      logger.debug({ label: req.label, stop: resp.stop_reason, usage: resp.usage }, 'ai: reply');
+      logger.info(
+        {
+          label: req.label,
+          provider: this.name,
+          model: resp.model,
+          stop: resp.stop_reason,
+          inputTokens: resp.usage.input_tokens,
+          cacheRead: resp.usage.cache_read_input_tokens,
+          outputTokens: resp.usage.output_tokens,
+          thinkingTokens: resp.usage.output_tokens_details?.thinking_tokens,
+        },
+        'ai: reply',
+      );
       if (resp.stop_reason === 'pause_turn' && resumes < MAX_PAUSE_TURN_RESUMES) {
         messages.push({ role: 'assistant', content: resp.content });
         continue;
@@ -271,6 +284,8 @@ interface CliSpec {
   keyEnv?: string;
   /** Working directory — set to keep the CLI away from workspace context. */
   cwd?: string;
+  /** This CLI reads MAX_THINKING_TOKENS: tool-free calls get it capped (#168). */
+  thinkingCap?: boolean;
 }
 
 /** Headless-CLI backend: spawn, parse JSON stdout, one retry on rate limit. */
@@ -308,7 +323,10 @@ class CliProvider implements AiProvider {
         return null;
       }
       const out = this.spec.parse(stdout);
-      if (out.text !== null) return out.text;
+      if (out.text !== null) {
+        logger.info({ label: req.label, provider: this.name, model: req.model, ...out.usage }, 'ai: reply');
+        return out.text;
+      }
       if (out.rateLimited && attempt < MAX_ATTEMPTS - 1) {
         logger.warn({ label: req.label, provider: this.name }, 'ai: cli rate-limited, retrying');
         await sleep(RATE_LIMIT_RETRY_DELAY_MS);
@@ -330,9 +348,12 @@ class CliProvider implements AiProvider {
    * variable in the child env, still filtered by the buildCliEnv allowlist.
    */
   private envSource(req: AiRequest): NodeJS.ProcessEnv {
-    const { keyEnv } = this.spec;
-    if (!keyEnv || !req.apiKey) return process.env;
-    return { ...process.env, [keyEnv]: req.apiKey };
+    const { keyEnv, thinkingCap } = this.spec;
+    return {
+      ...process.env,
+      ...(keyEnv && req.apiKey ? { [keyEnv]: req.apiKey } : {}),
+      ...(thinkingCap ? cliThinkingCap(req.webTools) : {}),
+    };
   }
 }
 
@@ -358,6 +379,7 @@ export function getAiProviderById(id: AiProviderId): AiProvider {
         defaultModel: config.CLAUDE_MODEL,
         envKeys: CLI_PROVIDER_ENV_KEYS.claude_code ?? [],
         keyEnv: AI_KEY_ENV_VARS.claude_code,
+        thinkingCap: true,
       });
       break;
     case 'gemini_cli':

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -18,6 +18,7 @@ import {
   parseCodexCliOutput,
   parseGeminiCliOutput,
   parseOpenAiChatResponse,
+  webToolsDirectOnly,
   type CliOutcome,
 } from './ai-provider-parse';
 import type { AiProviderId } from './ai-engine';
@@ -151,15 +152,17 @@ class AnthropicApiProvider implements AiProvider {
 
   private async run(req: AiRequest, client: Anthropic): Promise<string> {
     const messages: Anthropic.MessageParam[] = [{ role: 'user', content: req.user }];
+    const model = req.model ?? config.CLAUDE_MODEL;
+    const callers = webToolsDirectOnly(model) ? { allowed_callers: ['direct' as const] } : {};
     const tools = req.webTools
       ? [
-          { type: 'web_search_20260209' as const, name: 'web_search' as const, max_uses: WEB_SEARCH_MAX_USES },
-          { type: 'web_fetch_20260209' as const, name: 'web_fetch' as const, max_uses: WEB_FETCH_MAX_USES },
+          { type: 'web_search_20260209' as const, name: 'web_search' as const, max_uses: WEB_SEARCH_MAX_USES, ...callers },
+          { type: 'web_fetch_20260209' as const, name: 'web_fetch' as const, max_uses: WEB_FETCH_MAX_USES, ...callers },
         ]
       : undefined;
     for (let resumes = 0; ; resumes++) {
       const resp = await client.messages.create({
-        model: req.model ?? config.CLAUDE_MODEL,
+        model,
         max_tokens: anthropicMaxTokens(req.maxTokens),
         system: [{ type: 'text', text: req.system, cache_control: { type: 'ephemeral' } }],
         messages,

--- a/src/resume/scan.ts
+++ b/src/resume/scan.ts
@@ -20,7 +20,7 @@ export async function scanResume(resume: { id: number; text: string }): Promise<
   const scan = answer.data;
   await saveResumeScan(resume.id, scan, guardStructure(resume, scan));
   logger.info(
-    { id: resume.id, skills: scan.skills.length, issues: scan.issues.length, attempt: answer.attempt, ms: answer.ms },
+    { id: resume.id, skills: scan.skills.length, issues: scan.issues.length, attempt: answer.attempt, chars: answer.chars, ms: answer.ms },
     'resume: scanned',
   );
   return scan;

--- a/src/verification/liveness.test.ts
+++ b/src/verification/liveness.test.ts
@@ -6,6 +6,7 @@ import {
   isFetchableJobUrl,
   postingIdFromUrl,
   resolveLivenessProbe,
+  runLivenessLadder,
   type LivenessJobInput,
 } from './liveness';
 
@@ -374,4 +375,9 @@ describe('isFetchableJobUrl', () => {
       { liveness: 'uncertain', code: 'redirected_off_posting' },
     );
   });
+});
+
+it('a pasted posting with no URL gets its own code, not "unsafe link" (#161)', async () => {
+  // MANUAL has no board API to ask, so the ladder needs no network to answer.
+  assert.deepEqual(await runLivenessLadder(job({ url: '', atsType: 'MANUAL' })), { liveness: 'uncertain', code: 'no_url', rung: 2 });
 });

--- a/src/verification/liveness.ts
+++ b/src/verification/liveness.ts
@@ -26,6 +26,7 @@ export type LivenessCode =
   | 'insufficient_content'
   | 'page_ok'
   | 'unfetchable_url'
+  | 'no_url'
   | 'network_error'
   | 'conflicting_signals';
 
@@ -73,6 +74,7 @@ export const LIVENESS_CODE_LABEL: Record<LivenessCode, string> = {
   insufficient_content: 'the page rendered no readable content',
   page_ok: 'the posting page renders normally',
   unfetchable_url: 'the stored URL is not safely fetchable',
+  no_url: 'no posting URL stored — the free checks need one',
   network_error: 'the site could not be reached',
   conflicting_signals: 'the board API and the live page disagree',
 };
@@ -393,6 +395,8 @@ async function checkAtsApi(p: LivenessProbe): Promise<LivenessVerdict> {
 }
 
 async function checkPostingPage(url: string): Promise<LivenessVerdict> {
+  // A pasted posting often has no URL at all — that is not a dangerous link (#161).
+  if (url.trim().length === 0) return v('uncertain', 'no_url');
   if (!isFetchableJobUrl(url)) return v('uncertain', 'unfetchable_url');
   const got = await fetchRaw(url, 'follow');
   if (!got) return v('uncertain', 'network_error');

--- a/src/verification/verify.ts
+++ b/src/verification/verify.ts
@@ -21,10 +21,13 @@ export async function checkLiveness(job: LivenessJobInput & { id: number }): Pro
 }
 
 /** Runs the ghost-job check with web tools and stores the verdict. Null on AI failure. */
-export async function verifyJob(job: VerifyJobInput & { id: number }): Promise<JobVerification | null> {
+export async function verifyJob(
+  job: VerifyJobInput & { id: number },
+  onError?: (reason: string) => void,
+): Promise<JobVerification | null> {
   const answer = await askForJson(
     await getAiRuntime(),
-    { ...buildVerifyPrompt(job), maxTokens: VERIFY_MAX_TOKENS, label: 'job-verify', role: 'resume', timeoutMs: VERIFY_TIMEOUT_MS, webTools: true },
+    { ...buildVerifyPrompt(job), maxTokens: VERIFY_MAX_TOKENS, label: 'job-verify', role: 'resume', timeoutMs: VERIFY_TIMEOUT_MS, webTools: true, onError },
     parseVerifyResponse,
     { jobId: job.id },
   );

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -115,6 +115,8 @@ export interface JobDetailProps {
   pipelineStages: { key: string; label: string }[];
   verification: VerificationCardProps['verification'];
   verificationCount: number;
+  /** A verify run in flight for this job — the card points at its progress page instead of a second button (#161). */
+  verificationRun: VerificationCardProps['run'];
   resumeMatch: ResumeMatchCardProps;
   coverLetters: CoverLetterCardProps;
   flash?: FlashMessage | null;
@@ -139,6 +141,7 @@ export const JobDetailPage: FC<JobDetailProps> = ({
   pipelineStages,
   verification,
   verificationCount,
+  verificationRun,
   resumeMatch,
   coverLetters,
   flash,
@@ -275,6 +278,8 @@ export const JobDetailPage: FC<JobDetailProps> = ({
           }
           verification={verification}
           verificationCount={verificationCount}
+          run={verificationRun}
+          url={job.url}
         />
 
         <ResumeMatchCard {...resumeMatch} />

--- a/src/web/pages/run-steps.tsx
+++ b/src/web/pages/run-steps.tsx
@@ -20,7 +20,9 @@ export const RunSteps: FC<{
   /** Time already spent: finished steps from the registry, the active one as of this render. */
   stepMs?: Partial<Record<string, number>>;
   activeMs?: number;
-}> = ({ steps, currentIdx, view, stepMs = {}, activeMs }) => (
+  /** What a finished step found, in words — the free rungs of a verify run (#161). */
+  results?: Partial<Record<string, string>>;
+}> = ({ steps, currentIdx, view, stepMs = {}, activeMs, results = {} }) => (
   <>
     <ol class="mt-5 space-y-5" aria-label="Progress">
       {steps.map((s, i) => (
@@ -44,6 +46,9 @@ export const RunSteps: FC<{
               </span>
             </span>
             <span class="t-detail block text-xs">{view[s]?.detail}</span>
+            <span class="t-result block text-[13px] leading-5 text-ink-muted" data-result>
+              {results[s] ?? ''}
+            </span>
             <span
               class="t-activity mt-1.5 block text-[13px] leading-5 text-violet transition-opacity duration-300"
               data-activity

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -18,11 +18,11 @@ const STEP_VIEW: Record<RunStep, StepView> = {
     // Also reached by a plain re-scan and a first upload, where there is no
     // "new version" to speak of.
     label: 'Read the resume',
-    detail: 'headline, skills, ATS issues — about half a minute',
+    detail: 'headline, skills, ATS issues, the resume as a shape — half a minute to a minute',
   },
   keywords: {
     label: 'Quick AI check',
-    detail: 'the resume model judges every keyword, the gates and the score — no edit suggestions — about half a minute on Opus',
+    detail: 'the resume model judges every keyword, the gates and the score — no edit suggestions — half a minute to a minute',
   },
   match: {
     label: 'Full AI analysis',

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -6,6 +6,10 @@ import { RunSteps, type StepView } from './run-steps';
 import type { RunStep, TargetRun } from '../target-runs';
 
 const STEP_VIEW: Record<RunStep, StepView> = {
+  liveness: {
+    label: 'Ask the board and read the posting page',
+    detail: 'the free checks — seconds, no AI spent',
+  },
   fetch: {
     label: 'Read the posting page',
     detail: 'one request to the URL you gave — seconds',
@@ -34,7 +38,7 @@ const STEP_VIEW: Record<RunStep, StepView> = {
   },
   verify: {
     label: 'Research the company',
-    detail: 'ghost-check with web search — 2 to 4 minutes',
+    detail: 'seven named checks with web search — careers page, LinkedIn, reputation, posting age, salary, named humans, the posting itself — 2 to 4 minutes',
   },
   letter: {
     label: 'Write the cover letter',
@@ -100,6 +104,7 @@ export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
                 view={STEP_VIEW}
                 stepMs={run.stepMs}
                 activeMs={Date.now() - run.stageAt}
+                results={run.results}
               />
               <div class="mt-5 flex items-center justify-between gap-3 border-t border-line pt-3">
                 <Hint>

--- a/src/web/pages/verification-card.tsx
+++ b/src/web/pages/verification-card.tsx
@@ -15,9 +15,13 @@ export interface JobLivenessView {
 
 export interface VerificationCardProps {
   jobId: number;
+  /** Empty for a pasted posting — the free checks have nothing to ask then (#161). */
+  url: string;
   liveness: JobLivenessView | null;
   verification: JobVerification | null;
   verificationCount: number;
+  /** A run in flight: the buttons give way to a link to its progress page. */
+  run: { id: string; startedAt: number } | null;
 }
 
 const LIVENESS_VIEW: Record<string, { label: string; tone: Tone }> = {
@@ -55,9 +59,11 @@ const CHECK_LABEL: Record<VerificationEvidence['check'], string> = {
 
 export const VerificationCard: FC<VerificationCardProps> = ({
   jobId,
+  url,
   liveness,
   verification,
   verificationCount,
+  run,
 }) => (
   <div id="verification">
     <Card>
@@ -101,17 +107,25 @@ export const VerificationCard: FC<VerificationCardProps> = ({
           )}
         </div>
         <div class="flex shrink-0 flex-wrap items-center gap-2">
-          <ActionForm action={`/jobs/${jobId}/verify`}>
-            <Button variant={liveness || verification ? 'secondary' : 'violet'} size="sm">
-              {liveness || verification ? 'Re-check' : 'Verify'}
+          {run ? (
+            <Button href={`/target/runs/${run.id}`} variant="secondary" size="sm">
+              Checking… started {formatRelative(new Date(run.startedAt))} — open the progress page
             </Button>
-          </ActionForm>
-          {liveness && liveness.liveness !== 'uncertain' && (
-            <ActionForm action={`/jobs/${jobId}/verify`} hidden={{ deep: 1 }}>
-              <Button variant="violet" size="sm">
-                Deep check (AI)
-              </Button>
-            </ActionForm>
+          ) : (
+            <>
+              <ActionForm action={`/jobs/${jobId}/verify`}>
+                <Button variant={liveness || verification ? 'secondary' : 'violet'} size="sm">
+                  {liveness || verification ? 'Re-check' : 'Verify'}
+                </Button>
+              </ActionForm>
+              {liveness && liveness.liveness !== 'uncertain' && (
+                <ActionForm action={`/jobs/${jobId}/verify`} hidden={{ deep: 1 }}>
+                  <Button variant="violet" size="sm">
+                    Deep check (AI)
+                  </Button>
+                </ActionForm>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -150,8 +164,9 @@ export const VerificationCard: FC<VerificationCardProps> = ({
       )}
       {!verification && (
         <Hint class="mt-3">
-          The free checks answer in seconds; the AI deep check searches and reads pages for 2-4
-          minutes before answering.
+          {url
+            ? 'The free checks answer in seconds; the AI deep check searches and reads pages for 2-4 minutes before answering. Either way it runs on a progress page you can leave.'
+            : 'This posting has no URL, so the free checks have nothing to ask — Verify goes straight to the AI research, 2-4 minutes on a progress page you can leave.'}
         </Hint>
       )}
     </Card>

--- a/src/web/public/target-run.mjs
+++ b/src/web/public/target-run.mjs
@@ -41,11 +41,17 @@ const ACTIVITIES = {
     'Drafting edit suggestions with exact quotes…',
     'Listing what to remove and what already sells you…',
   ],
+  liveness: ["Asking the company's board API…", 'Reading the posting page…'],
+  // The prompt's seven named checks (EVIDENCE_CHECKS), in its order.
   verify: [
-    'Searching for the company and this posting…',
-    'Cross-checking the careers page and the ATS…',
-    'Weighing ghost-job signals…',
-    'Writing the company snapshot…',
+    "Looking for the company's careers page and this posting on it…",
+    'Searching LinkedIn for the company and the role…',
+    'Reading reputation and scam reports…',
+    'Judging how long the posting has been up…',
+    'Comparing the salary with the market…',
+    'Looking for named humans behind the posting…',
+    "Weighing the posting's own quality…",
+    'Writing the verdict and the company snapshot…',
   ],
   letter: [
     'Reading the posting and the resume…',
@@ -119,6 +125,8 @@ export function init(data, activity = defaultActivity) {
       li.dataset.state = idx === -1 || i < idx ? 'done' : i === idx ? 'active' : 'pending';
       const timeEl = li.querySelector('[data-step-time]');
       if (timeEl) timeEl.textContent = stepTime(li.dataset.state, li.dataset.step, state);
+      const resultEl = li.querySelector('[data-result]');
+      if (resultEl && state.results) resultEl.textContent = state.results[li.dataset.step] ?? '';
     }
     const active = steps.find((li) => li.dataset.state === 'active');
     if (!active) return;

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -35,7 +35,7 @@ import { draftStash } from '../draft-stash';
 import { scanInBackground } from '../../resume/scan';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
-import { claimRun, matchStep, startRun, updateRun } from '../target-runs';
+import { claimRun, findLiveRun, matchStep, startRun, updateRun } from '../target-runs';
 import { startSuggestionsRun } from '../suggestions-run';
 import {
   deleteCoverLettersForResume,
@@ -387,6 +387,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
       pipelineStages={allStages(parseStageConfig(settings.pipelineStages))}
       verification={verifications[0] ?? null}
       verificationCount={verifications.length}
+      verificationRun={verifyRunView(id)}
       resumeMatch={{
         jobId: id,
         resumes: resumes.map((r) => ({ id: r.id, name: r.name, isDefault: r.isDefault })),
@@ -500,44 +501,89 @@ jobsRoute.post('/jobs/:id/verify', async (c) => {
   if (!job) return c.text('Not found', 404);
 
   // Rungs 1-2 (ADR 0016): free ATS-API / page checks. A resolved verdict
-  // stops here at $0; `deep=1` (the "Deep check" button) always goes to AI.
+  // stops there at $0; `deep=1` (the "Deep check" button) always goes to AI.
+  // The whole ladder runs on the progress page (#161): the free rungs' answer
+  // lands under their step within seconds, the research step names what it
+  // checks, and a closed tab loses nothing. One run per job at a time.
   const form = await c.req.parseBody().catch(() => ({}) as Record<string, unknown>);
   const deep = form['deep'] === '1';
-  const live = await checkLiveness({
-    id: job.id,
-    url: job.url,
-    externalId: job.externalId,
-    atsType: job.company.atsType,
-    atsToken: job.company.atsToken,
+  const back = `/jobs/${id}#verification`;
+  const { run, joined } = claimRun(VERIFY_RUN_KEY(id), {
+    steps: deep ? ['verify'] : ['liveness', 'verify'],
+    jobTitle: job.title,
+    resumeName: '',
+    jobId: id,
+    heading: { running: 'Checking whether the job is real', failed: 'The check failed' },
+    subtitle: deep
+      ? 'Straight to the AI research.'
+      : job.url
+        ? 'The free checks first; the AI only when they cannot say.'
+        : 'No posting URL stored, so the free checks have nothing to ask — straight to the AI research.',
+    backUrl: back,
+    backLabel: 'Back to the job',
   });
-  if (!deep && live.liveness !== 'uncertain') {
-    const how = `${LIVENESS_CODE_LABEL[live.code]} (rung ${live.rung}, no AI spent)`;
-    return live.liveness === 'expired'
-      ? flashRedirect(`/jobs/${id}#verification`, 'warn', `Posting looks closed — ${how}.`)
-      : flashRedirect(
-          `/jobs/${id}#verification`,
-          'ok',
-          `Posting is live — ${how}. Deep check runs the full ghost-job analysis.`,
-        );
-  }
-
-  const row = await verifyJob({
-    id: job.id,
-    title: job.title,
-    companyName: job.company.name,
-    location: job.location,
-    url: job.url,
-    description: job.description,
-    postedAt: job.postedAt,
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
+  startRun(run.id, async () => {
+    if (!deep) {
+      const live = await checkLiveness({
+        id: job.id,
+        url: job.url,
+        externalId: job.externalId,
+        atsType: job.company.atsType,
+        atsToken: job.company.atsToken,
+      });
+      const how = `${LIVENESS_CODE_LABEL[live.code]} (rung ${live.rung}, no AI spent)`;
+      updateRun(run.id, { results: { liveness: how } });
+      if (live.liveness !== 'uncertain') {
+        updateRun(run.id, {
+          stage: 'done',
+          resultUrl: back,
+          flashKind: live.liveness === 'expired' ? 'warn' : 'ok',
+          flash:
+            live.liveness === 'expired'
+              ? `Posting looks closed — ${how}.`
+              : `Posting is live — ${how}. Deep check runs the full ghost-job analysis.`,
+        });
+        return;
+      }
+      updateRun(run.id, { stage: 'verify' });
+    }
+    let reason: string | null = null;
+    const row = await verifyJob(
+      {
+        id: job.id,
+        title: job.title,
+        companyName: job.company.name,
+        location: job.location,
+        url: job.url,
+        description: job.description,
+        postedAt: job.postedAt,
+      },
+      (r) => {
+        reason = r;
+      },
+    );
+    updateRun(
+      run.id,
+      row
+        ? {
+            stage: 'done',
+            resultUrl: back,
+            flash: `Verified: ${row.verdict} (${row.confidence}% confidence) — recommendation: ${row.recommendation}.`,
+          }
+        : { stage: 'error', error: `Verification failed${reason ? `: ${reason}` : ' — see the web logs'}.` },
+    );
   });
-  return row
-    ? flashRedirect(
-        `/jobs/${id}#verification`,
-        'ok',
-        `Verified: ${row.verdict} (${row.confidence}% confidence) — recommendation: ${row.recommendation}.`,
-      )
-    : flashRedirect(`/jobs/${id}#verification`, 'err', 'Verification failed — see the web logs.');
+  return c.redirect(`/target/runs/${run.id}`, 303);
 });
+
+/** One verify run per job at a time — a second click joins it, a reload of the job page sees it. */
+const VERIFY_RUN_KEY = (jobId: number): string => `verify:${jobId}`;
+
+function verifyRunView(jobId: number): { id: string; startedAt: number } | null {
+  const run = findLiveRun(VERIFY_RUN_KEY(jobId));
+  return run ? { id: run.id, startedAt: run.startedAt } : null;
+}
 
 jobsRoute.post('/jobs/:id/match', async (c) => {
   const id = Number(c.req.param('id'));

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -3,7 +3,7 @@ import { Hono, type Context } from 'hono';
 import { logger } from '../../logger';
 import type { ResumeReview } from '@prisma/client';
 import { reviewResume } from '../../resume/review';
-import { scanResume } from '../../resume/scan';
+import { scanInBackground, scanResume } from '../../resume/scan';
 import type { ResumeScan } from '../../resume/prompts';
 import { matchResumeToJob } from '../../resume/match';
 import { prisma } from '../../db';
@@ -193,7 +193,7 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
   // a duplicate version behind whatever the run registry then did. Keyed on
   // the text, because that is what the user submitted (issue #76).
   const { run, joined } = claimRun(`draft:${id}:${hashShortId(text)}:${job?.id ?? ''}:${asCopy ? 'copy' : 'version'}`, {
-    steps: job ? ['scan', 'keywords'] : ['scan'],
+    steps: job ? ['keywords'] : ['scan'],
     jobTitle: job?.title ?? '',
     resumeName: '',
     jobId: job?.id,
@@ -213,16 +213,19 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
     const saved = asCopy ? `Saved as a new resume "${resume.name}" (${note})` : `Saved as v${resume.version} (${note})`;
     updateRun(run.id, {
       resumeName: resume.name,
-      subtitle: `${saved}.${job ? ' Reading it, then scoring it against the posting.' : ''}`,
+      subtitle: `${saved}.${job ? ' Scoring it against the posting.' : ''}`,
     });
-    const scan = await scanResume(resume);
     if (!job) {
+      const scan = await scanResume(resume);
       updateRun(run.id, scan
         ? { stage: 'done', resultUrl: `/resumes/${resume.id}`, flash: `${saved}.` }
         : { stage: 'error', error: `${saved}, but the scan failed — try "Scan".` });
       return;
     }
-    updateRun(run.id, { stage: 'keywords' });
+    // The match reads the text, never the scan (target-plan §3.1 item 2), so
+    // the scan runs behind it as the re-upload route's does — it was 63 % of
+    // a six-minute wait on a CLI engine (#168).
+    scanInBackground(resume);
     const match = await matchResumeToJob(resume, {
       id: job.id,
       title: job.title,
@@ -234,7 +237,7 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
       ? {
           stage: 'done',
           resultUrl: `/jobs/${job.id}/target?match=${match.id}`,
-          flash: `${saved} and checked: AI match ${match.matchScore}/100.`,
+          flash: `${saved} and checked: AI match ${match.matchScore}/100. The headline and skills refresh in the background.`,
         }
       : {
           stage: 'error',

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -82,6 +82,7 @@ targetRoute.get('/target/runs/:id/state', (c) => {
     steps: run.steps,
     jobTitle: run.jobTitle,
     progress: run.progress ?? null,
+    results: run.results ?? {},
     stepMs: run.stepMs,
     stageElapsedMs: Date.now() - run.stageAt,
     elapsedMs: Date.now() - run.startedAt,
@@ -95,7 +96,7 @@ targetRoute.get('/target/runs/:id', (c) => {
     return flashRedirect('/target', 'err', 'That comparison run is gone (runs live ~30 min). Start again.');
   }
   if (run.stage === 'done' && run.resultUrl) {
-    return flashRedirect(run.resultUrl, run.reused ? 'warn' : 'ok', run.flash ?? 'Done.', {
+    return flashRedirect(run.resultUrl, run.flashKind ?? (run.reused ? 'warn' : 'ok'), run.flash ?? 'Done.', {
       rerun: run.reused,
       tailor: run.tailorUrl,
     });

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -11,6 +11,7 @@ import type { MatchMode } from '../resume/match-mode';
  */
 
 export type RunStep =
+  | 'liveness'
   | 'fetch'
   | 'extract'
   | 'scan'
@@ -47,6 +48,10 @@ export interface TargetRun {
   /** Page copy for runs that are not a comparison (the wizard's scan / score). */
   heading?: { running: string; failed: string };
   subtitle?: string;
+  /** One line under a finished step — what the free rungs found, in words (#161). */
+  results?: Partial<Record<RunStep, string>>;
+  /** The tone of the done-flash; 'ok' unless the run says otherwise ("posting looks closed"). */
+  flashKind?: 'ok' | 'warn';
   /** Data-driven progress of the active step, when the job reports it. */
   progress?: { done: number; total: number };
   /** Set on done: where to send the user, with the flash to show there. */


### PR DESCRIPTION
Closes #161.

Stacked on #181 (`thinking-cap`) — merge that first; GitHub retargets this one on its own. Two fixes and one change to shipped behaviour: **v1.59.2**.

## What — the three causes

- **1. The API path 400s on Haiku 4.5.** The 2026-02-09 web tools filter their results through code execution, which needs programmatic tool calling; Haiku 4.5 has none. `webToolsDirectOnly(model)` (pure, `ai-provider-parse.ts`) says which models lack it — anything but Opus 4.6+, Sonnet 4.6+, Fable, Mythos — and for those the same two tools are declared with `allowed_callers: ['direct']`, the escape hatch the error itself names. Opus and Sonnet keep the filtering. Decided by the live call the issue asked for (below).
- **2. The reason reaches the page.** `verifyJob(job, onError?)` forwards the provider's one-line, key-masked reason; the run's error state shows *"Verification failed: …"* instead of "see the web logs".
- **3. Verify runs on a progress page.** `POST /jobs/:id/verify` claims `verify:<jobId>` in the run registry with steps `liveness` + `verify` (`deep=1` → `verify` only). The free rungs' answer lands as a result line under their step (`TargetRun.results`, rendered by `RunSteps` and kept fresh by the poller); a resolved verdict ends the run there with today's flash, in the right tone (`flashKind`); the research step's activity line walks the prompt's seven named checks in order; a second click joins the run; the job page's card says *"Checking… started 3s ago — open the progress page"* while it runs; closing the tab loses nothing.
- **The smaller finding.** An empty URL is `no_url` ("no posting URL stored — the free checks need one"), not "the stored URL is not safely fetchable"; the card's hint says up front that such a posting goes straight to the research.
- Not built: streaming the tool calls into the activity line (the "Real" option) — the checklist is the "minimal" option the issue accepted; the stream-event parser stays a follow-up.
- CHANGELOG 1.59.2, version bump.

## Verification

- `npm run lint:types` + `npm test`: 1998 tests, 0 failures (new: the model → direct-only table; `no_url` from the ladder on a MANUAL job with an empty URL).
- **Cause 1, live** — the verify prompt of job 2094 (the pasted Hospitable posting) on `anthropic_api` with `claude-haiku-4-5-20251001` and the web tools: **40 s, `legit / apply / 92 %`, 8 evidence rows, a 441-char snapshot**, `stop: end_turn`, 2 852 output tokens, 138 481 tokens read from cache. On v1.59.0 the same request was a 400 in 270 ms.
- **Cause 3, live on a copy of the live database** (the engine as configured there: `claude_code` + Haiku, web tools):
  - `POST /jobs/2094/verify` → 303 to `/target/runs/…`; at t+3 s the state route reported stage `verify`, steps `['liveness', 'verify']`, `results.liveness = "no posting URL stored — the free checks need one (rung 2, no AI spent)"`;
  - `/jobs/2094` mid-run: *"Checking… started 3s ago — open the progress page"*;
  - a second `POST` redirected to the **same** run id;
  - done after 127 s → `/jobs/2094#verification`, flash `ok` *"Verified: legit (82% confidence) — recommendation: apply."*
- The live containers were not touched.

## Release notes

### What's new
- "Is this job real?" works on the Anthropic API with Haiku 4.5, says why when it fails, and runs on a progress page: the free checks answer under their step within seconds, the research step names the seven checks it runs, and a posting without a URL says so instead of "unsafe link".

### Schema
- no schema changes

### Verification
- 1998 tests; one live verify on the API path with Haiku (the 400 case, now a verdict); the run page driven end to end on a copy of the live database.

### References
- #161 · #97 · ADR 0009 · ADR 0016

Tag after merge: `git tag -a v1.59.2 -m "Verify: Haiku on the API path, the reason on failure, a progress page" <merge-sha>`
