### PR TITLE
The comparison reads the verification (#162, stages 0–1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.60.0] — 2026-09-05
+
+### Added
+- **The comparison reads the verification.** The Resume match card and the
+  resume editor's header carry one line from the latest "Is this job real?"
+  verdict — *"Verification says apply with caution (72 %): the posting cannot
+  be found on any public board. A quick check is enough here."* — with a link
+  to the evidence; `skip` warns that a comparison may be wasted effort and
+  Compare still works; a job never verified says so on the card and points at
+  Verify. The verifier's red flags and a ghost / scam reading of the posting's
+  own text appear under "Worth knowing — not scored", labelled *From
+  verification* (#162, stages 0 and 1). Nothing is stored on the match row, no
+  AI is spent, and the score does not move — a finding about the posting is
+  not a finding about the resume.
+
 ## [1.59.2] — 2026-09-05
 
 ### Fixed
@@ -2462,6 +2477,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.60.0]: https://github.com/applypack/applypack/compare/v1.59.2...v1.60.0
 [1.59.2]: https://github.com/applypack/applypack/compare/v1.59.1...v1.59.2
 [1.59.1]: https://github.com/applypack/applypack/compare/v1.59.0...v1.59.1
 [1.59.0]: https://github.com/applypack/applypack/compare/v1.58.0...v1.59.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.59.1] — 2026-09-05
+
+### Fixed
+- **Save & re-check no longer waits six minutes on the Claude Code CLI.**
+  Three causes, all measured (#168). `claude -p` turns extended thinking on,
+  and on "copy this resume into JSON" Haiku 4.5 spent 18 924 thinking tokens
+  for a 3 500-token answer — 227 s where the same call takes 34 s with the
+  budget at zero, same structure quality: every tool-free call on the CLI
+  now runs with `MAX_THINKING_TOKENS=0` (the verify call keeps the default;
+  it reasons over search results). The Save route waited for a scan the
+  comparison never reads — it runs in the background now, as the re-upload
+  route's has since 1.14.0, and the flash says the headline and skills
+  refresh behind it. And every reply logs one line with the model, the API
+  time, the output tokens and the thinking tokens on both the CLI and the API
+  path, so a slow call, a throttled call and a thinking call stop looking
+  alike. The run page's step copy states bands instead of "about half a
+  minute" for every engine.
+
+### Notes
+- `docs/ai-engines.md`'s 2026-08-31 table blamed prompt size for Haiku's
+  146 s on the CLI; it was this thinking budget running into the 180 s
+  timeout. Corrected.
+
 ## [1.59.0] — 2026-09-05
 
 ### Changed
@@ -2414,6 +2437,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.59.1]: https://github.com/applypack/applypack/compare/v1.59.0...v1.59.1
 [1.59.0]: https://github.com/applypack/applypack/compare/v1.58.0...v1.59.0
 [1.58.0]: https://github.com/applypack/applypack/compare/v1.57.3...v1.58.0
 [1.57.3]: https://github.com/applypack/applypack/compare/v1.57.2...v1.57.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.59.2] — 2026-09-05
+
+### Fixed
+- **Verify works on the API path with Haiku 4.5.** The web-search and
+  web-fetch tools of 2026-02-09 filter their results through code execution,
+  which needs programmatic tool calling — Opus 4.6+ and Sonnet 4.6+ have it,
+  Haiku 4.5 does not and answered 400 to every verify request (#161). On
+  models without it the same tools are declared with direct calls only, the
+  API's own escape hatch.
+- **A failed verify says why.** The provider's one-line reason (keys masked)
+  reaches the run page — *"Verification failed: 'claude-haiku-4-5-20251001'
+  does not support programmatic tool calling …"* — instead of "see the web
+  logs".
+
+### Changed
+- **Verify runs on a progress page.** The free rungs (the company's board
+  API, the posting page) are a step whose answer appears under it within
+  seconds — *"the posting page renders normally (rung 2, no AI spent)"* —
+  and the research step names the seven checks it runs as it runs them;
+  closing the tab loses nothing, a second click joins the run, and the job
+  page's card says "Checking… — open the progress page" while it is in
+  flight instead of offering a second button (#161). A pasted posting with
+  no URL says so up front (`no_url`) instead of "the stored URL is not
+  safely fetchable", and its Verify goes straight to the research.
+
 ## [1.59.1] — 2026-09-05
 
 ### Fixed
@@ -2437,6 +2462,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.59.2]: https://github.com/applypack/applypack/compare/v1.59.1...v1.59.2
 [1.59.1]: https://github.com/applypack/applypack/compare/v1.59.0...v1.59.1
 [1.59.0]: https://github.com/applypack/applypack/compare/v1.58.0...v1.59.0
 [1.58.0]: https://github.com/applypack/applypack/compare/v1.57.3...v1.58.0

--- a/docs/ai-engines.md
+++ b/docs/ai-engines.md
@@ -180,7 +180,7 @@ works on macOS too.)
   failed` lists the chain that was tried. Jobs are retried on the next
   cron tick; nothing is lost.
 
-## Measured: Haiku through the Claude Code CLI cannot hold the cover-letter prompt
+## Measured: the Claude Code CLI thinks before it answers — and Haiku thinks a lot
 
 Benchmarked 2026-08-31 on one job + one resume, cover-letter role only:
 
@@ -193,14 +193,31 @@ Benchmarked 2026-08-31 on one job + one resume, cover-letter role only:
 | claude_code | haiku-4.5 | 146 s / timeout | unreliable |
 | claude_code | `haiku` alias | 2 x 180 s timeout | **failed, no letter** |
 
-The CLI is killed by our own 180 s per-attempt timeout (`code: 143,
-killed: true`), and the alias behaves the same as the dated id, so this is
-not a model-id problem. The classifier runs haiku through the same CLI all
-day without trouble — the difference is prompt size: the letter sends ~10 KB
-of system prompt plus the whole resume, the classifier sends a fraction of
-that.
+The 2026-08-31 reading of this table — "the difference is prompt size" — was
+wrong, and #168 measured the real cause on 2026-09-05 with the resume-scan
+prompt (6.2 KB system + 5.8 KB user), one call at a time:
 
-**Practical rule:** for the cover-letter role pick opus or sonnet on
-`claude_code`, or use `anthropic_api` (fastest of all). Leaving the Cover
-letter slot empty is safe — it inherits the resume model, which is opus by
-default.
+| Lane | Wall | Output tokens | of which thinking |
+|---|---:|---:|---:|
+| claude_code + haiku-4.5, CLI defaults | **227 s** | 22 515 | **18 924** |
+| claude_code + haiku-4.5, `MAX_THINKING_TOKENS=0` | **34 s** | 3 512 | 0 |
+| claude_code + opus-5, CLI defaults | 69 s | 6 975 | 2 020 |
+| anthropic_api + haiku-4.5 | 41 s | 4 106 | 0 |
+
+Every lane generates at ~100 tokens/s; `claude -p` turns extended thinking
+on, and on "copy this resume into JSON" Haiku spends ~19 000 tokens thinking
+for a 3 500-token answer. The 146 s / timeout row above was the same thing
+running into our own 180 s per-attempt timeout.
+
+**What the app does now (v1.59.1):** every tool-free call on `claude_code`
+runs the child with `MAX_THINKING_TOKENS=0` (`src/ai-provider-parse.ts:
+cliThinkingCap`); the verify call keeps the CLI's default, because it
+reasons over search results. One `ai: reply` line per call names the model,
+the API time, the output tokens and the thinking tokens on both the CLI and
+the API path, so a slow call, a throttled call and a thinking call no longer
+look alike in `docker compose logs web`.
+
+**Practical rule:** Opus or Sonnet still judge resumes better than Haiku;
+pick them for the resume and cover-letter roles on `claude_code`, or use
+`anthropic_api` (fastest of all). Leaving the Cover letter slot empty is
+safe — it inherits the resume model, which is opus by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.59.1",
+  "version": "1.59.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.59.1",
+      "version": "1.59.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.59.0",
+      "version": "1.59.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.59.2",
+  "version": "1.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.59.2",
+      "version": "1.60.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.59.1",
+  "version": "1.59.2",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.59.2",
+  "version": "1.60.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -8,6 +8,8 @@ import {
   buildCodexCliArgs,
   buildGeminiCliArgs,
   CLI_PROVIDER_ENV_KEYS,
+  CLI_THINKING_CAP_ENV,
+  cliThinkingCap,
   describeAiFailure,
   parseClaudeCodeOutput,
   parseCodexCliOutput,
@@ -262,4 +264,23 @@ test('the largest answer budget keeps its full headroom under the SDK non-stream
 
 test('anthropicMaxTokens never asks for more than a non-streaming request may carry', () => {
   assert.ok(anthropicMaxTokens(100_000) <= 21_333);
+});
+
+test('the CLI reply keeps what the call spent — API time, output and thinking tokens, turns (#168)', () => {
+  const raw = JSON.stringify({
+    type: 'result', subtype: 'success', is_error: false, result: '{}',
+    duration_api_ms: 33_812, num_turns: 1,
+    usage: { output_tokens: 3_512, output_tokens_details: { thinking_tokens: 0 } },
+  });
+  assert.deepEqual(parseClaudeCodeOutput(raw).usage, { apiMs: 33_812, outputTokens: 3_512, thinkingTokens: 0, turns: 1 });
+  assert.deepEqual(parseClaudeCodeOutput(ok('{}')).usage, { apiMs: undefined, outputTokens: undefined, thinkingTokens: undefined, turns: undefined });
+});
+
+test('tool-free CLI calls get the thinking cap; the verify call keeps the CLI default', () => {
+  assert.deepEqual(cliThinkingCap(false), { MAX_THINKING_TOKENS: '0' });
+  assert.deepEqual(cliThinkingCap(undefined), { MAX_THINKING_TOKENS: '0' });
+  assert.deepEqual(cliThinkingCap(true), {});
+  assert.ok(CLI_PROVIDER_ENV_KEYS.claude_code?.includes(CLI_THINKING_CAP_ENV), 'the allowlist must let the cap through');
+  const env = buildCliEnv(CLI_PROVIDER_ENV_KEYS.claude_code ?? [], { PATH: '/bin', ...cliThinkingCap(false) });
+  assert.equal(env.MAX_THINKING_TOKENS, '0');
 });

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -12,6 +12,7 @@ import {
   cliThinkingCap,
   describeAiFailure,
   parseClaudeCodeOutput,
+  webToolsDirectOnly,
   parseCodexCliOutput,
   parseGeminiCliOutput,
   parseOpenAiChatResponse,
@@ -283,4 +284,13 @@ test('tool-free CLI calls get the thinking cap; the verify call keeps the CLI de
   assert.ok(CLI_PROVIDER_ENV_KEYS.claude_code?.includes(CLI_THINKING_CAP_ENV), 'the allowlist must let the cap through');
   const env = buildCliEnv(CLI_PROVIDER_ENV_KEYS.claude_code ?? [], { PATH: '/bin', ...cliThinkingCap(false) });
   assert.equal(env.MAX_THINKING_TOKENS, '0');
+});
+
+test('the web tools filter through code execution only where the model can call tools programmatically (#161)', () => {
+  for (const m of ['claude-opus-5', 'claude-opus-4-6', 'claude-opus-4-8', 'claude-sonnet-5', 'claude-sonnet-4-6', 'claude-fable-5-1']) {
+    assert.equal(webToolsDirectOnly(m), false, m);
+  }
+  for (const m of ['claude-haiku-4-5-20251001', 'claude-haiku-4-5', 'claude-opus-4-1-20250805', 'claude-sonnet-4-5', 'gpt-5-mini']) {
+    assert.equal(webToolsDirectOnly(m), true, m);
+  }
 });

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -68,6 +68,19 @@ export function anthropicMaxTokens(answerTokens: number): number {
  * collapses whitespace and caps the length. ADR 0027 keeps keys out of the
  * browser, and that must not depend on what a CLI happened to print.
  */
+/**
+ * The 2026-02-09 web tools filter their results through code execution, and
+ * that needs programmatic tool calling — Opus 4.6+, Sonnet 4.6+ and their
+ * successors. Haiku 4.5 (and anything older) answered 400 to the same request
+ * (#161); the API's own escape hatch is to allow direct calls only, which is
+ * the same tools without the filtering.
+ */
+const PROGRAMMATIC_TOOL_MODEL = /^claude-(opus-(4-[6-9]|5)|sonnet-(4-[6-9]|5)|fable|mythos)\b/;
+
+export function webToolsDirectOnly(model: string): boolean {
+  return !PROGRAMMATIC_TOOL_MODEL.test(model);
+}
+
 export function describeAiFailure(reason: string): string {
   const oneLine = reason.replace(/\s+/g, ' ').trim();
   if (oneLine.length === 0) return 'no reason reported';

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -13,13 +13,30 @@ const ClaudeCodeResultSchema = z.object({
   is_error: z.boolean(),
   result: z.string().optional(),
   api_error_status: z.number().nullable().optional(),
+  duration_api_ms: z.number().optional(),
+  num_turns: z.number().optional(),
+  usage: z
+    .object({
+      output_tokens: z.number().optional(),
+      output_tokens_details: z.object({ thinking_tokens: z.number().optional() }).optional(),
+    })
+    .optional(),
 });
+
+/** What one CLI call spent — logged per call, so a slow call, a throttled call and a thinking call stop looking alike (#168). */
+export interface CliUsage {
+  apiMs?: number;
+  outputTokens?: number;
+  thinkingTokens?: number;
+  turns?: number;
+}
 
 export interface CliOutcome {
   text: string | null;
   /** True for 429 / overloaded / quota — the caller may retry later. */
   rateLimited: boolean;
   error: string | null;
+  usage?: CliUsage;
 }
 
 const RATE_LIMIT_STATUS = 429;
@@ -82,7 +99,17 @@ export function parseClaudeCodeOutput(raw: string): CliOutcome {
       r.api_error_status === RATE_LIMIT_STATUS || RATE_LIMIT_PATTERN.test(message);
     return { text: null, rateLimited, error: `claude-code: ${message}` };
   }
-  return { text: r.result ?? '', rateLimited: false, error: null };
+  return {
+    text: r.result ?? '',
+    rateLimited: false,
+    error: null,
+    usage: {
+      apiMs: r.duration_api_ms,
+      outputTokens: r.usage?.output_tokens,
+      thinkingTokens: r.usage?.output_tokens_details?.thinking_tokens,
+      turns: r.num_turns,
+    },
+  };
 }
 
 /**
@@ -97,8 +124,21 @@ const CLI_BASE_ENV_KEYS = [
   'PATH', 'HOME', 'SHELL', 'TERM', 'USER', 'LOGNAME', 'TMPDIR', 'LANG', 'LC_ALL', 'TZ',
 ] as const;
 
+/**
+ * `claude -p` turns extended thinking on, and on "copy this resume into JSON"
+ * Haiku 4.5 spent ~19 000 thinking tokens for a 3 500-token answer — 227 s
+ * where the same call answers in 34 s with the budget at zero, same structure
+ * quality (#168). Every tool-free call gets the cap; the verify call keeps
+ * the CLI's default, it reasons over search results.
+ */
+export const CLI_THINKING_CAP_ENV = 'MAX_THINKING_TOKENS';
+
+export function cliThinkingCap(webTools: boolean | undefined): Record<string, string> {
+  return webTools ? {} : { [CLI_THINKING_CAP_ENV]: '0' };
+}
+
 export const CLI_PROVIDER_ENV_KEYS: Partial<Record<AiProviderId, readonly string[]>> = {
-  claude_code: ['CLAUDE_CODE_OAUTH_TOKEN', 'CLAUDE_CONFIG_DIR'],
+  claude_code: ['CLAUDE_CODE_OAUTH_TOKEN', 'CLAUDE_CONFIG_DIR', CLI_THINKING_CAP_ENV],
   gemini_cli: [
     'GEMINI_API_KEY',
     'GOOGLE_GENAI_USE_VERTEXAI',

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -12,6 +12,7 @@ import {
   buildCodexCliArgs,
   buildGeminiCliArgs,
   CLI_PROVIDER_ENV_KEYS,
+  cliThinkingCap,
   describeAiFailure,
   parseClaudeCodeOutput,
   parseCodexCliOutput,
@@ -164,7 +165,19 @@ class AnthropicApiProvider implements AiProvider {
         messages,
         tools,
       });
-      logger.debug({ label: req.label, stop: resp.stop_reason, usage: resp.usage }, 'ai: reply');
+      logger.info(
+        {
+          label: req.label,
+          provider: this.name,
+          model: resp.model,
+          stop: resp.stop_reason,
+          inputTokens: resp.usage.input_tokens,
+          cacheRead: resp.usage.cache_read_input_tokens,
+          outputTokens: resp.usage.output_tokens,
+          thinkingTokens: resp.usage.output_tokens_details?.thinking_tokens,
+        },
+        'ai: reply',
+      );
       if (resp.stop_reason === 'pause_turn' && resumes < MAX_PAUSE_TURN_RESUMES) {
         messages.push({ role: 'assistant', content: resp.content });
         continue;
@@ -271,6 +284,8 @@ interface CliSpec {
   keyEnv?: string;
   /** Working directory — set to keep the CLI away from workspace context. */
   cwd?: string;
+  /** This CLI reads MAX_THINKING_TOKENS: tool-free calls get it capped (#168). */
+  thinkingCap?: boolean;
 }
 
 /** Headless-CLI backend: spawn, parse JSON stdout, one retry on rate limit. */
@@ -308,7 +323,10 @@ class CliProvider implements AiProvider {
         return null;
       }
       const out = this.spec.parse(stdout);
-      if (out.text !== null) return out.text;
+      if (out.text !== null) {
+        logger.info({ label: req.label, provider: this.name, model: req.model, ...out.usage }, 'ai: reply');
+        return out.text;
+      }
       if (out.rateLimited && attempt < MAX_ATTEMPTS - 1) {
         logger.warn({ label: req.label, provider: this.name }, 'ai: cli rate-limited, retrying');
         await sleep(RATE_LIMIT_RETRY_DELAY_MS);
@@ -330,9 +348,12 @@ class CliProvider implements AiProvider {
    * variable in the child env, still filtered by the buildCliEnv allowlist.
    */
   private envSource(req: AiRequest): NodeJS.ProcessEnv {
-    const { keyEnv } = this.spec;
-    if (!keyEnv || !req.apiKey) return process.env;
-    return { ...process.env, [keyEnv]: req.apiKey };
+    const { keyEnv, thinkingCap } = this.spec;
+    return {
+      ...process.env,
+      ...(keyEnv && req.apiKey ? { [keyEnv]: req.apiKey } : {}),
+      ...(thinkingCap ? cliThinkingCap(req.webTools) : {}),
+    };
   }
 }
 
@@ -358,6 +379,7 @@ export function getAiProviderById(id: AiProviderId): AiProvider {
         defaultModel: config.CLAUDE_MODEL,
         envKeys: CLI_PROVIDER_ENV_KEYS.claude_code ?? [],
         keyEnv: AI_KEY_ENV_VARS.claude_code,
+        thinkingCap: true,
       });
       break;
     case 'gemini_cli':

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -18,6 +18,7 @@ import {
   parseCodexCliOutput,
   parseGeminiCliOutput,
   parseOpenAiChatResponse,
+  webToolsDirectOnly,
   type CliOutcome,
 } from './ai-provider-parse';
 import type { AiProviderId } from './ai-engine';
@@ -151,15 +152,17 @@ class AnthropicApiProvider implements AiProvider {
 
   private async run(req: AiRequest, client: Anthropic): Promise<string> {
     const messages: Anthropic.MessageParam[] = [{ role: 'user', content: req.user }];
+    const model = req.model ?? config.CLAUDE_MODEL;
+    const callers = webToolsDirectOnly(model) ? { allowed_callers: ['direct' as const] } : {};
     const tools = req.webTools
       ? [
-          { type: 'web_search_20260209' as const, name: 'web_search' as const, max_uses: WEB_SEARCH_MAX_USES },
-          { type: 'web_fetch_20260209' as const, name: 'web_fetch' as const, max_uses: WEB_FETCH_MAX_USES },
+          { type: 'web_search_20260209' as const, name: 'web_search' as const, max_uses: WEB_SEARCH_MAX_USES, ...callers },
+          { type: 'web_fetch_20260209' as const, name: 'web_fetch' as const, max_uses: WEB_FETCH_MAX_USES, ...callers },
         ]
       : undefined;
     for (let resumes = 0; ; resumes++) {
       const resp = await client.messages.create({
-        model: req.model ?? config.CLAUDE_MODEL,
+        model,
         max_tokens: anthropicMaxTokens(req.maxTokens),
         system: [{ type: 'text', text: req.system, cache_control: { type: 'ephemeral' } }],
         messages,

--- a/src/resume/scan.ts
+++ b/src/resume/scan.ts
@@ -20,7 +20,7 @@ export async function scanResume(resume: { id: number; text: string }): Promise<
   const scan = answer.data;
   await saveResumeScan(resume.id, scan, guardStructure(resume, scan));
   logger.info(
-    { id: resume.id, skills: scan.skills.length, issues: scan.issues.length, attempt: answer.attempt, ms: answer.ms },
+    { id: resume.id, skills: scan.skills.length, issues: scan.issues.length, attempt: answer.attempt, chars: answer.chars, ms: answer.ms },
     'resume: scanned',
   );
   return scan;

--- a/src/resume/verification-hint.test.ts
+++ b/src/resume/verification-hint.test.ts
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { verificationCautions, verificationHint } from './verification-hint';
+
+// The live row from the issue: suspicious / caution / 72 %, one ghost flag.
+const LIVE = {
+  recommendation: 'caution',
+  confidence: 72,
+  redFlags: ['the posting cannot be found on any public board'],
+  evidence: [
+    { check: 'careers_page', finding: 'No careers page lists this role', url: null, signal: 'ghost' },
+    { check: 'posting_quality', finding: 'Generic copy-paste text with no team named', url: null, signal: 'ghost' },
+    { check: 'reputation', finding: 'Well-reviewed company', url: 'https://example.com', signal: 'legit' },
+  ],
+};
+
+test('caution reads as "a quick check is enough", with the first flag', () => {
+  const h = verificationHint(LIVE);
+  assert.equal(h.tone, 'warn');
+  assert.equal(h.text, 'Verification says apply with caution (72 %): the posting cannot be found on any public board. A quick check is enough here.');
+});
+
+test('skip warns but does not forbid; apply is one short line', () => {
+  const skip = verificationHint({ ...LIVE, recommendation: 'skip', redFlags: [], confidence: 88.4 });
+  assert.equal(skip.tone, 'danger');
+  assert.match(skip.text, /^Verification says skip \(88 %\): No careers page lists this role\./);
+  assert.match(skip.text, /Compare still works/);
+  assert.deepEqual(verificationHint({ ...LIVE, recommendation: 'apply', redFlags: [], evidence: [], confidence: 92 }), {
+    tone: 'ok',
+    text: 'Verification says worth applying (92 %).',
+  });
+});
+
+test('the cautions carry the red flags and a bad reading of the posting text, labelled and capped', () => {
+  assert.deepEqual(verificationCautions(LIVE), [
+    'From verification: the posting cannot be found on any public board',
+    'From verification (posting quality): Generic copy-paste text with no team named',
+  ]);
+  const many = { ...LIVE, redFlags: ['a', 'b', 'c', 'd', 'e', 'f', 'g'] };
+  assert.equal(verificationCautions(many).length, 5);
+  assert.deepEqual(verificationCautions({ ...LIVE, redFlags: [], evidence: [] }), []);
+});

--- a/src/resume/verification-hint.ts
+++ b/src/resume/verification-hint.ts
@@ -1,0 +1,69 @@
+import { readEvidence } from '../verification/prompts';
+
+/*
+ * What a comparison shows about the stored "Is this job real?" verdict — read,
+ * never scored, never stored on the match row (#162, stages 0 and 1). The
+ * verifier's own definitions: `caution` = apply, but no more than a light
+ * tailoring; `skip` = fake, or clearly dead. Both stayed display-only on the
+ * verification card while the comparison ran three minutes later as if the
+ * check had never happened. Pure — tested in verification-hint.test.ts.
+ */
+
+export interface VerificationForHint {
+  recommendation: string;
+  confidence: number;
+  redFlags: string[];
+  /** The stored evidence JSON — read through readEvidence. */
+  evidence: unknown;
+}
+
+export interface VerificationHint {
+  tone: 'ok' | 'warn' | 'danger';
+  text: string;
+}
+
+const CAUTIONS_MAX = 5;
+
+/** The first thing the verifier held against the posting, if any. */
+function leadFlag(v: VerificationForHint): string | null {
+  const flag = v.redFlags[0]?.trim();
+  if (flag) return flag;
+  const bad = readEvidence(v.evidence).find((e) => e.signal === 'ghost' || e.signal === 'scam');
+  return bad?.finding.trim() || null;
+}
+
+/** One line for the match card and the resume editor's header. */
+export function verificationHint(v: VerificationForHint): VerificationHint {
+  const pct = `${Math.round(v.confidence)} %`;
+  const flag = leadFlag(v);
+  switch (v.recommendation) {
+    case 'skip':
+      return {
+        tone: 'danger',
+        text: `Verification says skip (${pct})${flag ? `: ${flag}` : ''}. A comparison may be wasted effort — the verifier is fallible, so Compare still works.`,
+      };
+    case 'caution':
+      return {
+        tone: 'warn',
+        text: `Verification says apply with caution (${pct})${flag ? `: ${flag}` : ''}. A quick check is enough here.`,
+      };
+    default:
+      return { tone: 'ok', text: `Verification says worth applying (${pct}).` };
+  }
+}
+
+/**
+ * The verifier's findings that belong among a comparison's cautions: the
+ * posting's red flags and a ghost / scam reading of the posting's own text.
+ * Displayed under "Worth knowing — not scored", labelled, never counted by
+ * score.ts (a finding about the posting is not a finding about the resume).
+ */
+export function verificationCautions(v: VerificationForHint): string[] {
+  const lines = v.redFlags.map((f) => `From verification: ${f.trim()}`);
+  for (const e of readEvidence(v.evidence)) {
+    if (e.check === 'posting_quality' && (e.signal === 'ghost' || e.signal === 'scam')) {
+      lines.push(`From verification (posting quality): ${e.finding.trim()}`);
+    }
+  }
+  return [...new Set(lines.filter((l) => l.length > 'From verification: '.length))].slice(0, CAUTIONS_MAX);
+}

--- a/src/verification/liveness.test.ts
+++ b/src/verification/liveness.test.ts
@@ -6,6 +6,7 @@ import {
   isFetchableJobUrl,
   postingIdFromUrl,
   resolveLivenessProbe,
+  runLivenessLadder,
   type LivenessJobInput,
 } from './liveness';
 
@@ -374,4 +375,9 @@ describe('isFetchableJobUrl', () => {
       { liveness: 'uncertain', code: 'redirected_off_posting' },
     );
   });
+});
+
+it('a pasted posting with no URL gets its own code, not "unsafe link" (#161)', async () => {
+  // MANUAL has no board API to ask, so the ladder needs no network to answer.
+  assert.deepEqual(await runLivenessLadder(job({ url: '', atsType: 'MANUAL' })), { liveness: 'uncertain', code: 'no_url', rung: 2 });
 });

--- a/src/verification/liveness.ts
+++ b/src/verification/liveness.ts
@@ -26,6 +26,7 @@ export type LivenessCode =
   | 'insufficient_content'
   | 'page_ok'
   | 'unfetchable_url'
+  | 'no_url'
   | 'network_error'
   | 'conflicting_signals';
 
@@ -73,6 +74,7 @@ export const LIVENESS_CODE_LABEL: Record<LivenessCode, string> = {
   insufficient_content: 'the page rendered no readable content',
   page_ok: 'the posting page renders normally',
   unfetchable_url: 'the stored URL is not safely fetchable',
+  no_url: 'no posting URL stored — the free checks need one',
   network_error: 'the site could not be reached',
   conflicting_signals: 'the board API and the live page disagree',
 };
@@ -393,6 +395,8 @@ async function checkAtsApi(p: LivenessProbe): Promise<LivenessVerdict> {
 }
 
 async function checkPostingPage(url: string): Promise<LivenessVerdict> {
+  // A pasted posting often has no URL at all — that is not a dangerous link (#161).
+  if (url.trim().length === 0) return v('uncertain', 'no_url');
   if (!isFetchableJobUrl(url)) return v('uncertain', 'unfetchable_url');
   const got = await fetchRaw(url, 'follow');
   if (!got) return v('uncertain', 'network_error');

--- a/src/verification/verify.ts
+++ b/src/verification/verify.ts
@@ -21,10 +21,13 @@ export async function checkLiveness(job: LivenessJobInput & { id: number }): Pro
 }
 
 /** Runs the ghost-job check with web tools and stores the verdict. Null on AI failure. */
-export async function verifyJob(job: VerifyJobInput & { id: number }): Promise<JobVerification | null> {
+export async function verifyJob(
+  job: VerifyJobInput & { id: number },
+  onError?: (reason: string) => void,
+): Promise<JobVerification | null> {
   const answer = await askForJson(
     await getAiRuntime(),
-    { ...buildVerifyPrompt(job), maxTokens: VERIFY_MAX_TOKENS, label: 'job-verify', role: 'resume', timeoutMs: VERIFY_TIMEOUT_MS, webTools: true },
+    { ...buildVerifyPrompt(job), maxTokens: VERIFY_MAX_TOKENS, label: 'job-verify', role: 'resume', timeoutMs: VERIFY_TIMEOUT_MS, webTools: true, onError },
     parseVerifyResponse,
     { jobId: job.id },
   );

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -115,6 +115,8 @@ export interface JobDetailProps {
   pipelineStages: { key: string; label: string }[];
   verification: VerificationCardProps['verification'];
   verificationCount: number;
+  /** A verify run in flight for this job — the card points at its progress page instead of a second button (#161). */
+  verificationRun: VerificationCardProps['run'];
   resumeMatch: ResumeMatchCardProps;
   coverLetters: CoverLetterCardProps;
   flash?: FlashMessage | null;
@@ -139,6 +141,7 @@ export const JobDetailPage: FC<JobDetailProps> = ({
   pipelineStages,
   verification,
   verificationCount,
+  verificationRun,
   resumeMatch,
   coverLetters,
   flash,
@@ -275,6 +278,8 @@ export const JobDetailPage: FC<JobDetailProps> = ({
           }
           verification={verification}
           verificationCount={verificationCount}
+          run={verificationRun}
+          url={job.url}
         />
 
         <ResumeMatchCard {...resumeMatch} />

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -33,6 +33,7 @@ import { freshFrame, freshFrameNotice } from '../../resume/keyword-frame';
 import { proposalOf, suggestionSheet, type Proposal } from '../../resume/change-sheet';
 import { hashShortId } from '../../text-utils';
 import { readMatchMode, type MatchMode } from '../../resume/match-mode';
+import { verificationCautions, verificationHint, type VerificationForHint, type VerificationHint } from '../../resume/verification-hint';
 import type { CountedKeyword } from '../../resume/keyword-matcher';
 import { effectiveRequirement, isIgnored } from '../../resume/keyword-overrides';
 import { REQUIREMENT_LEVELS, type RequirementLevel } from '../../resume/score';
@@ -52,6 +53,8 @@ export interface ResumeMatchCardProps {
   selectedKeywords: CountedKeyword[];
   /** Names the change sheet the Copy button hands over. */
   job: { title: string; companyName: string };
+  /** The latest "Is this job real?" verdict, read for one line and the cautions — never scored (#162). */
+  verification: VerificationForHint | null;
 }
 
 const PRIORITY_TONE: Record<MatchAction['priority'], Tone> = {
@@ -115,10 +118,12 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
   selected,
   selectedKeywords,
   job,
+  verification,
 }) => (
   <div id="resume-match">
     <Card>
       <SectionTitle>Resume match</SectionTitle>
+      <VerificationLine verification={verification} />
       {resumes.length === 0 ? (
         <Hint>
           No resumes uploaded.{' '}
@@ -176,6 +181,7 @@ export const ResumeMatchCard: FC<ResumeMatchCardProps> = ({
           keywords={selectedKeywords}
           factsBack={`/jobs/${jobId}?match=${selected.id}#resume-match`}
           job={job}
+          verification={verification}
         />
       )}
 
@@ -342,7 +348,9 @@ export const MatchReport: FC<{
   factsBack: string;
   /** Names the change sheet the Copy button hands over. */
   job: { title: string; companyName: string };
-}> = ({ match, previous, keywords, factsBack, job }) => {
+  /** The latest verdict's findings ride along the cautions (#162). */
+  verification: VerificationForHint | null;
+}> = ({ match, previous, keywords, factsBack, job, verification }) => {
   const bd = readBreakdown(match.breakdown);
   // A re-extracted frame counts different terms, so the older number is not a
   // baseline for this one (keyword-frame.ts). DeltaBox says so in words.
@@ -375,7 +383,7 @@ export const MatchReport: FC<{
 
       <DeltaBox match={match} previous={previous} />
       <HardRequirementsBlock hard={readHardRequirements(match.hardRequirements)} />
-      <MatchSignals match={match} />
+      <MatchSignals match={match} verification={verification} />
       <ConfirmFacts
         asks={keywords.filter((k) => k.status === 'ask_user')}
         matchId={match.id}
@@ -507,28 +515,73 @@ export const HardRequirementsBlock: FC<{ hard: MatchHardRequirement[] }> = ({ ha
     </div>
   );
 
+/**
+ * What the comparison says about the stored verdict before any AI is spent
+ * (#162 stage 0): one line, the verifier's own recommendation, a link to the
+ * card that holds the evidence — and the mirror of the cover card's hint
+ * when nothing is stored yet.
+ */
+export const VerificationLine: FC<{ verification: VerificationForHint | null; class?: string; href?: string }> = ({
+  verification,
+  class: className = 'mb-3',
+  href = '#verification',
+}) => {
+  const link = (
+    <a href={href} class="font-medium text-accent-strong hover:text-accent-deep">
+      {verification ? 'see the verification' : 'Verify first'}
+    </a>
+  );
+  if (!verification) {
+    return (
+      <Hint class={className}>
+        Not checked for ghost-job signals yet — {link} if you want that answered before you tailor.
+      </Hint>
+    );
+  }
+  const hint = verificationHint(verification);
+  return (
+    <p class={`${className} text-[13px] leading-5 ${VERIFICATION_TONE[hint.tone]}`}>
+      {hint.text} {link}.
+    </p>
+  );
+};
+
+const VERIFICATION_TONE: Record<VerificationHint['tone'], string> = {
+  ok: 'text-ink-muted',
+  warn: 'text-warn',
+  danger: 'text-danger',
+};
+
 /** Red flags, unscored cautions and strengths — the qualitative read on a match. */
-export const MatchSignals: FC<{ match: MatchWithResume }> = ({ match }) => (
-  <>
-    <MarkedList label="Red flags" items={match.redFlags} kind="x" tone="text-danger" />
-    {match.cautions.length > 0 && (
-      <div>
-        <div class={SUBHEAD}>Worth knowing — not scored</div>
-        <ul class="space-y-1 text-sm text-ink-muted">
-          {match.cautions.map((s) => (
-            <li class="flex gap-2">
-              <span class="mt-[3px] h-3.5 w-3.5 shrink-0 text-center text-xs leading-none text-ink-faint" aria-hidden="true">
-                ·
-              </span>
-              <span>{s}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-    )}
-    <MarkedList label="Already working for you" items={match.strengths} kind="check" tone="text-ok" />
-  </>
-);
+export const MatchSignals: FC<{ match: MatchWithResume; verification?: VerificationForHint | null }> = ({
+  match,
+  verification,
+}) => {
+  // The verifier's findings ride along the model's cautions, labelled — a
+  // finding about the posting is not a finding about the resume (#162 stage 1).
+  const cautions = [...match.cautions, ...(verification ? verificationCautions(verification) : [])];
+  return (
+    <>
+      <MarkedList label="Red flags" items={match.redFlags} kind="x" tone="text-danger" />
+      {cautions.length > 0 && (
+        <div>
+          <div class={SUBHEAD}>Worth knowing — not scored</div>
+          <ul class="space-y-1 text-sm text-ink-muted">
+            {cautions.map((s) => (
+              <li class="flex gap-2">
+                <span class="mt-[3px] h-3.5 w-3.5 shrink-0 text-center text-xs leading-none text-ink-faint" aria-hidden="true">
+                  ·
+                </span>
+                <span>{s}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <MarkedList label="Already working for you" items={match.strengths} kind="check" tone="text-ok" />
+    </>
+  );
+};
 
 /**
  * One suggestion: what the resume says now, the wording proposed for it, and

--- a/src/web/pages/run-steps.tsx
+++ b/src/web/pages/run-steps.tsx
@@ -20,7 +20,9 @@ export const RunSteps: FC<{
   /** Time already spent: finished steps from the registry, the active one as of this render. */
   stepMs?: Partial<Record<string, number>>;
   activeMs?: number;
-}> = ({ steps, currentIdx, view, stepMs = {}, activeMs }) => (
+  /** What a finished step found, in words — the free rungs of a verify run (#161). */
+  results?: Partial<Record<string, string>>;
+}> = ({ steps, currentIdx, view, stepMs = {}, activeMs, results = {} }) => (
   <>
     <ol class="mt-5 space-y-5" aria-label="Progress">
       {steps.map((s, i) => (
@@ -44,6 +46,9 @@ export const RunSteps: FC<{
               </span>
             </span>
             <span class="t-detail block text-xs">{view[s]?.detail}</span>
+            <span class="t-result block text-[13px] leading-5 text-ink-muted" data-result>
+              {results[s] ?? ''}
+            </span>
             <span
               class="t-activity mt-1.5 block text-[13px] leading-5 text-violet transition-opacity duration-300"
               data-activity

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -18,11 +18,11 @@ const STEP_VIEW: Record<RunStep, StepView> = {
     // Also reached by a plain re-scan and a first upload, where there is no
     // "new version" to speak of.
     label: 'Read the resume',
-    detail: 'headline, skills, ATS issues — about half a minute',
+    detail: 'headline, skills, ATS issues, the resume as a shape — half a minute to a minute',
   },
   keywords: {
     label: 'Quick AI check',
-    detail: 'the resume model judges every keyword, the gates and the score — no edit suggestions — about half a minute on Opus',
+    detail: 'the resume model judges every keyword, the gates and the score — no edit suggestions — half a minute to a minute',
   },
   match: {
     label: 'Full AI analysis',

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -6,6 +6,10 @@ import { RunSteps, type StepView } from './run-steps';
 import type { RunStep, TargetRun } from '../target-runs';
 
 const STEP_VIEW: Record<RunStep, StepView> = {
+  liveness: {
+    label: 'Ask the board and read the posting page',
+    detail: 'the free checks — seconds, no AI spent',
+  },
   fetch: {
     label: 'Read the posting page',
     detail: 'one request to the URL you gave — seconds',
@@ -34,7 +38,7 @@ const STEP_VIEW: Record<RunStep, StepView> = {
   },
   verify: {
     label: 'Research the company',
-    detail: 'ghost-check with web search — 2 to 4 minutes',
+    detail: 'seven named checks with web search — careers page, LinkedIn, reputation, posting age, salary, named humans, the posting itself — 2 to 4 minutes',
   },
   letter: {
     label: 'Write the cover letter',
@@ -100,6 +104,7 @@ export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
                 view={STEP_VIEW}
                 stepMs={run.stepMs}
                 activeMs={Date.now() - run.stageAt}
+                results={run.results}
               />
               <div class="mt-5 flex items-center justify-between gap-3 border-t border-line pt-3">
                 <Hint>

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -6,6 +6,7 @@ import type { FlashMessage } from '../flash';
 import { fitTone, formatRelative, type Tone } from '../format';
 import type { MatchWithResume } from '../../resume/store';
 import type { CountedKeyword } from '../../resume/keyword-matcher';
+import type { VerificationForHint } from '../../resume/verification-hint';
 import { effectiveKeywords } from '../../resume/keyword-overrides';
 import { readActions, readHardRequirements, readRemovals } from '../../resume/prompts';
 import { readMatchMode } from '../../resume/match-mode';
@@ -18,6 +19,7 @@ import {
   HardRequirementsDigest,
   KeywordTable,
   MatchSignals,
+  VerificationLine,
   RemovalsBlock,
   ScoreBreakdownChips,
   SuggestionsPrompt,
@@ -53,6 +55,8 @@ export interface TargetPageProps {
   resumeText: string;
   /** An instant check's parsed upload — opens in the editor as the unsaved draft (target-page.mjs). */
   draftText?: string | null;
+  /** The latest "Is this job real?" verdict — one line under the title, findings among the cautions (#162). */
+  verification: VerificationForHint | null;
   flash?: FlashMessage | null;
   /** What a Save can do with this resume's file — one sentence (docx-structure.ts, ADR 0038). */
   fileVerdict: string;
@@ -111,6 +115,7 @@ export const TargetPage: FC<TargetPageProps> = ({
   previous,
   resumeText,
   draftText,
+  verification,
   fileVerdict,
   cleanHref,
   flash,
@@ -217,6 +222,9 @@ export const TargetPage: FC<TargetPageProps> = ({
           )}
         </div>
       </div>
+      {verification && (
+        <VerificationLine verification={verification} class="-mt-2 mb-4" href={`/jobs/${job.id}#verification`} />
+      )}
 
       <Card class="mb-4">
         {/* Proportional columns instead of a scattered flex row: score | why (owns
@@ -607,7 +615,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                   <RemovalsBlock removals={removals} interactive />
                 </>
               )}
-              <MatchSignals match={match} />
+              <MatchSignals match={match} verification={verification} />
               {/* Wide screens open it on boot (target-page.mjs); narrow ones keep
                   it shut, because it is the longest block on the page by far. */}
               <details class="kw-fold">

--- a/src/web/pages/verification-card.tsx
+++ b/src/web/pages/verification-card.tsx
@@ -15,9 +15,13 @@ export interface JobLivenessView {
 
 export interface VerificationCardProps {
   jobId: number;
+  /** Empty for a pasted posting — the free checks have nothing to ask then (#161). */
+  url: string;
   liveness: JobLivenessView | null;
   verification: JobVerification | null;
   verificationCount: number;
+  /** A run in flight: the buttons give way to a link to its progress page. */
+  run: { id: string; startedAt: number } | null;
 }
 
 const LIVENESS_VIEW: Record<string, { label: string; tone: Tone }> = {
@@ -55,9 +59,11 @@ const CHECK_LABEL: Record<VerificationEvidence['check'], string> = {
 
 export const VerificationCard: FC<VerificationCardProps> = ({
   jobId,
+  url,
   liveness,
   verification,
   verificationCount,
+  run,
 }) => (
   <div id="verification">
     <Card>
@@ -101,17 +107,25 @@ export const VerificationCard: FC<VerificationCardProps> = ({
           )}
         </div>
         <div class="flex shrink-0 flex-wrap items-center gap-2">
-          <ActionForm action={`/jobs/${jobId}/verify`}>
-            <Button variant={liveness || verification ? 'secondary' : 'violet'} size="sm">
-              {liveness || verification ? 'Re-check' : 'Verify'}
+          {run ? (
+            <Button href={`/target/runs/${run.id}`} variant="secondary" size="sm">
+              Checking… started {formatRelative(new Date(run.startedAt))} — open the progress page
             </Button>
-          </ActionForm>
-          {liveness && liveness.liveness !== 'uncertain' && (
-            <ActionForm action={`/jobs/${jobId}/verify`} hidden={{ deep: 1 }}>
-              <Button variant="violet" size="sm">
-                Deep check (AI)
-              </Button>
-            </ActionForm>
+          ) : (
+            <>
+              <ActionForm action={`/jobs/${jobId}/verify`}>
+                <Button variant={liveness || verification ? 'secondary' : 'violet'} size="sm">
+                  {liveness || verification ? 'Re-check' : 'Verify'}
+                </Button>
+              </ActionForm>
+              {liveness && liveness.liveness !== 'uncertain' && (
+                <ActionForm action={`/jobs/${jobId}/verify`} hidden={{ deep: 1 }}>
+                  <Button variant="violet" size="sm">
+                    Deep check (AI)
+                  </Button>
+                </ActionForm>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -150,8 +164,9 @@ export const VerificationCard: FC<VerificationCardProps> = ({
       )}
       {!verification && (
         <Hint class="mt-3">
-          The free checks answer in seconds; the AI deep check searches and reads pages for 2-4
-          minutes before answering.
+          {url
+            ? 'The free checks answer in seconds; the AI deep check searches and reads pages for 2-4 minutes before answering. Either way it runs on a progress page you can leave.'
+            : 'This posting has no URL, so the free checks have nothing to ask — Verify goes straight to the AI research, 2-4 minutes on a progress page you can leave.'}
         </Hint>
       )}
     </Card>

--- a/src/web/public/target-run.mjs
+++ b/src/web/public/target-run.mjs
@@ -41,11 +41,17 @@ const ACTIVITIES = {
     'Drafting edit suggestions with exact quotes…',
     'Listing what to remove and what already sells you…',
   ],
+  liveness: ["Asking the company's board API…", 'Reading the posting page…'],
+  // The prompt's seven named checks (EVIDENCE_CHECKS), in its order.
   verify: [
-    'Searching for the company and this posting…',
-    'Cross-checking the careers page and the ATS…',
-    'Weighing ghost-job signals…',
-    'Writing the company snapshot…',
+    "Looking for the company's careers page and this posting on it…",
+    'Searching LinkedIn for the company and the role…',
+    'Reading reputation and scam reports…',
+    'Judging how long the posting has been up…',
+    'Comparing the salary with the market…',
+    'Looking for named humans behind the posting…',
+    "Weighing the posting's own quality…",
+    'Writing the verdict and the company snapshot…',
   ],
   letter: [
     'Reading the posting and the resume…',
@@ -119,6 +125,8 @@ export function init(data, activity = defaultActivity) {
       li.dataset.state = idx === -1 || i < idx ? 'done' : i === idx ? 'active' : 'pending';
       const timeEl = li.querySelector('[data-step-time]');
       if (timeEl) timeEl.textContent = stepTime(li.dataset.state, li.dataset.step, state);
+      const resultEl = li.querySelector('[data-result]');
+      if (resultEl && state.results) resultEl.textContent = state.results[li.dataset.step] ?? '';
     }
     const active = steps.find((li) => li.dataset.state === 'active');
     if (!active) return;

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -35,7 +35,7 @@ import { draftStash } from '../draft-stash';
 import { scanInBackground } from '../../resume/scan';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
-import { claimRun, matchStep, startRun, updateRun } from '../target-runs';
+import { claimRun, findLiveRun, matchStep, startRun, updateRun } from '../target-runs';
 import { startSuggestionsRun } from '../suggestions-run';
 import {
   deleteCoverLettersForResume,
@@ -387,6 +387,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
       pipelineStages={allStages(parseStageConfig(settings.pipelineStages))}
       verification={verifications[0] ?? null}
       verificationCount={verifications.length}
+      verificationRun={verifyRunView(id)}
       resumeMatch={{
         jobId: id,
         resumes: resumes.map((r) => ({ id: r.id, name: r.name, isDefault: r.isDefault })),
@@ -500,44 +501,89 @@ jobsRoute.post('/jobs/:id/verify', async (c) => {
   if (!job) return c.text('Not found', 404);
 
   // Rungs 1-2 (ADR 0016): free ATS-API / page checks. A resolved verdict
-  // stops here at $0; `deep=1` (the "Deep check" button) always goes to AI.
+  // stops there at $0; `deep=1` (the "Deep check" button) always goes to AI.
+  // The whole ladder runs on the progress page (#161): the free rungs' answer
+  // lands under their step within seconds, the research step names what it
+  // checks, and a closed tab loses nothing. One run per job at a time.
   const form = await c.req.parseBody().catch(() => ({}) as Record<string, unknown>);
   const deep = form['deep'] === '1';
-  const live = await checkLiveness({
-    id: job.id,
-    url: job.url,
-    externalId: job.externalId,
-    atsType: job.company.atsType,
-    atsToken: job.company.atsToken,
+  const back = `/jobs/${id}#verification`;
+  const { run, joined } = claimRun(VERIFY_RUN_KEY(id), {
+    steps: deep ? ['verify'] : ['liveness', 'verify'],
+    jobTitle: job.title,
+    resumeName: '',
+    jobId: id,
+    heading: { running: 'Checking whether the job is real', failed: 'The check failed' },
+    subtitle: deep
+      ? 'Straight to the AI research.'
+      : job.url
+        ? 'The free checks first; the AI only when they cannot say.'
+        : 'No posting URL stored, so the free checks have nothing to ask — straight to the AI research.',
+    backUrl: back,
+    backLabel: 'Back to the job',
   });
-  if (!deep && live.liveness !== 'uncertain') {
-    const how = `${LIVENESS_CODE_LABEL[live.code]} (rung ${live.rung}, no AI spent)`;
-    return live.liveness === 'expired'
-      ? flashRedirect(`/jobs/${id}#verification`, 'warn', `Posting looks closed — ${how}.`)
-      : flashRedirect(
-          `/jobs/${id}#verification`,
-          'ok',
-          `Posting is live — ${how}. Deep check runs the full ghost-job analysis.`,
-        );
-  }
-
-  const row = await verifyJob({
-    id: job.id,
-    title: job.title,
-    companyName: job.company.name,
-    location: job.location,
-    url: job.url,
-    description: job.description,
-    postedAt: job.postedAt,
+  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
+  startRun(run.id, async () => {
+    if (!deep) {
+      const live = await checkLiveness({
+        id: job.id,
+        url: job.url,
+        externalId: job.externalId,
+        atsType: job.company.atsType,
+        atsToken: job.company.atsToken,
+      });
+      const how = `${LIVENESS_CODE_LABEL[live.code]} (rung ${live.rung}, no AI spent)`;
+      updateRun(run.id, { results: { liveness: how } });
+      if (live.liveness !== 'uncertain') {
+        updateRun(run.id, {
+          stage: 'done',
+          resultUrl: back,
+          flashKind: live.liveness === 'expired' ? 'warn' : 'ok',
+          flash:
+            live.liveness === 'expired'
+              ? `Posting looks closed — ${how}.`
+              : `Posting is live — ${how}. Deep check runs the full ghost-job analysis.`,
+        });
+        return;
+      }
+      updateRun(run.id, { stage: 'verify' });
+    }
+    let reason: string | null = null;
+    const row = await verifyJob(
+      {
+        id: job.id,
+        title: job.title,
+        companyName: job.company.name,
+        location: job.location,
+        url: job.url,
+        description: job.description,
+        postedAt: job.postedAt,
+      },
+      (r) => {
+        reason = r;
+      },
+    );
+    updateRun(
+      run.id,
+      row
+        ? {
+            stage: 'done',
+            resultUrl: back,
+            flash: `Verified: ${row.verdict} (${row.confidence}% confidence) — recommendation: ${row.recommendation}.`,
+          }
+        : { stage: 'error', error: `Verification failed${reason ? `: ${reason}` : ' — see the web logs'}.` },
+    );
   });
-  return row
-    ? flashRedirect(
-        `/jobs/${id}#verification`,
-        'ok',
-        `Verified: ${row.verdict} (${row.confidence}% confidence) — recommendation: ${row.recommendation}.`,
-      )
-    : flashRedirect(`/jobs/${id}#verification`, 'err', 'Verification failed — see the web logs.');
+  return c.redirect(`/target/runs/${run.id}`, 303);
 });
+
+/** One verify run per job at a time — a second click joins it, a reload of the job page sees it. */
+const VERIFY_RUN_KEY = (jobId: number): string => `verify:${jobId}`;
+
+function verifyRunView(jobId: number): { id: string; startedAt: number } | null {
+  const run = findLiveRun(VERIFY_RUN_KEY(jobId));
+  return run ? { id: run.id, startedAt: run.startedAt } : null;
+}
 
 jobsRoute.post('/jobs/:id/match', async (c) => {
   const id = Number(c.req.param('id'));

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -397,6 +397,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
         selected,
         selectedKeywords,
         job: { title: job.title, companyName: job.company.name },
+        verification: verifications[0] ?? null,
       }}
       coverLetters={{
         jobId: id,
@@ -832,9 +833,10 @@ jobsRoute.post('/jobs/:id/cover/:letterId', async (c) => {
 jobsRoute.get('/jobs/:id/target', async (c) => {
   const id = Number(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
-  const [job, matches] = await Promise.all([
+  const [job, matches, verifications] = await Promise.all([
     prisma.job.findUnique({ where: { id }, include: { company: { select: { name: true } } } }),
     listMatchesForJob(id),
+    listVerificationsForJob(id),
   ]);
   if (!job) return c.text('Not found', 404);
   const requested = Number(c.req.query('match'));
@@ -860,6 +862,7 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
       previous={previousFor(match, matches)}
       resumeText={match.resumeText || resume.text}
       draftText={draftText}
+      verification={verifications[0] ?? null}
       fileVerdict={fileVerdict}
       cleanHref={file.clean ? `/resumes/${resume.id}/render` : null}
       flash={parseFlashCookie(c.req.header('cookie'))}

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -3,7 +3,7 @@ import { Hono, type Context } from 'hono';
 import { logger } from '../../logger';
 import type { ResumeReview } from '@prisma/client';
 import { reviewResume } from '../../resume/review';
-import { scanResume } from '../../resume/scan';
+import { scanInBackground, scanResume } from '../../resume/scan';
 import type { ResumeScan } from '../../resume/prompts';
 import { matchResumeToJob } from '../../resume/match';
 import { prisma } from '../../db';
@@ -193,7 +193,7 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
   // a duplicate version behind whatever the run registry then did. Keyed on
   // the text, because that is what the user submitted (issue #76).
   const { run, joined } = claimRun(`draft:${id}:${hashShortId(text)}:${job?.id ?? ''}:${asCopy ? 'copy' : 'version'}`, {
-    steps: job ? ['scan', 'keywords'] : ['scan'],
+    steps: job ? ['keywords'] : ['scan'],
     jobTitle: job?.title ?? '',
     resumeName: '',
     jobId: job?.id,
@@ -213,16 +213,19 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
     const saved = asCopy ? `Saved as a new resume "${resume.name}" (${note})` : `Saved as v${resume.version} (${note})`;
     updateRun(run.id, {
       resumeName: resume.name,
-      subtitle: `${saved}.${job ? ' Reading it, then scoring it against the posting.' : ''}`,
+      subtitle: `${saved}.${job ? ' Scoring it against the posting.' : ''}`,
     });
-    const scan = await scanResume(resume);
     if (!job) {
+      const scan = await scanResume(resume);
       updateRun(run.id, scan
         ? { stage: 'done', resultUrl: `/resumes/${resume.id}`, flash: `${saved}.` }
         : { stage: 'error', error: `${saved}, but the scan failed — try "Scan".` });
       return;
     }
-    updateRun(run.id, { stage: 'keywords' });
+    // The match reads the text, never the scan (target-plan §3.1 item 2), so
+    // the scan runs behind it as the re-upload route's does — it was 63 % of
+    // a six-minute wait on a CLI engine (#168).
+    scanInBackground(resume);
     const match = await matchResumeToJob(resume, {
       id: job.id,
       title: job.title,
@@ -234,7 +237,7 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
       ? {
           stage: 'done',
           resultUrl: `/jobs/${job.id}/target?match=${match.id}`,
-          flash: `${saved} and checked: AI match ${match.matchScore}/100.`,
+          flash: `${saved} and checked: AI match ${match.matchScore}/100. The headline and skills refresh in the background.`,
         }
       : {
           stage: 'error',

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -82,6 +82,7 @@ targetRoute.get('/target/runs/:id/state', (c) => {
     steps: run.steps,
     jobTitle: run.jobTitle,
     progress: run.progress ?? null,
+    results: run.results ?? {},
     stepMs: run.stepMs,
     stageElapsedMs: Date.now() - run.stageAt,
     elapsedMs: Date.now() - run.startedAt,
@@ -95,7 +96,7 @@ targetRoute.get('/target/runs/:id', (c) => {
     return flashRedirect('/target', 'err', 'That comparison run is gone (runs live ~30 min). Start again.');
   }
   if (run.stage === 'done' && run.resultUrl) {
-    return flashRedirect(run.resultUrl, run.reused ? 'warn' : 'ok', run.flash ?? 'Done.', {
+    return flashRedirect(run.resultUrl, run.flashKind ?? (run.reused ? 'warn' : 'ok'), run.flash ?? 'Done.', {
       rerun: run.reused,
       tailor: run.tailorUrl,
     });

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -11,6 +11,7 @@ import type { MatchMode } from '../resume/match-mode';
  */
 
 export type RunStep =
+  | 'liveness'
   | 'fetch'
   | 'extract'
   | 'scan'
@@ -47,6 +48,10 @@ export interface TargetRun {
   /** Page copy for runs that are not a comparison (the wizard's scan / score). */
   heading?: { running: string; failed: string };
   subtitle?: string;
+  /** One line under a finished step — what the free rungs found, in words (#161). */
+  results?: Partial<Record<RunStep, string>>;
+  /** The tone of the done-flash; 'ok' unless the run says otherwise ("posting looks closed"). */
+  flashKind?: 'ok' | 'warn';
   /** Data-driven progress of the active step, when the job reports it. */
   progress?: { done: number; total: number };
   /** Set on done: where to send the user, with the flash to show there. */


### PR DESCRIPTION
Part of #162 — stages 0 and 1 (read the stored verdict, spend nothing). Stages 2–4 stay open on the issue: the snapshot in the prompt wants its own ADR and a bench run; the canonical listing wants a schema field; the addressee prefill is a cover-card change of its own.

Stacked on #182 (`verify-run`) — merge that first; GitHub retargets this one on its own. One added behaviour: **v1.60.0**.

## What

- **Stage 0 — one line, no AI.** `src/resume/verification-hint.ts` (pure) turns the latest `JobVerification` row into a line in the verifier's own terms: `caution` → *"Verification says apply with caution (72 %): ‹first flag›. A quick check is enough here."*; `skip` → *"… A comparison may be wasted effort — the verifier is fallible, so Compare still works."*; `apply` → *"Verification says worth applying (82 %)."* The lead flag is the first red flag, else the first ghost / scam evidence finding. `VerificationLine` renders it at the top of the Resume match card and under the targeted view's header, linked to `#verification`; with no row the card shows the mirror of the cover card's hint — *"Not checked for ghost-job signals yet — Verify first if you want that answered before you tailor."* (the editor shows nothing in that case: no nagging where the work happens).
- **Stage 1 — the findings among the cautions.** `verificationCautions` = the row's `redFlags` plus a `posting_quality` finding marked ghost or scam, each prefixed *From verification*, deduplicated, capped at 5. `MatchSignals` appends them to the model's own cautions under "Worth knowing — not scored" on both pages. Never stored on the match row, never counted by `score.ts` — a finding about the posting is not a finding about the resume (constraint 3 of the issue).
- **The open question answered.** `skip` warns and does not block Full analysis — the live row calls a documented company "suspicious" because a pasted posting had no URL to find.
- Wiring: `ResumeMatchCardProps.verification`, `TargetPageProps.verification`, `MatchReport` threads it; `GET /jobs/:id/target` loads `listVerificationsForJob` beside the matches (the job page already had it).
- Not built here: the Compare form has two submit buttons and no default mode to switch, so the line carries the recommendation instead of changing the form.
- CHANGELOG 1.60.0, version bump.

## Verification

- `npm run lint:types` + `npm test`: 2001 tests, 0 failures (3 new on the pure module: the live row's shape — caution / 72 % / one ghost flag; skip and apply wording; the cautions' labels, dedupe and cap).
- On a copy of the live database, all four states rendered server-side and read back with curl and screenshots: the `apply` row (*worth applying (82 %)*), the `caution` row on `/jobs/2094` and on `/jobs/2094/target?match=8` (the line in the warn tone, the *From verification:* caution under "Worth knowing — not scored"), the same row set to `skip` (the danger tone, "Compare still works"), and a never-verified job (`/jobs/618`: the mirror hint on the card, nothing on the editor's header).
- The targeted view's header keeps its title column `shrink-0` for the run chips, so the line sits in a row of its own under the header and wraps instead of overflowing (caught on the first screenshot).
- The live containers were not touched.

## Release notes

### What's new
- The resume comparison reads the "Is this job real?" verdict: one line on the match card and the resume editor says what the verifier recommends and links to the evidence; its red flags appear among the comparison's cautions, labelled, never scored. A job never verified says so on the card.

### Schema
- no schema changes

### Verification
- 2001 tests; all four states (apply, caution, skip, none) rendered on a copy of the live database.

### References
- #162 (stages 0–1) · ADR 0009 · ADR 0012 · ADR 0021

Tag after merge: `git tag -a v1.60.0 -m "The comparison reads the verification" <merge-sha>`
