### PR TITLE
One upload button, the AI check behind it (#184, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.64.0] — 2026-09-05
+
+### Changed
+- **One upload button, and the AI check runs behind it.** The editor's
+  re-upload popover had two buttons — *Upload & check (seconds)*, which
+  opened the file as a draft and moved the number by a point or two, and
+  *Upload as vN & check with AI*, which took minutes on a progress page —
+  and read as "nothing happened" or "too slow" (#184). One **Upload & check**
+  now: the text opens in the editor within a second with the live estimate,
+  the quick AI check of that text starts in the background, and a chip
+  beside the score follows it — *AI check running · 22 s*, then *AI check
+  ready: AI match 91/100 — Use it*. Nothing is saved until Save as vN or
+  Save as a tailored copy on the bar; the check lands as a draft analysis.
+  **Re-check with AI** and **Full analysis** from the editor behave the
+  same way — the editor stays open, the chip follows the run, and text
+  typed meanwhile travels along as the next page's draft. The Compare page
+  does the same when a known resume's text changed.
+
 ## [1.63.0] — 2026-09-05
 
 ### Added
@@ -2569,6 +2587,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.64.0]: https://github.com/applypack/applypack/compare/v1.63.0...v1.64.0
 [1.63.0]: https://github.com/applypack/applypack/compare/v1.62.1...v1.63.0
 [1.62.1]: https://github.com/applypack/applypack/compare/v1.62.0...v1.62.1
 [1.62.0]: https://github.com/applypack/applypack/compare/v1.61.0...v1.62.0

--- a/docs/target-plan.md
+++ b/docs/target-plan.md
@@ -506,6 +506,10 @@ Sources: [jobscan.co](https://www.jobscan.co/blog/top-resume-keywords-boost-resu
   or instant check + full analysis auto-started in the background?~~ Decided
   2026-09-02 (block 3): instant check by default, nothing auto-runs — every
   auto-started analysis is 78–109 s of Opus on the CLI engine and the memo
-  only saves repeats. The background variant stays a separate branch if
-  ever wanted.
+  only saves repeats. **Revisited 2026-09-05 (#184, v1.64.0):** with the CLI
+  thinking cap a quick check is 19–26 s, and a user who uploads a file reads
+  a number that does not move as "nothing happened". One button now: the
+  draft opens at once, the quick check runs behind it (`web/draft-check.ts`),
+  a chip beside the score follows the run and offers the result; the memo
+  still makes a repeat free. The full analysis stays an explicit button.
 - Is the F8 curated lexicon worth its maintenance, or are F1-F7 enough?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.63.0",
+      "version": "1.64.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/draft-check.ts
+++ b/src/web/draft-check.ts
@@ -1,0 +1,58 @@
+import type { Resume } from '@prisma/client';
+import { findReusableMatch, matchResumeToJob } from '../resume/match';
+import { reuseNotice } from '../resume/match-reuse';
+import type { MatchJobInput } from '../resume/prompts';
+import { hashShortId } from '../text-utils';
+import { formatRelative } from './format';
+import { claimRun, startRun, updateRun, type TargetRun } from './target-runs';
+
+/**
+ * The quick AI check of a text that just landed in the editor as a draft
+ * (#184): a draft row over the resume's current version — no new version, no
+ * scan — that the page follows through the run's state and offers when it
+ * lands. A text already judged is answered from the stored row; the same
+ * text twice joins the run in flight. Started by the re-upload on the editor
+ * and by the Compare page when a known resume's text changed.
+ */
+export function startDraftCheck(input: {
+  job: MatchJobInput & { id: number };
+  resume: Pick<Resume, 'id' | 'name' | 'text' | 'version'>;
+  text: string;
+}): TargetRun {
+  const { job, resume, text } = input;
+  const { run, joined } = claimRun(`check:${job.id}:${resume.id}:${hashShortId(text)}`, {
+    steps: ['keywords'],
+    jobTitle: job.title,
+    resumeName: resume.name,
+    jobId: job.id,
+    backUrl: `/jobs/${job.id}/target`,
+    backLabel: 'Back to the editor',
+  });
+  if (joined) return run;
+  startRun(run.id, async () => {
+    const reused = await findReusableMatch(job.id, resume.id, text, 'fast');
+    if (reused) {
+      updateRun(run.id, {
+        stage: 'done',
+        resultUrl: `/jobs/${job.id}/target?match=${reused.row.id}`,
+        results: { keywords: `AI match ${reused.row.matchScore}/100 — the same text was judged ${formatRelative(reused.row.createdAt)}` },
+        flash: reuseNotice(formatRelative(reused.row.createdAt)),
+        reused: true,
+      });
+      return;
+    }
+    const row = await matchResumeToJob({ id: resume.id, text, version: resume.version }, job, { draft: text !== resume.text });
+    updateRun(
+      run.id,
+      row
+        ? {
+            stage: 'done',
+            resultUrl: `/jobs/${job.id}/target?match=${row.id}`,
+            results: { keywords: `AI match ${row.matchScore}/100` },
+            flash: `Checked — AI match ${row.matchScore}/100.`,
+          }
+        : { stage: 'error', error: 'The AI check failed — see the web logs.' },
+    );
+  });
+  return run;
+}

--- a/src/web/instant-check.test.ts
+++ b/src/web/instant-check.test.ts
@@ -14,12 +14,10 @@ test('the analysed text is unchanged, anything else is a draft', () => {
   assert.equal(decideInstantCheck(frame, frame.resumeText + '\n').kind, 'draft', 'a whitespace edit is a draft');
 });
 
-test('the draft notice names the file, the frame and the inherited statuses', () => {
-  const text = instantCheckNotice('cv-v3.pdf', '2h ago', 24);
-  assert.match(text, /"cv-v3\.pdf" checked in 24 ms — no AI call/);
-  assert.match(text, /analysis from 2h ago/);
-  assert.match(text, /confirms what is present/);
-  assert.match(text, /add \/ confirm \/ can't-claim keep the AI's verdict/);
+test('the draft notice names the file and says the AI check follows', () => {
+  const text = instantCheckNotice('cv-v3.pdf', 24);
+  assert.match(text, /"cv-v3\.pdf" opened in the editor in 24 ms/);
+  assert.match(text, /runs in the background/);
   assert.match(unchangedNotice('cv.pdf', '3m ago'), /"cv\.pdf" has the same text .* \(3m ago\)/);
 });
 

--- a/src/web/instant-check.ts
+++ b/src/web/instant-check.ts
@@ -1,11 +1,12 @@
 /*
- * Instant check (docs/target-plan.md §3.2 item 5): a re-uploaded resume is
- * parsed and shown as an unsaved draft over the latest analysis of the
- * posting — no AI call, no new version, nothing saved. The live estimate on
- * the page reads that analysis as its frame: the text confirms what is
- * `present`, while `add` / `ask_user` / `cannot_claim` stay the AI's verdict
- * on the resume it analysed, until "Re-check with AI" makes the draft
- * official. Pure — the routes decide what to fetch and where to redirect.
+ * Instant check (docs/target-plan.md §3.2 item 5, revisited by #184): a
+ * re-uploaded resume is parsed and shown as an unsaved draft over the latest
+ * analysis of the posting within a second — no new version, nothing saved —
+ * while the quick AI check of the same text runs behind it (draft-check.ts)
+ * and lands beside the score. Until then the live estimate reads the frame
+ * analysis: the text confirms what is `present`, while `add` / `ask_user` /
+ * `cannot_claim` stay the AI's verdict on the resume it analysed. Pure — the
+ * routes decide what to fetch and where to redirect.
  */
 
 /** The stored analysis a draft is checked against. */
@@ -28,12 +29,11 @@ export function decideInstantCheck(frame: Frame | null, text: string): InstantDe
   return frame.resumeText === text ? { kind: 'unchanged', frame } : { kind: 'draft', frame };
 }
 
-/** The flash over a checked draft; `when` is the frame's age ("2h ago"). */
-export function instantCheckNotice(filename: string, when: string, ms: number): string {
+/** The flash over the draft while its AI check runs behind it (#184). */
+export function instantCheckNotice(filename: string, ms: number): string {
   return (
-    `"${filename}" checked in ${ms} ms — no AI call. The estimate is measured against the analysis ` +
-    `from ${when}: the text confirms what is present; add / confirm / can't-claim keep the AI's ` +
-    `verdict on the analysed version until you re-check.`
+    `"${filename}" opened in the editor in ${ms} ms. The estimate below is measured against the last ` +
+    `analysis; the AI check of this text runs in the background and its number lands beside the score.`
   );
 }
 

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -55,6 +55,8 @@ export interface TargetPageProps {
   resumeText: string;
   /** An instant check's parsed upload — opens in the editor as the unsaved draft (target-page.mjs). */
   draftText?: string | null;
+  /** A background AI check the page follows: the chip beside the number polls it (#184). */
+  runId?: string | null;
   /** The latest "Is this job real?" verdict — one line under the title, findings among the cautions (#162). */
   verification: VerificationForHint | null;
   flash?: FlashMessage | null;
@@ -115,6 +117,7 @@ export const TargetPage: FC<TargetPageProps> = ({
   previous,
   resumeText,
   draftText,
+  runId,
   verification,
   fileVerdict,
   cleanHref,
@@ -142,6 +145,7 @@ export const TargetPage: FC<TargetPageProps> = ({
     aiScore: match.matchScore,
     resumeText,
     draftText: draftText ?? null,
+    runId: runId ?? null,
     jobText: job.description,
     keywords: scored,
     actions,
@@ -260,6 +264,8 @@ export const TargetPage: FC<TargetPageProps> = ({
                 <span id="ai-stale" hidden class="font-medium text-warn">
                   edited — re-check to refresh
                 </span>
+                {/* The background AI check, when one is running (#184): running · ready with "Use it" · failed. */}
+                <span data-ai-run hidden class="font-medium"></span>
               </div>
               {/* Which resume/version is named by the pane header and the run chips —
                   repeating it here was pure duplication. */}
@@ -322,10 +328,6 @@ export const TargetPage: FC<TargetPageProps> = ({
                 >
                   <input type="hidden" name="resumeId" value={resume.id} />
                   <input type="hidden" name="matchId" value={match.id} />
-                  {/* Set by the second button's click, not by the submitter's value: SUBMIT_ONCE
-                      disables the buttons in the submit event, and a disabled submitter is left
-                      out of the form data. */}
-                  <input type="hidden" name="uploadMode" value="check" />
                   <input
                     type="file"
                     name="file"
@@ -333,29 +335,14 @@ export const TargetPage: FC<TargetPageProps> = ({
                     accept={ACCEPTED_EXTENSIONS.join(',')}
                     class="block w-full text-xs text-ink file:mr-2 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink"
                   />
-                  <Button size="sm" class="w-full" title="Parses the file into the editor and scores it against this analysis — no AI call">
-                    Upload & check (seconds)
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    class="w-full"
-                    onclick="this.form.elements.uploadMode.value='analyze'"
-                    title={
-                      resume.ephemeral
-                        ? 'Replaces this comparison with a fresh quick AI check (~½ min)'
-                        : `Saves the file as v${resume.version + 1} and runs the quick AI check (~½ min); the scan runs in the background`
-                    }
-                  >
-                    {resume.ephemeral ? 'Upload & check with AI' : `Upload as v${resume.version + 1} & check with AI`}
+                  <Button size="sm" class="w-full" title="Opens the file in the editor at once; the quick AI check runs behind it">
+                    Upload & check
                   </Button>
                   <Hint>
-                    Check opens the new text as an unsaved draft scored against this analysis: the text confirms
-                    what is present, while add / confirm / can't-claim keep the AI's verdict on the analysed
-                    version until you re-check.{' '}
-                    {resume.ephemeral
-                      ? 'Nothing lands in your Resumes either way.'
-                      : `Nothing is saved — Save as v${resume.version + 1} keeps the text, not the file.`}
+                    The text opens here within a second with the live estimate; the AI check of it runs in the
+                    background and its number lands beside the score — about half a minute. Nothing is saved
+                    until you {resume.ephemeral ? 'Save as a new resume' : `Save as v${resume.version + 1} or as a tailored copy`} on the bar
+                    below.
                   </Hint>
                 </form>
               </div>
@@ -374,8 +361,10 @@ export const TargetPage: FC<TargetPageProps> = ({
               <div class={`${MENU_PANEL} space-y-2`}>
                 <form method="post" action={`/jobs/${job.id}/match`} id="reanalyze-form" onsubmit={SUBMIT_ONCE}>
                   <input type="hidden" name="resumeId" value={resume.id} />
+                  <input type="hidden" name="matchId" value={match.id} />
                   <input type="hidden" name="draftText" id="reanalyze-text" value="" />
-                  <input type="hidden" name="next" value="target" />
+                  {/* The editor stays open; the chip beside the number follows the run (#184). */}
+                  <input type="hidden" name="next" value="editor" />
                   {/* Set by the full-analysis and Rebuild buttons' clicks — a disabled submitter is left out of the form data. */}
                   <input type="hidden" name="mode" value="fast" />
                   <input type="hidden" name="rebuild" value="" />
@@ -655,6 +644,7 @@ export const TargetPage: FC<TargetPageProps> = ({
             Estimate <span id="bar-score">—</span>
             <span id="bar-delta" class="ml-1 text-xs font-medium"></span>
           </span>
+          <span data-ai-run hidden class="text-xs font-medium"></span>
           <div class="ml-auto flex flex-wrap items-center gap-2">
             <Button type="button" variant="ghost" size="sm" id="bar-discard">
               Discard

--- a/src/web/public/run-chip.mjs
+++ b/src/web/public/run-chip.mjs
@@ -1,0 +1,40 @@
+/*
+ * The AI-check chip beside the score (#184): what one poll of a background
+ * run's state reads as. Pure — tested from src/web/run-chip.test.ts; the page
+ * paints it and re-polls while the run is live.
+ */
+
+const TONE = { running: 'text-ink-muted', done: 'text-ok', error: 'text-danger' };
+
+/** The first step result the run recorded — "AI match 91/100" — whatever the step was called. */
+function firstResult(state) {
+  const results = state.results && typeof state.results === 'object' ? Object.values(state.results) : [];
+  return results.find((r) => typeof r === 'string' && r.length > 0) ?? null;
+}
+
+/**
+ * null = nothing to show (the run is gone). `link.label` is the one action:
+ * the progress page while it runs, the result when it landed.
+ */
+export function runChip(state, runUrl) {
+  if (!state || state.gone) return null;
+  if (state.stage === 'error') {
+    return { kind: 'error', tone: TONE.error, text: 'AI check failed', link: { href: runUrl, label: 'why' } };
+  }
+  if (state.stage === 'done') {
+    const result = firstResult(state) ?? 'done';
+    return {
+      kind: 'done',
+      tone: TONE.done,
+      text: `AI check ready: ${result}`,
+      link: state.resultUrl ? { href: state.resultUrl, label: 'Use it' } : null,
+    };
+  }
+  const seconds = Math.max(0, Math.round((state.elapsedMs ?? 0) / 1000));
+  return { kind: 'running', tone: TONE.running, text: `AI check running · ${seconds} s`, link: { href: runUrl, label: 'progress' } };
+}
+
+/** Whether the page should ask again. */
+export function runLive(state) {
+  return Boolean(state) && !state.gone && state.stage !== 'done' && state.stage !== 'error';
+}

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -18,6 +18,7 @@ import {
 import { computeScore, entriesFromLive } from './score.mjs';
 import { formatEditSheet } from './change-sheet.mjs';
 import { wireCopy, copyFrom, announce } from './copy.mjs';
+import { runChip, runLive } from './run-chip.mjs';
 import { applyReplacement, insertAfterLine, removeSpan, insertIntoSkills, inverseEdit, undoEdit } from './text-edits.mjs';
 
 // Full literal class names — the Tailwind CDN JIT only generates what it can
@@ -458,4 +459,50 @@ export function init(data) {
   if (typeof data.draftText === 'string') storeEdits();
   else loadEdits();
   render();
+
+  // A background AI check — started by the upload or by Re-check (#184): the
+  // chips beside the number and on the bar follow it and offer the result.
+  // The editor is never replaced under the user's hands: "Use it" navigates,
+  // and the text typed meanwhile travels along as the next page's draft.
+  if (data.runId) watchRun(data.runId);
+
+  function watchRun(id) {
+    const slots = [...document.querySelectorAll('[data-ai-run]')];
+    if (slots.length === 0) return;
+    const runUrl = '/target/runs/' + id;
+    const paint = (chip) => {
+      for (const el of slots) {
+        el.textContent = '';
+        el.hidden = !chip;
+        if (!chip) continue;
+        el.className = el.className.replace(/\btext-(ink-muted|ok|danger)\b/g, '').trim() + ' ' + chip.tone;
+        el.append(chip.text + (chip.link ? ' — ' : ''));
+        if (!chip.link) continue;
+        const a = document.createElement('a');
+        a.href = chip.link.href;
+        a.className = 'underline decoration-dotted underline-offset-2 hover:text-accent-deep';
+        a.textContent = chip.link.label;
+        if (chip.kind === 'done') a.addEventListener('click', carryDraft);
+        el.append(a);
+      }
+    };
+    const carryDraft = (e) => {
+      const to = new URL(e.currentTarget.href, location.href).searchParams.get('match');
+      if (!to || editor.value === data.resumeText) return;
+      try { localStorage.setItem('target-draft:' + to, editor.value); } catch {}
+    };
+    const tick = async () => {
+      let state = null;
+      try {
+        const res = await fetch(runUrl + '/state');
+        state = res.status === 404 ? { gone: true } : await res.json();
+      } catch {
+        setTimeout(tick, 3000);
+        return;
+      }
+      paint(runChip(state, runUrl));
+      if (runLive(state)) setTimeout(tick, 2000);
+    };
+    tick();
+  }
 }

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { JobStatus, type Prisma } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../../db';
+import { startDraftCheck } from '../draft-check';
 import { logger } from '../../logger';
 import { hashShortId } from '../../text-utils';
 import { appliedResumeColumns } from '../applied-resume';
@@ -35,7 +36,7 @@ import { draftStash } from '../draft-stash';
 import { scanInBackground } from '../../resume/scan';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
-import { claimRun, findLiveRun, matchStep, startRun, updateRun } from '../target-runs';
+import { claimRun, findLiveRun, getRun, matchStep, startRun, updateRun } from '../target-runs';
 import { startSuggestionsRun } from '../suggestions-run';
 import {
   deleteCoverLettersForResume,
@@ -609,9 +610,16 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
   // "Rebuild keywords": read the terms out of the posting again instead of
   // inheriting the frame this posting has been carrying (issue #79).
   const rebuild = form.rebuild === '1';
-  const toTarget = form.next === 'target';
+  // The editor's Re-check keeps the editor open and follows the run from there (#184).
+  const inline = form.next === 'editor';
+  const toTarget = form.next === 'target' || inline;
   const resultUrl = (matchId: number) =>
     toTarget ? `/jobs/${id}/target?match=${matchId}` : `/jobs/${id}?match=${matchId}#resume-match`;
+  const editorUrl = (runId: string) => `/jobs/${id}/target?match=${Number(form.matchId) || ''}&run=${runId}`;
+  const follow = (runUrl: string) =>
+    inline
+      ? flashRedirect(editorUrl(runUrl.slice(runUrl.lastIndexOf('/') + 1)), 'ok', BACKGROUND_CHECK_NOTICE)
+      : c.redirect(runUrl, 303);
 
   // The same text was already judged: show that analysis instead of paying
   // for it again — unless "Re-run anyway" or a rebuild asked for a fresh call.
@@ -627,7 +635,7 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
       });
     }
     if (reused) {
-      return c.redirect(startSuggestionsRun({ match: reused.row, job: jobInput, resumeName: resume.name, resultUrl: resultUrl(reused.row.id) }), 303);
+      return follow(startSuggestionsRun({ match: reused.row, job: jobInput, resumeName: resume.name, resultUrl: resultUrl(reused.row.id) }));
     }
   }
 
@@ -637,10 +645,11 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
     `match:${id}:${resume.id}:${mode}:${rebuild ? 'rebuild' : 'frame'}:${hashShortId(text)}`,
     { steps: [matchStep(mode)], jobTitle: job.title, resumeName: resume.name, jobId: id },
   );
-  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
+  if (joined) return follow(`/target/runs/${run.id}`);
   startRun(run.id, async () => {
-    // Ephemeral (scratch) compares keep only the current analysis.
-    if (resume.hidden) await deleteMatchesForResume(resume.id);
+    // Ephemeral (scratch) compares keep only the current analysis — unless the
+    // editor is watching one of them, in which case the row it shows must stay.
+    if (resume.hidden && !inline) await deleteMatchesForResume(resume.id);
     const row = await matchResumeToJob({ id: resume.id, version: resume.version, text }, jobInput, { draft, mode, rebuild });
     if (!row) {
       updateRun(run.id, { stage: 'error', error: 'Comparison failed — see the web logs.' });
@@ -650,13 +659,16 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
       stage: 'done',
       resultUrl: resultUrl(row.id),
       tailorUrl: `/jobs/${id}/target?match=${row.id}`,
+      results: { [matchStep(mode)]: `AI match ${row.matchScore}/100` },
       flash: rebuild
         ? `Keywords rebuilt from the posting — AI match ${row.matchScore}/100, counted over a fresh set of terms.`
         : `${draft ? 'Draft' : `"${resume.name}"`} ${mode === 'fast' ? 'checked' : 'compared'} — AI match ${row.matchScore}/100.`,
     });
   });
-  return c.redirect(`/target/runs/${run.id}`, 303);
+  return follow(`/target/runs/${run.id}`);
 });
+
+const BACKGROUND_CHECK_NOTICE = 'The AI check runs in the background — its number lands beside the score when it is done.';
 
 /** "Get suggestions" on a quick check: the lazy second call, the verdicts and the score untouched (ADR 0029). */
 jobsRoute.post('/jobs/:id/matches/:matchId/suggestions', async (c) => {
@@ -852,6 +864,9 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
   // An instant check arrives with its parsed upload — taken once; from then on the browser holds it.
   const draftKey = c.req.query('draft');
   const draftText = draftTextForPage(draftKey ? draftStash.take(draftKey) : null, match.id);
+  // A background AI check the page follows (#184); a run that is gone is simply not shown.
+  const runId = c.req.query('run');
+  const watched = runId ? getRun(runId) : null;
   return c.html(
     <TargetPage
       job={{ id: job.id, title: job.title, companyName: job.company.name, location: job.location, description: job.description }}
@@ -862,6 +877,7 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
       previous={previousFor(match, matches)}
       resumeText={match.resumeText || resume.text}
       draftText={draftText}
+      runId={watched?.id ?? null}
       verification={verifications[0] ?? null}
       fileVerdict={fileVerdict}
       cleanHref={file.clean ? `/resumes/${resume.id}/render` : null}
@@ -879,98 +895,41 @@ jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit
   const form = await c.req.parseBody();
   const resumeId = Number(form.resumeId);
   if (!Number.isFinite(resumeId)) return c.text('Bad resume id', 400);
-  const [job, existing] = await Promise.all([
+  const [job, resume] = await Promise.all([
     prisma.job.findUnique({ where: { id }, include: { company: { select: { name: true } } } }),
     getResume(resumeId),
   ]);
-  if (!job || !existing) return c.text('Not found', 404);
+  if (!job || !resume) return c.text('Not found', 404);
   const upload = await readResumeUpload(form);
   if ('error' in upload) return flashRedirect(`/jobs/${id}/target`, 'err', upload.error);
 
-  // The default is the instant check: the new text becomes an unsaved draft
-  // over the analysis the page showed — no AI call, no new version, nothing
-  // written (docs/target-plan.md §3.2 item 5). "Upload & analyze" opts into
-  // the full run below.
-  if (form.uploadMode !== 'analyze') {
-    const decision = decideInstantCheck(await frameFor(id, resumeId, Number(form.matchId)), upload.text);
-    if (decision.kind !== 'analyze') {
-      const when = formatRelative(decision.frame.createdAt);
-      const page = `/jobs/${id}/target?match=${decision.frame.id}`;
-      if (decision.kind === 'unchanged') {
-        return flashRedirect(page, 'warn', unchangedNotice(upload.sourceFilename, when));
-      }
-      const key = draftStash.put({ matchId: decision.frame.id, text: upload.text });
-      const ms = Date.now() - started;
-      logger.info(
-        { jobId: id, matchId: decision.frame.id, resumeId, file: upload.sourceFilename, chars: upload.text.length, ms },
-        'resume: instant check',
-      );
-      return flashRedirect(`${page}&draft=${key}`, 'ok', instantCheckNotice(upload.sourceFilename, when, ms));
-    }
+  // One button (#184): the file opens in the editor at once as an unsaved
+  // draft over the analysis the page showed, and the quick AI check of that
+  // text runs behind it — the page follows the run and offers the result when
+  // it lands. Nothing is saved; a version is the sticky bar's decision. With
+  // no analysis to show the draft against, the check runs on the progress page.
+  const decision = decideInstantCheck(await frameFor(id, resumeId, Number(form.matchId)), upload.text);
+  if (decision.kind === 'unchanged') {
+    const page = `/jobs/${id}/target?match=${decision.frame.id}`;
+    return flashRedirect(page, 'warn', unchangedNotice(upload.sourceFilename, formatRelative(decision.frame.createdAt)));
   }
-
-  // Scratch (ephemeral) resumes are replaced in place with no scan and no
-  // history — a fresh upload means a fresh analysis, nothing saved.
-  const ephemeral = existing.hidden;
-  const newName = ephemeral ? nameFromFilename(upload.sourceFilename) : existing.name;
-  const { run, joined } = claimRun(`reupload:${id}:${resumeId}:${hashShortId(upload.text)}`, {
-    steps: ['keywords'],
-    jobTitle: job.title,
-    resumeName: newName,
-    jobId: id,
+  const run = startDraftCheck({
+    job: { id: job.id, title: job.title, companyName: job.company.name, location: job.location, description: job.description },
+    resume,
+    text: upload.text,
   });
-  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
-  startRun(run.id, async () => {
-    let resume;
-    if (ephemeral) {
-      resume = await upsertScratchResume({ name: newName, ...upload });
-    } else {
-      resume = await replaceResumeFile(resumeId, upload);
-      // The match never reads the scan, so the new version's scan runs
-      // alongside it instead of ahead of it — a whole resume-model call off
-      // the wait. Cost: Resume.skills stay one version stale until it lands.
-      scanInBackground(resume);
-    }
-    // A file whose text did not change is already answered.
-    const reused = await findReusableMatch(job.id, resume.id, resume.text, 'fast');
-    if (reused) {
-      updateRun(run.id, {
-        stage: 'done',
-        resultUrl: `/jobs/${id}/target?match=${reused.row.id}`,
-        flash: `${ephemeral ? `"${newName}"` : `v${resume.version}`} uploaded. ${reuseNotice(formatRelative(reused.row.createdAt))}`,
-        reused: true,
-      });
-      return;
-    }
-    if (ephemeral) {
-      await deleteMatchesForResume(resume.id);
-      await deleteCoverLettersForResume(resume.id);
-    }
-    const row = await matchResumeToJob(resume, {
-      id: job.id,
-      title: job.title,
-      companyName: job.company.name,
-      location: job.location,
-      description: job.description,
-    });
-    if (!row) {
-      updateRun(run.id, {
-        stage: 'error',
-        error: ephemeral
-          ? 'Upload worked, but the comparison failed — see the web logs.'
-          : `v${resume.version} uploaded, but the comparison failed — see the web logs.`,
-      });
-      return;
-    }
-    updateRun(run.id, {
-      stage: 'done',
-      resultUrl: `/jobs/${id}/target?match=${row.id}`,
-      flash: ephemeral
-        ? `"${newName}" checked — AI match ${row.matchScore}/100.`
-        : `v${resume.version} uploaded and checked — AI match ${row.matchScore}/100.`,
-    });
-  });
-  return c.redirect(`/target/runs/${run.id}`, 303);
+  if (decision.kind === 'analyze') return c.redirect(`/target/runs/${run.id}`, 303);
+  const key = draftStash.put({ matchId: decision.frame.id, text: upload.text });
+  const ms = Date.now() - started;
+  logger.info(
+    { jobId: id, matchId: decision.frame.id, resumeId, file: upload.sourceFilename, chars: upload.text.length, ms, runId: run.id },
+    'resume: instant check',
+  );
+  return flashRedirect(
+    `/jobs/${id}/target?match=${decision.frame.id}&draft=${key}&run=${run.id}`,
+    'ok',
+    instantCheckNotice(upload.sourceFilename, ms),
+  );
 });
 
 /** The analysis a re-upload is checked against: the one the page showed, else the resume's latest for the job. */

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -21,6 +21,7 @@ import { suggestForMatch } from '../../resume/suggestions';
 import { suggestionsKey } from '../suggestions-run';
 import { draftStash } from '../draft-stash';
 import { decideInstantCheck, instantCheckNotice } from '../instant-check';
+import { startDraftCheck } from '../draft-check';
 import { TargetStartPage } from '../pages/target-start';
 import { TargetRunPage } from '../pages/target-run';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
@@ -83,6 +84,8 @@ targetRoute.get('/target/runs/:id/state', (c) => {
     jobTitle: run.jobTitle,
     progress: run.progress ?? null,
     results: run.results ?? {},
+    resultUrl: run.resultUrl ?? null,
+    error: run.error ?? null,
     stepMs: run.stepMs,
     stageElapsedMs: Date.now() - run.stageAt,
     elapsedMs: Date.now() - run.startedAt,
@@ -262,10 +265,12 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
       const decision = decideInstantCheck(await getLatestMatchForResumeAndJob(job.id, resume.id), resume.text);
       if (decision.kind === 'draft') {
         const key = draftStash.put({ matchId: decision.frame.id, text: resume.text });
+        // The AI check of the new text runs behind the draft; the editor follows it (#184).
+        const check = startDraftCheck({ job: jobInput, resume, text: resume.text });
         updateRun(run.id, {
           stage: 'done',
-          resultUrl: `/jobs/${job.id}/target?match=${decision.frame.id}&draft=${key}`,
-          flash: instantCheckNotice(resume.name, formatRelative(decision.frame.createdAt), Date.now() - checkStarted),
+          resultUrl: `/jobs/${job.id}/target?match=${decision.frame.id}&draft=${key}&run=${check.id}`,
+          flash: instantCheckNotice(resume.name, Date.now() - checkStarted),
         });
         return;
       }

--- a/src/web/run-chip.test.ts
+++ b/src/web/run-chip.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// @ts-expect-error — plain JS with no declaration file; the shape is asserted below.
+const mod = import('./public/run-chip.mjs') as Promise<{
+  runChip: (state: Record<string, unknown> | null, runUrl: string) => { kind: string; text: string; link: { href: string; label: string } | null } | null;
+  runLive: (state: Record<string, unknown> | null) => boolean;
+}>;
+
+test('the chip follows a run: running with its seconds, ready with the result and Use it, failed with why', async () => {
+  const { runChip, runLive } = await mod;
+  const running = runChip({ stage: 'keywords', elapsedMs: 21_600, results: {} }, '/target/runs/x');
+  assert.deepEqual(running, { kind: 'running', tone: 'text-ink-muted', text: 'AI check running · 22 s', link: { href: '/target/runs/x', label: 'progress' } });
+  const done = runChip({ stage: 'done', results: { keywords: 'AI match 91/100' }, resultUrl: '/jobs/1/target?match=9' }, '/target/runs/x');
+  assert.deepEqual(done, { kind: 'done', tone: 'text-ok', text: 'AI check ready: AI match 91/100', link: { href: '/jobs/1/target?match=9', label: 'Use it' } });
+  assert.equal(runChip({ stage: 'error', error: 'nope' }, '/target/runs/x')?.link?.label, 'why');
+  assert.equal(runChip({ gone: true }, '/target/runs/x'), null);
+  assert.equal(runLive({ stage: 'keywords' }), true);
+  assert.equal(runLive({ stage: 'done' }), false);
+  assert.equal(runLive({ gone: true }), false);
+});


### PR DESCRIPTION
Part of #184 — the flow (items 1 and 2 of the issue). The lane measurements, the budgets and the model defaults (items 3–4) follow in their own PR on top of this one. One changed behaviour: **v1.64.0**.

## What

- **One button.** The editor's re-upload popover had *Upload & check (seconds)* — the file as a draft over the shown analysis, the number moving a point or two — and *Upload as vN & check with AI* — minutes on a progress page. Nazar read the first as "nothing happened" and the second as "too slow", and both readings were right. Now **Upload & check**: `POST /jobs/:id/target/reupload` parses the file, stashes it as the draft (as before) and starts the quick AI check of that text as a background run (`web/draft-check.ts`), then redirects to the editor with `&draft=…&run=…`. With no earlier analysis to show the draft against, the check runs on the progress page as before.
- **The check lands beside the score, not under the cursor.** `[data-ai-run]` chips — one on the score line, one on the sticky bar — poll `/target/runs/:id/state` (which now carries `resultUrl` and `error`): *AI check running · 22 s — progress* → *AI check ready: AI match 54/100 — Use it* → the new analysis, or *AI check failed — why*. `public/run-chip.mjs` (pure, tested) says what a state reads as; `target-page.mjs` paints it. "Use it" navigates; text typed meanwhile travels along as the next page's draft (`target-draft:<newMatchId>`), so nothing the user wrote is lost and the editor is never replaced under their hands.
- **Nothing is saved by the upload.** The check is a draft row (`draft: true`) over the resume's current version — no new version, no scan. Save as vN / Save as a tailored copy on the bar stay the saving decisions (Nazar's answer to question 2).
- **Re-check with AI and Full analysis from the editor** post `next=editor`: the run is claimed as before, the editor gets the flash and the chip instead of the progress page; a second press with the same text joins the run in flight; the memo still answers an unchanged text at once. The `/jobs/:id` card's Compare keeps the progress page.
- The Compare page (`/target`) does the same when a known resume's text changed: the draft opens with `&run=` and the check runs behind it.
- `docs/target-plan.md` §8: the 2026-09-02 "nothing auto-runs" decision revisited, with the reason it changed. CHANGELOG 1.64.0, version bump.

## Verification

- `npm run lint:types` + `npm test`: 2013 tests, 0 failures (new: the chip for running / ready / failed / gone; the notice).
- **On a copy of the live database** (the engine as configured there — `claude_code` + Haiku 4.5): a fixture .docx posted to the re-upload route answered in 303 with `&draft=…&run=…`; the editor opened with the new text and the live estimate (61, −22 vs AI), the two chips read *AI check ready: AI match 54/100 — Use it* within half a minute (a draft row, `?match=12`), **Use it** landed on that analysis with the editor showing the checked text, no unsaved-changes bar, no chip. **Re-check with AI** from the editor with an edited text answered 303 back to the editor with `&run=`; the same POST again joined the run (same run id); the run finished in 37 s with *AI match 70/100* and its `resultUrl`.
- The live containers were not touched.

## Release notes

### What's new
- Re-uploading a resume in the editor is one button: the file opens at once with the live estimate, the AI check runs in the background, and a chip beside the score offers the result when it lands. Re-check with AI and Full analysis keep the editor open the same way.

### Schema
- no schema changes

### Verification
- 2013 tests; the upload, the join and Re-check driven on a copy of the live database, the chip watched in the browser.

### References
- #184 · #168 · docs/target-plan.md §3.2 item 5 and §8

Tag after merge: `git tag -a v1.64.0 -m "One upload button, the AI check behind it" <merge-sha>`
