### PR TITLE
Default models per lane, budgets with a reason (#184, part 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,10 @@ ANTHROPIC_API_KEY=
 # Claude model for both classifier stages (Haiku 4.5 by default).
 CLAUDE_MODEL=claude-haiku-4-5-20251001
 # Claude model for resume scan + comparison (a few calls a day).
-CLAUDE_MODEL_RESUME=claude-opus-5
+# Empty = the engine's own default (Sonnet 5 on the Claude CLI, Haiku 4.5 on the API — measured 2026-09-05).
+CLAUDE_MODEL_RESUME=
+# Empty = Opus 5, the strongest writer.
+CLAUDE_MODEL_COVER=
 
 # Claude Code CLI (Claude.ai subscription).
 CLAUDE_CODE_BIN=claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.65.0] — 2026-09-05
+
+### Changed
+- **Default models per engine, from a measurement.** With the CLI's
+  thinking capped (v1.59.1) Sonnet 5 answers a quick check there in 19 s
+  and never broke its JSON, while Haiku 4.5 took 21–26 s and returned JSON
+  that could not be parsed in two of three calls; on the API Haiku is the
+  fast one at 18 s while Sonnet 5 and Opus 5 think for a minute. So an empty
+  Resume model slot now means Sonnet 5 on the Claude CLI and Haiku 4.5 on
+  the API, and an empty Cover letter slot means Opus 5, the writer, instead
+  of following the resume slot; `CLAUDE_MODEL_RESUME` and the new
+  `CLAUDE_MODEL_COVER` in `.env` still override (#184). The whole table —
+  scan, quick check, full analysis, suggestions, review on six lanes — is
+  in docs/target-plan.md §2.3.
+- **A resume call fails with a reason instead of waiting five minutes.**
+  Each tool-free call has a budget about twice its slowest measured lane —
+  quick check 90 s, scan / suggestions / review 120 s, full analysis
+  180 s — and the run page says what the engine answered (*"Comparison
+  failed: claude timed out after 90 s"*) instead of "see the web logs".
+- **The progress page states this install's lane.** *"Quick AI check —
+  about 20 s on Sonnet 5 through the Claude CLI"* instead of "half a minute
+  to a minute" for everyone; the AI engine tab warns when the resume slot
+  resolves to Haiku on the CLI.
+
 ## [1.64.0] — 2026-09-05
 
 ### Changed
@@ -2587,6 +2611,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.65.0]: https://github.com/applypack/applypack/compare/v1.64.0...v1.65.0
 [1.64.0]: https://github.com/applypack/applypack/compare/v1.63.0...v1.64.0
 [1.63.0]: https://github.com/applypack/applypack/compare/v1.62.1...v1.63.0
 [1.62.1]: https://github.com/applypack/applypack/compare/v1.62.0...v1.62.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.64.0] — 2026-09-05
+
+### Changed
+- **One upload button, and the AI check runs behind it.** The editor's
+  re-upload popover had two buttons — *Upload & check (seconds)*, which
+  opened the file as a draft and moved the number by a point or two, and
+  *Upload as vN & check with AI*, which took minutes on a progress page —
+  and read as "nothing happened" or "too slow" (#184). One **Upload & check**
+  now: the text opens in the editor within a second with the live estimate,
+  the quick AI check of that text starts in the background, and a chip
+  beside the score follows it — *AI check running · 22 s*, then *AI check
+  ready: AI match 91/100 — Use it*. Nothing is saved until Save as vN or
+  Save as a tailored copy on the bar; the check lands as a draft analysis.
+  **Re-check with AI** and **Full analysis** from the editor behave the
+  same way — the editor stays open, the chip follows the run, and text
+  typed meanwhile travels along as the next page's draft. The Compare page
+  does the same when a known resume's text changed.
+
 ## [1.63.0] — 2026-09-05
 
 ### Added
@@ -2569,6 +2587,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.64.0]: https://github.com/applypack/applypack/compare/v1.63.0...v1.64.0
 [1.63.0]: https://github.com/applypack/applypack/compare/v1.62.1...v1.63.0
 [1.62.1]: https://github.com/applypack/applypack/compare/v1.62.0...v1.62.1
 [1.62.0]: https://github.com/applypack/applypack/compare/v1.61.0...v1.62.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Creating a search profile from a resume (both entry points) | `src/web/profile-from-resume.ts` → `POST /resumes/:id/profile` and `POST /welcome/profile/create`; born inactive |
 | Prefill the profile from a resume scan | `src/resume/profile-draft.ts:buildProfileDraft` (pure) + `POST /settings/profiles/:id/fill-from-resume` (renders a draft, saves nothing — ADR 0015) |
 | Model for cover letters (empty = follows the resume model) | `/settings` → AI engine → "Cover letter model" (role `cover` in `ai-engine.ts`; pickers save on change) |
-| Model for resume calls | per-engine "Resume model" on `/settings` → AI engine; Claude engines fall back to `CLAUDE_MODEL_RESUME` in `.env` (default `claude-opus-5`) |
+| Model for resume calls, and for cover letters | per-engine "Resume model" / "Cover letter model" on `/settings` → AI engine; an empty slot takes `ai-engine.ts:defaultModelFor` — Sonnet 5 on the Claude CLI, Haiku 4.5 on the API, Opus 5 for the letter (measured 2026-09-05, docs/target-plan.md §2.3); `CLAUDE_MODEL_RESUME` / `CLAUDE_MODEL_COVER` in `.env` override. The budgets per call are `resume/prompts.ts:RESUME_TIMEOUT_MS`, the run page's band per lane `web/lane.ts` |
 | Ghost-job checklist prompt + verdict schema | `src/verification/prompts.ts` |
 | Liveness ladder (free ATS-API + page checks before AI verify) | `src/verification/liveness.ts` (ADR 0016), run by `verify.ts:checkLiveness` |
 | Letting a call use web search (API server tools / CLI WebSearch) | `AiRequest.webTools` in `src/ai-provider.ts`, args in `ai-provider-parse.ts:buildClaudeCodeArgs` |

--- a/docs/target-plan.md
+++ b/docs/target-plan.md
@@ -115,6 +115,38 @@ file again 117 → 2 s. §2.2's "~150-300 s" first-compare estimate was right
 for the CLI engine; the API-engine column stays unmeasured (not in the
 owner's chain).
 
+**Measured 2026-09-05** (#184; the reference pair — resume 6, 5 983 chars,
+against job 2094, a 7 721-char posting — through each engine directly with
+the prompts and budgets the call sites send; wall seconds, one call each;
+the CLI with the thinking cap of v1.59.1, the API as it ships):
+
+| Call | CLI Haiku 4.5 | CLI Sonnet 5 | CLI Opus 5 | API Haiku 4.5 | API Sonnet 5 | API Opus 5 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| scan | 50 | 44 | 54 | 35 | 75 | 72 |
+| quick check | 21, 26 (one reply unparseable) | **19** | 26 | **18** | 64 (thinks) | 39 |
+| full analysis | 75 (unparseable) | **34** | 58 | 44 | cut off at 16 000 output tokens, 13 808 of them thinking | 111 |
+| suggestions | 36 | 28 | 43 | — | — | — |
+| review | 54 | 39 | 51 | — | — | — |
+
+- Haiku on the CLI returned JSON that could not be parsed in 2 of 3
+  match calls; the app retries once, which doubles the wait. Sonnet and
+  Opus: 0 of 10.
+- The same pair scored 97–100 on Haiku, 75–79 on Sonnet, 65–83 on Opus
+  (69–72 through the CLI): Haiku is the generous one. The gold bench
+  (`npm run bench:resume`, fast and full) passes on all three; term
+  overlap with Haiku's frame is 77 % on Sonnet and 63–66 % on Opus.
+- The API's suggestions and review went unmeasured: this install's
+  Anthropic key was gone from `.env` and the database by the second pass.
+- Where the quick-check prompt goes (24 887 chars ≈ 6 200 tokens): the
+  rules 9 442, the resume 5 983, the posting 7 721, the context — two
+  confirmed facts, the 7 of 128 other-resume hints that name a posting
+  term, 15 previous keywords — 1 741. A smaller prompt is not where the
+  time is; the reply's 1.7–2.7 k tokens and the model's speed are.
+- Hence v1.65.0: an empty resume slot resolves to Sonnet 5 on the CLI and
+  Haiku 4.5 on the API, the cover slot to Opus 5; the budgets in
+  `prompts.ts:RESUME_TIMEOUT_MS`; the bands on the run page
+  (`web/lane.ts`).
+
 ---
 
 ## 3. Speed plan

--- a/docs/target-plan.md
+++ b/docs/target-plan.md
@@ -506,6 +506,10 @@ Sources: [jobscan.co](https://www.jobscan.co/blog/top-resume-keywords-boost-resu
   or instant check + full analysis auto-started in the background?~~ Decided
   2026-09-02 (block 3): instant check by default, nothing auto-runs — every
   auto-started analysis is 78–109 s of Opus on the CLI engine and the memo
-  only saves repeats. The background variant stays a separate branch if
-  ever wanted.
+  only saves repeats. **Revisited 2026-09-05 (#184, v1.64.0):** with the CLI
+  thinking cap a quick check is 19–26 s, and a user who uploads a file reads
+  a number that does not move as "nothing happened". One button now: the
+  draft opens at once, the quick check runs behind it (`web/draft-check.ts`),
+  a chip beside the score follows the run and offers the result; the memo
+  still makes a repeat free. The full analysis stays an explicit button.
 - Is the F8 curated lexicon worth its maintenance, or are F1-F7 enough?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.63.0",
+      "version": "1.64.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.64.0",
+      "version": "1.65.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/ai-engine.test.ts
+++ b/src/ai-engine.test.ts
@@ -18,10 +18,19 @@ const ENV: AiEngineEnv = {
   codexUsable: false,
   classifierModel: 'claude-haiku-4-5-20251001',
   resumeModel: 'claude-opus-5',
+  coverModel: '',
   openAiModel: '',
 };
 
 describe('resolveAiEngine', () => {
+  it('an empty .env resume model takes the backend default: Sonnet on the CLI, Haiku on the API; cover Opus', () => {
+    const out = resolveAiEngine({ order: ['claude_code', 'anthropic_api'], models: {} }, { ...ENV, resumeModel: '', hasAnthropicKey: true });
+    assert.equal(out.modelFor('claude_code', 'resume'), 'claude-sonnet-5');
+    assert.equal(out.modelFor('anthropic_api', 'resume'), 'claude-haiku-4-5-20251001');
+    assert.equal(out.modelFor('claude_code', 'cover'), 'claude-opus-5');
+    assert.equal(out.modelFor('anthropic_api', 'classifier'), ENV.classifierModel);
+  });
+
   it('seeds a one-engine chain from .env when nothing is stored', () => {
     const out = resolveAiEngine(null, ENV);
     assert.deepEqual(out.chain, ['claude_code']);
@@ -170,10 +179,11 @@ describe('cover role', () => {
     codexUsable: false,
     classifierModel: 'claude-haiku-4-5-20251001',
     resumeModel: 'claude-opus-5',
+    coverModel: '',
     openAiModel: '',
   };
 
-  it('follows the resume slot until it is set explicitly', () => {
+  it('takes the writer by default, whatever the resume slot says, until it is set explicitly', () => {
     const bare = resolveAiEngine({ order: ['claude_code'], models: {} }, env);
     assert.equal(bare.modelFor('claude_code', 'cover'), 'claude-opus-5');
 
@@ -181,7 +191,7 @@ describe('cover role', () => {
       { order: ['claude_code'], models: { claude_code: { resume: 'claude-sonnet-5' } } },
       env,
     );
-    assert.equal(viaResume.modelFor('claude_code', 'cover'), 'claude-sonnet-5');
+    assert.equal(viaResume.modelFor('claude_code', 'cover'), 'claude-opus-5');
 
     const explicit = resolveAiEngine(
       { order: ['claude_code'], models: { claude_code: { resume: 'claude-sonnet-5', cover: 'claude-opus-5' } } },

--- a/src/ai-engine.ts
+++ b/src/ai-engine.ts
@@ -155,10 +155,25 @@ export interface AiEngineEnv {
   geminiUsable: boolean;
   codexUsable: boolean;
   classifierModel: string;
+  /** CLAUDE_MODEL_RESUME / CLAUDE_MODEL_COVER from .env; '' = the backend's default for the role. */
   resumeModel: string;
+  coverModel: string;
   /** OPENAI_MODEL from .env, used when the openai_api slot is empty. */
   openAiModel: string;
 }
+
+/**
+ * The resume role's default per Claude backend, measured 2026-09-05 on the
+ * reference pair (docs/target-plan.md §2.3): the CLI caps thinking, so
+ * Sonnet 5 answers a quick check there in 19 s and never broke its JSON
+ * (Haiku did, twice in three calls); on the API Haiku 4.5 is the fast one
+ * at 18 s while Sonnet and Opus think for a minute. Letters want the writer.
+ */
+const RESUME_MODEL_DEFAULT: Record<'anthropic_api' | 'claude_code', string> = {
+  claude_code: 'claude-sonnet-5',
+  anthropic_api: 'claude-haiku-4-5-20251001',
+};
+const COVER_MODEL_DEFAULT = 'claude-opus-5';
 
 /** Engines that certainly cannot complete a call on this host right now. */
 export function providerUnusable(id: AiProviderId, env: AiEngineEnv): boolean {
@@ -184,7 +199,9 @@ export function defaultModelFor(id: AiProviderId, role: AiRole, env: AiEngineEnv
   switch (id) {
     case 'anthropic_api':
     case 'claude_code':
-      return role === 'classifier' ? env.classifierModel : env.resumeModel;
+      if (role === 'classifier') return env.classifierModel;
+      if (role === 'cover') return env.coverModel || COVER_MODEL_DEFAULT;
+      return env.resumeModel || RESUME_MODEL_DEFAULT[id];
     case 'gemini_cli':
       return role === 'classifier' ? 'gemini-2.5-flash' : 'gemini-2.5-pro';
     case 'openai_api':
@@ -259,14 +276,11 @@ export function resolveAiEngine(raw: unknown, env: AiEngineEnv): ResolvedAiEngin
     chain,
     skipped,
     modelFor(id, role) {
-      // An empty "cover" slot inherits the resume one: the extra role costs
-      // nothing until someone deliberately points it at another model.
-      const slots: AiRole[] = role === 'cover' ? ['cover', 'resume'] : [role];
-      for (const slot of slots) {
-        const stored = config.models[id]?.[slot]?.trim();
-        if (stored && modelFitsProvider(stored, id)) return stored;
-      }
-      return defaultModelFor(id, role === 'cover' ? 'resume' : role, env);
+      // An empty slot takes the backend's default for THAT role — the cover's
+      // is the strongest writer whatever the resume slot says (#184).
+      const stored = config.models[id]?.[role]?.trim();
+      if (stored && modelFitsProvider(stored, id)) return stored;
+      return defaultModelFor(id, role, env);
     },
   };
 }

--- a/src/ai-runtime.ts
+++ b/src/ai-runtime.ts
@@ -48,6 +48,7 @@ export function getAiEngineEnv(keys: AiKeys = {}): AiEngineEnv {
     codexUsable: codexAuthConfigured(),
     classifierModel: config.CLAUDE_MODEL,
     resumeModel: config.CLAUDE_MODEL_RESUME,
+    coverModel: config.CLAUDE_MODEL_COVER,
     openAiModel: config.OPENAI_MODEL,
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,9 @@ export const ConfigSchema = z.object({
   CLAUDE_MODEL: z.string().default('claude-haiku-4-5-20251001'),
   // Resume scan + resume-vs-job comparison: a few calls a day where judgment
   // matters more than cost, so a stronger model than the classifier's.
-  CLAUDE_MODEL_RESUME: z.string().default('claude-opus-5'),
+  /** Empty = the backend's own default for the role (ai-engine.ts:defaultModelFor). */
+  CLAUDE_MODEL_RESUME: z.string().default(''),
+  CLAUDE_MODEL_COVER: z.string().default(''),
   // Path to the Claude Code CLI when AI_PROVIDER=claude_code.
   CLAUDE_CODE_BIN: z.string().default('claude'),
   // Path to the Gemini CLI when the gemini_cli engine is selected.

--- a/src/resume/match.ts
+++ b/src/resume/match.ts
@@ -6,6 +6,7 @@ import {
   buildMatchPrompt,
   MATCH_FAST_MAX_TOKENS,
   MATCH_MAX_TOKENS,
+  RESUME_TIMEOUT_MS,
   parseMatchResponse,
   PROMPT_VERSION,
   readKeywords,
@@ -32,7 +33,6 @@ import {
 
 const PREVIOUS_KEYWORDS_MAX = 40;
 
-const MATCH_TIMEOUT_MS = 5 * 60_000;
 
 /**
  * One resume-vs-posting comparison, persisted as a ResumeMatch row. `resume.text`
@@ -51,7 +51,7 @@ const MATCH_TIMEOUT_MS = 5 * 60_000;
 export async function matchResumeToJob(
   resume: { id: number; text: string; version: number },
   job: MatchJobInput & { id: number },
-  opts: { draft?: boolean; mode?: MatchMode; rebuild?: boolean } = {},
+  opts: { draft?: boolean; mode?: MatchMode; rebuild?: boolean; onError?: (reason: string) => void } = {},
 ): Promise<ResumeMatch | null> {
   const mode = opts.mode ?? 'fast';
   const [facts, otherSkills, previousMatch, matcher] = await Promise.all([
@@ -93,7 +93,8 @@ export async function matchResumeToJob(
       maxTokens: mode === 'fast' ? MATCH_FAST_MAX_TOKENS : MATCH_MAX_TOKENS,
       label: mode === 'fast' ? 'resume-match-fast' : 'resume-match',
       role: 'resume',
-      timeoutMs: MATCH_TIMEOUT_MS,
+      timeoutMs: mode === 'fast' ? RESUME_TIMEOUT_MS.fast : RESUME_TIMEOUT_MS.full,
+      onError: opts.onError,
     },
     parseMatchResponse,
     { jobId: job.id, resumeId: resume.id },

--- a/src/resume/prompts.ts
+++ b/src/resume/prompts.ts
@@ -241,6 +241,26 @@ export type CoverResult = z.infer<typeof CoverSchema>;
 export const REVIEW_MAX_TOKENS = 6_000;
 
 /**
+ * How long each tool-free resume call may take before it fails with a
+ * reason (#184): about twice the slowest lane measured 2026-09-05
+ * (docs/target-plan.md §2.3). A call still running past this is not going
+ * to answer in time, and a five-minute wait for a killed process was the
+ * worst thing on the site.
+ */
+export const RESUME_TIMEOUT_MS = {
+  /** measured 35–75 s */
+  scan: 120_000,
+  /** 18–39 s; 64 s on Sonnet through the API, which thinks */
+  fast: 90_000,
+  /** 34–111 s */
+  full: 180_000,
+  /** 28–43 s */
+  suggestions: 120_000,
+  /** 39–54 s */
+  review: 120_000,
+} as const;
+
+/**
  * Bumped when the rubric or its rules change materially; stored with the score.
  * v2: the candidate's answers to earlier asks ride into the prompt, and the
  * rules say to write the figure into the rewrite instead of asking again.

--- a/src/resume/review.ts
+++ b/src/resume/review.ts
@@ -9,11 +9,11 @@ import {
   parseReviewResponse,
   REVIEW_MAX_TOKENS,
   REVIEW_PROMPT_VERSION,
+  RESUME_TIMEOUT_MS,
 } from './prompts';
 import { scoreReview } from './review-score';
 import { createReview } from './store';
 
-const REVIEW_TIMEOUT_MS = 5 * 60_000;
 
 /**
  * One strength review of one resume, judged on its own — no posting, no
@@ -32,7 +32,7 @@ export async function reviewResume(resume: {
   roleTypes: string[];
   /** Raw Resume.answers JSON — the figures an earlier run asked for (ADR 0030 phase 3). */
   answers?: unknown;
-}): Promise<ResumeReview | null> {
+}, onError?: (reason: string) => void): Promise<ResumeReview | null> {
   const answers = readAnswers(resume.answers);
   const prompt = buildReviewPrompt(resume.text, {
     atsChecks: parseWarnings(resume.text).map((w) => w.message),
@@ -41,7 +41,7 @@ export async function reviewResume(resume: {
   });
   const answer = await askForJson(
     await getAiRuntime(),
-    { ...prompt, maxTokens: REVIEW_MAX_TOKENS, label: 'resume-review', role: 'resume', timeoutMs: REVIEW_TIMEOUT_MS },
+    { ...prompt, maxTokens: REVIEW_MAX_TOKENS, label: 'resume-review', role: 'resume', timeoutMs: RESUME_TIMEOUT_MS.review, onError },
     parseReviewResponse,
     { resumeId: resume.id },
   );

--- a/src/resume/scan.ts
+++ b/src/resume/scan.ts
@@ -1,18 +1,20 @@
 import { logger } from '../logger';
 import { getAiRuntime } from '../ai-runtime';
 import { askForJson } from '../ai-json';
-import { buildScanPrompt, parseScanResponse, SCAN_MAX_TOKENS, type ResumeScan } from './prompts';
+import { buildScanPrompt, parseScanResponse, RESUME_TIMEOUT_MS, SCAN_MAX_TOKENS, type ResumeScan } from './prompts';
 import type { JsonResume } from './json-resume';
 import { anchorStructure, structureIsUsable } from './structure-anchor';
 import { saveResumeScan } from './store';
 
-const SCAN_TIMEOUT_MS = 5 * 60_000;
 
 /** Extracts the structured profile of a resume and stores it. Null on AI failure. */
-export async function scanResume(resume: { id: number; text: string }): Promise<ResumeScan | null> {
+export async function scanResume(
+  resume: { id: number; text: string },
+  onError?: (reason: string) => void,
+): Promise<ResumeScan | null> {
   const answer = await askForJson(
     await getAiRuntime(),
-    { ...buildScanPrompt(resume.text), maxTokens: SCAN_MAX_TOKENS, label: 'resume-scan', role: 'resume', timeoutMs: SCAN_TIMEOUT_MS },
+    { ...buildScanPrompt(resume.text), maxTokens: SCAN_MAX_TOKENS, label: 'resume-scan', role: 'resume', timeoutMs: RESUME_TIMEOUT_MS.scan, onError },
     parseScanResponse,
     { id: resume.id },
   );

--- a/src/resume/suggestions.ts
+++ b/src/resume/suggestions.ts
@@ -10,13 +10,13 @@ import {
   SUGGESTIONS_MAX_TOKENS,
   type MatchJobInput,
   type MatchSuggestions,
+  RESUME_TIMEOUT_MS,
 } from './prompts';
 import { readBreakdown } from './score';
 import { loadKeywordMatcher } from './keyword-matcher';
 import { gateActions } from './replacement-gate';
 import { listFacts, updateMatchSuggestions } from './store';
 
-const SUGGESTIONS_TIMEOUT_MS = 5 * 60_000;
 
 /**
  * The lazy second half of a quick check (ADR 0029): the stored verdicts —
@@ -25,7 +25,11 @@ const SUGGESTIONS_TIMEOUT_MS = 5 * 60_000;
  * analysis with the same score. Judged against the text the row analysed,
  * never the resume's current one. Null on AI failure.
  */
-export async function suggestForMatch(match: ResumeMatch, job: MatchJobInput): Promise<ResumeMatch | null> {
+export async function suggestForMatch(
+  match: ResumeMatch,
+  job: MatchJobInput,
+  onError?: (reason: string) => void,
+): Promise<ResumeMatch | null> {
   const facts = await listFacts();
   const prompt = buildSuggestionsPrompt(match.resumeText, job, {
     summary: match.summary,
@@ -37,7 +41,7 @@ export async function suggestForMatch(match: ResumeMatch, job: MatchJobInput): P
   });
   const answer = await askForJson(
     await getAiRuntime(),
-    { ...prompt, maxTokens: SUGGESTIONS_MAX_TOKENS, label: 'resume-suggestions', role: 'resume', timeoutMs: SUGGESTIONS_TIMEOUT_MS },
+    { ...prompt, maxTokens: SUGGESTIONS_MAX_TOKENS, label: 'resume-suggestions', role: 'resume', timeoutMs: RESUME_TIMEOUT_MS.suggestions, onError },
     // Every array defaults to empty, so "{}" parses — but a reply with nothing
     // in it would flip the row to "full" and lock the button out for good.
     (text) => {

--- a/src/scripts/resume-bench-once.ts
+++ b/src/scripts/resume-bench-once.ts
@@ -356,7 +356,7 @@ async function main(): Promise<void> {
       model: defaultModelFor(engineArg, 'resume', getAiEngineEnv()),
     }];
   } else {
-    targets = [{ tag: config.AI_PROVIDER, provider: getAiProvider(), model: config.CLAUDE_MODEL_RESUME }];
+    targets = [{ tag: config.AI_PROVIDER, provider: getAiProvider(), model: defaultModelFor(config.AI_PROVIDER, 'resume', getAiEngineEnv()) }];
   }
 
   if (modelArg !== undefined && !targets.some((t) => modelFitsProvider(modelArg, t.tag))) {

--- a/src/web/draft-check.ts
+++ b/src/web/draft-check.ts
@@ -1,0 +1,58 @@
+import type { Resume } from '@prisma/client';
+import { findReusableMatch, matchResumeToJob } from '../resume/match';
+import { reuseNotice } from '../resume/match-reuse';
+import type { MatchJobInput } from '../resume/prompts';
+import { hashShortId } from '../text-utils';
+import { formatRelative } from './format';
+import { claimRun, startRun, updateRun, type TargetRun } from './target-runs';
+
+/**
+ * The quick AI check of a text that just landed in the editor as a draft
+ * (#184): a draft row over the resume's current version — no new version, no
+ * scan — that the page follows through the run's state and offers when it
+ * lands. A text already judged is answered from the stored row; the same
+ * text twice joins the run in flight. Started by the re-upload on the editor
+ * and by the Compare page when a known resume's text changed.
+ */
+export function startDraftCheck(input: {
+  job: MatchJobInput & { id: number };
+  resume: Pick<Resume, 'id' | 'name' | 'text' | 'version'>;
+  text: string;
+}): TargetRun {
+  const { job, resume, text } = input;
+  const { run, joined } = claimRun(`check:${job.id}:${resume.id}:${hashShortId(text)}`, {
+    steps: ['keywords'],
+    jobTitle: job.title,
+    resumeName: resume.name,
+    jobId: job.id,
+    backUrl: `/jobs/${job.id}/target`,
+    backLabel: 'Back to the editor',
+  });
+  if (joined) return run;
+  startRun(run.id, async () => {
+    const reused = await findReusableMatch(job.id, resume.id, text, 'fast');
+    if (reused) {
+      updateRun(run.id, {
+        stage: 'done',
+        resultUrl: `/jobs/${job.id}/target?match=${reused.row.id}`,
+        results: { keywords: `AI match ${reused.row.matchScore}/100 — the same text was judged ${formatRelative(reused.row.createdAt)}` },
+        flash: reuseNotice(formatRelative(reused.row.createdAt)),
+        reused: true,
+      });
+      return;
+    }
+    const row = await matchResumeToJob({ id: resume.id, text, version: resume.version }, job, { draft: text !== resume.text });
+    updateRun(
+      run.id,
+      row
+        ? {
+            stage: 'done',
+            resultUrl: `/jobs/${job.id}/target?match=${row.id}`,
+            results: { keywords: `AI match ${row.matchScore}/100` },
+            flash: `Checked — AI match ${row.matchScore}/100.`,
+          }
+        : { stage: 'error', error: 'The AI check failed — see the web logs.' },
+    );
+  });
+  return run;
+}

--- a/src/web/draft-check.ts
+++ b/src/web/draft-check.ts
@@ -4,7 +4,7 @@ import { reuseNotice } from '../resume/match-reuse';
 import type { MatchJobInput } from '../resume/prompts';
 import { hashShortId } from '../text-utils';
 import { formatRelative } from './format';
-import { claimRun, startRun, updateRun, type TargetRun } from './target-runs';
+import { claimRun, runFailure, startRun, updateRun, type TargetRun } from './target-runs';
 
 /**
  * The quick AI check of a text that just landed in the editor as a draft
@@ -41,7 +41,13 @@ export function startDraftCheck(input: {
       });
       return;
     }
-    const row = await matchResumeToJob({ id: resume.id, text, version: resume.version }, job, { draft: text !== resume.text });
+    let reason = '';
+    const row = await matchResumeToJob({ id: resume.id, text, version: resume.version }, job, {
+      draft: text !== resume.text,
+      onError: (r) => {
+        reason = r;
+      },
+    });
     updateRun(
       run.id,
       row
@@ -51,7 +57,7 @@ export function startDraftCheck(input: {
             results: { keywords: `AI match ${row.matchScore}/100` },
             flash: `Checked — AI match ${row.matchScore}/100.`,
           }
-        : { stage: 'error', error: 'The AI check failed — see the web logs.' },
+        : { stage: 'error', error: runFailure('The AI check failed', reason) },
     );
   });
   return run;

--- a/src/web/instant-check.test.ts
+++ b/src/web/instant-check.test.ts
@@ -14,12 +14,10 @@ test('the analysed text is unchanged, anything else is a draft', () => {
   assert.equal(decideInstantCheck(frame, frame.resumeText + '\n').kind, 'draft', 'a whitespace edit is a draft');
 });
 
-test('the draft notice names the file, the frame and the inherited statuses', () => {
-  const text = instantCheckNotice('cv-v3.pdf', '2h ago', 24);
-  assert.match(text, /"cv-v3\.pdf" checked in 24 ms — no AI call/);
-  assert.match(text, /analysis from 2h ago/);
-  assert.match(text, /confirms what is present/);
-  assert.match(text, /add \/ confirm \/ can't-claim keep the AI's verdict/);
+test('the draft notice names the file and says the AI check follows', () => {
+  const text = instantCheckNotice('cv-v3.pdf', 24);
+  assert.match(text, /"cv-v3\.pdf" opened in the editor in 24 ms/);
+  assert.match(text, /runs in the background/);
   assert.match(unchangedNotice('cv.pdf', '3m ago'), /"cv\.pdf" has the same text .* \(3m ago\)/);
 });
 

--- a/src/web/instant-check.ts
+++ b/src/web/instant-check.ts
@@ -1,11 +1,12 @@
 /*
- * Instant check (docs/target-plan.md §3.2 item 5): a re-uploaded resume is
- * parsed and shown as an unsaved draft over the latest analysis of the
- * posting — no AI call, no new version, nothing saved. The live estimate on
- * the page reads that analysis as its frame: the text confirms what is
- * `present`, while `add` / `ask_user` / `cannot_claim` stay the AI's verdict
- * on the resume it analysed, until "Re-check with AI" makes the draft
- * official. Pure — the routes decide what to fetch and where to redirect.
+ * Instant check (docs/target-plan.md §3.2 item 5, revisited by #184): a
+ * re-uploaded resume is parsed and shown as an unsaved draft over the latest
+ * analysis of the posting within a second — no new version, nothing saved —
+ * while the quick AI check of the same text runs behind it (draft-check.ts)
+ * and lands beside the score. Until then the live estimate reads the frame
+ * analysis: the text confirms what is `present`, while `add` / `ask_user` /
+ * `cannot_claim` stay the AI's verdict on the resume it analysed. Pure — the
+ * routes decide what to fetch and where to redirect.
  */
 
 /** The stored analysis a draft is checked against. */
@@ -28,12 +29,11 @@ export function decideInstantCheck(frame: Frame | null, text: string): InstantDe
   return frame.resumeText === text ? { kind: 'unchanged', frame } : { kind: 'draft', frame };
 }
 
-/** The flash over a checked draft; `when` is the frame's age ("2h ago"). */
-export function instantCheckNotice(filename: string, when: string, ms: number): string {
+/** The flash over the draft while its AI check runs behind it (#184). */
+export function instantCheckNotice(filename: string, ms: number): string {
   return (
-    `"${filename}" checked in ${ms} ms — no AI call. The estimate is measured against the analysis ` +
-    `from ${when}: the text confirms what is present; add / confirm / can't-claim keep the AI's ` +
-    `verdict on the analysed version until you re-check.`
+    `"${filename}" opened in the editor in ${ms} ms. The estimate below is measured against the last ` +
+    `analysis; the AI check of this text runs in the background and its number lands beside the score.`
   );
 }
 

--- a/src/web/lane.test.ts
+++ b/src/web/lane.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { bandFor, laneLabel, laneOf } from './lane';
+
+test('the lane is the engine and the model family; anything else is unmeasured', () => {
+  assert.equal(laneOf('claude_code', 'claude-sonnet-5'), 'cli-sonnet');
+  assert.equal(laneOf('claude_code', 'claude-haiku-4-5-20251001'), 'cli-haiku');
+  assert.equal(laneOf('anthropic_api', 'claude-opus-5'), 'api-opus');
+  assert.equal(laneOf('anthropic_api', ''), 'other');
+  assert.equal(laneOf('gemini_cli', 'gemini-2.5-pro'), 'other');
+  assert.equal(laneOf('openai_api', 'claude-sonnet-5'), 'other');
+});
+
+test('a measured lane names its band per step; an unmeasured one names nothing', () => {
+  assert.equal(bandFor('keywords', 'cli-sonnet'), '20 s');
+  assert.equal(bandFor('match', 'api-opus'), '110 s');
+  assert.equal(bandFor('letter', 'cli-sonnet'), null);
+  assert.equal(bandFor('keywords', 'other'), null);
+  assert.equal(laneLabel('cli-haiku'), 'Haiku 4.5 through the Claude CLI');
+  assert.equal(laneLabel('other'), 'this engine');
+});

--- a/src/web/lane.ts
+++ b/src/web/lane.ts
@@ -1,0 +1,55 @@
+/*
+ * Which lane the resume calls run on — engine × model family — and what
+ * each step costs there, measured 2026-09-05 on the reference pair, a
+ * 6 000-character resume against a 7 700-character posting
+ * (docs/target-plan.md §2.3). The run page states the band for the lane
+ * this install is on instead of one "half a minute to a minute" for all.
+ * Pure — tested in lane.test.ts.
+ */
+
+export type Lane = 'cli-haiku' | 'cli-sonnet' | 'cli-opus' | 'api-haiku' | 'api-sonnet' | 'api-opus' | 'other';
+type MeasuredLane = Exclude<Lane, 'other'>;
+type TimedStep = 'scan' | 'keywords' | 'match' | 'suggestions' | 'review';
+
+const LABEL: Record<MeasuredLane, string> = {
+  'cli-haiku': 'Haiku 4.5 through the Claude CLI',
+  'cli-sonnet': 'Sonnet 5 through the Claude CLI',
+  'cli-opus': 'Opus 5 through the Claude CLI',
+  'api-haiku': 'Haiku 4.5 on the API',
+  'api-sonnet': 'Sonnet 5 on the API',
+  'api-opus': 'Opus 5 on the API',
+};
+
+/**
+ * Wall seconds per call. The CLI caps thinking (v1.59.1), so Sonnet and
+ * Opus are quick there; on the API Sonnet 5 and Opus 5 think for a minute
+ * and the API's suggestions / review were not measured ("~" is the CLI
+ * ratio applied to the API's quick check).
+ */
+const BANDS: Record<MeasuredLane, Record<TimedStep, string>> = {
+  'cli-sonnet': { scan: '45 s', keywords: '20 s', match: '35 s', suggestions: '30 s', review: '40 s' },
+  'cli-haiku': { scan: '50 s', keywords: '25 s, twice that when a reply has to be retried', match: '75 s', suggestions: '35 s', review: '55 s' },
+  'cli-opus': { scan: '55 s', keywords: '25 s', match: '60 s', suggestions: '45 s', review: '50 s' },
+  'api-haiku': { scan: '35 s', keywords: '20 s', match: '45 s', suggestions: '~30 s', review: '~40 s' },
+  'api-sonnet': { scan: '75 s', keywords: '65 s', match: 'more than 2 minutes', suggestions: '~1 minute', review: '~1 minute' },
+  'api-opus': { scan: '70 s', keywords: '40 s', match: '110 s', suggestions: '~1 minute', review: '~1 minute' },
+};
+
+export function laneOf(provider: string, model: string): Lane {
+  const family = /haiku/i.test(model) ? 'haiku' : /sonnet/i.test(model) ? 'sonnet' : /opus/i.test(model) ? 'opus' : null;
+  if (!family) return 'other';
+  if (provider === 'claude_code') return `cli-${family}`;
+  if (provider === 'anthropic_api') return `api-${family}`;
+  return 'other';
+}
+
+export function laneLabel(lane: Lane): string {
+  return lane === 'other' ? 'this engine' : LABEL[lane];
+}
+
+/** The measured band for a step on a lane, or null when either is not one we measured. */
+export function bandFor(step: string, lane: Lane): string | null {
+  if (lane === 'other') return null;
+  const bands: Record<string, string> = BANDS[lane];
+  return bands[step] ?? null;
+}

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -1207,7 +1207,7 @@ const AiEngineCard: FC<{ engine: AiEngineRow }> = ({ engine: e }) => (
             freeText={e.freeTextModels}
           />
         </Field>
-        <Field label="Resume model" hint="Resume scan, match, verification — judgment calls.">
+        <Field label="Resume model" hint="Resume scan, match, verification — judgment calls. Empty = Sonnet 5 on the Claude CLI, Haiku 4.5 on the API (measured 2026-09-05).">
           <ModelPicker
             name="resume"
             value={e.resumeModel}
@@ -1216,7 +1216,7 @@ const AiEngineCard: FC<{ engine: AiEngineRow }> = ({ engine: e }) => (
             freeText={e.freeTextModels}
           />
         </Field>
-        <Field label="Cover letter model" hint="Writing quality, not analysis. Empty follows the resume model.">
+        <Field label="Cover letter model" hint="Writing quality, not analysis. Empty = Opus 5, the strongest writer.">
           <ModelPicker
             name="cover"
             value={e.coverModel}
@@ -1225,6 +1225,13 @@ const AiEngineCard: FC<{ engine: AiEngineRow }> = ({ engine: e }) => (
             freeText={e.freeTextModels}
           />
         </Field>
+        {e.id === 'claude_code' && /haiku/.test(e.resumeModel || e.resumeDefault) && (
+          <Hint class="sm:col-span-3">
+            Measured 2026-09-05 on this lane: Haiku 4.5 answers a quick check in 21–26 s but returned
+            JSON that could not be parsed in 2 of 3 calls, and each costs a retry. Sonnet 5 answered
+            in 19 s with none — it is the default when this slot is empty.
+          </Hint>
+        )}
         </div>
         <div class="mt-3 flex items-center gap-3">
           {/* The no-JS path: settings-models.mjs hides this and saves on change. */}

--- a/src/web/pages/target-run.tsx
+++ b/src/web/pages/target-run.tsx
@@ -4,6 +4,7 @@ import { Layout } from '../layout';
 import { Button, Card, Hint } from '../ui';
 import { RunSteps, type StepView } from './run-steps';
 import type { RunStep, TargetRun } from '../target-runs';
+import { bandFor, laneLabel, type Lane } from '../lane';
 
 const STEP_VIEW: Record<RunStep, StepView> = {
   liveness: {
@@ -22,19 +23,19 @@ const STEP_VIEW: Record<RunStep, StepView> = {
     // Also reached by a plain re-scan and a first upload, where there is no
     // "new version" to speak of.
     label: 'Read the resume',
-    detail: 'headline, skills, ATS issues, the resume as a shape — half a minute to a minute',
+    detail: 'headline, skills, ATS issues, the resume as a shape',
   },
   keywords: {
     label: 'Quick AI check',
-    detail: 'the resume model judges every keyword, the gates and the score — no edit suggestions — half a minute to a minute',
+    detail: 'the resume model judges every keyword, the gates and the score — no edit suggestions',
   },
   match: {
     label: 'Full AI analysis',
-    detail: 'the resume model reads both texts and writes the full report with edit suggestions — 1½ to 2 minutes on Opus',
+    detail: 'the resume model reads both texts and writes the full report with edit suggestions',
   },
   suggestions: {
     label: 'Edit suggestions',
-    detail: 'what to change and what to remove, written from the stored keyword verdicts — the score stays — about a minute on Opus',
+    detail: 'what to change and what to remove, written from the stored keyword verdicts — the score stays',
   },
   verify: {
     label: 'Research the company',
@@ -46,7 +47,7 @@ const STEP_VIEW: Record<RunStep, StepView> = {
   },
   review: {
     label: 'Review the resume',
-    detail: 'six dimensions graded with quotes from your own text, then the advice — about a minute on Opus',
+    detail: 'six dimensions graded with quotes from your own text, then the advice',
   },
   score: {
     label: 'Score the best matches',
@@ -54,12 +55,32 @@ const STEP_VIEW: Record<RunStep, StepView> = {
   },
 };
 
+/** What the timed steps cost when the lane is not one we measured. */
+const GENERIC_BAND: Partial<Record<RunStep, string>> = {
+  scan: 'half a minute to a minute',
+  keywords: 'half a minute to a minute',
+  match: '1½ to 2 minutes on Opus',
+  suggestions: 'about a minute on Opus',
+  review: 'about a minute on Opus',
+};
+
+/** The step copy with this install's measured band appended — "about 20 s on Sonnet 5 through the Claude CLI" (#184). */
+function stepView(lane: Lane): Record<RunStep, StepView> {
+  const out = { ...STEP_VIEW };
+  for (const step of Object.keys(GENERIC_BAND) as RunStep[]) {
+    const band = bandFor(step, lane);
+    const when = band ? `about ${band} on ${laneLabel(lane)}` : GENERIC_BAND[step];
+    out[step] = { ...STEP_VIEW[step], detail: `${STEP_VIEW[step].detail} — ${when}` };
+  }
+  return out;
+}
+
 /**
  * Live progress: /static/target-run.mjs polls the state route, advances the
  * step icons and fades a "what the analysis is doing right now" line under
  * the active step. Terminal states reload into the server-side redirect.
  */
-export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
+export const TargetRunPage: FC<{ run: TargetRun; lane: Lane }> = ({ run, lane }) => {
   const failed = run.stage === 'error';
   const currentIdx = run.steps.indexOf(run.stage as RunStep);
   const elapsed = Math.max(0, Math.round((Date.now() - run.startedAt) / 1000));
@@ -101,7 +122,7 @@ export const TargetRunPage: FC<{ run: TargetRun }> = ({ run }) => {
               <RunSteps
                 steps={run.steps}
                 currentIdx={currentIdx}
-                view={STEP_VIEW}
+                view={stepView(lane)}
                 stepMs={run.stepMs}
                 activeMs={Date.now() - run.stageAt}
                 results={run.results}

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -55,6 +55,8 @@ export interface TargetPageProps {
   resumeText: string;
   /** An instant check's parsed upload — opens in the editor as the unsaved draft (target-page.mjs). */
   draftText?: string | null;
+  /** A background AI check the page follows: the chip beside the number polls it (#184). */
+  runId?: string | null;
   /** The latest "Is this job real?" verdict — one line under the title, findings among the cautions (#162). */
   verification: VerificationForHint | null;
   flash?: FlashMessage | null;
@@ -115,6 +117,7 @@ export const TargetPage: FC<TargetPageProps> = ({
   previous,
   resumeText,
   draftText,
+  runId,
   verification,
   fileVerdict,
   cleanHref,
@@ -142,6 +145,7 @@ export const TargetPage: FC<TargetPageProps> = ({
     aiScore: match.matchScore,
     resumeText,
     draftText: draftText ?? null,
+    runId: runId ?? null,
     jobText: job.description,
     keywords: scored,
     actions,
@@ -260,6 +264,8 @@ export const TargetPage: FC<TargetPageProps> = ({
                 <span id="ai-stale" hidden class="font-medium text-warn">
                   edited — re-check to refresh
                 </span>
+                {/* The background AI check, when one is running (#184): running · ready with "Use it" · failed. */}
+                <span data-ai-run hidden class="font-medium"></span>
               </div>
               {/* Which resume/version is named by the pane header and the run chips —
                   repeating it here was pure duplication. */}
@@ -322,10 +328,6 @@ export const TargetPage: FC<TargetPageProps> = ({
                 >
                   <input type="hidden" name="resumeId" value={resume.id} />
                   <input type="hidden" name="matchId" value={match.id} />
-                  {/* Set by the second button's click, not by the submitter's value: SUBMIT_ONCE
-                      disables the buttons in the submit event, and a disabled submitter is left
-                      out of the form data. */}
-                  <input type="hidden" name="uploadMode" value="check" />
                   <input
                     type="file"
                     name="file"
@@ -333,29 +335,14 @@ export const TargetPage: FC<TargetPageProps> = ({
                     accept={ACCEPTED_EXTENSIONS.join(',')}
                     class="block w-full text-xs text-ink file:mr-2 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink"
                   />
-                  <Button size="sm" class="w-full" title="Parses the file into the editor and scores it against this analysis — no AI call">
-                    Upload & check (seconds)
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    class="w-full"
-                    onclick="this.form.elements.uploadMode.value='analyze'"
-                    title={
-                      resume.ephemeral
-                        ? 'Replaces this comparison with a fresh quick AI check (~½ min)'
-                        : `Saves the file as v${resume.version + 1} and runs the quick AI check (~½ min); the scan runs in the background`
-                    }
-                  >
-                    {resume.ephemeral ? 'Upload & check with AI' : `Upload as v${resume.version + 1} & check with AI`}
+                  <Button size="sm" class="w-full" title="Opens the file in the editor at once; the quick AI check runs behind it">
+                    Upload & check
                   </Button>
                   <Hint>
-                    Check opens the new text as an unsaved draft scored against this analysis: the text confirms
-                    what is present, while add / confirm / can't-claim keep the AI's verdict on the analysed
-                    version until you re-check.{' '}
-                    {resume.ephemeral
-                      ? 'Nothing lands in your Resumes either way.'
-                      : `Nothing is saved — Save as v${resume.version + 1} keeps the text, not the file.`}
+                    The text opens here within a second with the live estimate; the AI check of it runs in the
+                    background and its number lands beside the score — about half a minute. Nothing is saved
+                    until you {resume.ephemeral ? 'Save as a new resume' : `Save as v${resume.version + 1} or as a tailored copy`} on the bar
+                    below.
                   </Hint>
                 </form>
               </div>
@@ -374,8 +361,10 @@ export const TargetPage: FC<TargetPageProps> = ({
               <div class={`${MENU_PANEL} space-y-2`}>
                 <form method="post" action={`/jobs/${job.id}/match`} id="reanalyze-form" onsubmit={SUBMIT_ONCE}>
                   <input type="hidden" name="resumeId" value={resume.id} />
+                  <input type="hidden" name="matchId" value={match.id} />
                   <input type="hidden" name="draftText" id="reanalyze-text" value="" />
-                  <input type="hidden" name="next" value="target" />
+                  {/* The editor stays open; the chip beside the number follows the run (#184). */}
+                  <input type="hidden" name="next" value="editor" />
                   {/* Set by the full-analysis and Rebuild buttons' clicks — a disabled submitter is left out of the form data. */}
                   <input type="hidden" name="mode" value="fast" />
                   <input type="hidden" name="rebuild" value="" />
@@ -655,6 +644,7 @@ export const TargetPage: FC<TargetPageProps> = ({
             Estimate <span id="bar-score">—</span>
             <span id="bar-delta" class="ml-1 text-xs font-medium"></span>
           </span>
+          <span data-ai-run hidden class="text-xs font-medium"></span>
           <div class="ml-auto flex flex-wrap items-center gap-2">
             <Button type="button" variant="ghost" size="sm" id="bar-discard">
               Discard

--- a/src/web/public/run-chip.mjs
+++ b/src/web/public/run-chip.mjs
@@ -1,0 +1,40 @@
+/*
+ * The AI-check chip beside the score (#184): what one poll of a background
+ * run's state reads as. Pure — tested from src/web/run-chip.test.ts; the page
+ * paints it and re-polls while the run is live.
+ */
+
+const TONE = { running: 'text-ink-muted', done: 'text-ok', error: 'text-danger' };
+
+/** The first step result the run recorded — "AI match 91/100" — whatever the step was called. */
+function firstResult(state) {
+  const results = state.results && typeof state.results === 'object' ? Object.values(state.results) : [];
+  return results.find((r) => typeof r === 'string' && r.length > 0) ?? null;
+}
+
+/**
+ * null = nothing to show (the run is gone). `link.label` is the one action:
+ * the progress page while it runs, the result when it landed.
+ */
+export function runChip(state, runUrl) {
+  if (!state || state.gone) return null;
+  if (state.stage === 'error') {
+    return { kind: 'error', tone: TONE.error, text: 'AI check failed', link: { href: runUrl, label: 'why' } };
+  }
+  if (state.stage === 'done') {
+    const result = firstResult(state) ?? 'done';
+    return {
+      kind: 'done',
+      tone: TONE.done,
+      text: `AI check ready: ${result}`,
+      link: state.resultUrl ? { href: state.resultUrl, label: 'Use it' } : null,
+    };
+  }
+  const seconds = Math.max(0, Math.round((state.elapsedMs ?? 0) / 1000));
+  return { kind: 'running', tone: TONE.running, text: `AI check running · ${seconds} s`, link: { href: runUrl, label: 'progress' } };
+}
+
+/** Whether the page should ask again. */
+export function runLive(state) {
+  return Boolean(state) && !state.gone && state.stage !== 'done' && state.stage !== 'error';
+}

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -18,6 +18,7 @@ import {
 import { computeScore, entriesFromLive } from './score.mjs';
 import { formatEditSheet } from './change-sheet.mjs';
 import { wireCopy, copyFrom, announce } from './copy.mjs';
+import { runChip, runLive } from './run-chip.mjs';
 import { applyReplacement, insertAfterLine, removeSpan, insertIntoSkills, inverseEdit, undoEdit } from './text-edits.mjs';
 
 // Full literal class names — the Tailwind CDN JIT only generates what it can
@@ -458,4 +459,50 @@ export function init(data) {
   if (typeof data.draftText === 'string') storeEdits();
   else loadEdits();
   render();
+
+  // A background AI check — started by the upload or by Re-check (#184): the
+  // chips beside the number and on the bar follow it and offer the result.
+  // The editor is never replaced under the user's hands: "Use it" navigates,
+  // and the text typed meanwhile travels along as the next page's draft.
+  if (data.runId) watchRun(data.runId);
+
+  function watchRun(id) {
+    const slots = [...document.querySelectorAll('[data-ai-run]')];
+    if (slots.length === 0) return;
+    const runUrl = '/target/runs/' + id;
+    const paint = (chip) => {
+      for (const el of slots) {
+        el.textContent = '';
+        el.hidden = !chip;
+        if (!chip) continue;
+        el.className = el.className.replace(/\btext-(ink-muted|ok|danger)\b/g, '').trim() + ' ' + chip.tone;
+        el.append(chip.text + (chip.link ? ' — ' : ''));
+        if (!chip.link) continue;
+        const a = document.createElement('a');
+        a.href = chip.link.href;
+        a.className = 'underline decoration-dotted underline-offset-2 hover:text-accent-deep';
+        a.textContent = chip.link.label;
+        if (chip.kind === 'done') a.addEventListener('click', carryDraft);
+        el.append(a);
+      }
+    };
+    const carryDraft = (e) => {
+      const to = new URL(e.currentTarget.href, location.href).searchParams.get('match');
+      if (!to || editor.value === data.resumeText) return;
+      try { localStorage.setItem('target-draft:' + to, editor.value); } catch {}
+    };
+    const tick = async () => {
+      let state = null;
+      try {
+        const res = await fetch(runUrl + '/state');
+        state = res.status === 404 ? { gone: true } : await res.json();
+      } catch {
+        setTimeout(tick, 3000);
+        return;
+      }
+      paint(runChip(state, runUrl));
+      if (runLive(state)) setTimeout(tick, 2000);
+    };
+    tick();
+  }
 }

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { JobStatus, type Prisma } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../../db';
+import { startDraftCheck } from '../draft-check';
 import { logger } from '../../logger';
 import { hashShortId } from '../../text-utils';
 import { appliedResumeColumns } from '../applied-resume';
@@ -35,7 +36,7 @@ import { draftStash } from '../draft-stash';
 import { scanInBackground } from '../../resume/scan';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
-import { claimRun, findLiveRun, matchStep, startRun, updateRun } from '../target-runs';
+import { claimRun, findLiveRun, getRun, matchStep, startRun, updateRun } from '../target-runs';
 import { startSuggestionsRun } from '../suggestions-run';
 import {
   deleteCoverLettersForResume,
@@ -609,9 +610,16 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
   // "Rebuild keywords": read the terms out of the posting again instead of
   // inheriting the frame this posting has been carrying (issue #79).
   const rebuild = form.rebuild === '1';
-  const toTarget = form.next === 'target';
+  // The editor's Re-check keeps the editor open and follows the run from there (#184).
+  const inline = form.next === 'editor';
+  const toTarget = form.next === 'target' || inline;
   const resultUrl = (matchId: number) =>
     toTarget ? `/jobs/${id}/target?match=${matchId}` : `/jobs/${id}?match=${matchId}#resume-match`;
+  const editorUrl = (runId: string) => `/jobs/${id}/target?match=${Number(form.matchId) || ''}&run=${runId}`;
+  const follow = (runUrl: string) =>
+    inline
+      ? flashRedirect(editorUrl(runUrl.slice(runUrl.lastIndexOf('/') + 1)), 'ok', BACKGROUND_CHECK_NOTICE)
+      : c.redirect(runUrl, 303);
 
   // The same text was already judged: show that analysis instead of paying
   // for it again — unless "Re-run anyway" or a rebuild asked for a fresh call.
@@ -627,7 +635,7 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
       });
     }
     if (reused) {
-      return c.redirect(startSuggestionsRun({ match: reused.row, job: jobInput, resumeName: resume.name, resultUrl: resultUrl(reused.row.id) }), 303);
+      return follow(startSuggestionsRun({ match: reused.row, job: jobInput, resumeName: resume.name, resultUrl: resultUrl(reused.row.id) }));
     }
   }
 
@@ -637,10 +645,11 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
     `match:${id}:${resume.id}:${mode}:${rebuild ? 'rebuild' : 'frame'}:${hashShortId(text)}`,
     { steps: [matchStep(mode)], jobTitle: job.title, resumeName: resume.name, jobId: id },
   );
-  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
+  if (joined) return follow(`/target/runs/${run.id}`);
   startRun(run.id, async () => {
-    // Ephemeral (scratch) compares keep only the current analysis.
-    if (resume.hidden) await deleteMatchesForResume(resume.id);
+    // Ephemeral (scratch) compares keep only the current analysis — unless the
+    // editor is watching one of them, in which case the row it shows must stay.
+    if (resume.hidden && !inline) await deleteMatchesForResume(resume.id);
     const row = await matchResumeToJob({ id: resume.id, version: resume.version, text }, jobInput, { draft, mode, rebuild });
     if (!row) {
       updateRun(run.id, { stage: 'error', error: 'Comparison failed — see the web logs.' });
@@ -650,13 +659,16 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
       stage: 'done',
       resultUrl: resultUrl(row.id),
       tailorUrl: `/jobs/${id}/target?match=${row.id}`,
+      results: { [matchStep(mode)]: `AI match ${row.matchScore}/100` },
       flash: rebuild
         ? `Keywords rebuilt from the posting — AI match ${row.matchScore}/100, counted over a fresh set of terms.`
         : `${draft ? 'Draft' : `"${resume.name}"`} ${mode === 'fast' ? 'checked' : 'compared'} — AI match ${row.matchScore}/100.`,
     });
   });
-  return c.redirect(`/target/runs/${run.id}`, 303);
+  return follow(`/target/runs/${run.id}`);
 });
+
+const BACKGROUND_CHECK_NOTICE = 'The AI check runs in the background — its number lands beside the score when it is done.';
 
 /** "Get suggestions" on a quick check: the lazy second call, the verdicts and the score untouched (ADR 0029). */
 jobsRoute.post('/jobs/:id/matches/:matchId/suggestions', async (c) => {
@@ -852,6 +864,9 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
   // An instant check arrives with its parsed upload — taken once; from then on the browser holds it.
   const draftKey = c.req.query('draft');
   const draftText = draftTextForPage(draftKey ? draftStash.take(draftKey) : null, match.id);
+  // A background AI check the page follows (#184); a run that is gone is simply not shown.
+  const runId = c.req.query('run');
+  const watched = runId ? getRun(runId) : null;
   return c.html(
     <TargetPage
       job={{ id: job.id, title: job.title, companyName: job.company.name, location: job.location, description: job.description }}
@@ -862,6 +877,7 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
       previous={previousFor(match, matches)}
       resumeText={match.resumeText || resume.text}
       draftText={draftText}
+      runId={watched?.id ?? null}
       verification={verifications[0] ?? null}
       fileVerdict={fileVerdict}
       cleanHref={file.clean ? `/resumes/${resume.id}/render` : null}
@@ -879,98 +895,41 @@ jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit
   const form = await c.req.parseBody();
   const resumeId = Number(form.resumeId);
   if (!Number.isFinite(resumeId)) return c.text('Bad resume id', 400);
-  const [job, existing] = await Promise.all([
+  const [job, resume] = await Promise.all([
     prisma.job.findUnique({ where: { id }, include: { company: { select: { name: true } } } }),
     getResume(resumeId),
   ]);
-  if (!job || !existing) return c.text('Not found', 404);
+  if (!job || !resume) return c.text('Not found', 404);
   const upload = await readResumeUpload(form);
   if ('error' in upload) return flashRedirect(`/jobs/${id}/target`, 'err', upload.error);
 
-  // The default is the instant check: the new text becomes an unsaved draft
-  // over the analysis the page showed — no AI call, no new version, nothing
-  // written (docs/target-plan.md §3.2 item 5). "Upload & analyze" opts into
-  // the full run below.
-  if (form.uploadMode !== 'analyze') {
-    const decision = decideInstantCheck(await frameFor(id, resumeId, Number(form.matchId)), upload.text);
-    if (decision.kind !== 'analyze') {
-      const when = formatRelative(decision.frame.createdAt);
-      const page = `/jobs/${id}/target?match=${decision.frame.id}`;
-      if (decision.kind === 'unchanged') {
-        return flashRedirect(page, 'warn', unchangedNotice(upload.sourceFilename, when));
-      }
-      const key = draftStash.put({ matchId: decision.frame.id, text: upload.text });
-      const ms = Date.now() - started;
-      logger.info(
-        { jobId: id, matchId: decision.frame.id, resumeId, file: upload.sourceFilename, chars: upload.text.length, ms },
-        'resume: instant check',
-      );
-      return flashRedirect(`${page}&draft=${key}`, 'ok', instantCheckNotice(upload.sourceFilename, when, ms));
-    }
+  // One button (#184): the file opens in the editor at once as an unsaved
+  // draft over the analysis the page showed, and the quick AI check of that
+  // text runs behind it — the page follows the run and offers the result when
+  // it lands. Nothing is saved; a version is the sticky bar's decision. With
+  // no analysis to show the draft against, the check runs on the progress page.
+  const decision = decideInstantCheck(await frameFor(id, resumeId, Number(form.matchId)), upload.text);
+  if (decision.kind === 'unchanged') {
+    const page = `/jobs/${id}/target?match=${decision.frame.id}`;
+    return flashRedirect(page, 'warn', unchangedNotice(upload.sourceFilename, formatRelative(decision.frame.createdAt)));
   }
-
-  // Scratch (ephemeral) resumes are replaced in place with no scan and no
-  // history — a fresh upload means a fresh analysis, nothing saved.
-  const ephemeral = existing.hidden;
-  const newName = ephemeral ? nameFromFilename(upload.sourceFilename) : existing.name;
-  const { run, joined } = claimRun(`reupload:${id}:${resumeId}:${hashShortId(upload.text)}`, {
-    steps: ['keywords'],
-    jobTitle: job.title,
-    resumeName: newName,
-    jobId: id,
+  const run = startDraftCheck({
+    job: { id: job.id, title: job.title, companyName: job.company.name, location: job.location, description: job.description },
+    resume,
+    text: upload.text,
   });
-  if (joined) return c.redirect(`/target/runs/${run.id}`, 303);
-  startRun(run.id, async () => {
-    let resume;
-    if (ephemeral) {
-      resume = await upsertScratchResume({ name: newName, ...upload });
-    } else {
-      resume = await replaceResumeFile(resumeId, upload);
-      // The match never reads the scan, so the new version's scan runs
-      // alongside it instead of ahead of it — a whole resume-model call off
-      // the wait. Cost: Resume.skills stay one version stale until it lands.
-      scanInBackground(resume);
-    }
-    // A file whose text did not change is already answered.
-    const reused = await findReusableMatch(job.id, resume.id, resume.text, 'fast');
-    if (reused) {
-      updateRun(run.id, {
-        stage: 'done',
-        resultUrl: `/jobs/${id}/target?match=${reused.row.id}`,
-        flash: `${ephemeral ? `"${newName}"` : `v${resume.version}`} uploaded. ${reuseNotice(formatRelative(reused.row.createdAt))}`,
-        reused: true,
-      });
-      return;
-    }
-    if (ephemeral) {
-      await deleteMatchesForResume(resume.id);
-      await deleteCoverLettersForResume(resume.id);
-    }
-    const row = await matchResumeToJob(resume, {
-      id: job.id,
-      title: job.title,
-      companyName: job.company.name,
-      location: job.location,
-      description: job.description,
-    });
-    if (!row) {
-      updateRun(run.id, {
-        stage: 'error',
-        error: ephemeral
-          ? 'Upload worked, but the comparison failed — see the web logs.'
-          : `v${resume.version} uploaded, but the comparison failed — see the web logs.`,
-      });
-      return;
-    }
-    updateRun(run.id, {
-      stage: 'done',
-      resultUrl: `/jobs/${id}/target?match=${row.id}`,
-      flash: ephemeral
-        ? `"${newName}" checked — AI match ${row.matchScore}/100.`
-        : `v${resume.version} uploaded and checked — AI match ${row.matchScore}/100.`,
-    });
-  });
-  return c.redirect(`/target/runs/${run.id}`, 303);
+  if (decision.kind === 'analyze') return c.redirect(`/target/runs/${run.id}`, 303);
+  const key = draftStash.put({ matchId: decision.frame.id, text: upload.text });
+  const ms = Date.now() - started;
+  logger.info(
+    { jobId: id, matchId: decision.frame.id, resumeId, file: upload.sourceFilename, chars: upload.text.length, ms, runId: run.id },
+    'resume: instant check',
+  );
+  return flashRedirect(
+    `/jobs/${id}/target?match=${decision.frame.id}&draft=${key}&run=${run.id}`,
+    'ok',
+    instantCheckNotice(upload.sourceFilename, ms),
+  );
 });
 
 /** The analysis a re-upload is checked against: the one the page showed, else the resume's latest for the job. */

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -36,7 +36,7 @@ import { draftStash } from '../draft-stash';
 import { scanInBackground } from '../../resume/scan';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
-import { claimRun, findLiveRun, getRun, matchStep, startRun, updateRun } from '../target-runs';
+import { claimRun, findLiveRun, getRun, matchStep, runFailure, startRun, updateRun } from '../target-runs';
 import { startSuggestionsRun } from '../suggestions-run';
 import {
   deleteCoverLettersForResume,
@@ -650,9 +650,17 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
     // Ephemeral (scratch) compares keep only the current analysis — unless the
     // editor is watching one of them, in which case the row it shows must stay.
     if (resume.hidden && !inline) await deleteMatchesForResume(resume.id);
-    const row = await matchResumeToJob({ id: resume.id, version: resume.version, text }, jobInput, { draft, mode, rebuild });
+    let reason = '';
+    const row = await matchResumeToJob({ id: resume.id, version: resume.version, text }, jobInput, {
+      draft,
+      mode,
+      rebuild,
+      onError: (r) => {
+        reason = r;
+      },
+    });
     if (!row) {
-      updateRun(run.id, { stage: 'error', error: 'Comparison failed — see the web logs.' });
+      updateRun(run.id, { stage: 'error', error: runFailure('Comparison failed', reason) });
       return;
     }
     updateRun(run.id, {

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -43,7 +43,7 @@ import { createProfileFromResume, newProfileDraft } from '../profile-from-resume
 import { ResumeDetailPage } from '../pages/resume-detail';
 import { ResumesPage } from '../pages/resumes';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
-import { claimRun, startRun, updateRun } from '../target-runs';
+import { claimRun, startRun, updateRun, runFailure } from '../target-runs';
 import { hashShortId } from '../../text-utils';
 import {
   MAX_RESUME_NAME_CHARS,
@@ -215,24 +215,26 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
       resumeName: resume.name,
       subtitle: `${saved}.${job ? ' Scoring it against the posting.' : ''}`,
     });
+    let reason = '';
+    const noteReason = (r: string) => {
+      reason = r;
+    };
     if (!job) {
-      const scan = await scanResume(resume);
+      const scan = await scanResume(resume, noteReason);
       updateRun(run.id, scan
         ? { stage: 'done', resultUrl: `/resumes/${resume.id}`, flash: `${saved}.` }
-        : { stage: 'error', error: `${saved}, but the scan failed — try "Scan".` });
+        : { stage: 'error', error: runFailure(`${saved}, but the scan failed`, reason) });
       return;
     }
     // The match reads the text, never the scan (target-plan §3.1 item 2), so
     // the scan runs behind it as the re-upload route's does — it was 63 % of
     // a six-minute wait on a CLI engine (#168).
     scanInBackground(resume);
-    const match = await matchResumeToJob(resume, {
-      id: job.id,
-      title: job.title,
-      companyName: job.company.name,
-      location: job.location,
-      description: job.description,
-    });
+    const match = await matchResumeToJob(
+      resume,
+      { id: job.id, title: job.title, companyName: job.company.name, location: job.location, description: job.description },
+      { onError: noteReason },
+    );
     updateRun(run.id, match
       ? {
           stage: 'done',
@@ -241,7 +243,7 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
         }
       : {
           stage: 'error',
-          error: `${saved}, but the comparison failed — see the web logs.`,
+          error: runFailure(`${saved}, but the comparison failed`, reason),
         });
   });
   return c.redirect(`/target/runs/${run.id}`, 303);

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -226,7 +226,7 @@ async function loadSettingsProps() {
       classifierDefault,
       resumeDefault,
       // An empty cover slot follows the resume model, so that is the default shown.
-      coverDefault: aiConfig.models[id]?.resume?.trim() || resumeDefault,
+      coverDefault: defaultModelFor(id, 'cover', aiEnv) || 'CLI default',
       options: PROVIDER_MODEL_OPTIONS[id],
       freeTextModels: id === 'openai_api',
       paid: PROVIDER_PAID[id],

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
+import { getAiRuntime } from '../../ai-runtime';
+import { laneOf, type Lane } from '../lane';
 import { z } from 'zod';
 import { hashShortId } from '../../text-utils';
 import { classifyInBackground } from '../../jobs/classify-existing';
@@ -26,7 +28,7 @@ import { TargetStartPage } from '../pages/target-start';
 import { TargetRunPage } from '../pages/target-run';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
 import { formatRelative } from '../format';
-import { alsoClaims, claimRun, getRun, matchStep, startRun, updateRun, type RunStep } from '../target-runs';
+import { alsoClaims, claimRun, getRun, matchStep, startRun, updateRun, type RunStep, runFailure } from '../target-runs';
 import {
   MAX_RESUME_NAME_CHARS,
   nameFromFilename,
@@ -93,7 +95,7 @@ targetRoute.get('/target/runs/:id/state', (c) => {
 });
 
 /** The progress page: target-run.mjs polls the state route until the chain resolves. */
-targetRoute.get('/target/runs/:id', (c) => {
+targetRoute.get('/target/runs/:id', async (c) => {
   const run = getRun(c.req.param('id'));
   if (!run) {
     return flashRedirect('/target', 'err', 'That comparison run is gone (runs live ~30 min). Start again.');
@@ -104,8 +106,15 @@ targetRoute.get('/target/runs/:id', (c) => {
       tailor: run.tailorUrl,
     });
   }
-  return c.html(<TargetRunPage run={run} />);
+  return c.html(<TargetRunPage run={run} lane={await resumeLane()} />);
 });
+
+/** Engine × model the resume calls run on — the run page states its measured band (#184). */
+async function resumeLane(): Promise<Lane> {
+  const runtime = await getAiRuntime();
+  const id = runtime.chain[0];
+  return id ? laneOf(id, runtime.modelFor(id, 'resume')) : 'other';
+}
 
 targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
   const form = await c.req.parseBody();
@@ -237,9 +246,12 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
         steps: needExtract ? ['extract', 'suggestions'] : ['suggestions'],
         stage: 'suggestions',
       });
-      const row = await suggestForMatch(reused.row, jobInput);
+      let reason = '';
+      const row = await suggestForMatch(reused.row, jobInput, (r) => {
+        reason = r;
+      });
       if (!row) {
-        updateRun(run.id, { stage: 'error', error: SUGGESTIONS_FAILED });
+        updateRun(run.id, { stage: 'error', error: reason ? `${SUGGESTIONS_FAILED.replace(/\.$/, '')}: ${reason}.` : SUGGESTIONS_FAILED });
         return;
       }
       updateRun(run.id, {
@@ -283,16 +295,15 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
     }
 
     // 4. One resume-model call, then straight into the targeted workspace.
-    const row = await matchResumeToJob(
-      { id: resume.id, version: resume.version, text: resume.text },
-      jobInput,
-      { mode: f.mode },
-    );
+    let reason = '';
+    const row = await matchResumeToJob({ id: resume.id, version: resume.version, text: resume.text }, jobInput, {
+      mode: f.mode,
+      onError: (r) => {
+        reason = r;
+      },
+    });
     if (!row) {
-      updateRun(run.id, {
-        stage: 'error',
-        error: 'The posting was saved, but the AI comparison failed — see the web logs.',
-      });
+      updateRun(run.id, { stage: 'error', error: runFailure('The posting was saved, but the AI comparison failed', reason) });
       return;
     }
     updateRun(run.id, {

--- a/src/web/routes/target.tsx
+++ b/src/web/routes/target.tsx
@@ -21,6 +21,7 @@ import { suggestForMatch } from '../../resume/suggestions';
 import { suggestionsKey } from '../suggestions-run';
 import { draftStash } from '../draft-stash';
 import { decideInstantCheck, instantCheckNotice } from '../instant-check';
+import { startDraftCheck } from '../draft-check';
 import { TargetStartPage } from '../pages/target-start';
 import { TargetRunPage } from '../pages/target-run';
 import { clearFlashCookie, flashRedirect, parseFlashCookie } from '../flash';
@@ -83,6 +84,8 @@ targetRoute.get('/target/runs/:id/state', (c) => {
     jobTitle: run.jobTitle,
     progress: run.progress ?? null,
     results: run.results ?? {},
+    resultUrl: run.resultUrl ?? null,
+    error: run.error ?? null,
     stepMs: run.stepMs,
     stageElapsedMs: Date.now() - run.stageAt,
     elapsedMs: Date.now() - run.startedAt,
@@ -262,10 +265,12 @@ targetRoute.post('/target', resumeUploadLimit('/target'), async (c) => {
       const decision = decideInstantCheck(await getLatestMatchForResumeAndJob(job.id, resume.id), resume.text);
       if (decision.kind === 'draft') {
         const key = draftStash.put({ matchId: decision.frame.id, text: resume.text });
+        // The AI check of the new text runs behind the draft; the editor follows it (#184).
+        const check = startDraftCheck({ job: jobInput, resume, text: resume.text });
         updateRun(run.id, {
           stage: 'done',
-          resultUrl: `/jobs/${job.id}/target?match=${decision.frame.id}&draft=${key}`,
-          flash: instantCheckNotice(resume.name, formatRelative(decision.frame.createdAt), Date.now() - checkStarted),
+          resultUrl: `/jobs/${job.id}/target?match=${decision.frame.id}&draft=${key}&run=${check.id}`,
+          flash: instantCheckNotice(resume.name, Date.now() - checkStarted),
         });
         return;
       }

--- a/src/web/run-chip.test.ts
+++ b/src/web/run-chip.test.ts
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// @ts-expect-error — plain JS with no declaration file; the shape is asserted below.
+const mod = import('./public/run-chip.mjs') as Promise<{
+  runChip: (state: Record<string, unknown> | null, runUrl: string) => { kind: string; text: string; link: { href: string; label: string } | null } | null;
+  runLive: (state: Record<string, unknown> | null) => boolean;
+}>;
+
+test('the chip follows a run: running with its seconds, ready with the result and Use it, failed with why', async () => {
+  const { runChip, runLive } = await mod;
+  const running = runChip({ stage: 'keywords', elapsedMs: 21_600, results: {} }, '/target/runs/x');
+  assert.deepEqual(running, { kind: 'running', tone: 'text-ink-muted', text: 'AI check running · 22 s', link: { href: '/target/runs/x', label: 'progress' } });
+  const done = runChip({ stage: 'done', results: { keywords: 'AI match 91/100' }, resultUrl: '/jobs/1/target?match=9' }, '/target/runs/x');
+  assert.deepEqual(done, { kind: 'done', tone: 'text-ok', text: 'AI check ready: AI match 91/100', link: { href: '/jobs/1/target?match=9', label: 'Use it' } });
+  assert.equal(runChip({ stage: 'error', error: 'nope' }, '/target/runs/x')?.link?.label, 'why');
+  assert.equal(runChip({ gone: true }, '/target/runs/x'), null);
+  assert.equal(runLive({ stage: 'keywords' }), true);
+  assert.equal(runLive({ stage: 'done' }), false);
+  assert.equal(runLive({ gone: true }), false);
+});

--- a/src/web/suggestions-run.ts
+++ b/src/web/suggestions-run.ts
@@ -33,7 +33,10 @@ export function startSuggestionsRun(input: {
   });
   if (joined) return `/target/runs/${run.id}`;
   startRun(run.id, async () => {
-    const row = await suggestForMatch(match, job);
+    let reason = '';
+    const row = await suggestForMatch(match, job, (r) => {
+      reason = r;
+    });
     updateRun(
       run.id,
       row
@@ -42,7 +45,7 @@ export function startSuggestionsRun(input: {
             resultUrl: input.resultUrl,
             flash: suggestionsFlash({ actions: readActions(row.actions).length, removals: readRemovals(row.removals).length }),
           }
-        : { stage: 'error', error: SUGGESTIONS_FAILED },
+        : { stage: 'error', error: reason ? `${SUGGESTIONS_FAILED.replace(/\.$/, '')}: ${reason}.` : SUGGESTIONS_FAILED },
     );
   });
   return `/target/runs/${run.id}`;

--- a/src/web/target-runs.ts
+++ b/src/web/target-runs.ts
@@ -171,6 +171,11 @@ export function getRun(id: string): TargetRun | null {
 }
 
 /** Runs the async chain; any uncaught failure flips the run to error. */
+/** The run's error line: the provider's one-line reason when there is one, else where to look (#184). */
+export function runFailure(what: string, reason: string): string {
+  return reason ? `${what}: ${reason}.` : `${what} — see the web logs.`;
+}
+
 export function startRun(id: string, fn: () => Promise<void>): void {
   void fn().catch((err) => {
     logger.error({ err, runId: id }, 'web: compare run failed');


### PR DESCRIPTION
Closes #184 (with #190). Stacked on #190 (`upload-and-check`) — merge that first; GitHub retargets this one on its own. Items 3 and 4 of the issue: the measurement, the budgets, the stated lane, the model defaults. **v1.65.0**.

## What — measured first

Every resume call — scan, quick check, full analysis, suggestions, review — through each engine directly, with the prompts and budgets the call sites send, on the reference pair (resume 6, 5 983 chars, against job 2094, a 7 721-char posting). Wall seconds, one call each; the CLI with the thinking cap of v1.59.1, the API as it ships (the full table with its notes is `docs/target-plan.md` §2.3):

| Call | CLI Haiku 4.5 | CLI Sonnet 5 | CLI Opus 5 | API Haiku 4.5 | API Sonnet 5 | API Opus 5 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| scan | 50 | 44 | 54 | 35 | 75 | 72 |
| quick check | 21, 26 (one reply unparseable) | **19** | 26 | **18** | 64 (thinks) | 39 |
| full analysis | 75 (unparseable) | **34** | 58 | 44 | cut off: 16 000 output tokens, 13 808 thinking | 111 |
| suggestions | 36 | 28 | 43 | — | — | — |
| review | 54 | 39 | 51 | — | — | — |

- Haiku on the CLI returned JSON that could not be parsed in 2 of 3 match calls (the app retries once, which doubles the wait); Sonnet and Opus 0 of 10. The same pair scored 97–100 on Haiku, 75–79 on Sonnet, 65–83 on Opus — Haiku is the generous one; the gold bench (`npm run bench:resume`, fast and full, three fixtures × five checks) passes on all three.
- Where the quick-check prompt goes (≈ 6 200 tokens): the rules 9 442 chars, the resume 5 983, the posting 7 721, the context 1 741 — a smaller prompt is not where the time is; the reply and the model's speed are. Item 3's "slim the prompt" is therefore not done, with the numbers that say why.
- The API's suggestions and review went unmeasured: the install's Anthropic key was gone from `.env` (commented out) and from the database by the second pass. On the API Sonnet 5 and Opus 5 think — the cap the CLI has (`MAX_THINKING_TOKENS=0`) has no API twin here yet; a follow-up once a key is back to probe `thinking: { type: 'disabled' }` on the adaptive models.

## What — then built

- **Defaults per lane** (`ai-engine.ts:defaultModelFor`): an empty Resume slot is Sonnet 5 on the Claude CLI and Haiku 4.5 on the API; an empty Cover letter slot is Opus 5 — the writer — instead of following the resume slot (Nazar's answer to question 3: "Haiku everywhere except cover letters, or better"; Sonnet beats Haiku on the CLI on both axes). `CLAUDE_MODEL_RESUME` is empty by default now and the new `CLAUDE_MODEL_COVER` joins it; both still override. The settings hints say so; the AI tab warns when the resume slot resolves to Haiku on the CLI, with the numbers.
- **Budgets with a reason** (`prompts.ts:RESUME_TIMEOUT_MS`): quick check 90 s, scan / suggestions / review 120 s, full analysis 180 s — about twice the slowest measured lane — instead of five minutes everywhere. `matchResumeToJob`, `scanResume`, `suggestForMatch` and `reviewResume` take `onError`, and the runs say *"Comparison failed: claude timed out after 90 s"* (`target-runs.ts:runFailure`) instead of "see the web logs" — the same contract Verify got in v1.59.2.
- **The stated lane** (`web/lane.ts`, pure, tested): the run page's timed steps read *"Quick AI check — about 20 s on Sonnet 5 through the Claude CLI"* for the lane the install is on, the generic band only for an engine we did not measure.
- CHANGELOG 1.65.0, version bump; `.env.example`, CLAUDE.md, docs/target-plan.md §2.3.

## Verification

- `npm run lint:types` + `npm test`: 2016 tests, 0 failures (new: the per-engine defaults and the cover default; the lane mapping and bands; the cover role no longer inherits the resume slot).
- On a copy of the live database (chain `claude_code`, the resume slot resolving to Haiku from `.env`): the AI tab shows the new hints and the Haiku-on-CLI note; a Re-check run's progress page reads *about 25 s, twice that when a reply has to be retried on Haiku 4.5 through the Claude CLI* under the quick-check step.
- Not exercised live: a call hitting its budget — the timeout path is the providers' existing one (`describeAiFailure` masks and caps the reason), only the numbers and the forwarding are new.
- The live containers were not touched. **On this install** `.env` still pins `CLAUDE_MODEL_RESUME=claude-haiku-4-5-20251001`; removing that line lets the CLI lane take Sonnet 5.

## Release notes

### What's new
- Every resume call has a budget and fails with the engine's reason; the progress page states how long each step takes on your engine and model; the default resume model is Sonnet 5 on the Claude CLI and Haiku 4.5 on the API, and cover letters default to Opus 5 (`CLAUDE_MODEL_COVER`).

### Schema
- no schema changes

### Verification
- 2016 tests; 27 measured calls across six lanes; the settings tab and a run page read back on a copy of the live database.

### References
- #184 · #168 · #159 · docs/target-plan.md §2.3

Tag after merge: `git tag -a v1.65.0 -m "Default models per lane, budgets with a reason" <merge-sha>`
