### PR TITLE
One ring on the targeted view, and no second score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.72.0] — 2026-09-07
+
+### Changed
+- **The targeted view leads with one ring.** The score used to be a small dial
+  beside its own number, with a second live score — number, bar and delta —
+  in the right rail. That rail is gone: a keyword edit re-scores the stored row
+  server-side, so the ring itself moves, and while the text is dirty the sticky
+  bar already carries the estimate and its difference from the last analysis.
+  One number on the card instead of two, neither of which was labelled in a way
+  a reader could act on.
+- **The ring says what it is on hover.** The number now sits inside a larger
+  ring, and hovering or focusing it opens a two-sentence explanation: what the
+  0–100 measures, and which edits move it. Keyboard and touch open the same
+  panel — nothing on the card depends on hover.
+
+### Removed
+- **The labels around the score.** "AI match · moderate" restated the number,
+  and the draft marker and the run's age are already on that run's own chip
+  above. "edited — analyse again" is what the sticky bar says in full, with the
+  button next to it. `/100` moved into the hover text and the button's screen
+  reader label.
+- **"What made the number" / "what it does not count" on the targeted view.**
+  The five lines added in 1.71.0 stay on the `/jobs/:id` match card; the editor
+  page keeps the model's own sentence, the ceiling and the edit counts. The
+  component is unchanged — the targeted view simply no longer renders it.
+
+### Verification
+- `npm run lint:types` + 2105 tests green; browser console clean.
+- Checked at 1440 px and 375 px: no horizontal scroll, and the ring column
+  measures 112 px whether or not the editor is dirty (the old stale marker
+  widened it under the first keystroke and squeezed the summary).
+- Rings drawn at 27, 56 and 100; hover and keyboard focus both open the panel,
+  and the focus ring is a circle, not a rounded box.
+
 ## [1.71.0] — 2026-09-07
 
 ### Added
@@ -2923,6 +2957,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.72.0]: https://github.com/applypack/applypack/compare/v1.71.0...v1.72.0
 [1.71.0]: https://github.com/applypack/applypack/compare/v1.70.0...v1.71.0
 [1.70.0]: https://github.com/applypack/applypack/compare/v1.69.0...v1.70.0
 [1.69.0]: https://github.com/applypack/applypack/compare/v1.68.0...v1.69.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.71.0",
+  "version": "1.72.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -230,7 +230,7 @@ export function previousFor(selected: MatchWithResume, matches: MatchWithResume[
   );
 }
 
-/** "Why this score" — component chips under the number. Shared with the targeted view. */
+/** "Why this score" — the lines under the number on the /jobs match card. */
 /*
  * What the number was made of, in sentences (docs/score-lines-plan.md). This
  * replaced a row of the formula's own parts — "Keywords 60/60 · Alignment
@@ -238,7 +238,7 @@ export function previousFor(selected: MatchWithResume, matches: MatchWithResume[
  * place on the page, same amount of it, and the arithmetic moves into the
  * tooltips where it is still there for anyone who wants it.
  */
-export const ScoreBreakdownChips: FC<{ bd: ScoreBreakdown; keywords: MatchKeyword[]; hard: MatchHardRequirement[] }> = ({
+const ScoreBreakdownChips: FC<{ bd: ScoreBreakdown; keywords: MatchKeyword[]; hard: MatchHardRequirement[] }> = ({
   bd,
   keywords,
   hard,

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -251,26 +251,34 @@ export const ScoreBreakdownChips: FC<{ bd: ScoreBreakdown; keywords: MatchKeywor
           bullet" under a 100 asks why the 100 is a 100, and the heading
           answers before they ask. */}
       <LineGroup heading="what it does not count" lines={lines.diagnostic} />
-      {/* Two different questions (§4 of the intelligence analysis): the score is
-          how well this RESUME shows the fit, the ceiling is how well the
-          CANDIDATE fits. A wide gap is good news — all of it is editing. */}
-      {bd.ceiling !== undefined && (
-        <p
-          class="border-t border-line pt-1.5 text-ink-muted"
-          title="How well you fit, if the resume said everything it honestly could: every claimable keyword written in, alignment perfect. Going above the ceiling would need experience this resume does not have."
-        >
-          {bd.ceiling > bd.score ? (
-            <>
-              you fit <span class="font-medium tabular-nums text-ink">{bd.ceiling}</span> — editing can reach it
-            </>
-          ) : (
-            <span class="font-medium text-ok">the resume already shows everything it can</span>
-          )}
-        </p>
-      )}
+      <ScoreCeilingLine bd={bd} class="border-t border-line pt-1.5" />
     </div>
   );
 };
+
+/*
+ * Two different questions (§4 of the intelligence analysis): the score is how
+ * well this RESUME shows the fit, the ceiling is how well the CANDIDATE fits.
+ * A wide gap is good news — all of it is editing.
+ *
+ * Its own component because the targeted view keeps this sentence and shows
+ * none of the lines above it.
+ */
+export const ScoreCeilingLine: FC<{ bd: ScoreBreakdown; class?: string }> = ({ bd, class: className = '' }) =>
+  bd.ceiling === undefined ? null : (
+    <p
+      class={`text-xs text-ink-muted ${className}`}
+      title="How well you fit, if the resume said everything it honestly could: every claimable keyword written in, alignment perfect. Going above the ceiling would need experience this resume does not have."
+    >
+      {bd.ceiling > bd.score ? (
+        <>
+          you fit <span class="font-medium tabular-nums text-ink">{bd.ceiling}</span> — editing can reach it
+        </>
+      ) : (
+        <span class="font-medium text-ok">the resume already shows everything it can</span>
+      )}
+    </p>
+  );
 
 const LINE_TONE: Record<NonNullable<ScoreLine['tone']>, string> = {
   ok: 'text-ok',

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -222,77 +222,61 @@ export const TargetPage: FC<TargetPageProps> = ({
             the middle, never under 14rem — the rail grows while editing) | actions
             rail. The gates line spans the full width below. */}
         <div class="grid grid-cols-1 items-start gap-x-8 gap-y-4 lg:grid-cols-[auto_minmax(14rem,1fr)_auto]">
-          {/* Primary: the honest score — the AI rubric verdict. Static until a
-              re-check. The ring and one line: everything that used to label it
-              ("AI match", the quality word, the draft marker) either repeated
-              the run chips above or named a rubric the reader never asked
-              about. Hovering the ring says what the number is. */}
-          <div class="w-36">
-            {/* The number sits inside the ring: one object to read instead of a
-                dial next to a figure it was already drawing. The button is the
-                hover target for the explanation, and a button because nothing
-                may depend on hover — the same panel opens on keyboard focus and
-                on a tap. */}
-            <div class="group relative mx-auto w-28">
-              <button
-                type="button"
-                aria-describedby="score-help"
-                aria-label={`Match score ${match.matchScore} of 100 — what this number is`}
-                class="relative block cursor-help rounded-full"
+          {/* Primary: the honest score — the AI rubric verdict. The ring and
+              nothing else. Everything that used to label it said something the
+              page already said: "AI match" and the quality word restated the
+              number, the draft marker and the age are on this run's own chip
+              above, and "edited — analyse again" is what the sticky bar says
+              in full the moment the text is dirty. Hovering the ring says what
+              the number is. */}
+          <div class="group relative w-28">
+            <button
+              type="button"
+              aria-describedby="score-help"
+              aria-label={`Match score ${match.matchScore} of 100 — what this number is`}
+              class="relative block cursor-help rounded-full"
+            >
+              <svg viewBox="0 0 96 96" class="h-28 w-28 -rotate-90" aria-hidden="true">
+                <circle cx="48" cy="48" r="42" fill="none" stroke="rgb(var(--line))" stroke-width="7" />
+                <circle
+                  cx="48"
+                  cy="48"
+                  r="42"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="7"
+                  stroke-linecap="round"
+                  stroke-dasharray="263.9"
+                  stroke-dashoffset={String(263.9 - (263.9 * match.matchScore) / 100)}
+                  class={AI_TONE[fitTone(match.matchScore)]}
+                />
+              </svg>
+              {/* The number alone. "/100" is in the sentence the ring shows
+                  on hover, and in the button's own label for a screen reader —
+                  it does not need to sit inside the dial as well. */}
+              <span
+                class="absolute inset-0 flex items-center justify-center text-[32px] font-semibold leading-none tabular-nums tracking-tight text-ink"
+                aria-hidden="true"
               >
-                <svg viewBox="0 0 96 96" class="h-28 w-28 -rotate-90" aria-hidden="true">
-                  <circle cx="48" cy="48" r="42" fill="none" stroke="rgb(var(--line))" stroke-width="7" />
-                  <circle
-                    cx="48"
-                    cy="48"
-                    r="42"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="7"
-                    stroke-linecap="round"
-                    stroke-dasharray="263.9"
-                    stroke-dashoffset={String(263.9 - (263.9 * match.matchScore) / 100)}
-                    class={AI_TONE[fitTone(match.matchScore)]}
-                  />
-                </svg>
-                {/* The number alone. "/100" is in the sentence the ring shows
-                    on hover, and in the button's own label for a screen reader —
-                    it does not need to sit inside the dial as well. */}
-                <span
-                  class="absolute inset-0 flex items-center justify-center text-[32px] font-semibold leading-none tabular-nums tracking-tight text-ink"
-                  aria-hidden="true"
-                >
-                  {match.matchScore}
-                </span>
-              </button>
-              {/* Kept in the accessibility tree (opacity, not `hidden`) so
-                  aria-describedby has something to read on focus. */}
-              <div
-                id="score-help"
-                role="tooltip"
-                class="pointer-events-none absolute left-0 top-full z-30 mt-2 w-72 max-w-[calc(100vw-3rem)] space-y-1.5 rounded-lg border border-line bg-surface-raised p-3 text-xs leading-5 text-ink-muted opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
-              >
-                <p>
-                  <span class="font-medium text-ink">AI match, 0–100.</span> How well this resume answers
-                  this posting: the words it asks for, whether you have its core stack, and how your title,
-                  summary and most recent role read at a glance.
-                </p>
-                <p class="text-ink-faint">
-                  Re-levelling, ignoring or adding a keyword moves it at once. Editing the text does not —
-                  that needs “Analyse my resume again”.
-                </p>
-              </div>
-            </div>
-            {/* How old the number is, and — the moment the text is edited — that
-                it no longer describes it. One slot, so the column never widens
-                under the typing and squeezes the summary beside it. */}
-            <div class="mt-2 text-center text-xs text-ink-faint">
-              <span id="ai-fresh">
-                {fast ? 'quick check' : 'full analysis'} {formatRelative(match.createdAt)}
+                {match.matchScore}
               </span>
-              <span id="ai-stale" hidden class="font-medium text-warn">
-                edited — analyse again
-              </span>
+            </button>
+            {/* Kept in the accessibility tree (opacity, not `hidden`) so
+                aria-describedby has something to read on focus. */}
+            <div
+              id="score-help"
+              role="tooltip"
+              class="pointer-events-none absolute left-0 top-full z-30 mt-2 w-72 max-w-[calc(100vw-3rem)] space-y-1.5 rounded-lg border border-line bg-surface-raised p-3 text-xs leading-5 text-ink-muted opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
+            >
+              <p>
+                <span class="font-medium text-ink">AI match, 0–100.</span> How well this resume answers
+                this posting: the words it asks for, whether you have its core stack, and how your title,
+                summary and most recent role read at a glance.
+              </p>
+              <p class="text-ink-faint">
+                Re-levelling, ignoring or adding a keyword moves it at once. Editing the text does not —
+                that needs “Analyse my resume again”.
+              </p>
             </div>
           </div>
 

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -23,7 +23,7 @@ import {
   reachOf,
   VerificationLine,
   RemovalsBlock,
-  ScoreBreakdownChips,
+  ScoreCeilingLine,
   SuggestionsPrompt,
 } from './resume-match-card';
 import { ACCEPTED_EXTENSIONS } from '../../resume/resume-text';
@@ -99,14 +99,6 @@ const AI_TONE: Record<Tone, string> = {
 
 /** Score at which the card tells the user to stop polishing and apply. */
 const READY_TO_APPLY = 85;
-
-/** Same cutoffs as fitTone — the word next to the number, so colour never stands alone. */
-function matchQuality(score: number): string {
-  if (score >= READY_TO_APPLY) return 'excellent';
-  if (score >= 70) return 'strong';
-  if (score >= 50) return 'moderate';
-  return 'weak';
-}
 
 export const TargetPage: FC<TargetPageProps> = ({
   job,
@@ -230,14 +222,18 @@ export const TargetPage: FC<TargetPageProps> = ({
             the middle, never under 14rem — the rail grows while editing) | actions
             rail. The gates line spans the full width below. */}
         <div class="grid grid-cols-1 items-start gap-x-8 gap-y-4 lg:grid-cols-[auto_minmax(14rem,1fr)_auto]">
-          {/* Primary: the honest score — the AI rubric verdict. Static until a re-check. */}
-          <div class="flex items-center gap-5">
+          {/* Primary: the honest score — the AI rubric verdict. Static until a
+              re-check. The ring and one line: everything that used to label it
+              ("AI match", the quality word, the draft marker) either repeated
+              the run chips above or named a rubric the reader never asked
+              about. Hovering the ring says what the number is. */}
+          <div class="w-36">
             {/* The number sits inside the ring: one object to read instead of a
                 dial next to a figure it was already drawing. The button is the
                 hover target for the explanation, and a button because nothing
                 may depend on hover — the same panel opens on keyboard focus and
                 on a tap. */}
-            <div class="group relative shrink-0">
+            <div class="group relative mx-auto w-28">
               <button
                 type="button"
                 aria-describedby="score-help"
@@ -259,11 +255,14 @@ export const TargetPage: FC<TargetPageProps> = ({
                     class={AI_TONE[fitTone(match.matchScore)]}
                   />
                 </svg>
-                <span class="absolute inset-0 flex flex-col items-center justify-center leading-none" aria-hidden="true">
-                  <span class="text-[30px] font-semibold tabular-nums tracking-tight text-ink">
-                    {match.matchScore}
-                  </span>
-                  <span class="mt-1.5 text-[11px] font-medium text-ink-faint">/ 100</span>
+                {/* The number alone. "/100" is in the sentence the ring shows
+                    on hover, and in the button's own label for a screen reader —
+                    it does not need to sit inside the dial as well. */}
+                <span
+                  class="absolute inset-0 flex items-center justify-center text-[32px] font-semibold leading-none tabular-nums tracking-tight text-ink"
+                  aria-hidden="true"
+                >
+                  {match.matchScore}
                 </span>
               </button>
               {/* Kept in the accessibility tree (opacity, not `hidden`) so
@@ -276,7 +275,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                 <p>
                   <span class="font-medium text-ink">AI match, 0–100.</span> How well this resume answers
                   this posting: the words it asks for, whether you have its core stack, and how your title,
-                  summary and most recent role read at a glance. The lines beside it are what made it.
+                  summary and most recent role read at a glance.
                 </p>
                 <p class="text-ink-faint">
                   Re-levelling, ignoring or adding a keyword moves it at once. Editing the text does not —
@@ -284,47 +283,42 @@ export const TargetPage: FC<TargetPageProps> = ({
                 </p>
               </div>
             </div>
-            <div>
-              <div class="text-[13px] font-medium text-ink-muted">
-                AI match ·{' '}
-                <span class={AI_TONE[fitTone(match.matchScore)]}>{matchQuality(match.matchScore)}</span>
-              </div>
-              {/* Its own line, and shorter than the run line below it: inline, the
-                  marker widened this auto column the moment the user typed, and the
-                  summary beside it jumped narrower. It names the button it wants. */}
-              <div id="ai-stale" hidden class="mt-0.5 text-[13px] font-medium text-warn">
-                edited — analyse again
-              </div>
-              {/* Which resume/version is named by the pane header and the run chips —
-                  repeating it here was pure duplication. */}
-              <div class="mt-0.5 text-xs text-ink-faint">
-                {match.draft ? 'draft · ' : ''}
+            {/* How old the number is, and — the moment the text is edited — that
+                it no longer describes it. One slot, so the column never widens
+                under the typing and squeezes the summary beside it. */}
+            <div class="mt-2 text-center text-xs text-ink-faint">
+              <span id="ai-fresh">
                 {fast ? 'quick check' : 'full analysis'} {formatRelative(match.createdAt)}
-              </div>
-              {/* The number alone used to decide this, so "stop polishing" sat
-                  above three suggested edits, five removals and an unconfirmed
-                  hard requirement on a live 100/100. A score is not a verdict
-                  while something is still open (web/score-lines.ts). */}
-              {breakdown &&
-                readyToApply({
-                  breakdown,
-                  keywords: scored,
-                  hard,
-                  score: match.matchScore,
-                  threshold: READY_TO_APPLY,
-                  edits: actions.length + removals.length,
-                }) && (
-                  <div class="mt-1 text-[13px] font-medium text-ok">
-                    Ready to apply — stop polishing, send it.
-                  </div>
-                )}
+              </span>
+              <span id="ai-stale" hidden class="font-medium text-warn">
+                edited — analyse again
+              </span>
             </div>
           </div>
 
-          {/* Why this score: the stack verdict + the deterministic components. */}
+          {/* The verdict in the model's own sentence, then the two things a
+              reader does something with: how high editing can take this, and
+              whether it is already there. The rubric's own breakdown — what
+              made the number, what it does not count — is off this page for
+              now; it is still on the /jobs match card. */}
           <div class="min-w-0 space-y-1.5">
             <p class="text-sm leading-6 text-ink">{match.summary}</p>
-            {breakdown && <ScoreBreakdownChips bd={breakdown} keywords={scored} hard={hard} />}
+            {breakdown && <ScoreCeilingLine bd={breakdown} />}
+            {/* The number alone used to decide this, so "stop polishing" sat
+                above three suggested edits, five removals and an unconfirmed
+                hard requirement on a live 100/100. A score is not a verdict
+                while something is still open (web/score-lines.ts). */}
+            {breakdown &&
+              readyToApply({
+                breakdown,
+                keywords: scored,
+                hard,
+                score: match.matchScore,
+                threshold: READY_TO_APPLY,
+                edits: actions.length + removals.length,
+              }) && (
+                <p class="text-[13px] font-medium text-ok">Ready to apply — stop polishing, send it.</p>
+              )}
             {(fast || actions.length > 0 || removals.length > 0) && (
               <button
                 type="button"

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -231,35 +231,69 @@ export const TargetPage: FC<TargetPageProps> = ({
             rail. The gates line spans the full width below. */}
         <div class="grid grid-cols-1 items-start gap-x-8 gap-y-4 lg:grid-cols-[auto_minmax(14rem,1fr)_auto]">
           {/* Primary: the honest score — the AI rubric verdict. Static until a re-check. */}
-          <div class="flex items-center gap-4">
-            <svg viewBox="0 0 96 96" class="h-20 w-20 -rotate-90" aria-hidden="true">
-              <circle cx="48" cy="48" r="40" fill="none" stroke="rgb(var(--line))" stroke-width="8" />
-              <circle
-                cx="48"
-                cy="48"
-                r="40"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="8"
-                stroke-linecap="round"
-                stroke-dasharray="251.3"
-                stroke-dashoffset={String(251.3 - (251.3 * match.matchScore) / 100)}
-                class={AI_TONE[fitTone(match.matchScore)]}
-              />
-            </svg>
-            <div>
-              <div class="text-3xl font-semibold tabular-nums tracking-tight text-ink">
-                {match.matchScore}
-                <span class="text-base font-normal text-ink-faint">/100</span>
+          <div class="flex items-center gap-5">
+            {/* The number sits inside the ring: one object to read instead of a
+                dial next to a figure it was already drawing. The button is the
+                hover target for the explanation, and a button because nothing
+                may depend on hover — the same panel opens on keyboard focus and
+                on a tap. */}
+            <div class="group relative shrink-0">
+              <button
+                type="button"
+                aria-describedby="score-help"
+                aria-label={`Match score ${match.matchScore} of 100 — what this number is`}
+                class="relative block cursor-help rounded-full"
+              >
+                <svg viewBox="0 0 96 96" class="h-28 w-28 -rotate-90" aria-hidden="true">
+                  <circle cx="48" cy="48" r="42" fill="none" stroke="rgb(var(--line))" stroke-width="7" />
+                  <circle
+                    cx="48"
+                    cy="48"
+                    r="42"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="7"
+                    stroke-linecap="round"
+                    stroke-dasharray="263.9"
+                    stroke-dashoffset={String(263.9 - (263.9 * match.matchScore) / 100)}
+                    class={AI_TONE[fitTone(match.matchScore)]}
+                  />
+                </svg>
+                <span class="absolute inset-0 flex flex-col items-center justify-center leading-none" aria-hidden="true">
+                  <span class="text-[30px] font-semibold tabular-nums tracking-tight text-ink">
+                    {match.matchScore}
+                  </span>
+                  <span class="mt-1.5 text-[11px] font-medium text-ink-faint">/ 100</span>
+                </span>
+              </button>
+              {/* Kept in the accessibility tree (opacity, not `hidden`) so
+                  aria-describedby has something to read on focus. */}
+              <div
+                id="score-help"
+                role="tooltip"
+                class="pointer-events-none absolute left-0 top-full z-30 mt-2 w-72 max-w-[calc(100vw-3rem)] space-y-1.5 rounded-lg border border-line bg-surface-raised p-3 text-xs leading-5 text-ink-muted opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
+              >
+                <p>
+                  <span class="font-medium text-ink">AI match, 0–100.</span> How well this resume answers
+                  this posting: the words it asks for, whether you have its core stack, and how your title,
+                  summary and most recent role read at a glance. The lines beside it are what made it.
+                </p>
+                <p class="text-ink-faint">
+                  Re-levelling, ignoring or adding a keyword moves it at once. Editing the text does not —
+                  that needs “Analyse my resume again”.
+                </p>
               </div>
-              {/* Wraps: the stale marker must not widen this auto column and squeeze the summary. */}
-              <div class="flex flex-wrap items-center gap-x-2 text-[13px] font-medium text-ink-muted">
+            </div>
+            <div>
+              <div class="text-[13px] font-medium text-ink-muted">
                 AI match ·{' '}
                 <span class={AI_TONE[fitTone(match.matchScore)]}>{matchQuality(match.matchScore)}</span>
-                <span id="ai-stale" hidden class="font-medium text-warn">
-                  edited — re-check to refresh
-                </span>
-                {/* The background AI check, when one is running (#184): running · ready with "Use it" · failed. */}
+              </div>
+              {/* Its own line, and shorter than the run line below it: inline, the
+                  marker widened this auto column the moment the user typed, and the
+                  summary beside it jumped narrower. It names the button it wants. */}
+              <div id="ai-stale" hidden class="mt-0.5 text-[13px] font-medium text-warn">
+                edited — analyse again
               </div>
               {/* Which resume/version is named by the pane header and the run chips —
                   repeating it here was pure duplication. */}
@@ -413,34 +447,9 @@ export const TargetPage: FC<TargetPageProps> = ({
             </details>
             </div>
 
-            {/* Always on — this is the number that moves. It used to appear
-                only once the text was dirty, so a user who re-levelled a
-                keyword, ignored one or added one saw the big AI number and
-                nothing else, and reported that the score never reacts. It
-                re-counts on every keystroke and again on every page render,
-                which is what a keyword edit produces. */}
-            <div id="live-est" class="lg:max-w-[280px] lg:text-right">
-              <div class="flex flex-wrap items-center gap-x-2 text-[13px] font-medium text-ink-muted lg:justify-end">
-                Live estimate
-                <span id="live-delta" class="text-xs font-medium"></span>
-              </div>
-              <div class="mt-1 flex items-center gap-2.5 lg:justify-end">
-                <span id="score-value" class="text-2xl font-semibold tabular-nums text-ink-faint">
-                  —
-                </span>
-                <span class="h-1.5 w-24 overflow-hidden rounded-full bg-line" aria-hidden="true">
-                  <span id="score-bar" class="block h-full rounded-full bg-warn" style="width:0%"></span>
-                </span>
-              </div>
-              <div id="score-detail" class="mt-0.5 text-xs text-ink-faint">
-                {scored.length} keywords from the AI match
-              </div>
-              <Hint class="mt-1">
-                {breakdown
-                  ? `Counts the words a scanner would find, live: it moves as you edit the text and again whenever you re-level, ignore or add a keyword. The big number keeps the analysis from ${formatRelative(match.createdAt)}, because only the AI judges the parts a word search cannot see.`
-                  : 'Keywords only, live as you type. Analyse again to get the full score.'}
-              </Hint>
-            </div>
+            {/* No second score here: a keyword edit re-scores the stored row
+                server-side (routes/keywords.ts), so the ring itself moves, and
+                the sticky bar carries the estimate while the text is dirty. */}
           </div>
 
           {postingNotice && (
@@ -657,7 +666,12 @@ export const TargetPage: FC<TargetPageProps> = ({
               kept in this browser tab{resume.ephemeral ? ' — copy them out before you leave' : ' until you save'}
             </span>
           </div>
-          <span class="text-sm font-medium tabular-nums text-ink">
+          {/* The only live number on the page now, and only while the text is
+              dirty — which is the one moment the ring cannot answer. */}
+          <span
+            class="text-sm font-medium tabular-nums text-ink"
+            title="Counts the keywords a scanner would find in the text as it stands. The ring keeps the AI's verdict until you analyse again."
+          >
             Estimate <span id="bar-score">—</span>
             <span id="bar-delta" class="ml-1 text-xs font-medium"></span>
           </span>

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -97,8 +97,8 @@ export function init(data) {
     // The live number, for the sticky bar alone: the full score formula when
     // the match carries a breakdown (alignment fixed from the last AI run,
     // keywords + cap live), else the plain coverage percentage for
-    // pre-ADR-0012 matches. The ring above keeps the AI's own verdict — a
-    // keyword edit re-scores it server-side, a text edit marks it stale.
+    // pre-ADR-0012 matches. The ring above keeps the AI's own verdict, which
+    // only a re-run moves; a keyword edit re-scores it server-side instead.
     let display = scored.score;
     if (data.scoring) {
       display = computeScore(entriesFromLive(scored.rows), data.scoring.alignment, data.scoring.redFlagCount, data.scoring.penalty ?? null).score;

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -23,9 +23,7 @@ import { applyReplacement, insertAfterLine, removeSpan, insertIntoSkills, invers
 
 // Full literal class names — the Tailwind CDN JIT only generates what it can
 // see verbatim in the document, composed strings would come out unstyled.
-const TONE_TEXT = { ok: 'text-ok', info: 'text-info', warn: 'text-warn', danger: 'text-danger' };
-const TONE_BG = { ok: 'bg-ok', info: 'bg-info', warn: 'bg-warn', danger: 'bg-danger' };
-
+//
 // A missing chip wears the colour its mark wears in the posting (target.mjs):
 // red for a must, amber for a preferred, slate for a nice-to-have. Keyed by
 // keywordRank — 4 a primary-stack must … 0 context.
@@ -39,10 +37,6 @@ const CHIP_LEVEL = {
   1: 'bg-surface-overlay text-ink-muted ring-line',
   0: 'bg-surface-overlay text-ink-muted ring-line',
 };
-
-function tone(score) {
-  return score >= 85 ? 'ok' : score >= 70 ? 'info' : score >= 50 ? 'warn' : 'danger';
-}
 
 /** Why an edit did not happen — every error the text operations can return. */
 const REASON = {
@@ -59,13 +53,9 @@ export function init(data) {
   const editor = document.getElementById('editor');
   const backdrop = document.getElementById('backdrop');
   const jd = document.getElementById('jd');
-  const scoreBar = document.getElementById('score-bar');
-  const scoreValue = document.getElementById('score-value');
-  const scoreDetail = document.getElementById('score-detail');
   const chips = document.getElementById('missing-chips');
   const saveButtons = document.querySelectorAll('[data-save-button]');
   const aiStale = document.getElementById('ai-stale');
-  const liveDelta = document.getElementById('live-delta');
   const dirtyBar = document.getElementById('dirty-bar');
   const barScore = document.getElementById('bar-score');
   const barDelta = document.getElementById('bar-delta');
@@ -105,41 +95,21 @@ export function init(data) {
   function render() {
     const text = editor.value;
     const scored = scoreKeywords(data.keywords, text);
-    // Live number: full score formula when the match carries a breakdown
-    // (alignment fixed from the last AI run, keywords + cap live), else the
-    // plain coverage percentage for pre-ADR-0012 matches.
+    // The live number, for the sticky bar alone: the full score formula when
+    // the match carries a breakdown (alignment fixed from the last AI run,
+    // keywords + cap live), else the plain coverage percentage for
+    // pre-ADR-0012 matches. The ring above keeps the AI's own verdict — a
+    // keyword edit re-scores it server-side, a text edit marks it stale.
     let display = scored.score;
-    let capNote = '';
-    let maxNote = '';
     if (data.scoring) {
-      const est = computeScore(entriesFromLive(scored.rows), data.scoring.alignment, data.scoring.redFlagCount, data.scoring.penalty ?? null);
-      display = est.score;
-      if (est.cap !== null) capNote = ' · capped ' + est.cap + ' — primary ' + est.primaryPresent + '/' + est.primaryTotal;
-      if (est.ceiling !== undefined) maxNote = ' · max ' + est.ceiling;
+      display = computeScore(entriesFromLive(scored.rows), data.scoring.alignment, data.scoring.redFlagCount, data.scoring.penalty ?? null).score;
     }
-    scoreValue.textContent = String(display);
-    scoreValue.className = 'text-2xl font-semibold tabular-nums ' + TONE_TEXT[tone(display)];
-    scoreBar.style.width = display + '%';
-    scoreBar.className = 'block h-full rounded-full transition-[width] duration-300 ' + TONE_BG[tone(display)];
     barScore.textContent = String(display);
     if (data.scoring) {
       const d = display - data.aiScore;
-      const deltaText = d === 0 ? 'same as AI' : (d > 0 ? '+' : '') + d + ' vs AI';
-      const deltaTone = d > 0 ? 'text-ok' : d < 0 ? 'text-danger' : 'text-ink-faint';
-      liveDelta.textContent = deltaText;
-      liveDelta.className = 'text-xs font-medium ' + deltaTone;
-      barDelta.textContent = deltaText;
-      barDelta.className = 'ml-1 text-xs font-medium ' + deltaTone;
+      barDelta.textContent = d === 0 ? 'same as the last analysis' : (d > 0 ? '+' : '') + d + ' vs the last analysis';
+      barDelta.className = 'ml-1 text-xs font-medium ' + (d > 0 ? 'text-ok' : d < 0 ? 'text-danger' : 'text-ink-faint');
     }
-    const counted = scored.rows.filter((r) => !r.excluded);
-    const missing = counted.filter((r) => !r.found);
-    const missingNames = missing
-      .slice(0, 3)
-      .map((r) => (r.term.length > 26 ? r.term.slice(0, 24) + '…' : r.term))
-      .join(', ');
-    scoreDetail.textContent = counted.filter((r) => r.found).length + ' of ' + counted.length + ' keywords present'
-      + (missing.length ? ' · missing: ' + missingNames + (missing.length > 3 ? ' +' + (missing.length - 3) : '') : '')
-      + capNote + maxNote;
 
     const spans = resumeSpans(data.keywords, data.actions, data.removals, text);
     if (located) {

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -55,8 +55,6 @@ export function init(data) {
   const jd = document.getElementById('jd');
   const chips = document.getElementById('missing-chips');
   const saveButtons = document.querySelectorAll('[data-save-button]');
-  const aiFresh = document.getElementById('ai-fresh');
-  const aiStale = document.getElementById('ai-stale');
   const dirtyBar = document.getElementById('dirty-bar');
   const barScore = document.getElementById('bar-score');
   const barDelta = document.getElementById('bar-delta');
@@ -165,11 +163,9 @@ export function init(data) {
     }
     if (chips.children.length === 0) chips.innerHTML = '<span class="text-xs text-ink-faint">Every countable keyword is present.</span>';
 
+    // Nothing marks the ring as stale: the sticky bar says it in full while
+    // the text is dirty — the estimate, the delta and the button to re-run.
     const dirty = text !== data.resumeText;
-    // One line under the ring, two things it can say: how old the number is,
-    // or that the text moved on since it was made.
-    aiFresh.hidden = dirty;
-    aiStale.hidden = !dirty;
     dirtyBar.hidden = !dirty;
     for (const b of saveButtons) b.disabled = !dirty;
     const saveText = document.getElementById('save-text');

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -55,6 +55,7 @@ export function init(data) {
   const jd = document.getElementById('jd');
   const chips = document.getElementById('missing-chips');
   const saveButtons = document.querySelectorAll('[data-save-button]');
+  const aiFresh = document.getElementById('ai-fresh');
   const aiStale = document.getElementById('ai-stale');
   const dirtyBar = document.getElementById('dirty-bar');
   const barScore = document.getElementById('bar-score');
@@ -165,6 +166,9 @@ export function init(data) {
     if (chips.children.length === 0) chips.innerHTML = '<span class="text-xs text-ink-faint">Every countable keyword is present.</span>';
 
     const dirty = text !== data.resumeText;
+    // One line under the ring, two things it can say: how old the number is,
+    // or that the text moved on since it was made.
+    aiFresh.hidden = dirty;
     aiStale.hidden = !dirty;
     dirtyBar.hidden = !dirty;
     for (const b of saveButtons) b.disabled = !dirty;


### PR DESCRIPTION
One number on the targeted view, and a ring that explains itself.

## The problem

The card carried two scores. The AI's verdict sat as a small dial beside its
own figure; a second live estimate — its own number, bar and delta — sat in the
right rail under the heading "Live estimate". Neither was labelled in a way a
reader could act on, and the second one answered a question the page already
answered twice: a keyword edit re-scores the stored row server-side
(`routes/keywords.ts`), so the ring moves on its own, and while the text is
dirty the sticky bar already shows the estimate and its difference.

## What changed

- **One ring, the number inside it**, 112 px. Hovering or focusing it opens two
  sentences: what the 0–100 measures, and which edits move it.
- **The right-rail live estimate is gone.** The live number stays where it is
  the only answer available — the sticky bar, while the text is dirty. Its
  delta now reads "vs the last analysis" instead of "vs AI", and the label
  carries a title explaining what it counts.
- **The labels around the score are gone**: "AI match · moderate" restated the
  number; the draft marker and the age are on that run's own chip above;
  "edited — analyse again" is what the sticky bar says in full, with the button.
  `/100` moved into the hover text and the button's screen reader label.
- **"What made the number" / "what it does not count" is off this page.** The
  five lines from 1.71.0 stay on the `/jobs/:id` match card. The editor page
  keeps the model's sentence, the ceiling, the edit counts and the hard
  requirements — each the only place on the page carrying that fact.

## Accessibility

The ring is a `<button>` with `aria-describedby`, not a hover-only region:
keyboard focus and a tap open the same panel, per the repo's
"nothing depends on hover" rule. The panel is dimmed with opacity rather than
`hidden`, so a screen reader can read it. The focus ring is a circle.

## Verification

- `npm run lint:types` + 2105 tests green; browser console clean.
- 1440 px and 375 px: no horizontal scroll; the tooltip stays inside the
  viewport on mobile (37 → 325 px of 375).
- The ring column measures 112 px whether or not the editor is dirty — the old
  stale marker widened it under the first keystroke and squeezed the summary.
- Rings drawn at 27, 56 and 100. Editing the text still moves the sticky bar's
  estimate (56 → 58, "+2 vs the last analysis"). The `/jobs/:id` match card is
  unchanged and still renders the full breakdown.

## Pre-merge review

Ran `code-review-expert` over `git diff main...HEAD`. No P0/P1. Two P2 fixed in
`3b18115`: a `render()` comment describing the stale marker this branch removes,
and a dead `export` on `ScoreBreakdownChips` whose doc still named the targeted
view as a consumer.

Two P3 accepted as they are: the ring is a button that performs no action on
click (it exists to host focus for the tooltip; `aria-describedby` delivers the
text on focus), and the tooltip is `pointer-events-none` so its text cannot be
selected — deliberate, since a hoverable panel over the summary would block
clicks beneath it.

## Follow-ups

- The `/jobs/:id` match card still shows the full breakdown block. If the
  editor page's leaner reading is the right one, that card should follow — but
  that is a separate call about a different page.
- Nothing marks the ring as stale while the text is dirty. The sticky bar
  covers it today; if the number ever reads as misleading, the marker is one
  line to restore.

## Release notes

## What's new
- The targeted view leads with one score ring; the number sits inside it, and
  hovering or focusing the ring says what the number is and what moves it.
- The "Live estimate" panel is gone — the ring already moves on a keyword edit,
  and the sticky bar carries the estimate while the text is dirty.
- The labels around the score ("AI match · moderate", the draft marker, the run
  age, `/100`) are gone: each repeated the run chip above or the number itself.
- "What made the number" / "what it does not count" moves off the editor page
  and stays on the `/jobs/:id` match card.

## Schema
- no schema changes

## Verification
- lint:types + 2105 tests green; checked at 1440 px and 375 px, console clean;
  rings drawn at 27 / 56 / 100; keyboard focus opens the same panel as hover.

## References
- Follows 1.71.0 (docs/score-lines-plan.md), which added the breakdown lines
  this release removes from the editor page only.
