### PR TITLE
The score reacts to your edits, and takes a "yes" for what it cannot see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.73.0] — 2026-09-08
+
+### Changed
+- **The ring is the live number.** The score in the targeted view now
+  recounts on every keystroke — the number, the arc and its colour — with the
+  same formula the server runs (`score.mjs` mirrors `score.ts`): keywords and
+  the primary-stack cap live, alignment and the red-flag penalty held at what
+  the last analysis judged. The sticky bar's own "Estimate" is gone; it had
+  become the second copy of the same number. A parity test pins the ring's four
+  colour steps to `fitTone`.
+- **The gap chips show every gap.** The row above the editor filtered on the
+  matcher's `excluded` flag, which is set for a term the resume cannot back —
+  so it hid exactly the hardest gaps. On one live pair it showed one chip for
+  the only addable keyword and left out WordPress, the primary must capping
+  that score at 70, along with SASS and BEM. Those now appear, dashed, hardest
+  first, with no "+ add" — typing the word is what does not help.
+
+### Added
+- **"Confirm your experience" offers the terms the AI could not back.** A
+  `cannot_claim` verdict was a dead end: `applyFacts` already flipped a
+  confirmed one to `add`, but neither page ever offered it, and the prompt
+  tells the model to choose the lower status when unsure. The card now has a
+  second tier behind a summary ("N more the AI found no evidence for"), on both
+  the targeted view and the `/jobs/:id` match card; a dashed chip opens it and
+  moves focus to it. Measured on the live pair: "I have it" on WordPress took
+  the score 56 → 58 and the ceiling 70 → 84 with no AI call, and typing the
+  word then took it to 61 and turned it green in the posting. A term the user
+  answered "I don't" to stays a chip but is not re-asked.
+
+### Fixed
+- A gap chip's tooltip said "not in your resume" about a word the user had just
+  typed; it now says the word is there and nothing backs it.
+
+### Verification
+- `npm run lint:types` + 2108 tests green (three new: ring colour parity, the
+  gap rule, the two confirm tiers); browser console clean on both pages.
+- The confirm loop run end to end against a snapshot of a real row, then the
+  row and the fact restored. 1440 px and 375 px: no horizontal scroll, the new
+  card wraps.
+
 ## [1.72.0] — 2026-09-07
 
 ### Changed
@@ -2957,6 +2997,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[1.73.0]: https://github.com/applypack/applypack/compare/v1.72.0...v1.73.0
 [1.72.0]: https://github.com/applypack/applypack/compare/v1.71.0...v1.72.0
 [1.71.0]: https://github.com/applypack/applypack/compare/v1.70.0...v1.71.0
 [1.70.0]: https://github.com/applypack/applypack/compare/v1.69.0...v1.70.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.72.0",
+  "version": "1.73.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/resume/facts.ts
+++ b/src/resume/facts.ts
@@ -25,6 +25,9 @@ function names(k: MatchKeyword): string[] {
   return [canonicalTerm(k.term), ...k.aliases];
 }
 
+/** The note a denial leaves on a keyword — read back by keyword-overrides.ts:confirmable, so it is not re-asked. */
+export const DENIED_NOTE = 'user: does not have it';
+
 /**
  * Flip keyword statuses from stored facts. Confirmed → "add" (the user's
  * context lands in the note); denied → "cannot_claim". Text evidence outranks
@@ -50,7 +53,7 @@ export function applyFacts(
     }
     if (fact.status === 'denied' && k.status === 'ask_user') {
       changed++;
-      return { ...k, status: 'cannot_claim' as const, note: 'user: does not have it' };
+      return { ...k, status: 'cannot_claim' as const, note: DENIED_NOTE };
     }
     return k;
   });

--- a/src/resume/facts.ts
+++ b/src/resume/facts.ts
@@ -25,7 +25,7 @@ function names(k: MatchKeyword): string[] {
   return [canonicalTerm(k.term), ...k.aliases];
 }
 
-/** The note a denial leaves on a keyword — read back by keyword-overrides.ts:confirmable, so it is not re-asked. */
+/** The note a denial leaves on a keyword. keyword-overrides.ts:confirmable reads it back, so a "no" is not re-asked. */
 export const DENIED_NOTE = 'user: does not have it';
 
 /**

--- a/src/resume/keyword-overrides.test.ts
+++ b/src/resume/keyword-overrides.test.ts
@@ -7,6 +7,7 @@ import {
   effectiveKeywords,
   effectiveRequirement,
   isIgnored,
+  confirmable,
 } from './keyword-overrides';
 import type { MatchKeyword } from './prompts';
 import { scoreMatch } from './score';
@@ -257,4 +258,24 @@ test('a rebuilt frame keeps every override — the machine guess resets, the hum
     undefined,
     'a term only the rebuild found arrives clean',
   );
+});
+
+test('confirmable offers what the model asked and what it could not back, minus denials and context', () => {
+  const k = (term: string, status: MatchKeyword['status'], extra: Partial<MatchKeyword> = {}): MatchKeyword =>
+    ({ term, priority: 1, requirement: 'must', primary: false, status, aliases: [], where: null, note: null, ...extra }) as MatchKeyword;
+  const { asks, unproven } = confirmable([
+    k('Docker', 'ask_user'),
+    k('WordPress', 'cannot_claim'),
+    k('SASS', 'cannot_claim'),
+    // The user already said no — that IS the answer, not a question to repeat.
+    k('Oracle', 'cannot_claim', { note: 'user: does not have it' }),
+    // Context is not scored either way, so a yes changes nothing.
+    k('JIRA', 'cannot_claim', { requirement: 'context' }),
+    // An override to context counts the same as the model saying it.
+    k('Kafka', 'cannot_claim', { override: { requirement: 'context' } }),
+    k('PHP', 'present'),
+    k('Ajax', 'add'),
+  ]);
+  assert.deepEqual(asks.map((x) => x.term), ['Docker']);
+  assert.deepEqual(unproven.map((x) => x.term), ['WordPress', 'SASS']);
 });

--- a/src/resume/keyword-overrides.test.ts
+++ b/src/resume/keyword-overrides.test.ts
@@ -10,6 +10,7 @@ import {
   confirmable,
 } from './keyword-overrides';
 import type { MatchKeyword } from './prompts';
+import { DENIED_NOTE } from './facts';
 import { scoreMatch } from './score';
 import { loadKeywordMatcher } from './keyword-matcher';
 
@@ -268,7 +269,7 @@ test('confirmable offers what the model asked and what it could not back, minus 
     k('WordPress', 'cannot_claim'),
     k('SASS', 'cannot_claim'),
     // The user already said no — that IS the answer, not a question to repeat.
-    k('Oracle', 'cannot_claim', { note: 'user: does not have it' }),
+    k('Oracle', 'cannot_claim', { note: DENIED_NOTE }),
     // Context is not scored either way, so a yes changes nothing.
     k('JIRA', 'cannot_claim', { requirement: 'context' }),
     // An override to context counts the same as the model saying it.

--- a/src/resume/keyword-overrides.ts
+++ b/src/resume/keyword-overrides.ts
@@ -273,7 +273,7 @@ export function carryOverrides(
  * one live pair the model marked SASS and BEM cannot_claim for a twelve-year
  * CSS developer and WordPress for a twelve-year PHP developer, the candidate
  * typed all three in, the score did not move, and nothing on the page could
- * take a "yes". A confirmed fact flips the term to "add" (applyFacts above),
+ * take a "yes". A confirmed fact flips the term to "add" (facts.ts:applyFacts),
  * so the same answer that unblocks an ask unblocks these.
  *
  * Out: a term the user already denied (that IS their answer), and a context

--- a/src/resume/keyword-overrides.ts
+++ b/src/resume/keyword-overrides.ts
@@ -1,4 +1,4 @@
-import { canonicalTerm } from './facts';
+import { canonicalTerm, DENIED_NOTE } from './facts';
 import { withTableAliases } from './keyword-aliases';
 import type { KeywordMatcher } from './keyword-matcher';
 import type { MatchKeyword } from './prompts';
@@ -261,4 +261,28 @@ export function carryOverrides(
     });
   }
   return { keywords, carried, readded };
+}
+
+/**
+ * What the "Confirm your experience" card offers, in two tiers.
+ *
+ * `asks` is what the model chose to ask. `unproven` is every other term it
+ * could not back — offered too, because "cannot_claim" is a verdict on the
+ * RESUME TEXT, not on the person, and the prompt tells the model to pick the
+ * lower status when unsure. Left un-offered, that verdict was a dead end: on
+ * one live pair the model marked SASS and BEM cannot_claim for a twelve-year
+ * CSS developer and WordPress for a twelve-year PHP developer, the candidate
+ * typed all three in, the score did not move, and nothing on the page could
+ * take a "yes". A confirmed fact flips the term to "add" (applyFacts above),
+ * so the same answer that unblocks an ask unblocks these.
+ *
+ * Out: a term the user already denied (that IS their answer), and a context
+ * term, which the score does not count either way.
+ */
+export function confirmable(keywords: MatchKeyword[]): { asks: MatchKeyword[]; unproven: MatchKeyword[] } {
+  const asks = keywords.filter((k) => k.status === 'ask_user');
+  const unproven = keywords.filter(
+    (k) => k.status === 'cannot_claim' && k.note !== DENIED_NOTE && effectiveRequirement(k) !== 'context',
+  );
+  return { asks, unproven };
 }

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -35,7 +35,7 @@ import { hashShortId } from '../../text-utils';
 import { readMatchMode, type MatchMode } from '../../resume/match-mode';
 import { verificationCautions, verificationHint, type VerificationForHint, type VerificationHint } from '../../resume/verification-hint';
 import type { CountedKeyword } from '../../resume/keyword-matcher';
-import { effectiveRequirement, isIgnored } from '../../resume/keyword-overrides';
+import { effectiveRequirement, isIgnored, confirmable } from '../../resume/keyword-overrides';
 import { REQUIREMENT_LEVELS, type RequirementLevel } from '../../resume/score';
 import { readBreakdown, type ScoreBreakdown } from '../../resume/score';
 import { noEditsLine, type Reach } from '../no-edits';
@@ -329,56 +329,79 @@ export const HardRequirementsDigest: FC<{ hard: MatchHardRequirement[] }> = ({ h
   );
 };
 
-/** ask_user keywords → confirm/deny forms. Answers persist as CandidateFact rows. */
-export const ConfirmFacts: FC<{ asks: MatchKeyword[]; matchId: number; back: string }> = ({
+/** One term the user can answer for. Answers persist as CandidateFact rows. */
+const FactRow: FC<{ k: MatchKeyword; matchId: number; back: string }> = ({ k, matchId, back }) => (
+  <li class="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:gap-3">
+    <div class="min-w-0 flex-1 text-sm">
+      <span class="font-medium text-ink">{k.term}</span>
+      {k.note && <span class="ml-2 text-xs text-ink-faint">{k.note}</span>}
+      {k.elsewhere && (
+        <Badge tone="violet" class="ml-2">
+          in "{k.elsewhere}"
+        </Badge>
+      )}
+    </div>
+    <div class="flex shrink-0 flex-wrap items-center gap-1.5">
+      <form method="post" action="/facts" class="flex items-center gap-1.5">
+        <input type="hidden" name="term" value={k.term} />
+        <input type="hidden" name="decision" value="confirmed" />
+        <input type="hidden" name="matchId" value={String(matchId)} />
+        <input type="hidden" name="back" value={back} />
+        <Input
+          name="note"
+          maxlength="300"
+          placeholder="where / when? (optional)"
+          aria-label={`Where or when did you use ${k.term}?`}
+          class="!w-44 !px-2 !py-1 !text-xs"
+        />
+        <Button size="sm" variant="violet">
+          I have it
+        </Button>
+      </form>
+      <ActionForm action="/facts" hidden={{ term: k.term, decision: 'denied', matchId, back }}>
+        <Button size="sm" variant="ghost">
+          I don't
+        </Button>
+      </ActionForm>
+    </div>
+  </li>
+);
+
+/**
+ * The card takes both tiers of `facts.ts:confirmable`. The asks are open; the
+ * terms the model could not back sit behind a summary, because on a resume
+ * from another profession there are twenty-five of them and a wall of forms
+ * is not an offer. The dashed chips above the editor open it (target-page.mjs).
+ */
+export const ConfirmFacts: FC<{ asks: MatchKeyword[]; unproven: MatchKeyword[]; matchId: number; back: string }> = ({
   asks,
+  unproven,
   matchId,
   back,
 }) =>
-  asks.length === 0 ? null : (
+  asks.length === 0 && unproven.length === 0 ? null : (
     <div>
       <div class={SUBHEAD}>Confirm your experience — the posting wants these</div>
-      <ul class="divide-y divide-line rounded-md border border-violet/30">
-        {asks.map((k) => (
-          <li class="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:gap-3">
-            <div class="min-w-0 flex-1 text-sm">
-              <span class="font-medium text-ink">{k.term}</span>
-              {k.note && <span class="ml-2 text-xs text-ink-faint">{k.note}</span>}
-              {k.elsewhere && (
-                <Badge tone="violet" class="ml-2">
-                  in "{k.elsewhere}"
-                </Badge>
-              )}
-            </div>
-            <div class="flex shrink-0 flex-wrap items-center gap-1.5">
-              <form method="post" action="/facts" class="flex items-center gap-1.5">
-                <input type="hidden" name="term" value={k.term} />
-                <input type="hidden" name="decision" value="confirmed" />
-                <input type="hidden" name="matchId" value={String(matchId)} />
-                <input type="hidden" name="back" value={back} />
-                <Input
-                  name="note"
-                  maxlength="300"
-                  placeholder="where / when? (optional)"
-                  aria-label={`Where or when did you use ${k.term}?`}
-                  class="!w-44 !px-2 !py-1 !text-xs"
-                />
-                <Button size="sm" variant="violet">
-                  I have it
-                </Button>
-              </form>
-              <ActionForm
-                action="/facts"
-                hidden={{ term: k.term, decision: 'denied', matchId, back }}
-              >
-                <Button size="sm" variant="ghost">
-                  I don't
-                </Button>
-              </ActionForm>
-            </div>
-          </li>
-        ))}
-      </ul>
+      {asks.length > 0 && (
+        <ul class="divide-y divide-line rounded-md border border-violet/30">
+          {asks.map((k) => (
+            <FactRow k={k} matchId={matchId} back={back} />
+          ))}
+        </ul>
+      )}
+      {unproven.length > 0 && (
+        <details id="confirm-unproven" class={`${asks.length > 0 ? 'mt-2 ' : ''}rounded-md border border-line`}>
+          <summary class="cursor-pointer px-3 py-2 text-[13px] text-ink-muted transition-colors duration-150 hover:text-ink">
+            <span class="font-medium text-ink">{unproven.length} more</span> the AI found no evidence for —
+            typing the word earns nothing, but if you have the experience, say so here and it counts
+          </summary>
+          <ul class="divide-y divide-line border-t border-line">
+            {unproven.map((k) => (
+              <FactRow k={k} matchId={matchId} back={back} />
+            ))}
+          </ul>
+        </details>
+      )}
       <Hint class="mt-1.5">
         Answers are stored once and reused in every future comparison. Confirming updates this
         score instantly — no AI call.
@@ -433,11 +456,7 @@ export const MatchReport: FC<{
       <DeltaBox match={match} previous={previous} />
       <HardRequirementsBlock hard={readHardRequirements(match.hardRequirements)} />
       <MatchSignals match={match} verification={verification} />
-      <ConfirmFacts
-        asks={keywords.filter((k) => k.status === 'ask_user')}
-        matchId={match.id}
-        back={factsBack}
-      />
+      <ConfirmFacts {...confirmable(keywords)} matchId={match.id} back={factsBack} />
 
       {readMatchMode(match.breakdown) === 'fast' ? (
         <SuggestionsPrompt matchId={match.id} jobId={match.jobId} />

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -368,7 +368,7 @@ const FactRow: FC<{ k: MatchKeyword; matchId: number; back: string }> = ({ k, ma
 );
 
 /**
- * The card takes both tiers of `facts.ts:confirmable`. The asks are open; the
+ * The card takes both tiers of `keyword-overrides.ts:confirmable`. The asks are open; the
  * terms the model could not back sit behind a summary, because on a resume
  * from another profession there are twenty-five of them and a wall of forms
  * is not an offer. The dashed chips above the editor open it (target-page.mjs).

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -786,6 +786,10 @@ const TARGET_CSS = `
   .card-done { opacity: 0.55; }
   .card-done:hover, .card-done:focus-within { opacity: 1; }
   .chip { cursor: pointer; }
+  /* A gap the resume cannot back yet — the same dashed underline the panes use
+     for 'no evidence yet', so the chip and the mark read as one thing. Typing
+     the word does not clear it; writing the evidence does. */
+  .chip-unproven { text-decoration: underline dashed; text-decoration-thickness: 1px; text-underline-offset: 3px; }
   .runs-toggle::-webkit-details-marker { display: none; }
   .runs-toggle::before { content: '▸ '; }
   details[open] > .runs-toggle::before { content: '▾ '; }

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -100,6 +100,9 @@ const AI_TONE: Record<Tone, string> = {
 /** Score at which the card tells the user to stop polishing and apply. */
 const READY_TO_APPLY = 85;
 
+/** The ring's circumference, 2πr for r=42 — the dash length the arc is cut from. */
+const RING_LENGTH = 263.9;
+
 export const TargetPage: FC<TargetPageProps> = ({
   job,
   resume,
@@ -133,15 +136,14 @@ export const TargetPage: FC<TargetPageProps> = ({
   const olderRuns = matches.filter((m) => !shownRuns.some((s) => s.id === m.id));
   const clientData = {
     matchId: match.id,
-    aiScore: match.matchScore,
     resumeText,
     jobText: job.description,
     keywords: scored,
     actions,
     removals,
-    // Fixed score parts for the live estimate; null on pre-ADR-0012 matches.
-    // penalty rides along frozen: the flag texts were judged against the
-    // analysed snapshot, so live typing must not re-derive the offset.
+    // The score parts the live count holds fixed; null on pre-ADR-0012
+    // matches. penalty rides along frozen: the flag texts were judged against
+    // the analysed snapshot, so live typing must not re-derive the offset.
     scoring: breakdown
       ? { alignment: breakdown.alignment, redFlagCount: match.redFlags.length, penalty: breakdown.penalty }
       : null,
@@ -232,13 +234,18 @@ export const TargetPage: FC<TargetPageProps> = ({
           <div class="group relative w-28">
             <button
               type="button"
+              id="score-ring"
               aria-describedby="score-help"
               aria-label={`Match score ${match.matchScore} of 100 — what this number is`}
               class="relative block cursor-help rounded-full"
             >
               <svg viewBox="0 0 96 96" class="h-28 w-28 -rotate-90" aria-hidden="true">
                 <circle cx="48" cy="48" r="42" fill="none" stroke="rgb(var(--line))" stroke-width="7" />
+                {/* Server-rendered at the stored score, then moved by
+                    target-page.mjs on every edit — the script reads the dash
+                    length off this attribute rather than repeating 2πr. */}
                 <circle
+                  id="score-arc"
                   cx="48"
                   cy="48"
                   r="42"
@@ -246,15 +253,16 @@ export const TargetPage: FC<TargetPageProps> = ({
                   stroke="currentColor"
                   stroke-width="7"
                   stroke-linecap="round"
-                  stroke-dasharray="263.9"
-                  stroke-dashoffset={String(263.9 - (263.9 * match.matchScore) / 100)}
-                  class={AI_TONE[fitTone(match.matchScore)]}
+                  stroke-dasharray={RING_LENGTH}
+                  stroke-dashoffset={String(RING_LENGTH - (RING_LENGTH * match.matchScore) / 100)}
+                  class={`transition-[stroke-dashoffset] duration-300 ${AI_TONE[fitTone(match.matchScore)]}`}
                 />
               </svg>
               {/* The number alone. "/100" is in the sentence the ring shows
                   on hover, and in the button's own label for a screen reader —
                   it does not need to sit inside the dial as well. */}
               <span
+                id="score-number"
                 class="absolute inset-0 flex items-center justify-center text-[32px] font-semibold leading-none tabular-nums tracking-tight text-ink"
                 aria-hidden="true"
               >
@@ -269,13 +277,15 @@ export const TargetPage: FC<TargetPageProps> = ({
               class="pointer-events-none absolute left-0 top-full z-30 mt-2 w-72 max-w-[calc(100vw-3rem)] space-y-1.5 rounded-lg border border-line bg-surface-raised p-3 text-xs leading-5 text-ink-muted opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
             >
               <p>
-                <span class="font-medium text-ink">AI match, 0–100.</span> How well this resume answers
+                <span class="font-medium text-ink">Match score, 0–100.</span> How well this resume answers
                 this posting: the words it asks for, whether you have its core stack, and how your title,
                 summary and most recent role read at a glance.
               </p>
               <p class="text-ink-faint">
-                Re-levelling, ignoring or adding a keyword moves it at once. Editing the text does not —
-                that needs “Analyse my resume again”.
+                It moves as you edit: the words are counted live — except one marked{' '}
+                <span class="font-medium">no evidence yet</span>, which earns nothing until you confirm it.
+                What a word search cannot read stays as the last analysis judged it, so run “Analyse my
+                resume again” once the text is settled.
               </p>
             </div>
           </div>
@@ -644,15 +654,6 @@ export const TargetPage: FC<TargetPageProps> = ({
               kept in this browser tab{resume.ephemeral ? ' — copy them out before you leave' : ' until you save'}
             </span>
           </div>
-          {/* The only live number on the page now, and only while the text is
-              dirty — which is the one moment the ring cannot answer. */}
-          <span
-            class="text-sm font-medium tabular-nums text-ink"
-            title="Counts the keywords a scanner would find in the text as it stands. The ring keeps the AI's verdict until you analyse again."
-          >
-            Estimate <span id="bar-score">—</span>
-            <span id="bar-delta" class="ml-1 text-xs font-medium"></span>
-          </span>
           <div class="ml-auto flex flex-wrap items-center gap-2">
             <Button type="button" variant="ghost" size="sm" id="bar-discard">
               Discard

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -8,6 +8,7 @@ import type { MatchWithResume } from '../../resume/store';
 import type { CountedKeyword } from '../../resume/keyword-matcher';
 import type { VerificationForHint } from '../../resume/verification-hint';
 import { effectiveKeywords, confirmable } from '../../resume/keyword-overrides';
+import { DENIED_NOTE } from '../../resume/facts';
 import { readActions, readHardRequirements, readRemovals } from '../../resume/prompts';
 import { readMatchMode } from '../../resume/match-mode';
 import { readBreakdown } from '../../resume/score';
@@ -139,6 +140,8 @@ export const TargetPage: FC<TargetPageProps> = ({
     resumeText,
     jobText: job.description,
     keywords: scored,
+    // So a chip can tell the user's own "I don't" from a term the model could not back.
+    deniedNote: DENIED_NOTE,
     actions,
     removals,
     // The score parts the live count holds fixed; null on pre-ADR-0012

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -7,7 +7,7 @@ import { fitTone, formatRelative, type Tone } from '../format';
 import type { MatchWithResume } from '../../resume/store';
 import type { CountedKeyword } from '../../resume/keyword-matcher';
 import type { VerificationForHint } from '../../resume/verification-hint';
-import { effectiveKeywords } from '../../resume/keyword-overrides';
+import { effectiveKeywords, confirmable } from '../../resume/keyword-overrides';
 import { readActions, readHardRequirements, readRemovals } from '../../resume/prompts';
 import { readMatchMode } from '../../resume/match-mode';
 import { readBreakdown } from '../../resume/score';
@@ -124,7 +124,7 @@ export const TargetPage: FC<TargetPageProps> = ({
   const actions = readActions(match.actions);
   const removals = readRemovals(match.removals);
   const hard = readHardRequirements(match.hardRequirements);
-  const asks = scored.filter((k) => k.status === 'ask_user');
+  const { asks, unproven } = confirmable(scored);
   const highActions = actions.filter((a) => a.priority === 'high').length;
   // A quick check has no suggestions yet — the tab offers the second call instead (ADR 0029).
   const fast = readMatchMode(match.breakdown) === 'fast';
@@ -455,9 +455,14 @@ export const TargetPage: FC<TargetPageProps> = ({
         </div>
       </Card>
 
-      {asks.length > 0 && (
+      {(asks.length > 0 || unproven.length > 0) && (
         <Card class="mb-4">
-          <ConfirmFacts asks={asks} matchId={match.id} back={`/jobs/${job.id}/target?match=${match.id}`} />
+          <ConfirmFacts
+            asks={asks}
+            unproven={unproven}
+            matchId={match.id}
+            back={`/jobs/${job.id}/target?match=${match.id}`}
+          />
         </Card>
       )}
 

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -47,6 +47,21 @@ const CHIP_LEVEL = {
   0: 'bg-surface-overlay text-ink-muted ring-line',
 };
 
+/**
+ * What stands between this resume and a higher score, for the chips above the
+ * editor. Two kinds, and the second used to be missing from the row entirely:
+ * a term the resume evidences but does not spell (type it and the score moves),
+ * and one the resume cannot back at all — which `scoreKeywords` marks
+ * `excluded`, because it earns nothing however often the word appears.
+ * Filtering on `excluded` therefore hid the hardest gaps: on one live pair the
+ * row showed a single chip for the one addable keyword, and left out
+ * WordPress — the primary must that capped that score at 70 — along with SASS
+ * and BEM. A weight-0 context term is still no gap at all.
+ */
+export function keywordGaps(rows) {
+  return rows.filter((r) => r.weight > 0 && (r.status === 'cannot_claim' || !r.found));
+}
+
 /** Why an edit did not happen — every error the text operations can return. */
 const REASON = {
   'not-found': "Couldn't find this text in the editor, it may already be edited",
@@ -146,14 +161,18 @@ export function init(data) {
 
     chips.innerHTML = '';
     // Hardest requirement first, then the words the posting keeps repeating.
-    for (const r of orderKeywords(scored.rows.filter((r) => !r.found && !r.excluded), data.jobText)) {
+    for (const r of orderKeywords(keywordGaps(scored.rows), data.jobText)) {
+      const unproven = r.status === 'cannot_claim';
       const b = document.createElement('button');
       b.type = 'button';
-      b.className = CHIP_BASE + ' ' + (CHIP_LEVEL[keywordRank(r)] ?? CHIP_LEVEL[2]);
+      b.className =
+        CHIP_BASE + ' ' + (CHIP_LEVEL[keywordRank(r)] ?? CHIP_LEVEL[2]) + (unproven ? ' chip-unproven' : '');
       b.textContent = r.count > 1 ? r.term + ' ×' + r.count : r.term;
       b.title = [
         wantsLabel(r),
-        gapLabel(r, false),
+        // The honest sentence differs once the word IS in the text: this used
+        // to say "not in your resume" about a word the user had just typed.
+        gapLabel(r, r.found),
         r.count > 1 ? '×' + r.count + ' in the posting' : null,
         r.where ? 'add in: ' + r.where : null,
         r.note,

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -23,7 +23,16 @@ import { applyReplacement, insertAfterLine, removeSpan, insertIntoSkills, invers
 
 // Full literal class names — the Tailwind CDN JIT only generates what it can
 // see verbatim in the document, composed strings would come out unstyled.
-//
+
+// The ring's stroke, by score. Same four steps and the same cut-offs as the
+// server's format.ts:fitTone, so the colour does not change under the user
+// when an analysis lands on a score the live count already showed.
+const RING_TONE = { ok: 'text-ok', info: 'text-info', warn: 'text-warn', neutral: 'text-ink-faint' };
+
+export function ringTone(score) {
+  return score >= 85 ? 'ok' : score >= 70 ? 'info' : score >= 50 ? 'warn' : 'neutral';
+}
+
 // A missing chip wears the colour its mark wears in the posting (target.mjs):
 // red for a must, amber for a preferred, slate for a nice-to-have. Keyed by
 // keywordRank — 4 a primary-stack must … 0 context.
@@ -56,8 +65,11 @@ export function init(data) {
   const chips = document.getElementById('missing-chips');
   const saveButtons = document.querySelectorAll('[data-save-button]');
   const dirtyBar = document.getElementById('dirty-bar');
-  const barScore = document.getElementById('bar-score');
-  const barDelta = document.getElementById('bar-delta');
+  const ringButton = document.getElementById('score-ring');
+  const ringArc = document.getElementById('score-arc');
+  const ringNumber = document.getElementById('score-number');
+  // 2πr, straight off the element the server drew, so the two cannot drift.
+  const ringLength = Number(ringArc.getAttribute('stroke-dasharray'));
   const panes = document.getElementById('panes');
   const storageKey = 'target-draft:' + data.matchId;
   const editsKey = 'target-edits:' + data.matchId;
@@ -91,24 +103,35 @@ export function init(data) {
     } catch {}
   }
 
+  /** The ring: the number, the arc and the label a screen reader reads. */
+  function paintRing(score) {
+    ringNumber.textContent = String(score);
+    ringArc.style.strokeDashoffset = String(ringLength - (ringLength * score) / 100);
+    ringArc.setAttribute(
+      'class',
+      'transition-[stroke-dashoffset] duration-300 ' + RING_TONE[ringTone(score)],
+    );
+    ringButton.setAttribute('aria-label', 'Match score ' + score + ' of 100 — what this number is');
+  }
+
   function render() {
     const text = editor.value;
     const scored = scoreKeywords(data.keywords, text);
-    // The live number, for the sticky bar alone: the full score formula when
-    // the match carries a breakdown (alignment fixed from the last AI run,
-    // keywords + cap live), else the plain coverage percentage for
-    // pre-ADR-0012 matches. The ring above keeps the AI's own verdict, which
-    // only a re-run moves; a keyword edit re-scores it server-side instead.
+    // The number in the ring, recomputed on every keystroke and on every page
+    // render — which is what a keyword override produces. The full score
+    // formula when the match carries a breakdown (alignment and the red-flag
+    // penalty held at what the last analysis judged, keywords and the
+    // primary-stack cap live), else the plain coverage percentage for
+    // pre-ADR-0012 matches.
+    //
+    // The same arithmetic the server runs (score.mjs mirrors score.ts), so
+    // this is the score, not a second opinion about it: only the parts a word
+    // search cannot read wait for the next analysis.
     let display = scored.score;
     if (data.scoring) {
       display = computeScore(entriesFromLive(scored.rows), data.scoring.alignment, data.scoring.redFlagCount, data.scoring.penalty ?? null).score;
     }
-    barScore.textContent = String(display);
-    if (data.scoring) {
-      const d = display - data.aiScore;
-      barDelta.textContent = d === 0 ? 'same as the last analysis' : (d > 0 ? '+' : '') + d + ' vs the last analysis';
-      barDelta.className = 'ml-1 text-xs font-medium ' + (d > 0 ? 'text-ok' : d < 0 ? 'text-danger' : 'text-ink-faint');
-    }
+    paintRing(display);
 
     const spans = resumeSpans(data.keywords, data.actions, data.removals, text);
     if (located) {

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -174,10 +174,12 @@ export function init(data) {
         // to say "not in your resume" about a word the user had just typed.
         gapLabel(r, r.found),
         r.count > 1 ? '×' + r.count + ' in the posting' : null,
-        r.where ? 'add in: ' + r.where : null,
+        unproven ? 'click to say you have it — then it counts' : r.where ? 'add in: ' + r.where : null,
         r.note,
       ].filter(Boolean).join(' · ');
-      b.addEventListener('click', () => jumpToSection(r.where));
+      // A dashed chip has nowhere in the text to send you — typing the word is
+      // exactly what does not help. It opens the one control that does.
+      b.addEventListener('click', () => (unproven ? openConfirm() : jumpToSection(r.where)));
       chips.appendChild(b);
       // "Add to Skills" only where it can honestly work: the model (or a fact the
       // user confirmed — applyFacts flips confirmed to `add` before this page
@@ -218,6 +220,17 @@ export function init(data) {
     if (copyEdits) copyEdits.disabled = !dirty;
     paintCards();
     store(text);
+  }
+
+  /** Open the "no evidence" tier of the confirm card and bring it into view. */
+  function openConfirm() {
+    const box = document.getElementById('confirm-unproven');
+    if (!box) return;
+    box.open = true;
+    box.scrollIntoView({ block: 'center' });
+    box.classList.remove('flash-target');
+    void box.offsetWidth; // restart the animation when clicked twice
+    box.classList.add('flash-target');
   }
 
   function jumpToSection(where) {

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -163,6 +163,9 @@ export function init(data) {
     // Hardest requirement first, then the words the posting keeps repeating.
     for (const r of orderKeywords(keywordGaps(scored.rows), data.jobText)) {
       const unproven = r.status === 'cannot_claim';
+      // The user's own "I don't" is a cannot_claim too, carrying the note the
+      // denial left. Still a gap, so still a chip — but not an offer to confirm.
+      const denied = unproven && r.note === data.deniedNote;
       const b = document.createElement('button');
       b.type = 'button';
       b.className =
@@ -174,12 +177,12 @@ export function init(data) {
         // to say "not in your resume" about a word the user had just typed.
         gapLabel(r, r.found),
         r.count > 1 ? '×' + r.count + ' in the posting' : null,
-        unproven ? 'click to say you have it — then it counts' : r.where ? 'add in: ' + r.where : null,
-        r.note,
+        denied ? 'you said you do not have it' : unproven ? 'click to say you have it — then it counts' : r.where ? 'add in: ' + r.where : null,
+        denied ? null : r.note,
       ].filter(Boolean).join(' · ');
       // A dashed chip has nowhere in the text to send you — typing the word is
       // exactly what does not help. It opens the one control that does.
-      b.addEventListener('click', () => (unproven ? openConfirm() : jumpToSection(r.where)));
+      b.addEventListener('click', () => (unproven && !denied ? openConfirm() : jumpToSection(r.where)));
       chips.appendChild(b);
       // "Add to Skills" only where it can honestly work: the model (or a fact the
       // user confirmed — applyFacts flips confirmed to `add` before this page
@@ -228,6 +231,8 @@ export function init(data) {
     if (!box) return;
     box.open = true;
     box.scrollIntoView({ block: 'center' });
+    // Focus follows the disclosure, as it does when the summary itself is pressed.
+    box.querySelector('summary')?.focus({ preventScroll: true });
     box.classList.remove('flash-target');
     void box.offsetWidth; // restart the animation when clicked twice
     box.classList.add('flash-target');

--- a/src/web/target.test.ts
+++ b/src/web/target.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { fitTone } from './format';
 
 // The matcher ships to the browser as a static ES module; node loads it the same way.
 // @ts-expect-error — plain JS with no declaration file; the shape is asserted below.
@@ -135,6 +136,20 @@ test('target-page module imports without a DOM and exposes init', async () => {
   // @ts-expect-error — plain JS with no declaration file.
   const page = (await import('./public/target-page.mjs')) as { init: unknown };
   assert.equal(typeof page.init, 'function');
+});
+
+test('the ring\'s live tone agrees with the server\'s fitTone at every cut-off', async () => {
+  // The ring is drawn by the server at the stored score and then repainted by
+  // target-page.mjs on every edit. Two implementations of the same four steps:
+  // if they drift, the colour changes under the user when an analysis lands on
+  // a number the live count already showed.
+  // @ts-expect-error — plain JS with no declaration file.
+  const { ringTone } = (await import('./public/target-page.mjs')) as {
+    ringTone: (score: number) => string;
+  };
+  for (const score of [0, 1, 49, 50, 51, 69, 70, 71, 84, 85, 86, 99, 100]) {
+    assert.equal(ringTone(score), fitTone(score), `score ${score}`);
+  }
 });
 
 test('resumeSpans marks keywords and quoted edits, edits first on ties', async () => {

--- a/src/web/target.test.ts
+++ b/src/web/target.test.ts
@@ -152,6 +152,29 @@ test('the ring\'s live tone agrees with the server\'s fitTone at every cut-off',
   }
 });
 
+test('the gap chips keep an unbackable term, typed in or not', async () => {
+  // The chips answer "what is between me and a higher score". A cannot_claim
+  // term earns nothing however often the word appears, so scoreKeywords marks
+  // it `excluded` — and filtering the chips on `excluded` hid exactly the
+  // hardest gaps, including the primary must that caps the score.
+  // @ts-expect-error — plain JS with no declaration file.
+  const { keywordGaps } = (await import('./public/target-page.mjs')) as {
+    keywordGaps: (rows: { term: string; weight: number; found: boolean; status: string }[]) => { term: string }[];
+  };
+  const rows = [
+    { term: 'WordPress', weight: 3, found: false, status: 'cannot_claim' },
+    { term: 'SASS', weight: 3, found: true, status: 'cannot_claim' },
+    { term: 'Ajax', weight: 3, found: false, status: 'add' },
+    { term: 'PHP', weight: 3, found: true, status: 'present' },
+    { term: 'JIRA', weight: 0, found: false, status: 'present' },
+  ];
+  assert.deepEqual(
+    keywordGaps(rows).map((r) => r.term),
+    // SASS stays although the word is in the text; PHP is earned, JIRA is context.
+    ['WordPress', 'SASS', 'Ajax'],
+  );
+});
+
 test('resumeSpans marks keywords and quoted edits, edits first on ties', async () => {
   const { resumeSpans } = await matcher;
   const spans = resumeSpans(


### PR DESCRIPTION
The score reacts to your edits — and the one case where it can't now says so, and takes a "yes".

## The complaint, measured

"I added WordPress, SASS and BEM and the score did not change; Ajax worked."

Three things behind that, one of them a real design hole:

| What was typed | Status from the AI | What happened | Why |
|---|---|---|---|
| Ajax | `add` | 56 → 58, green in the posting | the resume evidences it, only the word was missing |
| WordPress, SASS, BEM | `cannot_claim` | nothing | the score gives an unbacked word zero credit however often it appears (ADR 0012, gotcha 11) |

The zero is correct — a score that rewards keyword stuffing lies to the person about to apply. But `cannot_claim` was a **dead end**: `applyFacts` already flips a confirmed one to `add` and re-scores with no AI call, yet neither page ever offered it, and the prompt tells the model to choose the lower status when unsure. So it marked SASS and BEM `cannot_claim` for a twelve-year CSS developer and WordPress for a twelve-year PHP developer, and nothing on the page could take a "yes".

And the row that answers "what is between me and a higher score" was filtering on the matcher's `excluded` flag — set for exactly those terms — so it showed one chip (Ajax) and hid WordPress, the primary must capping the score at 70.

## What changed

- **The ring is the live number** (`13bee63`). Recounted on every keystroke — number, arc, colour — with the same formula the server runs (`score.mjs` mirrors `score.ts`); alignment and the red-flag penalty held at the last analysis. The sticky bar's "Estimate" goes: it had become the second copy. `ringTone` gets a parity test against `fitTone` at every cut-off.
- **The gap chips show every gap** (`d764b4c`). `keywordGaps` keeps a `cannot_claim` term whether or not the word is in the text, dashed, hardest first, no "+ add". The chip tooltip now says "the word is there, but nothing backs it" once typed — it used to say "not in your resume" about a word just typed (`found` was hard-coded `false`).
- **"Confirm your experience" offers the terms the AI could not back** (`b432d2a`). `keyword-overrides.ts:confirmable` splits keywords into `asks` (open, as before) and `unproven` (behind a summary — a resume from another profession has twenty-five). Both pages use it. A dashed chip opens the tier and moves focus to it. A term the user answered "I don't" to stays a chip but is not re-asked.

Measured end to end on a snapshot of a real row (then restored): "I have it" on WordPress → flash "score 56 → 58", ceiling 70 → 84, chip gains "+ add", the posting's mark loses its dashed underline; typing the word → 61, green.

## Pre-merge review

`code-review-expert` over `git diff main...HEAD`. No P0/P1. Fixed in the release commit: a denied term's chip offered a confirm the card could not give (P2); two doc comments named the file `confirmable` was moved out of (P2); the test spelled the denial note instead of importing `DENIED_NOTE` (P3); focus stayed on the chip after opening the card (P3).

## Follow-ups (not in this PR)

- The model over-assigns `cannot_claim` where `ask_user` fits (the prompt says "when unsure, choose the lower"). The card now catches it, but the prompt could ask more and guess less — a `PROMPT_VERSION` bump with a measured pass over the gold fixtures.
- After a confirm, the summary sentence and the hard-requirement line still carry the last analysis's wording ("WordPress missing") until "Analyse my resume again"; the flash says the score moved but not that those two lines have not.

## Verification

- `npm run lint:types` + 2108 tests (three new); console clean on `/jobs/:id/target` and `/jobs/:id`.
- 1440 px and 375 px: no horizontal scroll; the new card wraps; all four rows fit open.
- Rings at 27 / 56 / 100; keyboard focus opens the tooltip and the card.

## Release notes

## What's new
- The score ring in the targeted view moves as you type — same formula as the server, no second number.
- The "missing" chips now show every gap, including the ones the resume cannot back yet (dashed, no "+ add").
- "Confirm your experience" offers those terms too: say "I have it" and the score moves at once, no AI call; typing the word then counts and turns green in the posting.
- A chip's tooltip tells the truth about a word you just typed.

## Schema
- no schema changes

## Verification
- lint:types + 2108 tests green; confirm loop measured on a real row (56 → 58 → 61); 1440 px and 375 px, console clean.

## References
- [#198](https://github.com/applypack/applypack/pull/198) (v1.72.0) — the ring this release makes live.
- ADR 0012 (the code scores, the model grades), gotcha 11 (an unbacked word earns nothing).
