### PR TITLE
A word in your resume counts, whatever the last analysis called it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [1.74.0] — 2026-09-08
+
+### Changed
+- **A word in your resume counts, whatever the last analysis called it.**
+  Typing `WordPress` or `BEM` into the editor moved nothing while `Ajax`
+  moved +3: the live count gave a term the AI had marked `cannot_claim` zero
+  credit however often it appeared, and the persist-time anchoring pass never
+  revisited that verdict — so a WordPress on the resume's own title line held
+  one comparison at 41, capped at 70 as a missing primary. Both sides now read
+  presence off the text (ADR 0045): a written term is `present`, an unwritten
+  `present` or `add` is `add` (half credit, and it still covers the primary
+  cap), an unwritten `ask_user` or `cannot_claim` earns nothing until it is
+  written or confirmed. The ring is the score the next analysis stores for the
+  same text, and a test holds the two equal edit by edit. The thin-evidence
+  signal stays where it was: the "skills line only" badge, not the number.
+- The gap chips, the pane marks and the plain coverage percentage follow: a
+  typed word is green and no longer a chip, every weighted term is in the
+  denominator, and the confirm tier says it is the other way in, not the only.
+
+### Added
+- `node dist/scripts/reanchor-matches.js [--dry-run]` lifts a stored
+  `cannot_claim` the comparison's own text snapshot spells — 29 keywords on 27
+  comparisons of the live corpus — through the write path a keyword edit
+  already uses. Only that flip: rows from before the 0044 addendum keep the
+  statuses they were scored under.
+
 ## [1.73.0] — 2026-09-08
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | Why a keyword the model returned is not in the table at all | `src/resume/keyword-shape.ts:dropMalformedKeywords` (pure, ADR 0044 addendum) — a years-of-experience or degree requirement is a gate, a bare quantity ("0 to 1", "10x") is not a thing to search for, and nothing over five words is a term. Runs first in `match.ts`, before anchoring; a keyword the user added themselves is never dropped |
 | How strongly the resume shows a keyword (a skills line, a sentence, a sentence with a number) | `src/resume/evidence.ts:annotateEvidence` (pure) — measured off the text, never asked of the model; stamped in `match.ts`, shown as the "skills line only" / "with a number" badge, and handed to the suggestions call so REQUIRED COVERAGE reads a fact instead of guessing |
 | Whether a posting said enough to be trusted as a checklist | `src/resume/brief-depth.ts:postingDepth` (pure) over the stored brief — six signals, `high\|medium\|low`, and the sentence the target page shows when the posting is thin. Read-only: `brief.ts:storedBriefFor` never spends a call to render a page |
-| Why "matched" always agrees with the missing-keyword chips | `src/resume/keyword-anchor.ts:anchorStatuses` (pure) — `present` vs `add` is one question about the TEXT, so the matcher settles it both ways: a `present` it cannot find becomes `add`, an `add` it can find becomes `present`. `ask_user` and `cannot_claim` are never touched (typing a word does not make a claim true). This flip on one keyword is what made one live pair score 79 and then 30 |
+| Why "matched" always agrees with the missing-keyword chips, and why a typed word counts | `src/resume/keyword-anchor.ts:anchorStatuses` (pure, ADR 0045) — whether the word is in the TEXT is one question, so the matcher settles the status for every verdict: a term it can find is `present` whatever the model said (a `cannot_claim` on the resume's own title line held one pair at 41 for a 52), an unwritten `present` becomes `add`, an unwritten `ask_user` / `cannot_claim` stays. `score.mjs:entriesFromLive` is the same rule per keystroke, and `src/web/score.test.ts` holds the two equal on every text. "Named, but nothing behind it" is the `evidence` grade, never the status. Stored rows from before the rule: `node dist/scripts/reanchor-matches.js --dry-run` |
 | Whether a keyword's group label is one the brief actually wrote | `src/resume/keyword-group.ts:reconcileGroups` (pure, ADR 0044) — runs at persist time in `match.ts` between `annotateElsewhere` and the score; an unbacked label is dropped (an invented one would charge one weight for two requirements), and no brief means no groups at all |
 | Why "React, Next.js, or Vue.js" costs one must-weight and not three | `src/resume/score.ts:foldGroups` (pure, ADR 0044) over the `group` label the brief put on each keyword — mirrored in `score.mjs`, parity fixture in `src/web/score.test.ts` |
 | Why a red flag sometimes costs nothing | `src/resume/red-flags.ts:countableFlags` (pure) — a flag that names a keyword the resume does not have restates something the keyword pool already charged for, so it is dropped before the formula sees it. What still costs: location, work authorization, a minimum missed, an excluded seniority, an injection attempt. Measured cause: one such sentence, written in three runs of five, was 80% of a ten-point spread on one pair (`npm run variance:compare`) |
@@ -601,6 +601,23 @@ Three rules, all in code now:
   with a reason, never text handed to a parser.
 - A reply that stopped inside the JSON is not retried (`ai-json.ts`) — the
   identical call stops in the identical place, so the retry was pure cost.
+
+### 17. A status is the model's verdict on the analysed text — the text outranks it
+
+Found 2026-09-08 on the targeted view: typing `Ajax` moved the ring +3,
+typing `WordPress` or `BEM` moved nothing — and that WordPress already sat on
+the resume's own title line while the stored row called it `cannot_claim`
+("no WordPress work anywhere in resume") and capped the score at 70 as a
+missing primary. `entriesFromLive` gave a typed `cannot_claim` zero "for
+claim safety" and `anchorStatuses` never revisited one, so the number under
+the editor and the number the next analysis stored disagreed about the same
+text; the first fix that morning (a confirm tier, "I have it") asked the
+candidate to restate what their resume already said. ADR 0045: presence is
+read off the text on both sides, for every status, and the model's "named,
+nothing behind it" is the `evidence` grade, never the status. Measured before
+deciding: 29 of 1 215 stored `cannot_claim` rows were written, and the 8
+homonyms among them (GCP = Good Clinical Practice) all sat on comparisons
+scoring 0.
 
 ### 12. stripHtml: decode entities FIRST, and never re-run it on its own output
 

--- a/docs/adr/0012-deterministic-match-score.md
+++ b/docs/adr/0012-deterministic-match-score.md
@@ -1,6 +1,6 @@
 # 0012 — The resume-match score is computed by application code, not by the model
 
-**Status:** Accepted (2026-08-28)
+**Status:** Accepted (2026-08-28) — the live-score rule on `cannot_claim` amended by [0045](./0045-the-resume-text-decides-presence.md)
 
 ## Context
 

--- a/docs/adr/0045-the-resume-text-decides-presence.md
+++ b/docs/adr/0045-the-resume-text-decides-presence.md
@@ -1,0 +1,71 @@
+# 0045 — The resume text decides whether a keyword is present
+
+**Status:** Accepted (2026-09-08). Amends the live-score rule of [0012](./0012-deterministic-match-score.md) and the anchoring rule of the [0044](./0044-the-posting-is-read-once-on-its-own.md) addendum.
+
+## Context
+
+ADR 0012 gave a `cannot_claim` keyword zero credit in the live editor "even
+when typed", for claim safety; the anchoring pass that settles `present` vs
+`add` against the resume text (`keyword-anchor.ts:anchorStatuses`) upgraded a
+written `add` or `ask_user` to `present` and never touched `cannot_claim`. So
+the status was a verdict the model gave on one text, and the number kept
+honouring it after the text changed.
+
+A live pair showed the cost (match 139, 2026-09-08): typing `Ajax` (an
+`add`) moved the ring +3, typing `WordPress` or `BEM` (`cannot_claim`) moved
+nothing — and WordPress already stood on the resume's own title line while
+the stored row said "no WordPress work anywhere in resume", capped the score
+at 70 as a missing primary and stored 41. The first fix that morning, a
+confirm tier ("I have it"), asked the candidate to restate what the resume
+said. The complaint was exact: the comparison should read the resume, not
+the facts stored about the person.
+
+Measured before deciding, over 138 stored comparisons and 2 202 keywords:
+1 215 `cannot_claim` rows, 29 of them written in the text, 8 of those a
+primary must. The 29 split into listed-only terms the model would not credit
+(Rust, Java, WordPress, jQuery, a hedged "Go"), a version the alias table
+folds (PHP 8 → PHP), a degree field (Engineering, on job titles), and 8
+homonyms — "GCP" meaning Good Clinical Practice on an engineer's resume —
+every homonym on a comparison scoring 0.
+
+## Decision
+
+Presence is a question about the text, and the matcher answers it for every
+status, on both sides of the split:
+
+| The text … | status stored (`anchorStatuses`) | live credit (`entriesFromLive`) | covers the primary cap |
+| --- | --- | --- | --- |
+| spells the term | `present`, whatever the model said | 1 | yes |
+| does not, model said `present` or `add` | `add` | 0.5 | yes |
+| does not, model said `ask_user` or `cannot_claim` | unchanged | 0 | no |
+
+`src/web/score.test.ts` runs both sides over one fixture, edit by edit, and
+demands equal breakdowns: the ring is the score the next analysis stores for
+the same text, for every part a word search can read. A stored denial does
+not outrank the text either — `facts.ts` already let a written word stand
+over a stale "no".
+
+What does not change: the model still judges the statuses, alignment, gates
+and red flags; "named, but nothing behind it" is the `evidence` grade
+(listed / described / measured), never the status; "+ add" is offered only
+for `add`, and the replacement gate still refuses wording that would
+introduce a `cannot_claim` term — a claim the app writes is not a claim the
+user writes. The confirm tier stays as the other way in: a fact stored once
+and reused. `src/scripts/reanchor-matches.ts` brings stored rows under the
+rule with no AI call.
+
+## Consequences
+
+✅ The number reads the resume; live and stored agree on the same text; no
+page asks for a "yes" about a word already on it; the primary cap lifts the
+moment the stack is written in.
+❌ A homonym earns its weight (GCP); a term listed with nothing behind it
+earns as much as one described — the badge says "skills line only", the
+number does not; a user can raise the number by typing. The app's job is the
+warning, not the veto.
+
+## When to revisit
+
+If evidence grading enters the score (evidence.ts's own trigger), "written"
+stops being binary and this rule becomes the floor of that scale. Or if a
+homonym shows up on a comparison that matters — one scoring above the noise.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,6 +53,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0042 — The verifier's company facts are context for the match, never evidence](./0042-company-facts-are-context-never-evidence.md) *(extends 0021 and 0037)*
 - [0043 — A posting refreshed from the company's own listing keeps its original and is re-judged](./0043-refresh-the-posting-from-the-companys-own-listing.md)
 - [0044 — The posting is read once, on its own, and the reading is kept](./0044-the-posting-is-read-once-on-its-own.md)
+- [0045 — The resume text decides whether a keyword is present](./0045-the-resume-text-decides-presence.md)
 
 ## When to write a new one
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/site/public/demo/score.mjs
+++ b/site/public/demo/score.mjs
@@ -151,27 +151,29 @@ export function computeScore(rawEntries, alignment, countedFlags, fixedPenalty =
 
 /**
  * Live entries from scoreKeywords() rows ({ requirement, primary, status, found }).
- * Textual presence earns full credit — except cannot_claim, which never counts
- * even when the user types the word (claim safety). An "add" keyword keeps its
- * half credit until the user actually writes it in. A "primary" mark only
- * counts on must requirements, mirroring entriesFromKeywords.
+ * The server's own entries for the statuses THIS text implies — the rule
+ * keyword-anchor.ts:anchorStatuses applies before every stored score (ADR
+ * 0045): a word the text spells is `present`, whatever the last analysis
+ * called it; a `present` or `add` the text does not spell is `add` (the facts
+ * behind it stand, the word does not — half credit, and it still covers the
+ * primary cap, so deleting a word never costs 49 points); an unwritten
+ * `ask_user` or `cannot_claim` earns nothing until it is written or confirmed.
+ * A "primary" mark only counts on must requirements, mirroring
+ * entriesFromKeywords. score.test.ts holds the two sides equal on every text.
  */
 export function entriesFromLive(rows) {
   return rows.map((r) => {
     const primary = r.primary === true && r.requirement === 'must';
-    const claimable = r.status !== 'cannot_claim';
-    const writable = r.status === 'present' || r.status === 'add';
+    const written = r.found === true;
+    const has = written || r.status === 'present' || r.status === 'add';
     return {
       requirement: r.requirement ?? 'preferred',
       primary,
-      credit: !claimable ? 0 : r.found ? 1 : r.status === 'add' ? 0.5 : 0,
-      // Same rule as the server's: an `add` primary is covered whether or not
-      // the word has been typed yet, so the estimate does not jump 49 points
-      // the moment the user deletes it.
-      primaryHit: primary && claimable && (r.found === true || r.status === 'add'),
-      primaryWritten: primary && claimable && r.found === true,
-      ceilCredit: writable ? 1 : 0,
-      ceilPrimaryHit: primary && writable,
+      credit: written ? 1 : has ? 0.5 : 0,
+      primaryHit: primary && has,
+      primaryWritten: primary && written,
+      ceilCredit: has ? 1 : 0,
+      ceilPrimaryHit: primary && has,
       group: r.group ?? null,
     };
   });

--- a/site/public/demo/target.mjs
+++ b/site/public/demo/target.mjs
@@ -60,25 +60,21 @@ const GAP_CLASS = {
   context: 'kw-gap kw-nice',
 };
 
-/** True when writing the word in would be honest: the resume backs it, or is being asked. */
-function claimable(k) {
-  return k.status !== 'cannot_claim';
-}
-
 /**
  * The class string for one keyword's marks. `found` is textual presence in the
- * resume — it only earns green where the claim is honest, mirroring the score,
- * which gives a cannot_claim term zero credit however often the word is typed.
+ * resume, and a word the resume spells is simply green — the score reads the
+ * text the same way, whatever the last analysis called the term (ADR 0045).
  */
 export function markClass(k, found) {
-  if (found && claimable(k)) return 'kw-have';
+  if (found) return 'kw-have';
   const gap = GAP_CLASS[levelOf(k)] ?? GAP_CLASS.preferred;
   // The stack the score caps on: the same red, louder.
   const core = k.primary === true && levelOf(k) === 'must' ? ' kw-core' : '';
-  // Nothing in the resume backs this word yet, so it cannot simply be typed
-  // in. A dashed underline, never a strikethrough — struck-through text on the
-  // posting's own must-have read as "ignore this", which is the opposite.
-  const unproven = claimable(k) && k.status !== 'ask_user' ? '' : ' kw-unproven';
+  // Nothing in the resume backs this word yet: writing it in counts, and so
+  // does confirming it. A dashed underline, never a strikethrough —
+  // struck-through text on the posting's own must-have read as "ignore this",
+  // which is the opposite.
+  const unproven = k.status === 'ask_user' || k.status === 'cannot_claim' ? ' kw-unproven' : '';
   return gap + core + unproven;
 }
 
@@ -203,19 +199,21 @@ export function findTerm(text, term, aliases = []) {
 
 /**
  * Weighted coverage of the keyword list in `text`.
- * keywords: [{ term, priority, requirement?, status, aliases? }]. Excluded
- * from the coverage percentage: cannot_claim keywords (you cannot honestly
- * add them — unless includeCannotClaim is set) and zero-weight "context"
- * keywords. Every row still carries found/count for highlighting, and the
- * full rows feed entriesFromLive() in score.mjs for the live score estimate.
+ * keywords: [{ term, priority, requirement?, status, aliases? }]. Every
+ * weighted term is in the denominator whatever the last analysis made of it —
+ * the posting's demand does not shrink because the resume cannot meet part of
+ * it — and a term earns its weight when the text spells it (ADR 0045). Only a
+ * zero-weight "context" term is `excluded`. Every row still carries
+ * found/count for highlighting, and the full rows feed entriesFromLive() in
+ * score.mjs for the live score.
  */
-export function scoreKeywords(keywords, text, { includeCannotClaim = false } = {}) {
+export function scoreKeywords(keywords, text) {
   const rows = [];
   let earned = 0;
   let total = 0;
   for (const k of keywords) {
     const weight = keywordWeight(k);
-    const excluded = (k.status === 'cannot_claim' && !includeCannotClaim) || weight === 0;
+    const excluded = weight === 0;
     const spans = findTerm(text, k.term, k.aliases ?? []);
     const found = spans.length > 0;
     if (!excluded) {
@@ -273,12 +271,8 @@ export function highlightHtml(text, spans) {
  * vocabulary the legend and the keyword table use, in the second person.
  */
 export function gapLabel(k, found) {
-  if (k.status === 'cannot_claim') {
-    return found
-      ? 'the word is there, but nothing in your resume backs it'
-      : 'not in your resume, and nothing here evidences it';
-  }
   if (found) return 'in your resume';
+  if (k.status === 'cannot_claim') return 'not in your resume, and nothing here evidences it';
   if (k.status === 'ask_user') return 'not written — confirm whether you have it';
   return 'not written — your resume evidences it, add the word';
 }
@@ -306,15 +300,11 @@ export function jobSpans(keywords, jobText, scored) {
 export function resumeSpans(keywords, actions, removals, resumeText) {
   const spans = [];
   // No level class here: a word the resume already spells is simply matched,
-  // whatever the posting thinks of it. The one exception is a term the resume
-  // cannot claim — the score gives it zero however often it is typed, so a
-  // plain green mark would promise points that never arrive.
+  // whatever the posting thinks of it — and whatever the last analysis made
+  // of it, since the score reads the text the same way (ADR 0045).
   for (const k of keywords) {
-    const unproven = k.status === 'cannot_claim';
-    const cls = unproven ? 'kw-present kw-unproven' : 'kw-present';
-    const note = unproven ? ' · nothing in this resume backs it — it earns nothing' : '';
     for (const s of findTerm(resumeText, k.term, k.aliases ?? [])) {
-      spans.push({ ...s, cls, title: `${k.term} · ${wantsLabel(k)}${note}` });
+      spans.push({ ...s, cls: 'kw-present', title: `${k.term} · ${wantsLabel(k)}` });
     }
   }
   for (const r of removals) {

--- a/src/resume/keyword-anchor-status.test.ts
+++ b/src/resume/keyword-anchor-status.test.ts
@@ -34,22 +34,26 @@ test('present vs add is settled by the text, both ways', async () => {
   assert.equal(out.downgraded, 1);
 });
 
-test('a denial outranks a word on the page; a question the text answers does not', async () => {
+test('a written word is present whatever the model called it; an unwritten verdict stands', async () => {
   const m = await matcher();
   const out = anchorStatuses(
     [
-      // The user said they do not have it (facts.ts). The text cannot overrule that.
+      // The model could not back it ("no Go work anywhere") — but the resume
+      // spells it, and that is the resume's claim to make (ADR 0045). How thin
+      // the claim is, `evidence` says.
       kw('Go', 'cannot_claim'),
       // "the resume does not evidence it, but they might" — the resume does.
       kw('React', 'ask_user'),
-      // Nothing in the text, so the question stands.
+      // Nothing in the text, so the question stands…
       kw('Kubernetes', 'ask_user'),
+      // …and so does the verdict.
+      kw('Angular', 'cannot_claim'),
     ],
     RESUME,
     m,
   );
-  assert.deepEqual(out.keywords.map((k) => k.status), ['cannot_claim', 'present', 'ask_user']);
-  assert.equal(out.upgraded, 1);
+  assert.deepEqual(out.keywords.map((k) => k.status), ['present', 'present', 'ask_user', 'cannot_claim']);
+  assert.equal(out.upgraded, 2);
   assert.equal(out.downgraded, 0);
 });
 

--- a/src/resume/keyword-anchor.ts
+++ b/src/resume/keyword-anchor.ts
@@ -27,36 +27,38 @@ export interface AnchorReport {
 }
 
 /**
- * The other half of the same idea, pointed at the RESUME (ADR 0044 addendum).
+ * The other half of the same idea, pointed at the RESUME (ADR 0045; the
+ * present/add half came with the ADR 0044 addendum).
  *
- * `present` and `add` differ on ONE question — is the word in the text? — and
- * that question has an answer the matcher can give. The model's answer to it
- * drifts: the same TypeScript in the same resume was called `present` in one
- * run and `add` in the next, which is how a comparison ended up scoring 79 and
- * then 30. The two statuses are therefore settled here, both ways:
+ * Whether a word is in the text is a question the matcher can answer, and the
+ * model's answer to it drifts: the same TypeScript in the same resume was
+ * called `present` in one run and `add` in the next, which is how a comparison
+ * scored 79 and then 30; the same WordPress, on the resume's own title line,
+ * was called `cannot_claim` ("no WordPress work anywhere in resume"), and the
+ * primary-stack cap held that comparison at 41 while a count of the same text
+ * says 52. So the text settles the status, for every verdict:
  *
- *  - `present` the matcher cannot find becomes `add`. It is a paraphrase —
- *    "automated testing" against a resume that says "Unit, integration & E2E
- *    testing" — so the claim behind it stands and the word does not. 5 of 137
- *    present keywords on the live corpus.
- *  - `add` the matcher CAN find becomes `present`. `add` means "evidenced but
- *    unwritten"; if the word is written, it is not that.
- *  - `ask_user` the matcher CAN find becomes `present` too. `ask_user` means
- *    "this resume does not evidence it, but the candidate might" — a premise
- *    the text refutes. Left alone it cost a live comparison 49 points: the
- *    resume says TypeScript in its skills line, one run called it `present`
- *    (score 53) and the next `ask_user` (score 30, the whole primary stack
- *    reading as absent), and the confirm card asked the candidate about a word
- *    they had already written.
+ *  - a term the matcher CAN find is `present`, whatever the model said. An
+ *    `add` that is written is not "unwritten"; an `ask_user` the text answers
+ *    is not a question (left alone, that one cost a live comparison 49
+ *    points, and the confirm card asked about a word already on the page);
+ *    and a `cannot_claim` the resume spells is a claim the resume makes —
+ *    how thinly is `evidence`'s answer (listed / described / measured), which
+ *    is where "named, but nothing behind it" belongs. A stored denial does not
+ *    outrank the text either: facts.ts already lets a written word stand over
+ *    a stale "no". The known cost is a homonym — on the live corpus 29 of the
+ *    1 215 `cannot_claim` rows were written, 8 of them "GCP" meaning Good
+ *    Clinical Practice on an engineer's resume, every one on a comparison
+ *    scoring 0 anyway.
+ *  - a `present` the matcher cannot find is `add`: a paraphrase — "automated
+ *    testing" against "Unit, integration & E2E testing" — so the claim behind
+ *    it stands and the word does not. 5 of 137 present keywords on the corpus.
+ *  - an unwritten `add`, `ask_user` or `cannot_claim` stays what it is.
  *
- * `cannot_claim` is NEVER upgraded, whatever the text says. It is the status a
- * user's own denial produces (facts.ts runs before this), and a denial outranks
- * a word on a page. It is also the honest answer when a term is named but the
- * model judged the resume cannot stand behind it — `evidence: listed` is where
- * that shows now.
- *
- * Without this, the table said matched while the chip above the editor offered
- * to add the same term, and the live estimate scored it zero.
+ * `score.mjs:entriesFromLive` applies the same rules in the browser, so the
+ * number under the editor is this score on the text as typed — before this,
+ * the table said matched while the chip offered to add the same term, and a
+ * typed word the model had not backed moved nothing until the next analysis.
  */
 export function anchorStatuses(
   keywords: MatchKeyword[],
@@ -66,7 +68,6 @@ export function anchorStatuses(
   let downgraded = 0;
   let upgraded = 0;
   const next = keywords.map((k) => {
-    if (k.status === 'cannot_claim') return k;
     const written = matcher.findTerm(resumeText, k.term, k.aliases).length > 0;
     if (written === (k.status === 'present')) return k;
     if (written) {

--- a/src/resume/keyword-overrides.ts
+++ b/src/resume/keyword-overrides.ts
@@ -269,12 +269,12 @@ export function carryOverrides(
  * `asks` is what the model chose to ask. `unproven` is every other term it
  * could not back — offered too, because "cannot_claim" is a verdict on the
  * RESUME TEXT, not on the person, and the prompt tells the model to pick the
- * lower status when unsure. Left un-offered, that verdict was a dead end: on
- * one live pair the model marked SASS and BEM cannot_claim for a twelve-year
- * CSS developer and WordPress for a twelve-year PHP developer, the candidate
- * typed all three in, the score did not move, and nothing on the page could
- * take a "yes". A confirmed fact flips the term to "add" (facts.ts:applyFacts),
- * so the same answer that unblocks an ask unblocks these.
+ * lower status when unsure. Writing the word into the resume counts on its own
+ * (ADR 0045); this tier is the other way in — a "yes" stored once and reused
+ * in every later comparison, which flips the term to "add"
+ * (facts.ts:applyFacts) and puts a "+ add" beside its chip. On one live pair
+ * the model marked SASS and BEM cannot_claim for a twelve-year CSS developer
+ * and WordPress for a twelve-year PHP developer.
  *
  * Out: a term the user already denied (that IS their answer), and a context
  * term, which the score does not count either way.

--- a/src/scripts/reanchor-matches.ts
+++ b/src/scripts/reanchor-matches.ts
@@ -1,0 +1,69 @@
+import { logger } from '../logger';
+import { prisma } from '../db';
+import { anchorStatuses } from '../resume/keyword-anchor';
+import { loadKeywordMatcher, type KeywordMatcher } from '../resume/keyword-matcher';
+import { readKeywords, type MatchKeyword } from '../resume/prompts';
+import { readBreakdown } from '../resume/score';
+import { rescoreMatchKeywords } from '../resume/store';
+
+/*
+ * One-shot backfill for ADR 0045: a stored comparison that calls a term
+ * `cannot_claim` while its own text snapshot spells it gets that term set to
+ * `present`, and is re-scored through the write path a keyword edit already
+ * uses (`rescoreMatchKeywords`: row lock, countable flags, the breakdown's
+ * markers kept). Only that flip — the one the ADR adds. Rows from before the
+ * 0044 addendum were never anchored at all, and the present → add half of the
+ * rule would move their scores retroactively for a reason that is not this
+ * one, so they keep the statuses they were scored under. Rows from before the
+ * deterministic score (ADR 0012) are left alone. No AI call, no other field
+ * touched. Idempotent. --dry-run reads only.
+ *
+ * Usage: node dist/scripts/reanchor-matches.js [--dry-run]
+ */
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main(): Promise<void> {
+  const matcher = await loadKeywordMatcher();
+  const rows = await prisma.resumeMatch.findMany({
+    select: { id: true, matchScore: true, keywords: true, resumeText: true, breakdown: true },
+    orderBy: { id: 'asc' },
+  });
+
+  let changed = 0;
+  for (const row of rows) {
+    if (!readBreakdown(row.breakdown)) continue;
+    const flipped = writtenCannotClaims(readKeywords(row.keywords), row.resumeText, matcher).map((k) => k.term);
+    if (flipped.length === 0) continue;
+    changed++;
+    if (DRY_RUN) {
+      logger.info({ matchId: row.id, score: row.matchScore, flipped }, 'reanchor-matches: would re-score');
+      continue;
+    }
+    // The edit runs again inside the lock, on the row as it is then.
+    const outcome = await rescoreMatchKeywords(row.id, (match) => {
+      const keywords = readKeywords(match.keywords);
+      const flips = new Set(writtenCannotClaims(keywords, match.resumeText, matcher));
+      return { keywords: keywords.map((k) => (flips.has(k) ? { ...k, status: 'present' as const } : k)), detail: null };
+    });
+    logger.info(
+      { matchId: row.id, before: outcome?.before, after: outcome?.after, flipped },
+      'reanchor-matches: re-scored',
+    );
+  }
+
+  logger.info({ matches: rows.length, changed, dryRun: DRY_RUN }, 'reanchor-matches: done');
+}
+
+/** The rows anchorStatuses would lift from `cannot_claim` — and nothing else it would move. */
+function writtenCannotClaims(keywords: MatchKeyword[], resumeText: string, matcher: KeywordMatcher): MatchKeyword[] {
+  const anchored = anchorStatuses(keywords, resumeText, matcher).keywords;
+  return keywords.filter((k, i) => k.status === 'cannot_claim' && anchored[i]?.status === 'present');
+}
+
+main()
+  .catch((err) => {
+    logger.error({ err }, 'reanchor-matches: failed');
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -393,7 +393,7 @@ export const ConfirmFacts: FC<{ asks: MatchKeyword[]; unproven: MatchKeyword[]; 
         <details id="confirm-unproven" class={`${asks.length > 0 ? 'mt-2 ' : ''}rounded-md border border-line`}>
           <summary class="cursor-pointer px-3 py-2 text-[13px] text-ink-muted transition-colors duration-150 hover:text-ink">
             <span class="font-medium text-ink">{unproven.length} more</span> the AI found no evidence for —
-            typing the word earns nothing, but if you have the experience, say so here and it counts
+            write the word into your resume where it is true, or say so here, and it counts
           </summary>
           <ul class="divide-y divide-line border-t border-line">
             {unproven.map((k) => (

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -285,10 +285,9 @@ export const TargetPage: FC<TargetPageProps> = ({
                 summary and most recent role read at a glance.
               </p>
               <p class="text-ink-faint">
-                It moves as you edit: the words are counted live — except one marked{' '}
-                <span class="font-medium">no evidence yet</span>, which earns nothing until you confirm it.
-                What a word search cannot read stays as the last analysis judged it, so run “Analyse my
-                resume again” once the text is settled.
+                It moves as you edit: every word is counted live, whatever the last analysis called it.
+                What a word search cannot read — how your title and summary read, the red flags — stays as
+                the last analysis judged it, so run “Analyse my resume again” once the text is settled.
               </p>
             </div>
           </div>
@@ -517,8 +516,9 @@ export const TargetPage: FC<TargetPageProps> = ({
           ></div>
           <Hint class="mt-2">
             Green is already in your resume; red is what this posting requires and yours does not
-            say. A dashed underline means nothing in your resume backs the word yet — confirm it or
-            treat it as a real gap, because typing it in would be a claim. Benefits, perks and legal
+            say. A dashed underline means nothing in your resume backs the word yet — write it in
+            where it is true and it counts, or confirm it below; the number reads your text, not our
+            guess about you. Benefits, perks and legal
             boilerplate are deliberately never keywords; hover a mark to see how often the posting
             says the word, and re-level or ignore any of them in the keyword table.
           </Hint>

--- a/src/web/public/score.mjs
+++ b/src/web/public/score.mjs
@@ -151,27 +151,29 @@ export function computeScore(rawEntries, alignment, countedFlags, fixedPenalty =
 
 /**
  * Live entries from scoreKeywords() rows ({ requirement, primary, status, found }).
- * Textual presence earns full credit — except cannot_claim, which never counts
- * even when the user types the word (claim safety). An "add" keyword keeps its
- * half credit until the user actually writes it in. A "primary" mark only
- * counts on must requirements, mirroring entriesFromKeywords.
+ * The server's own entries for the statuses THIS text implies — the rule
+ * keyword-anchor.ts:anchorStatuses applies before every stored score (ADR
+ * 0045): a word the text spells is `present`, whatever the last analysis
+ * called it; a `present` or `add` the text does not spell is `add` (the facts
+ * behind it stand, the word does not — half credit, and it still covers the
+ * primary cap, so deleting a word never costs 49 points); an unwritten
+ * `ask_user` or `cannot_claim` earns nothing until it is written or confirmed.
+ * A "primary" mark only counts on must requirements, mirroring
+ * entriesFromKeywords. score.test.ts holds the two sides equal on every text.
  */
 export function entriesFromLive(rows) {
   return rows.map((r) => {
     const primary = r.primary === true && r.requirement === 'must';
-    const claimable = r.status !== 'cannot_claim';
-    const writable = r.status === 'present' || r.status === 'add';
+    const written = r.found === true;
+    const has = written || r.status === 'present' || r.status === 'add';
     return {
       requirement: r.requirement ?? 'preferred',
       primary,
-      credit: !claimable ? 0 : r.found ? 1 : r.status === 'add' ? 0.5 : 0,
-      // Same rule as the server's: an `add` primary is covered whether or not
-      // the word has been typed yet, so the estimate does not jump 49 points
-      // the moment the user deletes it.
-      primaryHit: primary && claimable && (r.found === true || r.status === 'add'),
-      primaryWritten: primary && claimable && r.found === true,
-      ceilCredit: writable ? 1 : 0,
-      ceilPrimaryHit: primary && writable,
+      credit: written ? 1 : has ? 0.5 : 0,
+      primaryHit: primary && has,
+      primaryWritten: primary && written,
+      ceilCredit: has ? 1 : 0,
+      ceilPrimaryHit: primary && has,
       group: r.group ?? null,
     };
   });

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -49,17 +49,16 @@ const CHIP_LEVEL = {
 
 /**
  * What stands between this resume and a higher score, for the chips above the
- * editor. Two kinds, and the second used to be missing from the row entirely:
- * a term the resume evidences but does not spell (type it and the score moves),
- * and one the resume cannot back at all — which `scoreKeywords` marks
- * `excluded`, because it earns nothing however often the word appears.
- * Filtering on `excluded` therefore hid the hardest gaps: on one live pair the
- * row showed a single chip for the one addable keyword, and left out
- * WordPress — the primary must that capped that score at 70 — along with SASS
- * and BEM. A weight-0 context term is still no gap at all.
+ * editor: every weighted term the text does not spell. Two kinds, coloured
+ * alike by level and told apart by the dash — a term the resume evidences but
+ * does not say (type it and the score moves), and one nothing in the resume
+ * backs yet, which typing moves too (ADR 0045) and confirming is the other
+ * way into. A weight-0 context term is no gap at all, and neither is a word
+ * the text already carries, whatever the last analysis called it — the row
+ * once kept those, and offered a "yes" for a word the user had just typed.
  */
 export function keywordGaps(rows) {
-  return rows.filter((r) => r.weight > 0 && (r.status === 'cannot_claim' || !r.found));
+  return rows.filter((r) => r.weight > 0 && !r.found);
 }
 
 /** Why an edit did not happen — every error the text operations can return. */
@@ -173,15 +172,13 @@ export function init(data) {
       b.textContent = r.count > 1 ? r.term + ' ×' + r.count : r.term;
       b.title = [
         wantsLabel(r),
-        // The honest sentence differs once the word IS in the text: this used
-        // to say "not in your resume" about a word the user had just typed.
-        gapLabel(r, r.found),
+        gapLabel(r, false),
         r.count > 1 ? '×' + r.count + ' in the posting' : null,
-        denied ? 'you said you do not have it' : unproven ? 'click to say you have it — then it counts' : r.where ? 'add in: ' + r.where : null,
+        denied ? 'you said you do not have it' : unproven ? 'type it in where it is true, or click to say you have it' : r.where ? 'add in: ' + r.where : null,
         denied ? null : r.note,
       ].filter(Boolean).join(' · ');
-      // A dashed chip has nowhere in the text to send you — typing the word is
-      // exactly what does not help. It opens the one control that does.
+      // A dashed chip has no section to send you to — the resume never mentions
+      // the word. It opens the confirm card, the other way to make it count.
       b.addEventListener('click', () => (unproven && !denied ? openConfirm() : jumpToSection(r.where)));
       chips.appendChild(b);
       // "Add to Skills" only where it can honestly work: the model (or a fact the

--- a/src/web/public/target.mjs
+++ b/src/web/public/target.mjs
@@ -60,25 +60,21 @@ const GAP_CLASS = {
   context: 'kw-gap kw-nice',
 };
 
-/** True when writing the word in would be honest: the resume backs it, or is being asked. */
-function claimable(k) {
-  return k.status !== 'cannot_claim';
-}
-
 /**
  * The class string for one keyword's marks. `found` is textual presence in the
- * resume — it only earns green where the claim is honest, mirroring the score,
- * which gives a cannot_claim term zero credit however often the word is typed.
+ * resume, and a word the resume spells is simply green — the score reads the
+ * text the same way, whatever the last analysis called the term (ADR 0045).
  */
 export function markClass(k, found) {
-  if (found && claimable(k)) return 'kw-have';
+  if (found) return 'kw-have';
   const gap = GAP_CLASS[levelOf(k)] ?? GAP_CLASS.preferred;
   // The stack the score caps on: the same red, louder.
   const core = k.primary === true && levelOf(k) === 'must' ? ' kw-core' : '';
-  // Nothing in the resume backs this word yet, so it cannot simply be typed
-  // in. A dashed underline, never a strikethrough — struck-through text on the
-  // posting's own must-have read as "ignore this", which is the opposite.
-  const unproven = claimable(k) && k.status !== 'ask_user' ? '' : ' kw-unproven';
+  // Nothing in the resume backs this word yet: writing it in counts, and so
+  // does confirming it. A dashed underline, never a strikethrough —
+  // struck-through text on the posting's own must-have read as "ignore this",
+  // which is the opposite.
+  const unproven = k.status === 'ask_user' || k.status === 'cannot_claim' ? ' kw-unproven' : '';
   return gap + core + unproven;
 }
 
@@ -203,19 +199,21 @@ export function findTerm(text, term, aliases = []) {
 
 /**
  * Weighted coverage of the keyword list in `text`.
- * keywords: [{ term, priority, requirement?, status, aliases? }]. Excluded
- * from the coverage percentage: cannot_claim keywords (you cannot honestly
- * add them — unless includeCannotClaim is set) and zero-weight "context"
- * keywords. Every row still carries found/count for highlighting, and the
- * full rows feed entriesFromLive() in score.mjs for the live score estimate.
+ * keywords: [{ term, priority, requirement?, status, aliases? }]. Every
+ * weighted term is in the denominator whatever the last analysis made of it —
+ * the posting's demand does not shrink because the resume cannot meet part of
+ * it — and a term earns its weight when the text spells it (ADR 0045). Only a
+ * zero-weight "context" term is `excluded`. Every row still carries
+ * found/count for highlighting, and the full rows feed entriesFromLive() in
+ * score.mjs for the live score.
  */
-export function scoreKeywords(keywords, text, { includeCannotClaim = false } = {}) {
+export function scoreKeywords(keywords, text) {
   const rows = [];
   let earned = 0;
   let total = 0;
   for (const k of keywords) {
     const weight = keywordWeight(k);
-    const excluded = (k.status === 'cannot_claim' && !includeCannotClaim) || weight === 0;
+    const excluded = weight === 0;
     const spans = findTerm(text, k.term, k.aliases ?? []);
     const found = spans.length > 0;
     if (!excluded) {
@@ -273,12 +271,8 @@ export function highlightHtml(text, spans) {
  * vocabulary the legend and the keyword table use, in the second person.
  */
 export function gapLabel(k, found) {
-  if (k.status === 'cannot_claim') {
-    return found
-      ? 'the word is there, but nothing in your resume backs it'
-      : 'not in your resume, and nothing here evidences it';
-  }
   if (found) return 'in your resume';
+  if (k.status === 'cannot_claim') return 'not in your resume, and nothing here evidences it';
   if (k.status === 'ask_user') return 'not written — confirm whether you have it';
   return 'not written — your resume evidences it, add the word';
 }
@@ -306,15 +300,11 @@ export function jobSpans(keywords, jobText, scored) {
 export function resumeSpans(keywords, actions, removals, resumeText) {
   const spans = [];
   // No level class here: a word the resume already spells is simply matched,
-  // whatever the posting thinks of it. The one exception is a term the resume
-  // cannot claim — the score gives it zero however often it is typed, so a
-  // plain green mark would promise points that never arrive.
+  // whatever the posting thinks of it — and whatever the last analysis made
+  // of it, since the score reads the text the same way (ADR 0045).
   for (const k of keywords) {
-    const unproven = k.status === 'cannot_claim';
-    const cls = unproven ? 'kw-present kw-unproven' : 'kw-present';
-    const note = unproven ? ' · nothing in this resume backs it — it earns nothing' : '';
     for (const s of findTerm(resumeText, k.term, k.aliases ?? [])) {
-      spans.push({ ...s, cls, title: `${k.term} · ${wantsLabel(k)}${note}` });
+      spans.push({ ...s, cls: 'kw-present', title: `${k.term} · ${wantsLabel(k)}` });
     }
   }
   for (const r of removals) {

--- a/src/web/score.test.ts
+++ b/src/web/score.test.ts
@@ -7,6 +7,9 @@ import {
   type MatchAlignment,
   type ScoreEntry,
 } from '../resume/score';
+import { anchorStatuses } from '../resume/keyword-anchor';
+import type { KeywordMatcher } from '../resume/keyword-matcher';
+import { readKeywords, type MatchKeyword } from '../resume/prompts';
 
 // The browser copy ships as a static ES module; node loads it the same way.
 // @ts-expect-error — plain JS with no declaration file; parity is asserted below.
@@ -116,27 +119,87 @@ test('live entries equal server entries when the text matches the analysed snaps
   );
 });
 
-test('live credit: typing a cannot_claim term never counts, typing an add term earns full credit', async () => {
+test('live credit: a written word earns in full whatever the analysis called it (ADR 0045)', async () => {
   const { entriesFromLive } = await browser;
   const rows = [
     { requirement: 'must', primary: true, status: 'cannot_claim', found: true },
+    { requirement: 'must', primary: true, status: 'cannot_claim', found: false },
     { requirement: 'must', primary: true, status: 'add', found: true },
     { requirement: 'must', primary: false, status: 'add', found: false },
+    { requirement: 'must', primary: true, status: 'present', found: false },
     { requirement: 'must', primary: false, status: 'ask_user', found: true },
+    { requirement: 'must', primary: false, status: 'ask_user', found: false },
     { requirement: 'preferred', primary: true, status: 'present', found: true },
   ];
   const entries = entriesFromLive(rows);
   assert.deepEqual(
-    entries.map((e) => [e.credit, e.primaryHit, e.ceilCredit]),
+    entries.map((e) => [e.credit, e.primaryHit, e.primaryWritten, e.ceilCredit]),
     [
-      [0, false, 0], // cannot_claim: claim safety, even when typed
-      [1, true, 1], // add + found: written in, counts fully and lifts the cap
-      [0.5, false, 1], // add not yet written: keeps its half credit, reachable 1
-      [1, false, 0], // ask_user typed: counts in text, ceiling waits for confirmation
-      [1, false, 1], // preferred marked primary: demoted — never caps (v3)
+      [1, true, true, 1], // cannot_claim typed in: the resume now says it, and it lifts the cap
+      [0, false, false, 0], // cannot_claim unwritten: earns nothing until written or confirmed
+      [1, true, true, 1], // add + found: written in, counts fully and lifts the cap
+      [0.5, false, false, 1], // add not yet written: keeps its half credit, reachable 1
+      [0.5, true, false, 1], // present deleted from the text: the facts stand, the word does not
+      [1, false, false, 1], // ask_user typed: the text answers the question
+      [0, false, false, 0], // ask_user unwritten: the question stands
+      [1, false, false, 1], // preferred marked primary: demoted — never caps (v3)
     ],
   );
-  assert.equal(entries[4]?.primary, false);
+  assert.equal(entries[7]?.primary, false);
+});
+
+/*
+ * The invariant the ring promises: the number under the editor is the score
+ * the next analysis would store for the same text, for every part of the
+ * formula a word search can read. Both sides are real — the browser counts the
+ * text, the server anchors the statuses to it (keyword-anchor.ts) and scores
+ * them — and the fixture is a live comparison (match 139, 2026-09-08): PHP and
+ * WordPress primary, WordPress and BEM called cannot_claim, Ajax evidenced but
+ * unwritten. With WordPress on the resume's own title line the stored score
+ * was 41, capped at 70; typing BEM moved nothing, typing Ajax moved +3.
+ */
+test('the live number is the server score of the same text, edit by edit', async () => {
+  const { entriesFromLive, computeScore } = await browser;
+  // @ts-expect-error — plain JS with no declaration file.
+  const matcher = (await import('./public/target.mjs')) as KeywordMatcher & {
+    scoreKeywords: (keywords: MatchKeyword[], text: string) => { rows: Record<string, unknown>[] };
+  };
+  const row = (term: string, status: MatchKeyword['status'], requirement = 'must', primary = false) => ({
+    term,
+    priority: 1,
+    requirement,
+    primary,
+    status,
+    aliases: [],
+  });
+  const keywords = readKeywords([
+    row('PHP', 'present', 'must', true),
+    row('WordPress', 'cannot_claim', 'must', true),
+    row('WordPress Developer', 'cannot_claim'),
+    row('BEM', 'cannot_claim'),
+    row('Ajax', 'add'),
+    ...['Git', 'HTML5', 'JS', 'MySQL', 'SASS', 'jQuery'].map((t) => row(t, 'present')),
+    row('JIRA', 'present', 'context'),
+    row('e-commerce', 'add', 'context'),
+  ]);
+  const OFF: MatchAlignment = { title: 'off', summary: 'off', recent_role: 'off' };
+  const body = 'Skills: PHP, MySQL, HTML5, SASS, JS, jQuery, Git, JIRA\nBuilt e-commerce checkouts in PHP.';
+  const judged = `WordPress Developer | Go & React\n${body}`;
+  const texts: [string, string, number, number | null][] = [
+    ['without the title line', body, 41, SCORING_TS.caps.halfOrMore],
+    ['as the model judged it', judged, 52, null],
+    ['BEM typed in', `${judged}\nBEM`, 57, null],
+    ['Ajax typed in too', `${judged}\nBEM, Ajax`, 60, null],
+    ['PHP deleted', `${judged}\nBEM, Ajax`.replace(/PHP/g, 'Python'), 57, null],
+  ];
+  for (const [label, text, expected, cap] of texts) {
+    const live = computeScore(entriesFromLive(matcher.scoreKeywords(keywords, text).rows), OFF, 0);
+    const anchored = anchorStatuses(keywords, text, matcher).keywords;
+    const server = computeScoreTs(entriesFromKeywords(anchored), OFF, 0);
+    assert.deepEqual(live, server, label);
+    assert.equal(live.score, expected, label);
+    assert.equal(live.cap, cap, label);
+  }
 });
 
 test('an either/or group is one requirement, not three (ADR 0044)', () => {

--- a/src/web/target.test.ts
+++ b/src/web/target.test.ts
@@ -57,7 +57,7 @@ test('findTerm spans index the original text even with tabs, double spaces and c
   assert.equal(findTerm('continuous   delivery pipeline', 'continuous delivery').length, 1);
 });
 
-test('scoreKeywords weights requirement levels and excludes cannot_claim and context', async () => {
+test('scoreKeywords weights requirement levels; every weighted term is in the denominator', async () => {
   const { scoreKeywords } = await matcher;
   const keywords = [
     { term: 'PHP', priority: 1, requirement: 'must', status: 'present' },
@@ -66,15 +66,17 @@ test('scoreKeywords weights requirement levels and excludes cannot_claim and con
     { term: 'Laravel', priority: 2, requirement: 'preferred', status: 'present' },
   ];
   const r = scoreKeywords(keywords, RESUME);
-  // PHP 3 + Laravel 2 earned of 3 + 1 + 2 = 6 → 83
-  assert.equal(r.score, 83);
-  assert.equal(r.rows.find((x) => x.term === 'Angular')?.excluded, true);
-  assert.equal(scoreKeywords(keywords, RESUME, { includeCannotClaim: true }).score, 56);
+  // PHP 3 + Laravel 2 earned of 3 + 3 + 1 + 2 = 9 → 56. Angular counts against
+  // the resume although nothing backs it: the posting's demand is what it is.
+  assert.equal(r.score, 56);
+  assert.equal(r.rows.find((x) => x.term === 'Angular')?.excluded, false);
+  // Written in, it earns its weight like any other term (ADR 0045): 8 of 9.
+  assert.equal(scoreKeywords(keywords, `${RESUME}\nAngular`).score, 89);
   assert.equal(scoreKeywords([], RESUME).score, 0);
 
   // "context" keywords carry no weight and never count either way.
   const withContext = [...keywords, { term: 'PostgreSQL', priority: 4, requirement: 'context', status: 'present' }];
-  assert.equal(scoreKeywords(withContext, RESUME).score, 83);
+  assert.equal(scoreKeywords(withContext, RESUME).score, 56);
   assert.equal(scoreKeywords(withContext, RESUME).rows.find((x) => x.term === 'PostgreSQL')?.excluded, true);
 
   // Rows without a requirement level (pre-ADR-0012 matches) fall back to priority weights.
@@ -102,10 +104,13 @@ test('jobSpans colours by the level the posting asks at, not by AI status', asyn
   ]);
 });
 
-test('markClass: a cannot_claim term stays a gap even when the word is typed in', async () => {
+test('markClass: a word the resume spells is green, whatever the analysis called it', async () => {
   const { markClass } = await matcher;
   const k = { requirement: 'must', status: 'cannot_claim', primary: true };
-  assert.equal(markClass(k, true), 'kw-gap kw-must kw-core kw-unproven');
+  assert.equal(markClass(k, true), 'kw-have');
+  // Unwritten, it is the loudest gap on the page — dashed, since nothing backs it yet.
+  assert.equal(markClass(k, false), 'kw-gap kw-must kw-core kw-unproven');
+  assert.equal(markClass({ requirement: 'must', status: 'ask_user', primary: false }, false), 'kw-gap kw-must kw-unproven');
   assert.equal(markClass({ requirement: 'must', status: 'add', primary: false }, true), 'kw-have');
   assert.equal(markClass({ requirement: 'context', status: 'add', primary: false }, false), 'kw-gap kw-nice');
 });
@@ -152,11 +157,10 @@ test('the ring\'s live tone agrees with the server\'s fitTone at every cut-off',
   }
 });
 
-test('the gap chips keep an unbackable term, typed in or not', async () => {
-  // The chips answer "what is between me and a higher score". A cannot_claim
-  // term earns nothing however often the word appears, so scoreKeywords marks
-  // it `excluded` — and filtering the chips on `excluded` hid exactly the
-  // hardest gaps, including the primary must that caps the score.
+test('the gap chips are the weighted terms the text does not spell', async () => {
+  // The chips answer "what is between me and a higher score". A word the text
+  // carries is earned whatever the last analysis called it (ADR 0045); the
+  // row once kept a typed cannot_claim term, and offered a "yes" for it.
   // @ts-expect-error — plain JS with no declaration file.
   const { keywordGaps } = (await import('./public/target-page.mjs')) as {
     keywordGaps: (rows: { term: string; weight: number; found: boolean; status: string }[]) => { term: string }[];
@@ -170,8 +174,8 @@ test('the gap chips keep an unbackable term, typed in or not', async () => {
   ];
   assert.deepEqual(
     keywordGaps(rows).map((r) => r.term),
-    // SASS stays although the word is in the text; PHP is earned, JIRA is context.
-    ['WordPress', 'SASS', 'Ajax'],
+    // SASS is in the text, PHP is earned, JIRA is context.
+    ['WordPress', 'Ajax'],
   );
 });
 


### PR DESCRIPTION
A word in your resume counts, whatever the last analysis called it.

**Stacked on #199** (`target-live-ring`) — merge that one first, then retarget this PR to `main` before `--delete-branch`.

## The complaint, measured

"Typing `Ajax` moves the score; typing `WordPress` or `BEM` moves nothing until I re-analyse. The comparison should read the resume, not the skills stored about me."

On the live pair (match 139):

| Typed | Status from the AI | Live ring | Why |
|---|---|---|---|
| Ajax | `add` | +3 | half credit → full |
| BEM | `cannot_claim` | 0 | `entriesFromLive` gave a typed `cannot_claim` zero, by design (ADR 0012) |
| WordPress | `cannot_claim` — and already on the resume's **title line** | 0 | `anchorStatuses` never revisited a `cannot_claim`; the primary cap held the stored score at 70 → 41 |

The morning's confirm tier (#199) asked the candidate to restate what the resume already said. Corpus check before deciding: 2 202 keywords on 138 comparisons, 1 215 `cannot_claim`, **29 written in the text** (8 primary must). The 29: listed-only terms the model would not credit (Rust, Java, WordPress, jQuery, a hedged Go), a version the alias table folds (PHP 8 → PHP), a degree field (Engineering), and 8 homonyms (GCP = Good Clinical Practice) — every homonym on a comparison scoring 0.

## What changed (ADR 0045)

One rule, both sides: **presence is read off the text, for every status.**

| The text … | stored status (`anchorStatuses`) | live credit (`entriesFromLive`) | covers the cap |
|---|---|---|---|
| spells the term | `present`, whatever the model said | 1 | yes |
| does not; model said `present`/`add` | `add` | 0.5 | yes |
| does not; model said `ask_user`/`cannot_claim` | unchanged | 0 | no |

- `keyword-anchor.ts:anchorStatuses` — the `cannot_claim` early return goes; a written term is `present`. "Named, nothing behind it" is the `evidence` grade (skills line only), never the status.
- `score.mjs:entriesFromLive` — the server's entries for the statuses the text implies; a deleted `present` is `add` (half credit, still covers the cap — it no longer drops 49 points).
- `target.mjs` — a found word is green whatever its status; every weighted term is in the coverage denominator; `includeCannotClaim` gone. `target-page.mjs:keywordGaps` = weighted and unwritten.
- Page copy: the legend hint, the ring tooltip, the confirm tier's summary say "write it in where it is true, or say so here".
- **New test**: the live number equals the server score of the same text, edit by edit, on the match-139 fixture — 41 (no title line, cap 70) → 52 (as judged, cap lifted) → 57 (BEM) → 60 (Ajax) → 57 (PHP deleted → `add`).
- `scripts/reanchor-matches.ts [--dry-run]` — lifts stored `cannot_claim` rows the snapshot spells, through `rescoreMatchKeywords`. Only that flip: rows from before the 0044 addendum keep their statuses. **Applied to the live DB**: 27 comparisons / 29 keywords; 139: 41 → 52, 23: 30 → 61, 49: 23 → 40, 134: 27 → 33; 80: 2 → 0 (a flag naming the flipped term now counts — see follow-ups); the 0-score rows stayed 0.

## Pre-merge review

`code-review-expert` over `git diff target-live-ring`. No P0/P1.

## Follow-ups (not in this PR)

- P2 — a flipped `cannot_claim` keeps the model's note ("No WordPress work anywhere in resume") next to "in your resume". Honest, but reads as a contradiction; the badge already says "skills line only".
- P2 — `countableFlags` exempts a flag naming a keyword that is missing or listed-only; a flipped term with `described`/`measured` evidence (PHP 8 via the PHP alias, "Engineering" on a job title) makes the flag countable, so the stored score can drop 10 while the live ring holds the penalty frozen. Seen on match 80 (2 → 0) only.
- P2 — the prompt still tells the model "when unsure choose the lower" and defines `present` as "already in the resume"; it contradicted that on 29 rows. A `PROMPT_VERSION` bump could say a spelled term is `present` and put the doubt in `note` — less for the anchoring pass to undo.
- P3 — rows from before the 0044 addendum were never anchored (`present → add` drift on soft-skill terms); left alone on purpose.
- P3 — `package-lock.json` still says 1.69.0 (pre-existing; releases have not bumped it).

## Verification

- `npm run lint:types`; 2 109 tests (one new parity test; four flipped, with the reason in each).
- Rebuilt `web`; on `/jobs/2127/target?match=139`: ring 52 on load (row backfilled), 57 after typing `BEM`, 60 after `Ajax`, chips clear as the words go in, console clean.
- Backfill: dry run read, then applied (log above).

## Release notes

Tag on the merge commit: `git tag -a v1.74.0 -m "typed keywords count" <merge-sha>`

## What's new
- A word you write into your resume counts at once, whatever the last analysis said about it — `WordPress`, `BEM`, any term the AI marked "no evidence". The ring is the score the next analysis stores for the same text.
- Deleting a word the analysis had seen costs half its credit, not the whole primary-stack cap.
- Gap chips are the words your text does not carry; a typed word turns green and leaves the row. "Confirm your experience" is the other way in, not the only one.
- Stored comparisons whose statuses disagreed with their own text are lifted by `reanchor-matches` (27 rows on this install).

## Schema
- no schema changes

## Verification
- lint:types + 2 109 tests green; live page 52 → 57 → 60 edit by edit; backfill dry-run then applied.

## References
- ADR 0045 (amends 0012's live-score sentence and the 0044 addendum's anchoring rule); CLAUDE.md gotcha 17.
- #199 (v1.73.0) — the ring and the confirm tier this builds on.
