### PR TITLE
Screening: the posting on the screening, editable, re-scorable (2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.1.0] — 2026-09-09
+
+### Added
+- **The posting belongs to the screening.** `Screening.postingText` is a
+  snapshot of the job's description taken when the screening is created;
+  the screening page shows it under "Read the posting", edits it under
+  "Edit the posting for this screening" (never on the Job — the candidate
+  side keeps its own text), and every rubric draft and scoring call reads
+  the snapshot. After an edit the page says how many current scores
+  predate it and offers **Re-read the rubric** (a new yardstick) or
+  **Score everyone again** (the rubric as it is, against the new text).
+  Plan §4 of docs/screening-criteria-plan.md, stage A.
+
+### Changed
+- "Delete with files" is **Delete screening**, and the confirmation says
+  what goes (the screening, the uploaded copies, every verdict — from the
+  database) and what stays (your files on disk).
+
 ## [2.0.0] — 2026-09-09
 
 The other side of the table: a major because the product now has two users
@@ -3122,6 +3140,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.1.0]: https://github.com/applypack/applypack/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/applypack/applypack/compare/v1.76.0...v2.0.0
 [1.76.0]: https://github.com/applypack/applypack/compare/v1.75.0...v1.76.0
 [1.75.0]: https://github.com/applypack/applypack/compare/v1.74.0...v1.75.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,8 @@ When the question is **"where does X live?"**, save yourself a `find`:
 | The person's correction to a computed score, and why the table orders by it | `Applicant.scoreAdjustment` + `adjustmentNote` (±`export.ts:MAX_ADJUSTMENT`, a reason required) → `web/screen-view.ts:adjustedScore`; the computed score stays on the row's tooltip, the scorecard header and both exports (ADR 0047 addendum) |
 | Ticked rows → one action (decision, score again, delete) | `POST /screen/:id/applicants/bulk` (`ids[]` + `do`), the header checkbox and the count in `public/screen.mjs:wireSelection`; per-row decision selects post through their own hidden forms via the `form` attribute, so they never ride inside the bulk form |
 | CSV / Markdown of a screening | `src/screening/export.ts` (pure) over `src/web/screen-view.ts:exportRows` |
-| Retention of applicant data | `Screening.retainUntil` from `AppSettings.screeningRetentionDays`; deleted by `jobs/cleanup-job.ts`; "Delete with files" / "Keep N more days" on `/screen/:id` |
+| Retention of applicant data | `Screening.retainUntil` from `AppSettings.screeningRetentionDays`; deleted by `jobs/cleanup-job.ts`; "Delete screening" / "Keep N more days" on `/screen/:id` |
+| The posting a screening reads (a snapshot, editable, never the Job's live text) | `Screening.postingText` + `postingUpdatedAt`; `store.ts:postingOf` is what the brief and every call read; `POST /screen/:id/posting` saves, `POST /screen/:id/run-all` scores everyone again; `web/screen-view.ts:scoredBeforePosting` counts the verdicts older than the edit |
 | The notice an employer owes applicants, and the legal note | `src/screening/notice.ts` — shown with a Copy button on `/settings` → Screening |
 | Each cron's once-script (manual trigger) | `src/scripts/{fetch,digest,cleanup,stale,hn,discovery}-once.ts` |
 
@@ -421,7 +422,8 @@ When the question is **"how does the user toggle / configure X?"**:
 | Read one applicant's reasoning | the row's name → the scorecard: who / did / verdict, every gate and term with its quote, the score table, the questions (Copy), the facts to discuss, what was removed before the model read it, the redacted and the full text |
 | Record a decision | the Decision select on the row, or the scorecard's "Your decision" — the one write the tool never makes |
 | Hand the table to a hiring manager | `/screen/:id` → CSV / Markdown |
-| Delete a screening, or keep it longer | `/screen/:id` → "Delete with files" / "Keep N more days"; the default is `/settings` → Screening → Retention |
+| Read or edit the posting a screening uses, then re-score | `/screen/:id` → Position → "Read the posting" / "Edit the posting for this screening" → Save; the card then offers "Re-read the rubric" or "Score everyone again" and says how many scores predate the edit. The job page's text is untouched |
+| Delete a screening, or keep it longer | `/screen/:id` → "Delete screening" (the uploaded copies and verdicts go from the database; files on disk stay) / "Keep N more days"; the default is `/settings` → Screening → Retention |
 | Edit in place with a live score | comparison → "Open targeted view →" (`/jobs/:id/target`); **Analyse my resume again** is the one AI action there (always the full report), **Compare this file** runs the same thing on a freshly uploaded file, "Save as vN" keeps the draft |
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -542,7 +542,9 @@ exclusive to verification, ADR 0009).
 
 Off by default. `/settings` → Screening turns it on; the menu then has
 "Screening". A `Screening` is one position (`jobId`, any Job — a pasted
-posting becomes a MANUAL job as on `/target`) with a `rubric` (JSON,
+posting becomes a MANUAL job as on `/target`; `postingText` is the
+screening's own editable snapshot of the description, `postingUpdatedAt`
+marks an edit) with a `rubric` (JSON,
 `screening/rubric.ts`): gates, must-have and nice-to-have terms with a
 core-stack flag, level, minimum years, sector, education, weights. The
 draft is the posting brief (ADR 0044), edited by the person; a save that

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1952,7 +1952,7 @@ them with the same vocabulary) asked for three things. The analysis is
 [screening-criteria-plan.md](./screening-criteria-plan.md); the order is
 A → B1+B2 → C → D → E.
 
-- [ ] **A — the posting on the screening**: `Screening.postingText`
+- [x] **A — the posting on the screening** (v2.1.0): `Screening.postingText`
       (snapshot at creation, editable on the page, never written back to
       `Job`), a Position card with the text folded, Edit → "posting changed
       — re-read the rubric or Score everyone again"; "Delete with files" →

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/prisma/migrations/20260909150000_screening_posting_text/migration.sql
+++ b/prisma/migrations/20260909150000_screening_posting_text/migration.sql
@@ -1,0 +1,8 @@
+-- The posting belongs to the screening: a snapshot taken from the Job at
+-- creation, editable on the screening page, never written back.
+ALTER TABLE "screening" ADD COLUMN "postingText" TEXT,
+ADD COLUMN "postingUpdatedAt" TIMESTAMP(3);
+
+UPDATE "screening" s SET "postingText" = j."description" FROM "job" j WHERE j."id" = s."jobId";
+
+ALTER TABLE "screening" ALTER COLUMN "postingText" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -733,22 +733,28 @@ model JobVerification {
 // ---------------------------------------------------------------------------
 
 model Screening {
-  id            Int      @id @default(autoincrement())
-  jobId         Int
-  job           Job      @relation(fields: [jobId], references: [id], onDelete: Cascade)
-  title         String
+  id               Int       @id @default(autoincrement())
+  jobId            Int
+  job              Job       @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  title            String
   // What the screen checks (screening/rubric.ts:RubricSchema): the gates,
   // the must-have and nice-to-have terms, the level, the years, the domain
   // and the weights. Drafted from the posting brief, edited by the person.
-  rubric        Json
+  rubric           Json
   // Bumped on every rubric save that changes it; a verdict records the
   // version it was scored under, and an older one is shown as stale.
-  rubricVersion Int      @default(1)
+  rubricVersion    Int       @default(1)
+  // The posting as this screening reads it: a snapshot of the Job's
+  // description at creation, editable on the screening page and never
+  // written back to the Job (plan §4). `postingUpdatedAt` is stamped on an
+  // edit, so a verdict older than it reads as scored against other text.
+  postingText      String    @db.Text
+  postingUpdatedAt DateTime?
   // When the cleanup cron deletes this screening with every applicant file
   // and verdict (ADR 0048).
-  retainUntil   DateTime
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  retainUntil      DateTime
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
 
   applicants Applicant[]
 

--- a/src/screening/batch.ts
+++ b/src/screening/batch.ts
@@ -7,7 +7,7 @@ import { loadKeywordMatcher, type KeywordMatcher } from '../resume/keyword-match
 import { anchorScreenReply } from './anchor';
 import { buildScreenPrompt, parseScreenResponse, SCREEN_MAX_TOKENS, SCREEN_PROMPT_VERSION, SCREEN_TIMEOUT_MS } from './prompts';
 import { scoreScreening } from './score';
-import { createVerdict, getScreening, listPending, listReadable, rubricOf, type ScreeningWithJob } from './store';
+import { createVerdict, getScreening, listPending, listReadable, postingOf, rubricOf, type ScreeningWithJob } from './store';
 import type { Rubric } from './rubric';
 
 /*
@@ -221,12 +221,7 @@ export async function screenApplicant(
       {
         ...buildScreenPrompt({
           rubric,
-          job: {
-            title: screening.job.title,
-            companyName: screening.job.company.name,
-            location: screening.job.location,
-            description: screening.job.description,
-          },
+          job: postingOf(screening),
           applicantText: applicant.redactedText,
           number: applicant.number,
         }),

--- a/src/screening/store.ts
+++ b/src/screening/store.ts
@@ -20,8 +20,19 @@ export type ApplicantWithVerdict = ApplicantSummary & {
   stale: boolean;
 };
 export type ScreeningWithJob = Screening & {
-  job: { id: number; title: string; location: string; description: string; company: { name: string } };
+  job: { id: number; title: string; location: string; company: { name: string } };
 };
+
+/** The posting as a screening reads it — its own snapshot, never the Job's live text (plan §4). */
+export function postingOf(screening: ScreeningWithJob): { id: number; title: string; companyName: string; location: string; description: string } {
+  return {
+    id: screening.job.id,
+    title: screening.job.title,
+    companyName: screening.job.company.name,
+    location: screening.job.location,
+    description: screening.postingText,
+  };
+}
 
 export interface ScreeningSummary {
   id: number;
@@ -64,16 +75,27 @@ export async function listScreenings(): Promise<ScreeningSummary[]> {
   }));
 }
 
-export async function createScreening(input: { jobId: number; title: string; rubric: Rubric; retainUntil: Date }): Promise<Screening> {
+export async function createScreening(input: { jobId: number; title: string; postingText: string; rubric: Rubric; retainUntil: Date }): Promise<Screening> {
   return prisma.screening.create({
-    data: { jobId: input.jobId, title: input.title, rubric: input.rubric as Prisma.InputJsonValue, retainUntil: input.retainUntil },
+    data: {
+      jobId: input.jobId,
+      title: input.title,
+      postingText: input.postingText,
+      rubric: input.rubric as Prisma.InputJsonValue,
+      retainUntil: input.retainUntil,
+    },
   });
+}
+
+/** The person's edit to the posting — stamped, so older verdicts read as scored against other text. */
+export async function savePosting(id: number, postingText: string): Promise<void> {
+  await prisma.screening.update({ where: { id }, data: { postingText, postingUpdatedAt: new Date() } });
 }
 
 export async function getScreening(id: number): Promise<ScreeningWithJob | null> {
   return prisma.screening.findUnique({
     where: { id },
-    include: { job: { select: { id: true, title: true, location: true, description: true, company: { select: { name: true } } } } },
+    include: { job: { select: { id: true, title: true, location: true, company: { select: { name: true } } } } },
   });
 }
 
@@ -173,7 +195,7 @@ export async function getApplicant(id: number): Promise<(ApplicantWithVerdict & 
     include: {
       verdicts: { orderBy: { createdAt: 'desc' }, take: 1 },
       screening: {
-        include: { job: { select: { id: true, title: true, location: true, description: true, company: { select: { name: true } } } } },
+        include: { job: { select: { id: true, title: true, location: true, company: { select: { name: true } } } } },
       },
     },
   });

--- a/src/web/pages/screen-detail.tsx
+++ b/src/web/pages/screen-detail.tsx
@@ -22,6 +22,11 @@ export interface ScreenDetailProps {
     retainUntil: Date;
     createdAt: Date;
     job: { id: number; title: string; companyName: string; location: string };
+    /** The posting as this screening reads it — a snapshot, edited here, never on the Job (plan §4). */
+    postingText: string;
+    postingUpdatedAt: Date | null;
+    /** Current verdicts written before the last posting edit. */
+    scoredBeforePosting: number;
   };
   rubric: Rubric;
   rows: ApplicantRowView[];
@@ -64,25 +69,76 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
             </ActionForm>
             <ActionForm
               action={`/screen/${screening.id}/delete`}
-              confirm="Delete this screening with every applicant file and verdict? This cannot be undone."
+              confirm="Delete this screening? It removes the screening, the uploaded copies of the resumes and every verdict from the database. Your files on disk are not touched. This cannot be undone."
             >
               <Button variant="danger" size="sm">
-                Delete with files
+                Delete screening
               </Button>
             </ActionForm>
           </div>
         }
       >
-        Position:{' '}
-        <a href={`/jobs/${screening.job.id}`} class="text-ink hover:underline">
-          {screening.job.title}
-        </a>{' '}
-        · {screening.job.companyName}
-        {screening.job.location ? ` · ${screening.job.location}` : ''}. The order below is a priority to talk to,
-        read off each resume against the rubric; every mark has its quote on the scorecard, and the decision column
-        is yours alone.
+        The order below is a priority to talk to, read off each resume against the rubric; every mark has its quote
+        on the scorecard, and the decision column is yours alone.
       </PageHeader>
       <Flash flash={flash} />
+
+      {/* 0. The posting, as this screening reads it. */}
+      <Card class="mb-4" id="position">
+        <div class="flex flex-wrap items-baseline justify-between gap-2">
+          <SectionTitle>Position</SectionTitle>
+          <span class="text-[13px] text-ink-faint">
+            {screening.postingUpdatedAt
+              ? `edited here ${formatRelative(screening.postingUpdatedAt)}`
+              : 'as stored on the job'}{' '}
+            ·{' '}
+            <a href={`/jobs/${screening.job.id}`} class="hover:underline">
+              the job page
+            </a>
+          </span>
+        </div>
+        <p class="mt-1 text-sm text-ink">
+          <span class="font-medium">{screening.job.title}</span> · {screening.job.companyName}
+          {screening.job.location ? ` · ${screening.job.location}` : ''}
+        </p>
+        {screening.scoredBeforePosting > 0 && (
+          <div class="mt-3 flex flex-wrap items-center gap-3 rounded-md border border-warn/25 bg-warn/5 px-3.5 py-2.5 text-[13px] leading-5 text-warn" role="status">
+            <span>
+              The posting changed after {screening.scoredBeforePosting} of the current scores were written. Re-read the
+              rubric from it (a new yardstick), or score everyone again against the new text with the rubric as it is.
+            </span>
+            <ActionForm action={`/screen/${screening.id}/rubric/redraft`} once>
+              <Button variant="secondary" size="sm">
+                Re-read the rubric
+              </Button>
+            </ActionForm>
+            <ActionForm action={`/screen/${screening.id}/run-all`} once>
+              <Button variant="violet" size="sm" disabled={running}>
+                Score everyone again
+              </Button>
+            </ActionForm>
+          </div>
+        )}
+        <details class="mt-3">
+          <summary class="cursor-pointer text-[13px] font-medium text-ink">Read the posting</summary>
+          <pre class="mt-2 max-h-[28rem] overflow-auto whitespace-pre-wrap rounded-md bg-surface-overlay p-3 font-sans text-[13px] leading-5 text-ink">{screening.postingText}</pre>
+        </details>
+        <details class="mt-2">
+          <summary class="cursor-pointer text-[13px] font-medium text-ink">Edit the posting for this screening</summary>
+          <form method="post" action={`/screen/${screening.id}/posting`} class="mt-2 space-y-2">
+            <Textarea name="postingText" rows={14} aria-label="Posting text">
+              {screening.postingText}
+            </Textarea>
+            <div class="flex flex-wrap items-center gap-3">
+              <Button variant="secondary">Save the posting</Button>
+              <Hint>
+                Edits stay on this screening — the job page keeps its own text. After saving, re-read the rubric or
+                score everyone again; the page will say which scores predate the edit.
+              </Hint>
+            </div>
+          </form>
+        </details>
+      </Card>
 
 
       {/* 1. The rubric — open until the first run, a one-line summary after. */}
@@ -238,7 +294,9 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
                   : pending > 0
                     ? `${pending} of ${readable} readable applicant${readable === 1 ? '' : 's'} not scored under rubric v${screening.rubricVersion}.`
                     : readable > 0
-                      ? `All ${readable} readable applicant${readable === 1 ? '' : 's'} scored under rubric v${screening.rubricVersion} on ${engine.label}.`
+                      ? `All ${readable} readable applicant${readable === 1 ? '' : 's'} scored under rubric v${screening.rubricVersion} on ${engine.label}.${
+                          screening.scoredBeforePosting > 0 ? ` ${screening.scoredBeforePosting} of them before the posting was edited — see Position above.` : ''
+                        }`
                       : 'Add applicants above.'}
             </div>
             <div class="mt-1 text-[13px] text-ink-faint">

--- a/src/web/routes/screen.tsx
+++ b/src/web/routes/screen.tsx
@@ -34,7 +34,9 @@ import {
   listApplicants,
   listKnownApplicants,
   listScreenings,
+  postingOf,
   rubricOf,
+  savePosting,
   saveRubric,
   setAdjustment,
   setDecision,
@@ -47,7 +49,7 @@ import { ScreenListPage } from '../pages/screen-list';
 import { ScreenNewPage } from '../pages/screen-new';
 import { ScreenDetailPage } from '../pages/screen-detail';
 import { ScreenApplicantPage } from '../pages/screen-applicant';
-import { exportRows, rowView } from '../screen-view';
+import { exportRows, rowView, scoredBeforePosting } from '../screen-view';
 import { claimRun, startRun, updateRun } from '../target-runs';
 import { MAX_UPLOAD_MB } from '../upload';
 
@@ -117,11 +119,13 @@ screenRoute.post('/screen', postingUploadLimit, async (c) => {
 
   let jobId: number;
   let jobTitle: string;
+  let postingText: string;
   if (f.jobMode === 'existing') {
-    const job = f.jobId ? await prisma.job.findUnique({ where: { id: f.jobId }, select: { id: true, title: true } }) : null;
+    const job = f.jobId ? await prisma.job.findUnique({ where: { id: f.jobId }, select: { id: true, title: true, description: true } }) : null;
     if (!job) return flashRedirect('/screen/new', 'err', 'Pick a job from the list, or paste the posting.');
     jobId = job.id;
     jobTitle = job.title;
+    postingText = job.description;
   } else {
     let description = f.description.replace(/\r\n/g, '\n').trim();
     const file = form.file;
@@ -143,12 +147,14 @@ screenRoute.post('/screen', postingUploadLimit, async (c) => {
     );
     jobId = result.job.id;
     jobTitle = result.job.title;
+    postingText = result.job.description;
   }
 
   const settings = await getSettings();
   const screening = await createScreening({
     jobId,
     title: `${jobTitle} — ${new Date().toISOString().slice(0, 10)}`,
+    postingText,
     rubric: draftRubric(null),
     retainUntil: new Date(Date.now() + settings.screeningRetentionDays * DAY_MS),
   });
@@ -185,15 +191,8 @@ async function startRubricDraft(
       updateRun(run.id, { stage: 'error', error: 'The screening was deleted meanwhile.' });
       return;
     }
-    const jobInput = {
-      id: screening.job.id,
-      title: screening.job.title,
-      companyName: screening.job.company.name,
-      location: screening.job.location,
-      description: screening.job.description,
-    };
     let reason = '';
-    const briefed = await briefForPosting(jobInput, { onError: (r) => (reason = r) });
+    const briefed = await briefForPosting(postingOf(screening), { onError: (r) => (reason = r) });
     if (!briefed) {
       updateRun(run.id, {
         stage: 'done',
@@ -259,6 +258,9 @@ screenRoute.get('/screen/:id', async (c) => {
         retainUntil: screening.retainUntil,
         createdAt: screening.createdAt,
         job: { id: screening.job.id, title: screening.job.title, companyName: screening.job.company.name, location: screening.job.location },
+        postingText: screening.postingText,
+        postingUpdatedAt: screening.postingUpdatedAt,
+        scoredBeforePosting: scoredBeforePosting(rows, screening.postingUpdatedAt),
       }}
       rubric={rubricOf(screening)}
       rows={rows}
@@ -279,6 +281,37 @@ screenRoute.get('/screen/:id/state', async (c) => {
   if (!run) return c.json({ running: false, done: 0, failed: 0, total: 0, queued: [], inFlight: [], finished: [] });
   const { screeningId: _id, startedAt: _s, finishedAt: _f, ...view } = run;
   return c.json(view);
+});
+
+/** The posting as this screening reads it — edited here, never on the Job (plan §4). */
+screenRoute.post('/screen/:id/posting', async (c) => {
+  const screening = await loadScreening(idParam(c.req.param('id')));
+  if (!screening) return flashRedirect('/screen', 'err', 'That screening no longer exists.');
+  const form = await c.req.parseBody();
+  const text = typeof form.postingText === 'string' ? form.postingText.replace(/\r\n/g, '\n').trim() : '';
+  if (text.length < MIN_DESCRIPTION_CHARS) {
+    return flashRedirect(`/screen/${screening.id}#position`, 'err', `The posting needs at least ${MIN_DESCRIPTION_CHARS} characters.`);
+  }
+  if (text === screening.postingText) return flashRedirect(`/screen/${screening.id}#position`, 'ok', 'Posting unchanged.');
+  await savePosting(screening.id, text);
+  logger.info({ screeningId: screening.id, chars: text.length }, 'screening: posting edited');
+  return flashRedirect(
+    `/screen/${screening.id}#position`,
+    'ok',
+    'Posting saved for this screening. Stored scores were read against the old text — re-read the rubric from it, or score everyone again.',
+  );
+});
+
+/** "Score everyone again": every readable applicant back through the current rubric and posting. */
+screenRoute.post('/screen/:id/run-all', async (c) => {
+  const screening = await loadScreening(idParam(c.req.param('id')));
+  if (!screening) return flashRedirect('/screen', 'err', 'That screening no longer exists.');
+  const ids = (await listApplicants(screening.id, screening.rubricVersion)).filter((a) => a.parseStatus === 'ok').map((a) => a.id);
+  const outcome = await startScreeningRun(screening.id, { again: ids });
+  const back = `/screen/${screening.id}#results`;
+  if (outcome.kind === 'nothing') return flashRedirect(back, 'warn', 'No readable applicants to score.');
+  if (outcome.kind === 'missing') return flashRedirect('/screen', 'err', 'That screening no longer exists.');
+  return flashRedirect(back, 'ok', `Scoring all ${ids.length} readable applicant${ids.length === 1 ? '' : 's'} again — each row says where it is.`);
 });
 
 screenRoute.post('/screen/:id/rubric', async (c) => {

--- a/src/web/routes/screen.tsx
+++ b/src/web/routes/screen.tsx
@@ -306,7 +306,8 @@ screenRoute.post('/screen/:id/posting', async (c) => {
 screenRoute.post('/screen/:id/run-all', async (c) => {
   const screening = await loadScreening(idParam(c.req.param('id')));
   if (!screening) return flashRedirect('/screen', 'err', 'That screening no longer exists.');
-  const ids = (await listApplicants(screening.id, screening.rubricVersion)).filter((a) => a.parseStatus === 'ok').map((a) => a.id);
+  // The readable rows' ids only — never the texts of three hundred applicants for a button press.
+  const ids = (await listKnownApplicants(screening.id)).map((a) => a.id);
   const outcome = await startScreeningRun(screening.id, { again: ids });
   const back = `/screen/${screening.id}#results`;
   if (outcome.kind === 'nothing') return flashRedirect(back, 'warn', 'No readable applicants to score.');

--- a/src/web/screen-view.test.ts
+++ b/src/web/screen-view.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { adjustedScore, exportRows, groupRows, rowView } from './screen-view';
+import { adjustedScore, exportRows, groupRows, rowView, scoredBeforePosting } from './screen-view';
 import type { ApplicantWithVerdict } from '../screening/store';
 
 function applicant(over: Partial<ApplicantWithVerdict> & { verdict?: ApplicantWithVerdict['verdict'] }): ApplicantWithVerdict {
@@ -82,6 +82,13 @@ function verdict(score: number, bucket: 'pass' | 'ask' | 'fail', rubricVersion =
     createdAt: new Date(0),
   };
 }
+
+test('scoredBeforePosting counts verdicts older than the posting edit', () => {
+  const rows = [{ scoredAt: new Date('2026-09-09T10:00:00Z') }, { scoredAt: new Date('2026-09-09T12:00:00Z') }, { scoredAt: null }];
+  assert.equal(scoredBeforePosting(rows, null), 0, 'no edit, nothing stale');
+  assert.equal(scoredBeforePosting(rows, new Date('2026-09-09T11:00:00Z')), 1);
+  assert.equal(scoredBeforePosting(rows, new Date('2026-09-09T13:00:00Z')), 2);
+});
 
 test('rowView reads the stored verdict; groupRows orders by the adjusted score and separates', () => {
   const rows = [

--- a/src/web/screen-view.ts
+++ b/src/web/screen-view.ts
@@ -27,6 +27,12 @@ export interface VerdictView {
   questions: string[];
 }
 
+/** How many current verdicts predate an edit to the posting — the "posting changed" line. */
+export function scoredBeforePosting(rows: { scoredAt: Date | null }[], postingUpdatedAt: Date | null): number {
+  if (!postingUpdatedAt) return 0;
+  return rows.filter((r) => r.scoredAt !== null && r.scoredAt < postingUpdatedAt).length;
+}
+
 export interface ApplicantRowView {
   id: number;
   number: number;
@@ -42,6 +48,8 @@ export interface ApplicantRowView {
   adjustmentNote: string | null;
   /** Scored under an earlier rubric — the number is about a different yardstick. */
   stale: boolean;
+  /** When the current verdict was written; null without one. */
+  scoredAt: Date | null;
   verdict: VerdictView | null;
 }
 
@@ -85,6 +93,7 @@ export function rowView(a: ApplicantWithVerdict & { sameAsNumber?: number | null
     adjustment: a.scoreAdjustment,
     adjustmentNote: a.adjustmentNote,
     stale: a.stale,
+    scoredAt: a.verdict?.createdAt ?? null,
     verdict,
   };
 }


### PR DESCRIPTION
Stage A of `docs/screening-criteria-plan.md` (§4, TASKS §19.5): **the posting belongs to the screening**. Stacked on `employer-screening` (#211) — merge that first; this PR then shows only its own diff.

## What changed

- `Screening.postingText` — a snapshot of the job's description taken when the screening is created (backfilled by the migration for existing screenings); `postingUpdatedAt` stamped on an edit. Every rubric draft and every scoring call reads the snapshot (`store.ts:postingOf`), never the Job's live text — the candidate side keeps its own.
- A **Position** card on `/screen/:id`: title · company · location, "Read the posting" (folded prose), "Edit the posting for this screening" (a textarea, Save). After an edit the card says how many current scores predate it and offers **Re-read the rubric** (a new yardstick, everything stale) or **Score everyone again** (the rubric as it is, against the new text). The results line repeats the count.
- "Delete with files" → **Delete screening**, with the confirm saying what goes (the screening, the uploaded copies, every verdict — from the database) and what stays (your files on disk).

## Verified live

Screening created from a stored job: the snapshot equalled the job's description; after an edit the job's text was unchanged and the stamp set; "Score everyone again" with no applicants → a warning; two applicants uploaded → scored by themselves; a second edit → "The posting changed after 2 of the current scores"; Score everyone again → both re-scored under the new text. 2 161 unit tests, `lint:types` clean.

## Release notes (v2.1.0)

## What's new
- The posting is part of the screening: read it, edit it for this screening only, then re-read the rubric or score everyone again; the page says which scores predate the edit.
- "Delete screening" says exactly what it removes; files on disk are never touched.
## Schema
- `20260909150000_screening_posting_text`: `Screening.postingText` (backfilled), `postingUpdatedAt`.
## Verification
- 2 161 tests; live in Docker: snapshot, edit, re-score, both buttons; screenshot at 1200.
## References
- docs/screening-criteria-plan.md §4 · TASKS §19.5 A
