### PR TITLE
During a run a row's number reads as its previous score (v2.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.5.1] — 2026-09-10
+
+### Fixed
+- While a screening run is in flight, the number beside a row's "queued" /
+  "scoring…" / "scored — refresh" badge is that row's previous verdict,
+  and it now reads as one — muted, prefixed "was" — instead of looking like
+  the new score. The first real re-score showed "59" beside "scoring…" and
+  "61" after the refresh, which read as a score that changed by itself.
+
 ## [2.5.0] — 2026-09-09
 
 ### Added
@@ -3265,6 +3274,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.5.1]: https://github.com/applypack/applypack/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/applypack/applypack/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/applypack/applypack/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/applypack/applypack/compare/v2.2.0...v2.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/src/web/pages/screen-detail.tsx
+++ b/src/web/pages/screen-detail.tsx
@@ -672,6 +672,9 @@ const RUN_BADGE_CSS = `
   tr[data-run-state="queued"] .run-badge { background: rgb(var(--surface-overlay)); color: rgb(var(--ink-muted)); }
   tr[data-run-state="scoring"] .run-badge { background: rgb(var(--violet) / .12); color: rgb(var(--violet)); }
   tr[data-run-state="scored"] .run-badge { background: rgb(var(--ok) / .12); color: rgb(var(--ok)); }
+  /* While a row is in the run, the number beside the badge is its previous verdict — say so, or it reads as the new one. */
+  tr[data-run-state] .score-now { color: rgb(var(--ink-faint)); font-weight: 400; }
+  tr[data-run-state] .score-now::before { content: "was "; font-size: 11px; }
 `;
 
 const GroupRow: FC<{ tone: 'ok' | 'warn' | 'danger' | 'neutral'; label: string; count: number }> = ({ tone, label, count }) => (
@@ -703,7 +706,7 @@ function rowRunState(number: number, run: ScreenRunState | null): RowRunState {
   return null;
 }
 
-const RUN_BADGE: Record<Exclude<RowRunState, null>, string> = { queued: 'queued', scoring: 'scoring…', scored: 'scored — refresh' };
+const RUN_BADGE: Record<Exclude<RowRunState, null>, string> = { queued: 'queued', scoring: 'scoring…', scored: 'scored — refresh for the new number' };
 
 const ApplicantRow: FC<{ r: ApplicantRowView; screeningId: number; gates: string[]; run: ScreenRunState | null }> = ({ r, screeningId, gates, run }) => {
   const v = r.verdict && !r.stale ? r.verdict : null;
@@ -786,7 +789,7 @@ const ApplicantRow: FC<{ r: ApplicantRowView; screeningId: number; gates: string
           {state ? RUN_BADGE[state] : ''}
         </span>
         {v ? (
-          <span class="font-semibold text-ink" title={v.cap !== null ? `capped at ${v.cap}` : undefined}>
+          <span class="score-now font-semibold text-ink" title={v.cap !== null ? `capped at ${v.cap}` : undefined}>
             {adjusted}
             {v.cap !== null && <span class="text-ink-faint">*</span>}
             {r.adjustment !== 0 && (

--- a/src/web/public/screen.mjs
+++ b/src/web/public/screen.mjs
@@ -30,7 +30,7 @@ export function rowRunState(number, state) {
   return null;
 }
 
-const RUN_BADGE = { queued: 'queued', scoring: 'scoring…', scored: 'scored — refresh' };
+const RUN_BADGE = { queued: 'queued', scoring: 'scoring…', scored: 'scored — refresh for the new number' };
 
 function paintRows(state) {
   for (const tr of document.querySelectorAll('tr[data-applicant]')) {


### PR DESCRIPTION
Seen on the first real re-score: a row showed "59" next to "scoring…", then "61" after the refresh, and read as a score that changed by itself. The number beside the badge is the row's PREVIOUS verdict until the new one lands and the page is refreshed. It now says so: muted, prefixed "was", and the scored badge reads "scored — refresh for the new number". CSS only, keyed on the `data-run-state` the poller already flips; no schema, no logic change.

Not a scoring bug: the four documents are the same resume, all four verdicts of tonight's run are 61, and the 59 was that row's verdict from the previous run.

## Release notes (v2.5.1)
### What's new
- While a run is in flight, a row's number is shown as "was N" until its new verdict is on the page.
### Schema
- no schema changes
### Verification
- `npm run lint:types` clean, tests green; rendered live with the run state forced on a row.