### PR TITLE
security: one SSRF guard with resolved addresses and per-hop checks; capped zip inflate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3308,6 +3308,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.5.3]: https://github.com/applypack/applypack/compare/v2.5.2...v2.5.3
 [2.5.2]: https://github.com/applypack/applypack/compare/v2.5.1...v2.5.2
 [2.5.1]: https://github.com/applypack/applypack/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/applypack/applypack/compare/v2.4.0...v2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.5.3] — 2026-09-10
+
+### Security
+- **One SSRF guard, three layers.** The private-address check for a
+  user-supplied URL was a name check, and `localhost.`,
+  `[::ffff:169.254.169.254]` and `127.0.0.1.nip.io` all passed it. Now the
+  name is checked in every spelling, every address it resolves to must be
+  public before a connection is made, and redirects are walked one hop at a
+  time with the same two checks — a refused hop is never requested. Pasted
+  posting URLs, watched feeds and careers pages, Teamtailor custom domains
+  and the liveness ladder all go through it; the ladder's own second guard
+  is gone.
+- **The zip reader caps what an entry inflates to.** It compared against the
+  archive's own size field and inflated without a ceiling; a small archive
+  claiming small entries could take the web process down. The ceiling is on
+  the inflater now, with a total for an archive of resumes and a per-part
+  one for a .docx.
+- A quote inside a keyword term could break out of the highlight's `title`
+  attribute on the tailoring page and the demo; both quotes are escaped.
+- The screening CSV text-marks a cell that opens like a formula (`= + - @`),
+  so an applicant's file name or a quoted line cannot run in Excel.
+- A failed CLI call no longer logs the command line — which is the prompt,
+  and so the resume or the applicant's text — only stderr, the exit code and
+  the signal; the flash reads the same.
+
 ## [2.5.2] — 2026-09-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",

--- a/site/public/demo/target.mjs
+++ b/site/public/demo/target.mjs
@@ -244,8 +244,9 @@ export function locateQuote(text, quote) {
   return m ? { start: m.index, end: m.index + m[0].length } : null;
 }
 
+// Both quotes too: the output lands in a title="…" attribute as well as in text.
 function escapeHtml(s) {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
 /**

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -307,6 +307,7 @@ test('cliFailure names the reason without the command line — which is the prom
   assert.deepEqual(exited.log, { code: 1, stderr: 'Not logged in. Run `claude login`.' });
 
   assert.equal(cliFailure({ code: 2, message: secret }, 1).reason, 'exited with code 2');
+  assert.equal(cliFailure({ code: null, signal: 'SIGKILL', killed: false, message: secret }, 1).reason, 'ended by SIGKILL');
   assert.equal(cliFailure({ code: 'ENOENT', message: secret }, 1).reason, 'not found on PATH');
   assert.equal(cliFailure({ code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER', message: secret }, 1).reason, 'the reply exceeded the 1 MiB output cap');
   for (const f of [timeout, exited]) {

--- a/src/ai-provider-parse.test.ts
+++ b/src/ai-provider-parse.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  cliFailure,
   ANTHROPIC_THINKING_HEADROOM_TOKENS,
   anthropicMaxTokens,
   buildClaudeCodeArgs,
@@ -292,5 +293,23 @@ test('the web tools filter through code execution only where the model can call 
   }
   for (const m of ['claude-haiku-4-5-20251001', 'claude-haiku-4-5', 'claude-opus-4-1-20250805', 'claude-sonnet-4-5', 'gpt-5-mini']) {
     assert.equal(webToolsDirectOnly(m), true, m);
+  }
+});
+
+test('cliFailure names the reason without the command line — which is the prompt', () => {
+  const secret = 'Command failed: claude --system-prompt RESUME TEXT -- posting text';
+  const timeout = cliFailure({ killed: true, signal: 'SIGTERM', code: null, message: secret }, 180_000);
+  assert.equal(timeout.reason, 'timed out after 180 s');
+  assert.deepEqual(timeout.log, { signal: 'SIGTERM' });
+
+  const exited = cliFailure({ code: 1, message: secret, stderr: 'Not logged in. Run `claude login`.\n' }, 1);
+  assert.equal(exited.reason, 'Not logged in. Run `claude login`.');
+  assert.deepEqual(exited.log, { code: 1, stderr: 'Not logged in. Run `claude login`.' });
+
+  assert.equal(cliFailure({ code: 2, message: secret }, 1).reason, 'exited with code 2');
+  assert.equal(cliFailure({ code: 'ENOENT', message: secret }, 1).reason, 'not found on PATH');
+  assert.equal(cliFailure({ code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER', message: secret }, 1).reason, 'the reply exceeded the 1 MiB output cap');
+  for (const f of [timeout, exited]) {
+    assert.doesNotMatch(JSON.stringify(f), /RESUME TEXT|posting text/);
   }
 });

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -100,9 +100,10 @@ export function cliFailure(
   };
   if (e.code === 'ENOENT') return { reason: 'not found on PATH', log };
   if (e.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') return { reason: 'the reply exceeded the 1 MiB output cap', log };
-  if (e.killed === true || (typeof e.signal === 'string' && typeof e.code !== 'number')) {
-    return { reason: `timed out after ${Math.round(timeoutMs / 1000)} s`, log };
-  }
+  // execFile sets `killed` when it pulled the plug itself (the timeout); a
+  // signal it did not send came from outside — the OOM killer, a shutdown.
+  if (e.killed === true) return { reason: `timed out after ${Math.round(timeoutMs / 1000)} s`, log };
+  if (typeof e.signal === 'string' && typeof e.code !== 'number') return { reason: `ended by ${e.signal}`, log };
   if (stderr) return { reason: stderr, log };
   if (typeof e.code === 'number') return { reason: `exited with code ${e.code}`, log };
   return { reason: 'failed with no output', log };

--- a/src/ai-provider-parse.ts
+++ b/src/ai-provider-parse.ts
@@ -81,6 +81,33 @@ export function webToolsDirectOnly(model: string): boolean {
   return !PROGRAMMATIC_TOOL_MODEL.test(model);
 }
 
+/**
+ * Why a CLI child failed, without its command line: execFile's err.message
+ * is `Command failed: <bin> <args…>` and the args ARE the prompt — a resume,
+ * an applicant's text, the posting. The reason is read off stderr (where the
+ * CLI states it), the exit code and the signal, never off the message.
+ */
+export function cliFailure(
+  err: unknown,
+  timeoutMs: number,
+): { reason: string; log: { code?: string | number; signal?: string; stderr?: string } } {
+  const e = (err ?? {}) as { code?: unknown; signal?: unknown; killed?: unknown; stderr?: unknown };
+  const stderr = typeof e.stderr === 'string' ? e.stderr.trim().slice(0, 500) : '';
+  const log = {
+    ...(typeof e.code === 'string' || typeof e.code === 'number' ? { code: e.code } : {}),
+    ...(typeof e.signal === 'string' ? { signal: e.signal } : {}),
+    ...(stderr ? { stderr } : {}),
+  };
+  if (e.code === 'ENOENT') return { reason: 'not found on PATH', log };
+  if (e.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') return { reason: 'the reply exceeded the 1 MiB output cap', log };
+  if (e.killed === true || (typeof e.signal === 'string' && typeof e.code !== 'number')) {
+    return { reason: `timed out after ${Math.round(timeoutMs / 1000)} s`, log };
+  }
+  if (stderr) return { reason: stderr, log };
+  if (typeof e.code === 'number') return { reason: `exited with code ${e.code}`, log };
+  return { reason: 'failed with no output', log };
+}
+
 export function describeAiFailure(reason: string): string {
   const oneLine = reason.replace(/\s+/g, ' ').trim();
   if (oneLine.length === 0) return 'no reason reported';

--- a/src/ai-provider.ts
+++ b/src/ai-provider.ts
@@ -13,6 +13,7 @@ import {
   buildGeminiCliArgs,
   CLI_PROVIDER_ENV_KEYS,
   cliThinkingCap,
+  cliFailure,
   describeAiFailure,
   parseClaudeCodeOutput,
   parseCodexCliOutput,
@@ -316,13 +317,12 @@ class CliProvider implements AiProvider {
           env: buildCliEnv(this.spec.envKeys, this.envSource(req)),
         }));
       } catch (err) {
-        logger.error({ err, label: req.label, provider: this.name }, 'ai: cli process failed');
         // execFile puts the whole command line — prompt included — in
-        // err.message, so prefer stderr, where the CLI states the reason.
-        const stderr = (err as { stderr?: unknown }).stderr;
-        const detail =
-          typeof stderr === 'string' && stderr.trim().length > 0 ? stderr : errorReason(err);
-        req.onError?.(describeAiFailure(`${this.bin}: ${detail}`));
+        // err.message, so neither the log line nor the flash may carry `err`:
+        // the reason is read off stderr, the exit code and the signal.
+        const failure = cliFailure(err, req.timeoutMs ?? CLI_TIMEOUT_MS);
+        logger.error({ label: req.label, provider: this.name, ...failure.log }, 'ai: cli process failed');
+        req.onError?.(describeAiFailure(`${this.bin}: ${failure.reason}`));
         return null;
       }
       const out = this.spec.parse(stdout);

--- a/src/ats-probe.ts
+++ b/src/ats-probe.ts
@@ -1,5 +1,6 @@
 import { AtsType } from '@prisma/client';
 import { fetchWithRetry, HttpError } from './http';
+import { fetchPublicUrl } from './jobs/posting-url';
 import { douFeedUrl } from './fetchers/dou';
 import { djinniFeedUrl } from './fetchers/djinni';
 import { jobTechProbeUrl, parseJobTechTotal } from './fetchers/jobtech';
@@ -215,7 +216,7 @@ export async function probeAts(
         } catch (err) {
           return { ok: false, error: err instanceof Error ? err.message.replace(/^feed: /, '') : 'Invalid feed URL.' };
         }
-        const answer = await fetchWithRetry(url, { timeoutMs: 8_000 });
+        const answer = await fetchPublicUrl(url, { timeoutMs: 8_000 });
         const xml = await answer.text();
         if (!looksLikeFeed(xml)) return { ok: false, error: 'That URL answered something other than an RSS or Atom feed.' };
         const items = (xml.match(/<item[\s>]|<entry[\s>]/gi) ?? []).length;
@@ -234,7 +235,7 @@ export async function probeAts(
         } catch (err) {
           return { ok: false, error: err instanceof Error ? err.message.replace(/^career-page: /, '') : 'Invalid page URL.' };
         }
-        const answer = await fetchWithRetry(url, { timeoutMs: 8_000 });
+        const answer = await fetchPublicUrl(url, { timeoutMs: 8_000 });
         const html = await answer.text();
         if (looksLikeChallenge(html)) {
           return { ok: false, error: 'That page answered with a bot check, so its text cannot be watched.' };

--- a/src/fetchers/career-page.ts
+++ b/src/fetchers/career-page.ts
@@ -1,6 +1,5 @@
 import { logger } from '../logger';
-import { fetchWithRetry } from '../http';
-import { checkPostingUrl } from '../jobs/posting-url';
+import { checkPostingUrl, fetchPublicUrl } from '../jobs/posting-url';
 import { looksLikeChallenge } from '../watchlist/scan';
 import { decideChange } from '../watchlist/page-hash';
 import { stagePageChange } from '../watchlist/page-changes';
@@ -46,13 +45,12 @@ export interface CareerPageCompany {
 
 export async function fetchCareerPage(company: CareerPageCompany): Promise<NormalizedJob[]> {
   const url = careerPageUrl(company.atsToken);
-  const resp = await fetchWithRetry(url, {
+  // Every redirect hop is guarded before it is requested — the same rule
+  // every user-URL fetch in this project follows.
+  const resp = await fetchPublicUrl(url, {
     timeoutMs: TIMEOUT_MS,
     init: { headers: conditionalHeaders(company.id, url) },
   });
-  // Redirects are followed, so the host that answered is checked again — the
-  // same rule every user-URL fetch in this project follows.
-  careerPageUrl(resp.url || url);
   const html = await resp.text();
 
   // A bot check is not a change; hashing it would report the interstitial as

--- a/src/fetchers/feed.ts
+++ b/src/fetchers/feed.ts
@@ -1,6 +1,6 @@
 import Parser from 'rss-parser';
-import { fetchWithRetry, stripHtml } from '../http';
-import { checkPostingUrl } from '../jobs/posting-url';
+import { stripHtml } from '../http';
+import { checkPostingUrl, fetchPublicUrl } from '../jobs/posting-url';
 import { feedItemKey } from '../text-utils';
 import { conditionalHeaders, rememberResponse } from './conditional';
 import type { NormalizedJob } from '../types';
@@ -54,14 +54,13 @@ export interface FeedCompany {
 
 export async function fetchFeed(company: FeedCompany): Promise<NormalizedJob[]> {
   const url = feedUrl(company.atsToken);
-  const resp = await fetchWithRetry(url, {
+  // Every redirect hop is guarded before it is requested — a public feed URL
+  // can start redirecting into the private range, and then its "postings"
+  // would be whatever that host serves.
+  const resp = await fetchPublicUrl(url, {
     timeoutMs: TIMEOUT_MS,
     init: { headers: conditionalHeaders(company.id, url) },
   });
-  // Redirects are followed, so the host that actually answered is checked
-  // again — a public feed URL can start redirecting into the private range,
-  // and then its "postings" would be whatever that host serves.
-  feedUrl(resp.url || url);
   const feed = await parser.parseString(await resp.text());
   const jobs = feed.items.flatMap((item) => mapFeedItem(item, company.id) ?? []);
   rememberResponse(company.id, url, resp, jobs.length);

--- a/src/fetchers/teamtailor.ts
+++ b/src/fetchers/teamtailor.ts
@@ -1,8 +1,8 @@
 import Parser from 'rss-parser';
 import { findCountry } from '../countries';
-import { fetchWithRetry, stripHtml } from '../http';
+import { stripHtml } from '../http';
 import { conditionalHeaders, rememberResponse } from './conditional';
-import { isPrivateHost } from '../jobs/posting-url';
+import { fetchPublicUrl, isPrivateHost } from '../jobs/posting-url';
 import type { LocationHints, WorkplaceCode } from '../location';
 import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
@@ -63,7 +63,9 @@ export interface TeamtailorCompany {
 export async function fetchTeamtailor(company: TeamtailorCompany): Promise<NormalizedJob[]> {
   const host = teamtailorHost(company.atsToken);
   const url = teamtailorFeedUrl(host);
-  const resp = await fetchWithRetry(url, {
+  // A custom career domain is the user's host, so it goes through the same
+  // guard a pasted URL does — resolved, and every redirect hop checked.
+  const resp = await fetchPublicUrl(url, {
     timeoutMs: TIMEOUT_MS,
     init: { headers: conditionalHeaders(company.id, url) },
   });

--- a/src/http.ts
+++ b/src/http.ts
@@ -36,6 +36,8 @@ export class HttpError extends Error {
   }
 }
 
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
 export async function fetchWithRetry(
   url: string,
   options: FetchOptions = {},
@@ -64,6 +66,13 @@ export async function fetchWithRetry(
           await sleep(delay);
         }
         continue;
+      }
+
+      // A caller that asked for redirects unfollowed wants the 3xx back to
+      // judge the next hop itself (posting-url.ts:fetchPublicHops); a 304 is
+      // still the conditional answer and still thrown (ADR 0035).
+      if (options.init?.redirect === 'manual' && REDIRECT_STATUSES.has(resp.status)) {
+        return resp;
       }
 
       if (!resp.ok) {

--- a/src/jobs/posting-url.test.ts
+++ b/src/jobs/posting-url.test.ts
@@ -1,6 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { ashbyPostingText, checkPostingUrl, isPrivateHost, parseAshbyUrl, pickAshbyJob, postingTextFromHtml } from './posting-url';
+import {
+  ashbyPostingText,
+  checkPostingUrl,
+  fetchPublicHops,
+  isPrivateHost,
+  isPrivateIp,
+  parseAshbyUrl,
+  pickAshbyJob,
+  postingTextFromHtml,
+  resolvesToPublic,
+} from './posting-url';
 
 test('checkPostingUrl refuses junk, wrong protocols and ADR 0005 hosts', () => {
   assert.equal(checkPostingUrl('not a url').ok, false);
@@ -82,4 +92,88 @@ test('ashbyPostingText reads like a page: title, place, then the body as text �
   assert.match(r.text, /^Staff Engineer\nRemote \(US\)\n\nWe build things\./);
   assert.match(r.text, /• Go\n• Kubernetes/);
   assert.equal(ashbyPostingText({ title: 'Staff Engineer', location: null, descriptionHtml: '<p>short</p>' }).ok, false);
+});
+
+test('isPrivateIp reads every spelling of a private address (audit 2026-09-10)', () => {
+  for (const ip of [
+    '127.0.0.1', '10.0.0.1', '169.254.169.254', '224.0.0.1', '::1', '::', 'fe80::1', 'fd12::1',
+    '::ffff:169.254.169.254', '::ffff:a9fe:a9fe', '::ffff:127.0.0.1', '::ffff:7f00:1', '64:ff9b::a9fe:a9fe',
+  ]) {
+    assert.equal(isPrivateIp(ip), true, `${ip} must be private`);
+  }
+  for (const ip of ['8.8.8.8', '2606:4700::1111', '::ffff:8.8.8.8', '::ffff:808:808', '172.32.0.1']) {
+    assert.equal(isPrivateIp(ip), false, `${ip} must be public`);
+  }
+});
+
+test('isPrivateHost: a trailing dot, a mapped literal, an intranet name — the three bypasses', () => {
+  for (const h of ['localhost.', '[::ffff:a9fe:a9fe]', '::ffff:169.254.169.254', 'intranet', 'db.internal', 'nas.lan', 'router.home.arpa']) {
+    assert.equal(isPrivateHost(h), true, `${h} must be private`);
+  }
+  assert.equal(isPrivateHost('jobs.example.com.'), false);
+});
+
+test('checkPostingUrl refuses the literal bypasses and a URL carrying credentials', () => {
+  assert.equal(checkPostingUrl('http://localhost./x').ok, false);
+  assert.equal(checkPostingUrl('http://[::ffff:169.254.169.254]/').ok, false);
+  assert.equal(checkPostingUrl('http://intranet/x').ok, false);
+  assert.equal(checkPostingUrl('http://user:pass@example.com/x').ok, false);
+  assert.equal(checkPostingUrl('http://2130706433/').ok, false);
+  // The name still has to resolve somewhere public — that is layer 2, not this one.
+  assert.equal(checkPostingUrl('http://127.0.0.1.nip.io/').ok, true);
+});
+
+test('resolvesToPublic refuses a name whose records point inside, and a name with none', async () => {
+  const resolving = (map: Record<string, string[]>) => async (h: string) => {
+    const a = map[h];
+    if (!a) throw new Error('ENOTFOUND');
+    return a;
+  };
+  const dnsMap = resolving({
+    'jobs.example.com': ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'],
+    '127.0.0.1.nip.io': ['127.0.0.1'],
+    'mixed.example.com': ['93.184.216.34', '10.0.0.1'],
+  });
+  assert.deepEqual(await resolvesToPublic(new URL('https://jobs.example.com/1'), dnsMap), { ok: true });
+  assert.equal((await resolvesToPublic(new URL('http://127.0.0.1.nip.io/'), dnsMap)).ok, false);
+  assert.equal((await resolvesToPublic(new URL('http://mixed.example.com/'), dnsMap)).ok, false, 'one private record is enough');
+  assert.equal((await resolvesToPublic(new URL('http://nope.example.com/'), dnsMap)).ok, false);
+  // A literal was judged by checkPostingUrl already; nothing to resolve.
+  assert.deepEqual(await resolvesToPublic(new URL('http://8.8.8.8/'), dnsMap), { ok: true });
+});
+
+test('fetchPublicHops guards every redirect hop before it is requested', async () => {
+  const dnsMap = async (h: string) => (h === 'evil.example' ? ['169.254.169.254'] : ['93.184.216.34']);
+  const requested: string[] = [];
+  const chain: Record<string, { status: number; location: string | null }> = {
+    'https://a.example/1': { status: 302, location: '/2' },
+    'https://a.example/2': { status: 301, location: 'https://b.example/3' },
+    'https://b.example/3': { status: 200, location: null },
+    'https://a.example/meta': { status: 302, location: 'http://169.254.169.254/latest/meta-data/' },
+    'https://a.example/evil': { status: 302, location: 'http://evil.example/' },
+    'https://a.example/loop': { status: 302, location: '/loop' },
+  };
+  const fetchOnce = async (url: string) => {
+    requested.push(url);
+    return chain[url] ?? { status: 404, location: null };
+  };
+
+  const ok = await fetchPublicHops('https://a.example/1', fetchOnce, dnsMap);
+  assert.deepEqual(ok, { ok: true, response: { status: 200, location: null }, url: 'https://b.example/3' });
+
+  requested.length = 0;
+  const meta = await fetchPublicHops('https://a.example/meta', fetchOnce, dnsMap);
+  assert.equal(meta.ok, false);
+  assert.deepEqual(requested, ['https://a.example/meta'], 'the private hop is never requested');
+
+  requested.length = 0;
+  const evil = await fetchPublicHops('https://a.example/evil', fetchOnce, dnsMap);
+  assert.equal(evil.ok, false);
+  assert.deepEqual(requested, ['https://a.example/evil'], 'a public name resolving inside is never requested either');
+
+  const loop = await fetchPublicHops('https://a.example/loop', fetchOnce, dnsMap);
+  assert.equal(loop.ok, false);
+  if (!loop.ok) assert.match(loop.error, /too many times/);
+
+  assert.equal((await fetchPublicHops('http://localhost./x', fetchOnce, dnsMap)).ok, false);
 });

--- a/src/jobs/posting-url.ts
+++ b/src/jobs/posting-url.ts
@@ -1,5 +1,7 @@
+import dns from 'node:dns/promises';
+import { isIP } from 'node:net';
 import { z } from 'zod';
-import { fetchWithRetry, HttpError, stripHtml } from '../http';
+import { fetchWithRetry, HttpError, stripHtml, type FetchOptions } from '../http';
 import { MIN_DESCRIPTION_CHARS } from './manual-job';
 
 /*
@@ -91,21 +93,51 @@ export function ashbyPostingText(job: Pick<AshbyPosting, 'title' | 'location' | 
   return postingText([job.title, job.location ?? '', '', stripHtml(job.descriptionHtml ?? '').trim()].join('\n').trim());
 }
 
-/**
- * SSRF guard. ADR 0016 keeps the liveness ladder on fixed hosts; this flow
- * takes an arbitrary URL, so the private address space is refused instead —
- * before the request AND again on the post-redirect URL, since a public host
- * can redirect into 169.254.169.254 and hand cloud metadata to the model.
+/*
+ * SSRF guard. ADR 0016 keeps the liveness ladder on fixed hosts; every flow
+ * that takes an arbitrary URL — a pasted posting, a watched feed or careers
+ * page, a Teamtailor custom domain — goes through this one guard. Three
+ * layers, because a name check alone was bypassed by `localhost.`,
+ * `[::ffff:169.254.169.254]` and `127.0.0.1.nip.io` (audit 2026-09-10):
+ *
+ * 1. checkPostingUrl — pure: scheme, credentials, ADR 0005 hosts, private
+ *    names and private address literals in every spelling.
+ * 2. resolvesToPublic — the addresses the name resolves to, every one of
+ *    them public, before a connection is made.
+ * 3. fetchPublicHops — redirects are never followed blindly: each hop is a
+ *    new URL through layers 1 and 2, at most MAX_REDIRECTS of them, and a
+ *    refused hop is never requested.
+ *
+ * Residual: a name whose records change between our lookup and the
+ * socket's (DNS rebinding) is not pinned. Closing that needs a custom
+ * dispatcher, which is a dependency this project does not carry.
  */
-export function isPrivateHost(hostname: string): boolean {
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) return true;
-  if (host === '::1' || host === '::' || host === '0.0.0.0') return true;
-  // IPv6 link-local (fe80::/10 → fe80-febf) and unique-local (fc00::/7 → fc00-fdff).
-  if (/^(?:fe[89ab][0-9a-f]|f[cd][0-9a-f]{2}):/.test(host)) return true;
-  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (!v4) return false;
-  const [a, b] = [Number(v4[1]), Number(v4[2])];
+
+/** A private, loopback, link-local or otherwise non-routable address, in IPv4 or IPv6 spelling. */
+export function isPrivateIp(ip: string): boolean {
+  const addr = ip.toLowerCase().replace(/^\[|\]$/g, '');
+  const family = isIP(addr);
+  if (family === 4) return isPrivateV4(addr);
+  if (family !== 6) return false;
+  if (addr === '::1' || addr === '::') return true;
+  // IPv4 embedded in IPv6 — mapped (::ffff:a.b.c.d, which the URL parser
+  // writes as ::ffff:a9fe:a9fe) and NAT64's well-known prefix (64:ff9b::/96).
+  const embedded = /^(?:::ffff:|64:ff9b::)(.+)$/.exec(addr)?.[1];
+  if (embedded) {
+    if (isIP(embedded) === 4) return isPrivateV4(embedded);
+    const pair = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(embedded);
+    if (pair) {
+      const hi = parseInt(pair[1]!, 16);
+      const lo = parseInt(pair[2]!, 16);
+      return isPrivateV4(`${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`);
+    }
+  }
+  // Link-local (fe80::/10 → fe80-febf) and unique-local (fc00::/7 → fc00-fdff).
+  return /^(?:fe[89ab][0-9a-f]|f[cd][0-9a-f]{2}):/.test(addr);
+}
+
+function isPrivateV4(addr: string): boolean {
+  const [a = 0, b = 0] = addr.split('.').map(Number);
   return (
     a === 0 ||
     a === 10 ||
@@ -113,8 +145,108 @@ export function isPrivateHost(hostname: string): boolean {
     (a === 169 && b === 254) || // link-local, incl. the cloud metadata address
     (a === 172 && b >= 16 && b <= 31) ||
     (a === 192 && b === 168) ||
-    (a === 100 && b >= 64 && b <= 127) // carrier-grade NAT
+    (a === 100 && b >= 64 && b <= 127) || // carrier-grade NAT
+    a >= 224 // multicast and reserved
   );
+}
+
+const PRIVATE_NAME_SUFFIXES = ['.localhost', '.local', '.internal', '.lan', '.home.arpa'];
+
+/** A hostname (or address literal) that must never be fetched: the pure half of the guard. */
+export function isPrivateHost(hostname: string): boolean {
+  // A trailing dot is the same name to the resolver and a different string to a check.
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '');
+  if (isIP(host)) return isPrivateIp(host);
+  if (host === 'localhost' || PRIVATE_NAME_SUFFIXES.some((s) => host.endsWith(s))) return true;
+  // A public name has a dot in it; a bare word is an intranet name.
+  return !host.includes('.');
+}
+
+/** The addresses a name resolves to — injected so the guard is tested without the network. */
+export type Resolver = (hostname: string) => Promise<string[]>;
+
+export const lookupAddresses: Resolver = async (hostname) =>
+  (await dns.lookup(hostname, { all: true })).map((a) => a.address);
+
+const PUBLIC_ONLY = 'Only public posting URLs can be fetched.';
+
+/** Layer 2: every address behind the name is public. An address literal has nothing to resolve. */
+export async function resolvesToPublic(
+  url: URL,
+  resolve: Resolver = lookupAddresses,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (isIP(host)) return { ok: true };
+  let addresses: string[];
+  try {
+    addresses = await resolve(host);
+  } catch {
+    return { ok: false, error: 'That host does not resolve — check the URL.' };
+  }
+  if (addresses.length === 0) return { ok: false, error: 'That host does not resolve — check the URL.' };
+  return addresses.some(isPrivateIp) ? { ok: false, error: PUBLIC_ONLY } : { ok: true };
+}
+
+export const MAX_REDIRECTS = 5;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/** What a hop has to say about itself: the status, and where it points next. */
+export interface Hop {
+  status: number;
+  location: string | null;
+}
+
+/** What the hop walk hands back: the answer and the URL that gave it, or why it stopped. */
+export type HopResult<T> = { ok: true; response: T; url: string } | { ok: false; error: string };
+
+/**
+ * Layer 3: the request loop. `fetchOnce` makes ONE request with redirects
+ * left unfollowed; this walks the chain, guarding every hop before it is
+ * requested. The result carries the URL that answered, so the caller can
+ * record where it landed.
+ */
+export async function fetchPublicHops<T extends Hop>(
+  raw: string,
+  fetchOnce: (url: string) => Promise<T>,
+  resolve: Resolver = lookupAddresses,
+): Promise<HopResult<T>> {
+  const checked = checkPostingUrl(raw);
+  if (!checked.ok) return checked;
+  let url = checked.url;
+  for (let hops = 0; ; hops++) {
+    const pub = await resolvesToPublic(url, resolve);
+    if (!pub.ok) return pub;
+    const response = await fetchOnce(url.toString());
+    if (!REDIRECT_STATUSES.has(response.status) || !response.location) {
+      return { ok: true, response, url: url.toString() };
+    }
+    if (hops >= MAX_REDIRECTS) return { ok: false, error: 'That URL redirects too many times.' };
+    let next: URL;
+    try {
+      next = new URL(response.location, url);
+    } catch {
+      return { ok: false, error: 'That URL redirects somewhere unreadable.' };
+    }
+    const again = checkPostingUrl(next.toString());
+    if (!again.ok) return again;
+    url = again.url;
+  }
+}
+
+/** The guard said no — distinct from a network or HTTP failure, which pass through unchanged. */
+export class PublicUrlError extends Error {}
+
+/** fetchWithRetry for a user-supplied URL: the three layers, then the response that answered. */
+export async function fetchPublicUrl(raw: string, options: FetchOptions = {}): Promise<Response> {
+  const got = await fetchPublicHops(raw, (url) =>
+    fetchWithRetry(url, { ...options, init: { ...options.init, redirect: 'manual' } }).then((resp) => ({
+      status: resp.status,
+      location: resp.headers.get('location'),
+      resp,
+    })),
+  );
+  if (!got.ok) throw new PublicUrlError(got.error);
+  return got.response.resp;
 }
 
 export type PostingUrlResult = { ok: true; text: string } | { ok: false; error: string };
@@ -129,6 +261,9 @@ export function checkPostingUrl(raw: string): { ok: true; url: URL } | { ok: fal
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     return { ok: false, error: 'Only http(s) posting URLs can be fetched.' };
   }
+  if (url.username || url.password) {
+    return { ok: false, error: 'A posting URL with a password in it is not fetched.' };
+  }
   const host = url.hostname.toLowerCase();
   if (BLOCKED_POSTING_HOSTS.some((b) => host === b || host.endsWith(`.${b}`))) {
     return {
@@ -137,7 +272,7 @@ export function checkPostingUrl(raw: string): { ok: true; url: URL } | { ok: fal
     };
   }
   if (isPrivateHost(host)) {
-    return { ok: false, error: 'Only public posting URLs can be fetched.' };
+    return { ok: false, error: PUBLIC_ONLY };
   }
   return { ok: true, url };
 }
@@ -166,12 +301,10 @@ export async function fetchPostingText(raw: string, opts: { title?: string } = {
   const ashby = parseAshbyUrl(checked.url);
   if (ashby) return fetchAshbyPosting(ashby, opts.title);
   try {
-    const res = await fetchWithRetry(checked.url.toString(), { timeoutMs: FETCH_TIMEOUT_MS });
-    // Redirects are followed, so the host that actually answered is re-checked.
-    const landed = checkPostingUrl(res.url || checked.url.toString());
-    if (!landed.ok) return landed;
+    const res = await fetchPublicUrl(checked.url.toString(), { timeoutMs: FETCH_TIMEOUT_MS });
     return postingTextFromHtml(await res.text());
   } catch (err) {
+    if (err instanceof PublicUrlError) return { ok: false, error: err.message };
     if (err instanceof HttpError && (err.status === 403 || err.status === 429 || err.status === 503)) {
       return { ok: false, error: 'The page answered with a bot check — paste the posting text instead.' };
     }

--- a/src/jobs/posting-url.ts
+++ b/src/jobs/posting-url.ts
@@ -239,11 +239,12 @@ export class PublicUrlError extends Error {}
 /** fetchWithRetry for a user-supplied URL: the three layers, then the response that answered. */
 export async function fetchPublicUrl(raw: string, options: FetchOptions = {}): Promise<Response> {
   const got = await fetchPublicHops(raw, (url) =>
-    fetchWithRetry(url, { ...options, init: { ...options.init, redirect: 'manual' } }).then((resp) => ({
-      status: resp.status,
-      location: resp.headers.get('location'),
-      resp,
-    })),
+    fetchWithRetry(url, { ...options, init: { ...options.init, redirect: 'manual' } }).then(async (resp) => {
+      const location = resp.headers.get('location');
+      // A hop's body is never read; drained so the connection goes back to the pool.
+      if (REDIRECT_STATUSES.has(resp.status)) await resp.body?.cancel().catch(() => undefined);
+      return { status: resp.status, location, resp };
+    }),
   );
   if (!got.ok) throw new PublicUrlError(got.error);
   return got.response.resp;

--- a/src/resume/resume-text.ts
+++ b/src/resume/resume-text.ts
@@ -1,7 +1,7 @@
 import { extname } from 'node:path';
 import { docxToText, ResumeTextError } from './docx-text';
 import { pdfToText } from './pdf-text';
-import { ZipError } from './zip';
+import { MAX_INFLATED_PART_BYTES, ZipError, ZipLimitError } from './zip';
 
 export const ACCEPTED_EXTENSIONS = ['.pdf', '.docx', '.md', '.txt'] as const;
 const MIN_TEXT_CHARS = 200;
@@ -17,6 +17,9 @@ export async function extractResumeText(filename: string, bytes: Buffer): Promis
     try {
       text = docxToText(bytes);
     } catch (err) {
+      if (err instanceof ZipLimitError) {
+        throw new ResumeTextError(`The .docx is larger inside than this tool reads (${MAX_INFLATED_PART_BYTES / 1024 / 1024} MB in one part).`);
+      }
       if (err instanceof ZipError) throw new ResumeTextError('The file is not a valid .docx (not a zip archive).');
       throw err;
     }

--- a/src/resume/zip.test.ts
+++ b/src/resume/zip.test.ts
@@ -108,3 +108,15 @@ test('readZipEntry refuses a part past its ceiling', () => {
   assert.throws(() => readZipEntry(zip, 'word/document.xml', 100_000), ZipLimitError);
   assert.ok(readZipEntry(zip, 'word/document.xml') instanceof Buffer, 'the default ceiling is generous');
 });
+
+test('readZipEntries at a full ceiling skips the rest instead of asking zlib for nothing', () => {
+  const chunk = Buffer.alloc(1024, 0x64);
+  const zip = buildZip([
+    { name: 'a.txt', data: chunk, deflate: true },
+    { name: 'empty.txt', data: Buffer.alloc(0), deflate: true },
+    { name: 'b.txt', data: chunk, deflate: true },
+  ]);
+  const { entries, skipped } = readZipEntries(zip, Infinity, 1024);
+  assert.deepEqual(entries.map((e) => e.name), ['a.txt']);
+  assert.deepEqual(skipped, ['empty.txt', 'b.txt']);
+});

--- a/src/resume/zip.test.ts
+++ b/src/resume/zip.test.ts
@@ -1,12 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { deflateRawSync } from 'node:zlib';
-import { readZipEntry, ZipError } from './zip';
+import { readZipEntries, readZipEntry, ZipError, ZipLimitError } from './zip';
 
 interface Entry {
   name: string;
   data: Buffer;
   deflate: boolean;
+  /** What the central directory claims the entry inflates to — a lie, when set. */
+  claimed?: number;
 }
 
 /** Builds a valid zip in memory — the writer half our reader deliberately lacks. */
@@ -31,7 +33,7 @@ function buildZip(entries: Entry[], comment = ''): Buffer {
     central.writeUInt32LE(0x02014b50, 0);
     central.writeUInt16LE(method, 10);
     central.writeUInt32LE(payload.length, 20);
-    central.writeUInt32LE(e.data.length, 24);
+    central.writeUInt32LE(e.claimed ?? e.data.length, 24);
     central.writeUInt16LE(name.length, 28);
     central.writeUInt32LE(offset, 42);
     name.copy(central, 46);
@@ -75,4 +77,34 @@ test('readZipEntry survives an archive comment', () => {
 test('readZipEntry rejects non-zip input', () => {
   assert.throws(() => readZipEntry(Buffer.from('%PDF-1.4 not a zip'), 'x'), ZipError);
   assert.throws(() => readZipEntry(Buffer.alloc(0), 'x'), ZipError);
+});
+
+test('readZipEntries caps what an entry inflates to, not what the archive claims (audit 2026-09-10)', () => {
+  const big = Buffer.alloc(3 * 1024 * 1024, 0x61); // deflates to a few KB
+  const zip = buildZip([
+    { name: 'honest.txt', data: Buffer.from('hello'), deflate: true },
+    { name: 'liar.txt', data: big, deflate: true, claimed: 100 },
+    { name: 'stored.txt', data: Buffer.alloc(2 * 1024 * 1024, 0x62), deflate: false },
+  ]);
+  const { entries, skipped } = readZipEntries(zip, 1024 * 1024);
+  assert.deepEqual(entries.map((e) => e.name), ['honest.txt']);
+  assert.deepEqual(skipped, ['liar.txt', 'stored.txt']);
+});
+
+test('readZipEntries stops at the total ceiling, entry by entry', () => {
+  const chunk = Buffer.alloc(3 * 1024 * 1024, 0x63);
+  const zip = buildZip([
+    { name: 'a.pdf', data: chunk, deflate: true },
+    { name: 'b.pdf', data: chunk, deflate: true, claimed: 10 },
+    { name: 'c.txt', data: Buffer.from('small'), deflate: true },
+  ]);
+  const { entries, skipped } = readZipEntries(zip, Infinity, 4 * 1024 * 1024);
+  assert.deepEqual(entries.map((e) => e.name), ['a.pdf', 'c.txt']);
+  assert.deepEqual(skipped, ['b.pdf']);
+});
+
+test('readZipEntry refuses a part past its ceiling', () => {
+  const zip = buildZip([{ name: 'word/document.xml', data: Buffer.alloc(200_000, 0x3c), deflate: true, claimed: 1 }]);
+  assert.throws(() => readZipEntry(zip, 'word/document.xml', 100_000), ZipLimitError);
+  assert.ok(readZipEntry(zip, 'word/document.xml') instanceof Buffer, 'the default ceiling is generous');
 });

--- a/src/resume/zip.ts
+++ b/src/resume/zip.ts
@@ -18,6 +18,13 @@ const METHOD_STORED = 0;
 const METHOD_DEFLATE = 8;
 
 export class ZipError extends Error {}
+/** An entry that would inflate past the ceiling it was given — the archive's own size field is not consulted. */
+export class ZipLimitError extends ZipError {}
+
+/** One part of a .docx; the largest document.xml in the corpus is under 2 MB. */
+export const MAX_INFLATED_PART_BYTES = 64 * 1024 * 1024;
+/** Everything an archive of resumes may inflate to, in total — the web process holds it all at once. */
+export const MAX_INFLATED_TOTAL_BYTES = 512 * 1024 * 1024;
 
 export interface ZipEntry {
   name: string;
@@ -32,30 +39,52 @@ interface CentralRecord {
   localOffset: number;
 }
 
-/** Returns the decompressed bytes of `name`, or null when the archive has no such entry. */
-export function readZipEntry(zip: Buffer, name: string): Buffer | null {
+/**
+ * Returns the decompressed bytes of `name`, or null when the archive has no
+ * such entry. A part that inflates past `maxBytes` throws ZipLimitError.
+ */
+export function readZipEntry(zip: Buffer, name: string, maxBytes = MAX_INFLATED_PART_BYTES): Buffer | null {
   for (const record of centralDirectory(zip)) {
-    if (record.name === name) return inflate(zip, record);
+    if (record.name === name) return inflate(zip, record, maxBytes);
   }
   return null;
 }
 
 /**
  * Every file in the archive (directory entries skipped), in central-directory
- * order. An entry that would inflate past `maxEntryBytes` is not read — the
- * archive's own size says nothing about what a deflate stream expands to —
- * and its name comes back in `skipped`.
+ * order. An entry that would inflate past `maxEntryBytes`, or past what is
+ * left of `maxTotalBytes`, is not read and its name comes back in `skipped`.
+ * The archive's own size field is a hint that lets a cheap skip happen first;
+ * the ceiling is enforced on the inflater, because that field is whatever the
+ * archive's author wrote (audit 2026-09-10).
  */
-export function readZipEntries(zip: Buffer, maxEntryBytes = Infinity): { entries: ZipEntry[]; skipped: string[] } {
+export function readZipEntries(
+  zip: Buffer,
+  maxEntryBytes = Infinity,
+  maxTotalBytes = MAX_INFLATED_TOTAL_BYTES,
+): { entries: ZipEntry[]; skipped: string[] } {
   const entries: ZipEntry[] = [];
   const skipped: string[] = [];
+  let total = 0;
   for (const record of centralDirectory(zip)) {
     if (record.name.endsWith('/')) continue;
-    if (record.uncompressedSize > maxEntryBytes) {
+    const room = Math.min(maxEntryBytes, maxTotalBytes - total);
+    if (record.uncompressedSize > room) {
       skipped.push(record.name);
       continue;
     }
-    entries.push({ name: record.name, data: inflate(zip, record) });
+    let data: Buffer;
+    try {
+      data = inflate(zip, record, room);
+    } catch (err) {
+      if (err instanceof ZipLimitError) {
+        skipped.push(record.name);
+        continue;
+      }
+      throw err;
+    }
+    total += data.length;
+    entries.push({ name: record.name, data });
   }
   return { entries, skipped };
 }
@@ -82,7 +111,7 @@ function* centralDirectory(zip: Buffer): Generator<CentralRecord> {
   }
 }
 
-function inflate(zip: Buffer, record: CentralRecord): Buffer {
+function inflate(zip: Buffer, record: CentralRecord, maxBytes: number): Buffer {
   const { localOffset, compressedSize, method } = record;
   if (localOffset + LOCAL_MIN_LEN > zip.length || zip.readUInt32LE(localOffset) !== LOCAL_SIG) {
     throw new ZipError('corrupt local header');
@@ -90,9 +119,19 @@ function inflate(zip: Buffer, record: CentralRecord): Buffer {
   const dataStart =
     localOffset + LOCAL_MIN_LEN + zip.readUInt16LE(localOffset + 26) + zip.readUInt16LE(localOffset + 28);
   const data = zip.subarray(dataStart, dataStart + compressedSize);
-  if (method === METHOD_STORED) return Buffer.from(data);
-  if (method === METHOD_DEFLATE) return inflateRawSync(data);
-  throw new ZipError(`unsupported compression method ${method}`);
+  if (method === METHOD_STORED) {
+    if (data.length > maxBytes) throw new ZipLimitError(`${record.name} is larger than ${maxBytes} bytes`);
+    return Buffer.from(data);
+  }
+  if (method !== METHOD_DEFLATE) throw new ZipError(`unsupported compression method ${method}`);
+  try {
+    return Number.isFinite(maxBytes) ? inflateRawSync(data, { maxOutputLength: maxBytes }) : inflateRawSync(data);
+  } catch (err) {
+    if ((err as { code?: unknown }).code === 'ERR_BUFFER_TOO_LARGE') {
+      throw new ZipLimitError(`${record.name} inflates past ${maxBytes} bytes`);
+    }
+    throw err;
+  }
 }
 
 function findEndOfCentralDirectory(zip: Buffer): number {

--- a/src/resume/zip.ts
+++ b/src/resume/zip.ts
@@ -69,7 +69,9 @@ export function readZipEntries(
   for (const record of centralDirectory(zip)) {
     if (record.name.endsWith('/')) continue;
     const room = Math.min(maxEntryBytes, maxTotalBytes - total);
-    if (record.uncompressedSize > room) {
+    // zlib refuses a ceiling under one byte, so a full archive skips the rest
+    // outright instead of asking the inflater for nothing.
+    if (room < 1 || record.uncompressedSize > room) {
       skipped.push(record.name);
       continue;
     }

--- a/src/screening/export.test.ts
+++ b/src/screening/export.test.ts
@@ -69,12 +69,24 @@ test('toCsv quotes what needs quoting and marks the gates', () => {
   const csv = toCsv(SCREENING, ROWS);
   const lines = csv.split('\r\n');
   assert.ok(lines[0]!.startsWith('﻿Applicant,Name,File,Status,Bucket,Score,Your adjustment,Adjusted score,Confidence,Gate: EU work authorisation,Gate: German B2,'));
-  assert.ok(lines[1]!.includes(',81,+10 (referral from Ivan),91,high,'), 'the computed score, the correction and its reason, the adjusted number');
+  // The adjustment opens with a sign and is not a number, so it is text-marked for Excel.
+  assert.ok(lines[1]!.includes(",81,'+10 (referral from Ivan),91,high,"), 'the computed score, the correction and its reason, the adjusted number');
   assert.ok(lines[1]!.includes('"Олена, ""QA"""'), 'a comma and quotes inside a cell are escaped');
   assert.ok(lines[1]!.includes(',✓,?,6/7,9,senior,9.8 years across 3 employers · in a role now,To interview,'), 'the career line sits after the level');
   assert.ok(lines[1]!.includes(',Speaks Polish | Spoke at JavaDay 2024,Which level of German? | Who owned the ledger?'), 'stand-out facts before the questions');
   assert.ok(lines[2]!.startsWith('№5,,scan.pdf,unreadable,,,,,,,,'));
   assert.ok(lines[2]!.endsWith('another document of №2; no text layer'));
+});
+
+test('toCsv text-marks a cell that a spreadsheet would run as a formula', () => {
+  const rows: ExportRow[] = [
+    { ...ROWS[0]!, file: "=cmd|' /C calc'!A0.pdf", verdict: '@SUM(1)', questions: ['-2+3'], adjustment: 0, adjustmentNote: null },
+  ];
+  const line = toCsv(SCREENING, rows).split('\r\n')[1]!;
+  assert.ok(line.includes(",'=cmd|' /C calc'!A0.pdf,"), 'the file name an applicant chose');
+  assert.ok(line.includes(",'@SUM(1),"), 'model text');
+  assert.ok(line.includes(",'-2+3"), 'a leading minus that is not a number');
+  assert.ok(line.includes(',81,'), 'a plain number keeps its sign and stays a number');
 });
 
 test('toMarkdown groups by bucket and lists the unread files', () => {

--- a/src/screening/export.ts
+++ b/src/screening/export.ts
@@ -56,8 +56,18 @@ export const DECISION_LABELS: Record<string, string> = {
   declined: 'Declined',
 };
 
+/*
+ * Excel and LibreOffice run a cell that opens with = + - @ (or a tab or CR)
+ * as a formula, quoted or not; an apostrophe makes it text and stays out of
+ * sight. An applicant chooses their file name and the model quotes their
+ * resume, so both reach this table. A plain signed number is left alone.
+ */
+const FORMULA_LEADER = /^[=+\-@\t\r]/;
+const PLAIN_NUMBER = /^[-+]?\d+(?:[.,]\d+)?$/;
+
 function csvCell(v: unknown): string {
-  const s = v === null || v === undefined ? '' : String(v);
+  let s = v === null || v === undefined ? '' : String(v);
+  if (FORMULA_LEADER.test(s) && !PLAIN_NUMBER.test(s)) s = `'${s}`;
   return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 

--- a/src/verification/liveness.ts
+++ b/src/verification/liveness.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { DEFAULT_USER_AGENT, stripHtml } from '../http';
+import { checkPostingUrl, fetchPublicHops, type HopResult } from '../jobs/posting-url';
 
 /**
  * F1 liveness ladder (ADR 0016): free checks before the AI verify.
@@ -345,25 +346,12 @@ function hostOf(url: string): string {
 }
 
 /**
- * Rung-2 SSRF guard for stored (possibly hand-pasted) URLs: http(s) only,
- * no credentials, no IP literals, no localhost/intranet names.
+ * Rung-2 SSRF guard for stored (possibly hand-pasted) URLs — the project's
+ * one guard (posting-url.ts), not a second reading of the same rules: two
+ * implementations had drifted apart by the 2026-09-10 audit.
  */
 export function isFetchableJobUrl(raw: string): boolean {
-  let u: URL;
-  try {
-    u = new URL(raw);
-  } catch {
-    return false;
-  }
-  if (u.protocol !== 'https:' && u.protocol !== 'http:') return false;
-  if (u.username || u.password) return false;
-  const host = u.hostname.toLowerCase();
-  if (host === 'localhost' || host.endsWith('.localhost')) return false;
-  if (host.endsWith('.local') || host.endsWith('.internal') || host.endsWith('.lan')) return false;
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) return false;
-  if (host.includes(':') || host.startsWith('[')) return false;
-  if (!host.includes('.')) return false;
-  return true;
+  return checkPostingUrl(raw).ok;
 }
 
 // ---------------------------------------------------------------------------
@@ -398,22 +386,32 @@ async function checkPostingPage(url: string): Promise<LivenessVerdict> {
   // A pasted posting often has no URL at all — that is not a dangerous link (#161).
   if (url.trim().length === 0) return v('uncertain', 'no_url');
   if (!isFetchableJobUrl(url)) return v('uncertain', 'unfetchable_url');
-  const got = await fetchRaw(url, 'follow');
-  if (!got) return v('uncertain', 'network_error');
-  // A public host can redirect into the private range. classifyLiveness would
-  // reject the result anyway ('redirected_off_posting' fires on a host change),
-  // but that check exists to spot a bounce off the posting, not to hold a
-  // security boundary — re-run the guard so the refusal is deliberate.
-  if (!isFetchableJobUrl(got.finalUrl)) return v('uncertain', 'unfetchable_url');
-  return classifyLiveness(got.status, url, got.finalUrl, got.body);
+  // A public host can redirect into the private range, so the hops are walked
+  // one by one and each is guarded before it is requested. classifyLiveness
+  // still reads the URL that answered ('redirected_off_posting').
+  let got: HopResult<RawAnswer>;
+  try {
+    got = await fetchPublicHops(url, async (hop) => {
+      const answer = await fetchRaw(hop, 'manual');
+      if (!answer) throw new Error('network');
+      return answer;
+    });
+  } catch {
+    return v('uncertain', 'network_error');
+  }
+  if (!got.ok) return v('uncertain', 'unfetchable_url');
+  return classifyLiveness(got.response.status, url, got.url, got.response.body);
+}
+
+interface RawAnswer {
+  status: number;
+  location: string | null;
+  body: string;
 }
 
 // Not fetchWithRetry: here a 404 is a verdict, not an error to throw on,
-// and rung 1 must refuse redirects while rung 2 must follow and record them.
-async function fetchRaw(
-  url: string,
-  redirect: 'error' | 'follow',
-): Promise<{ status: number; finalUrl: string; body: string } | null> {
+// and rung 1 must refuse redirects while rung 2 walks them itself.
+async function fetchRaw(url: string, redirect: 'error' | 'manual'): Promise<RawAnswer | null> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
@@ -426,7 +424,7 @@ async function fetchRaw(
       },
     });
     const body = await resp.text().catch(() => '');
-    return { status: resp.status, finalUrl: resp.url || url, body };
+    return { status: resp.status, location: resp.headers.get('location'), body };
   } catch {
     return null;
   } finally {

--- a/src/watchlist/resolve.ts
+++ b/src/watchlist/resolve.ts
@@ -1,11 +1,11 @@
 import { AtsType } from '@prisma/client';
-import { fetchWithRetry, HttpError } from '../http';
+import { HttpError } from '../http';
 import { probeAts } from '../ats-probe';
 import { getSettings, getSourceKeys } from '../settings';
 import { aiCrawlerTokens, parseAiEngineConfig, type AiProviderId } from '../ai-engine';
 import { config } from '../config';
 import { extractAtsToken } from '../text-utils';
-import { checkPostingUrl } from '../jobs/posting-url';
+import { checkPostingUrl, fetchPublicUrl } from '../jobs/posting-url';
 import { bindingTokens, robotsAllows } from '../robots';
 import { looksLikeFeed } from '../fetchers/feed';
 import { boardHints, declaredJobFeeds, looksLikeChallenge, wellKnownFeeds } from './scan';
@@ -245,10 +245,11 @@ export async function liveResolveIo(): Promise<ResolveIo> {
   return {
     async get(url) {
       try {
-        const resp = await fetchWithRetry(url, { timeoutMs: FETCH_TIMEOUT_MS });
+        const resp = await fetchPublicUrl(url, { timeoutMs: FETCH_TIMEOUT_MS });
         return { status: resp.status, url: resp.url || url, body: await resp.text() };
       } catch (err) {
-        // fetchWithRetry throws on every non-2xx; the status is the answer.
+        // fetchWithRetry throws on every non-2xx; the status is the answer. A
+        // hop the guard refused is no answer at all, like a host that is down.
         if (err instanceof HttpError) return { status: err.status, url, body: err.body ?? '' };
         return { status: 0, url, body: '' };
       }

--- a/src/web/public/target.mjs
+++ b/src/web/public/target.mjs
@@ -244,8 +244,9 @@ export function locateQuote(text, quote) {
   return m ? { start: m.index, end: m.index + m[0].length } : null;
 }
 
+// Both quotes too: the output lands in a title="…" attribute as well as in text.
 function escapeHtml(s) {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
 /**

--- a/src/web/target.test.ts
+++ b/src/web/target.test.ts
@@ -132,7 +132,16 @@ test('highlightHtml wraps spans, escapes html and drops overlaps', async () => {
     { start: 3, end: 7, cls: 'y' },
     { start: 6, end: 7, cls: 'z', title: 'q"t' },
   ]);
-  assert.equal(html, 'a <mark class="x">&lt;b&gt;</mark> <mark class="z" title="q&quot;t">c</mark> d'.replace('&quot;', '"'));
+  assert.equal(html, 'a <mark class="x">&lt;b&gt;</mark> <mark class="z" title="q&quot;t">c</mark> d');
+});
+
+test('highlightHtml keeps a quote in a term inside the title attribute', async () => {
+  // The title is built from a keyword term, which the model reads off the
+  // posting: a quote in it must not close the attribute (audit 2026-09-10).
+  const { highlightHtml } = await matcher;
+  const html = highlightHtml('redis', [{ start: 0, end: 5, cls: 'x', title: 'a" onmouseover="alert(1)' }]);
+  assert.equal(html, '<mark class="x" title="a&quot; onmouseover=&quot;alert(1)">redis</mark>');
+  assert.doesNotMatch(html, /onmouseover="alert/);
 });
 
 test('target-page module imports without a DOM and exposes init', async () => {


### PR DESCRIPTION
The `security-p1` block of TASKS §20 — the two P1s and four P2s of [docs/audit-2026-09-10.md](https://github.com/applypack/applypack/blob/improvement-plan-2026-09/docs/audit-2026-09-10.md) (PR #223). Patch release: 2.5.3.

**SEC-1/SEC-3 — one SSRF guard, three layers** (`src/jobs/posting-url.ts`). The private-address check was a name check; `localhost.`, `[::ffff:169.254.169.254]` and `127.0.0.1.nip.io` all passed it. Now: `checkPostingUrl` (pure — scheme, credentials, ADR 0005, private names, address literals in every spelling incl. IPv4-mapped and NAT64), `resolvesToPublic` (every address behind the name, before a socket opens), `fetchPublicHops` (redirects walked one hop at a time, each through both checks, ≤ 5, a refused hop never requested). Wired into the pasted-posting fetch, watched feeds and careers pages, the probes, the watchlist resolver, Teamtailor custom domains, and the liveness ladder — whose own second guard is gone. `fetchWithRetry` hands a 3xx back when the caller asked for `redirect: 'manual'` (a 304 is still thrown).

**SEC-2 — the zip reader caps the inflater** (`src/resume/zip.ts`). It compared against the archive's own size field and inflated with no ceiling. Now `inflateRawSync(…, { maxOutputLength })` per entry, a total for an archive of resumes (512 MB) and a per-part cap for a .docx (64 MB); a lying header is skipped, not read.

**SEC-4** a quote in a keyword term no longer breaks out of the highlight's `title` attribute (`target.mjs`, site copy in lockstep). **SEC-5** the screening CSV text-marks a cell that opens like a formula. **PRIV-2** a failed CLI call logs stderr, the exit code and the signal — never `err`, whose message is the command line, i.e. the prompt.

**Verified**
- `lint:types` green; 2 182 tests (12 new: the three bypasses, the resolver, the hop walk, a lying zip header, the total ceiling, the attribute quote, the formula cells, the CLI reasons).
- Live, on a real socket through `dist/`: a 302 chain lands on the final hop with the 3xx passthrough; a hop into `169.254.169.254` is refused before any request; with the real resolver, `127.0.0.1.nip.io` is refused.
- `code-review-expert` pass: drained redirect bodies, a zero-room ceiling that zlib would have refused, the .docx limit message, a signal's name.

**Behaviour changes to know**
- A stored feed / careers URL carrying credentials, a bare intranet name, or one that resolves to a private address is refused from now on (`unknown` on `/companies` with the guard's sentence).
- The liveness ladder now treats a redirect onto an ADR 0005 host as `unfetchable_url` (it used to fetch and judge the page).

**Follow-ups (P3)**
- DNS rebinding between our lookup and the socket's is not pinned (needs a custom dispatcher — a dependency); documented in the module header.
- `dns.lookup` has no timeout of its own; the OS resolver's applies.
- The watchlist resolver maps a refused hop to status 0 ("nothing here") rather than the guard's sentence.
- The CSV adjustment cell reads `'+10 (reason)` in a plain text viewer (Excel and LibreOffice hide the mark).
- `deps-hono` (SEC-6) is the next block.