### PR TITLE
deps: hono 4.13.7 for the parseBody advisory (stacked on #224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3319,6 +3319,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.5.4]: https://github.com/applypack/applypack/compare/v2.5.3...v2.5.4
 [2.5.3]: https://github.com/applypack/applypack/compare/v2.5.2...v2.5.3
 [2.5.2]: https://github.com/applypack/applypack/compare/v2.5.1...v2.5.2
 [2.5.1]: https://github.com/applypack/applypack/compare/v2.5.0...v2.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.5.4] — 2026-09-10
+
+### Security
+- `hono` 4.12.15 → 4.13.7 and `@hono/node-server` 1.19.14 → 1.19.17: ten
+  advisories on the old version, one of them on a path this dashboard uses
+  (unbounded dot-notation nesting in `parseBody()`, GHSA-g6gw-c38x-mqfc).
+  The `package.json` floors now name the fixed versions, so a fresh install
+  cannot resolve below them. What is left in `npm audit` is `uuid` behind
+  `node-cron` 3, on a code path this project never calls; the 4.x major is
+  a separate decision (TASKS §20.4).
+
 ## [2.5.3] — 2026-09-10
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applypack",
-  "version": "1.69.0",
+  "version": "2.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applypack",
-      "version": "1.69.0",
+      "version": "2.5.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -511,9 +511,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1164,9 +1164,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
   "license": "MIT",
@@ -45,12 +45,12 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.121.0",
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^1.19.17",
     "@prisma/client": "^6.1.0",
     "@xmldom/xmldom": "0.9.12",
     "docx": "9.7.1",
     "dotenv": "^16.4.5",
-    "hono": "^4.6.14",
+    "hono": "^4.13.7",
     "jszip": "3.10.1",
     "node-cron": "^3.0.3",
     "pdfkit": "0.20.2",


### PR DESCRIPTION
Block `deps-hono` of TASKS §20 (SEC-6 in `docs/audit-2026-09-10.md`). **Stacked on #224 — retarget to `main` after #224 merges, before its branch is deleted.** Patch release: 2.5.4.

`npm audit fix`: `hono` 4.12.15 → 4.13.7, `@hono/node-server` 1.19.14 → 1.19.17 — the only two packages that change. Ten advisories on the old `hono`; the one on a path this dashboard uses is the unbounded dot-notation nesting in `parseBody()` (GHSA-g6gw-c38x-mqfc). The `package.json` floors now name the fixed versions.

**Verified**
- `lint:types` green, 2 182 tests.
- The built dashboard on the bumped `hono`, against the compose Postgres: `/health`, `/jobs` (with the three facets), `/applications`, `/settings`, `/companies`, `/resumes`, `/runs`, `/discovery`, `/screen`, `/welcome`, `/countries.json`, `/static/target.mjs` — all 200, byte sizes identical to the running 2.5.2 container; a cross-origin POST still 403.

**Left in `npm audit`, on purpose**
- `uuid` < 11.1.1 behind `node-cron` 3 (moderate; the `buf` path this project never calls) — the 4.x major is TASKS §20.4.
- `deepmerge-ts` < 8 behind `@prisma/config` — Prisma's own dependency; goes with the Prisma 7 decision.

**Observation, not fixed here:** with `DATABASE_URL` pointing at a port with no Postgres (the `.env` on this host says 5432; compose publishes 5433), every route answers 500 — `/health` included, which should be the 503 its handler writes, and `/static/*`, which needs no database. Something before the routes touches Prisma on every request. Filed under `route-hardening` in TASKS §20.