### PR TITLE
metadata: 33 sources in every public copy, the guard reads them all, two false sentences (stacked on #225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ All notable changes to this project are documented here. The format follows
   `node-cron` 3, on a code path this project never calls; the 4.x major is
   a separate decision (TASKS §20.4).
 
+### Fixed
+- Two sentences that were not true: the wizard's "only one search runs at
+  a time" (up to eight have run at once since v1.10.0) and the resume
+  page's "press Activate" (the button is Run).
+- The package description said 24 sources and the launch drafts 22, against
+  the 33 kinds the code has; `source-count.test.ts` now reads those copies
+  too, so the number cannot drift there again. The description also leads
+  with "runs locally with Docker" rather than "self-hosted".
+
 ## [2.5.3] — 2026-09-10
 
 ### Security

--- a/docs/launch/awesome-selfhosted-pr.md
+++ b/docs/launch/awesome-selfhosted-pr.md
@@ -6,7 +6,7 @@
 > machine-generated contributions that break the rules: Nazar reviews
 > this draft and submits it by hand from his own account.
 
-ApplyPack fits the list as a job-search console that checks 22 sources
+ApplyPack fits the list as a job-search console that checks 33 kinds of source
 hourly and keeps every AI report in the user's own Postgres; the live
 scoring demo at https://applypack.dev/demo/ goes into the entry's
 `demo_url`. Format below was checked against their CONTRIBUTING.md and a

--- a/docs/launch/reddit-selfhosted.md
+++ b/docs/launch/reddit-selfhosted.md
@@ -23,10 +23,11 @@ https://applypack.dev/demo/
 
 What it does:
 
-* Checks 22 sources hourly: ten ATS vendors (Greenhouse, Lever, Ashby,
-  Workable, SmartRecruiters, Recruitee, Breezy, BambooHR, Pinpoint,
-  Rippling) on company boards you pick, eleven aggregators, and the
-  monthly HN "Who is hiring" thread
+* Checks 33 kinds of source hourly: twelve ATS vendors (Greenhouse, Lever,
+  Ashby, Workable, SmartRecruiters, Recruitee, Breezy, BambooHR, Pinpoint,
+  Rippling, Personio, Teamtailor) on company boards you pick, twenty
+  aggregators with the monthly HN "Who is hiring" thread among them, and
+  any RSS or Atom feed you paste
 * An AI classifier reads each full description against your profile.
   "Remote · Germany" is not a US-remote match, and "full-stack" in a
   title is not a stack match; both rules exist because both burned me

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -46,7 +46,7 @@ model marked it cannot-claim against the original resume, and typing a
 word is not evidence. Delete TypeScript to watch the primary-stack cap
 bite.
 
-Scoring is one corner of the console. A worker checks 22 sources hourly
+Scoring is one corner of the console. A worker checks 33 kinds of source hourly
 (Greenhouse, Lever, Ashby and seven more ATS vendors on boards you pick,
 eleven aggregators, the monthly HN "Who is hiring" thread), a classifier
 reads each posting against your profile, and Telegram pings you above

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "applypack",
   "version": "2.5.4",
   "private": true,
-  "description": "Self-hosted AI console for the whole job search: finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 24 sources, 5 swappable AI backends, your data in your own Postgres.",
+  "description": "Runs locally with Docker: an AI console for the whole job search that finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 33 sources, 5 swappable AI backends, your data in your own Postgres, self-hosted on a VPS if you like.",
   "license": "MIT",
   "author": "Nazar Boyko (https://github.com/nazboyko)",
   "repository": {

--- a/src/source-count.test.ts
+++ b/src/source-count.test.ts
@@ -28,13 +28,32 @@ function countedSourcePhrases(text: string): number[] {
   return [...text.matchAll(/\b(\d+) (?:kinds of (?:job )?sources?|job sources?|sources?)\b/g)].map((m) => Number(m[1]));
 }
 
-const DOCS = ['README.md', 'site/public/index.html'];
+/*
+ * Every public copy of the number. package.json's description is what npm
+ * and GitHub tooling show; the launch drafts are what gets posted. The
+ * 2026-09-10 audit found 24 and 22 in those while README and the site said 33.
+ */
+const DOCS = [
+  'README.md',
+  'site/public/index.html',
+  'docs/launch/show-hn.md',
+  'docs/launch/reddit-selfhosted.md',
+  'docs/launch/awesome-selfhosted-pr.md',
+];
 
-test('the README and the landing page state the number of source kinds the enum has', () => {
+function publicCopies(): [string, string][] {
+  const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')) as { description?: string };
+  return [
+    ...DOCS.map((file): [string, string] => [file, readFileSync(join(ROOT, file), 'utf8')]),
+    ['package.json description', pkg.description ?? ''],
+  ];
+}
+
+test('every public copy states the number of source kinds the enum has', () => {
   const expected = sourceKindCount();
   assert.ok(expected >= 30, `enum parse looks wrong: ${expected}`);
-  for (const file of DOCS) {
-    const numbers = countedSourcePhrases(readFileSync(join(ROOT, file), 'utf8'));
+  for (const [file, text] of publicCopies()) {
+    const numbers = countedSourcePhrases(text);
     assert.ok(numbers.length > 0, `${file} no longer states a source count`);
     assert.deepEqual(
       numbers,

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -396,7 +396,7 @@ const SearchCard: FC<ResumeDetailProps['search'] & { resumeId: number }> = ({
             </ActionForm>
           </div>
           <Hint class="mt-3">
-            It starts switched off — your current search keeps running until you press Activate on
+            It starts switched off — your current search keeps running until you press Run on
             Settings → Profile. Location, salary and alert routing are yours to set; a resume
             cannot know them.
           </Hint>

--- a/src/web/pages/welcome.tsx
+++ b/src/web/pages/welcome.tsx
@@ -510,7 +510,7 @@ const ProfileStep: FC<WelcomeProps> = ({ profile, steps }) => {
             <div class="space-y-3 border-t border-line px-4 py-4">
               <Hint class="!mt-0">
                 It becomes a second search of its own, linked to that resume — one search per
-                resume. Only one runs at a time; you switch between them on Settings → Profile.
+                resume. Up to eight run at once; each is switched on or off on Settings → Profile.
               </Hint>
               <form
                 method="post"


### PR DESCRIPTION
Block `metadata-drift` of TASKS §20 (DOCS-1, COPY-1 in `docs/audit-2026-09-10.md`; plan §9, §15). **Stacked on #225 → #224 — retarget after each merge, before the base branch is deleted.** Rides in the 2.5.4 release.

- `package.json` description: 24 → 33 sources, opens with "Runs locally with Docker" (plan §9), self-hosted second.
- `docs/launch/*.md`: 22 → 33 kinds of source; "ten ATS vendors" → twelve, with Personio and Teamtailor named; the aggregator count.
- `src/source-count.test.ts` now derives the number from the enum for **every** public copy: README, the landing page, the three launch drafts and the package description — a new source fails CI until each says the new number.
- Two sentences that were false: `/welcome` "Only one runs at a time" → up to eight; `/resumes/:id` "press Activate" → Run.

**Verified:** `lint:types` green, 2 182 tests; the guard was watched failing on the old numbers ("show-hn.md says 22 where the enum has 33") before the copies were fixed.

**Owner items (not in the repo):** GitHub About → the package description; the social preview from `docs/brand/social-card.png`; label three or four open issues `good first issue` (#203, #204, #208 are one-file) — the landing, README and CONTRIBUTING send newcomers to an empty label today.