### PR TITLE
data-integrity: uniques and FK indexes (ADR 0053), the held stamp written with the row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.6.0] — 2026-09-10
+
+### Fixed
+- **A held match is stamped with its row.** Outside the alert window a
+  match was stored NEW and then stamped `alertHeldAt` in a second
+  statement; a crash between the two left a match nothing would ever send,
+  and the unique key kept it from being fetched again. The stamp is written
+  in the same insert as the verdicts (ADR 0053).
+- **One row per alert destination.** The same Telegram bot and chat, or the
+  same Discord webhook, added twice was two active rows and every alert
+  twice, forever. The database refuses the second now, the form says which
+  row already has it before it sends a test message, and the migration
+  collapses existing duplicates onto the oldest row — a search routed to a
+  later copy follows it.
+- **The same document twice in one screening is one row.** The intake read
+  its list of known files once, so two uploads at once both added the
+  file; a unique on the screening and the text's hash settles it, and a
+  file no text came out of is known by its bytes rather than by name and
+  size. Existing duplicates go with the migration, their verdicts with them.
+- A pasted posting is one transaction: the company row and the job row
+  appear together, and the same paste from two tabs is settled by the
+  unique key instead of a read the other tab can outrun.
+
+### Changed
+- Indexes on the referencing side of four foreign keys
+  (`job.crossListedOfJobId`, `job.appliedResumeId`, `screening.jobId`,
+  `cover_letter.resumeId`): a job delete no longer scans the job table for
+  cross-listings, and a resume delete no longer scans it for applications.
+
 ## [2.5.4] — 2026-09-10
 
 ### Security
@@ -3328,6 +3357,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.6.0]: https://github.com/applypack/applypack/compare/v2.5.4...v2.6.0
 [2.5.4]: https://github.com/applypack/applypack/compare/v2.5.3...v2.5.4
 [2.5.3]: https://github.com/applypack/applypack/compare/v2.5.2...v2.5.3
 [2.5.2]: https://github.com/applypack/applypack/compare/v2.5.1...v2.5.2

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2077,7 +2077,7 @@ then integrity, then the plan.
 Each block is one branch = one PR; a runtime block gets a tag per the
 release-discipline skill, a docs/site block does not.
 
-- [ ] **`security-p1`** (patch) — SEC-1 resolve every address before
+- [x] **`security-p1`** (patch) — shipped v2.5.3, #224. SEC-1 resolve every address before
       connecting, refuse private ranges incl. IPv4-mapped IPv6, manual
       redirects with the check per hop, never make the request on a
       refusal; SEC-3 `liveness.ts:isFetchableJobUrl` calls the same guard;
@@ -2088,11 +2088,11 @@ release-discipline skill, a docs/site block does not.
       `= + - @`; PRIV-2 the CLI failure log line carries stderr and the
       exit code, never `err`. Tests: the three bypass URLs, a crafted zip
       with a lying header, the attribute-XSS term, the formula cell.
-- [ ] **`deps-hono`** (patch) — SEC-6 `npm audit fix` → hono 4.13.7 +
+- [x] **`deps-hono`** (patch) — shipped v2.5.4, #225. SEC-6 `npm audit fix` → hono 4.13.7 +
       node-server 1.19.17; lint, tests, a smoke of `/settings` and one
       multi-value form (gotcha 1 sits on `parseBody`). `node-cron` 4 is a
       separate decision (§ needs-maintainer-review).
-- [ ] **`metadata-drift`** (docs, no tag) — DOCS-1 package.json 24 → 33
+- [x] **`metadata-drift`** (docs, no tag) — shipped with v2.5.4, #226. DOCS-1 package.json 24 → 33
       and open with "Runs locally with Docker" (§9); the three launch
       drafts 22 → 33, "ten" → "twelve"; `source-count.test.ts` `DOCS` +=
       package.json (the JSON field) and `docs/launch/*.md`; COPY-1 the two
@@ -2100,7 +2100,7 @@ release-discipline skill, a docs/site block does not.
       honestly until the label has entries. Owner: GitHub About text
       (TASKS §14), label 3–5 open issues (`#203`, `#204`, `#208` are
       scoped), the social preview.
-- [ ] **`data-integrity`** (minor) — DATA-2 one migration indexing
+- [x] **`data-integrity`** (minor) — shipped v2.6.0 (ADR 0053); DATA-9 left for a later pass, DATA-10's scratch-row / `isDefault` / `deleteProfile` races too. DATA-2 one migration indexing
       `Job.crossListedOfJobId`, `Job.appliedResumeId`, `Screening.jobId`,
       `CoverLetter.resumeId`; DATA-3 `alertHeldAt` in the create
       (`mayAlert` is known at `:107`) and the `ALERTED` write guarded as

--- a/docs/adr/0053-uniqueness-lives-in-the-database.md
+++ b/docs/adr/0053-uniqueness-lives-in-the-database.md
@@ -1,0 +1,58 @@
+# 0053 — Uniqueness lives in the database, and a row's state is written with the row
+
+**Status:** accepted (2026-09-10) — audit 2026-09-10 (DATA-3, DATA-7, DATA-8, DATA-10), TASKS §20 block `data-integrity`
+
+## Context
+
+Three places kept an invariant by reading before writing: "this bot and
+chat are not added yet" (a bare `create` on `notification_target`), "this
+file is not in the screening yet" (a list read once at the top of the
+upload loop), "this posting is not pasted yet" (`findUnique` then
+`create`). Each held as long as one request ran at a time. Two tabs, an
+hourly tick beside a "Fetch now", or a double-clicked submit made every one
+of them write twice — two destinations that each get every alert, two
+applicants of one person, a 500 on the paste. `Job (companyId, externalId)`
+already did it the other way: a unique key, and a `P2002` on the insert
+counted as the duplicate it is.
+
+A fourth place wrote a row's state in a second statement: a match found
+outside the alert window was inserted NEW and then stamped `alertHeldAt`.
+Between the two, a crash left a match with no stamp, which the delivery
+pass never picks up — and the unique key on the job means the posting is
+never fetched again either.
+
+## Decision
+
+- **A "one of these" rule is a unique constraint**, and the write path
+  catches `P2002` and reads it as the duplicate: `notification_target`
+  on (`botToken`, `chatId`) and on `webhookUrl` — NULLs are distinct to
+  Postgres, so a Telegram row never collides with a Discord one; `applicant`
+  on (`screeningId`, `textHash`), where a file no text came out of is
+  hashed by its bytes; the pasted job inside one transaction with its
+  company row. A request-time check stays where it saves a side effect
+  (the target form asks before it sends a test message), never as the only
+  guard.
+- **The migration collapses what is already duplicated onto the oldest
+  row** and re-points what referenced a later copy (a search routed to a
+  duplicate destination follows it). A constraint that fails to apply on a
+  populated database is worse than none.
+- **What is known when the row is inserted is written with the row.**
+  Whether a match is held for the alert window is decided before the
+  insert, so the stamp goes in the same statement as the verdicts (the
+  nested `scores.create` already made a scored job atomic for the same
+  reason).
+- **The referencing side of a foreign key is indexed** when a delete on the
+  referenced table is routine: cleanup deletes jobs nightly, and each delete
+  scanned `job` for cross-listings.
+
+## Consequences
+
+- A repeat destination or a repeat file is refused by the database with a
+  plain sentence on the page; nothing is written twice.
+- Two uploads of the same folder at once produce one row per file, whichever
+  tab wins; the loser's copy is counted as a repeat, not an error.
+- Existing duplicates disappear at upgrade. Later copies of an applicant
+  take their verdicts with them; `sameAsId` pointers to a removed copy
+  already read as "no longer here" on the page.
+- `alertHeldAt` is never set by a second statement; `deliverHeldAlerts` is
+  unchanged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,6 +61,7 @@ consequences (what we accept). Aim for 15–30 lines each.
 - [0050 — The rubric is a list of criteria the person chooses, answered one by one with a quote](./0050-the-rubric-is-a-list-of-criteria-the-person-chooses.md)
 - [0051 — A shortlist is compared head to head, twice, and the comparison is never a score](./0051-a-shortlist-is-compared-head-to-head-twice.md)
 - [0052 — Calibration reports agreement with the person's decisions and never tunes the rubric by itself](./0052-calibration-reports-agreement-and-never-tunes-the-rubric.md)
+- [0053 — Uniqueness lives in the database, and a row's state is written with the row](./0053-uniqueness-lives-in-the-database.md)
 
 ## When to write a new one
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "private": true,
   "description": "Runs locally with Docker: an AI console for the whole job search that finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 33 sources, 5 swappable AI backends, your data in your own Postgres, self-hosted on a VPS if you like.",
   "license": "MIT",

--- a/prisma/migrations/20260910130000_fk_indexes_and_unique_destinations/migration.sql
+++ b/prisma/migrations/20260910130000_fk_indexes_and_unique_destinations/migration.sql
@@ -1,0 +1,33 @@
+-- Audit 2026-09-10 (DATA-2, DATA-7, DATA-8; ADR 0053).
+
+-- The referencing side of four foreign keys, so a delete on the referenced
+-- row no longer scans the referencing table.
+CREATE INDEX "job_crossListedOfJobId_idx" ON "job"("crossListedOfJobId");
+CREATE INDEX "job_appliedResumeId_idx" ON "job"("appliedResumeId");
+CREATE INDEX "screening_jobId_idx" ON "screening"("jobId");
+CREATE INDEX "cover_letter_resumeId_idx" ON "cover_letter"("resumeId");
+
+-- One row per destination. Duplicates collapse onto the oldest row; a search
+-- routed to a later copy follows it, so no alert changes chat.
+WITH ranked AS (
+  SELECT id, FIRST_VALUE(id) OVER (PARTITION BY "kind", "botToken", "chatId", "webhookUrl" ORDER BY id) AS keep
+  FROM "notification_target"
+)
+UPDATE "profile" p SET "notificationTargetId" = r.keep
+FROM ranked r WHERE p."notificationTargetId" = r.id AND r.id <> r.keep;
+
+WITH ranked AS (
+  SELECT id, FIRST_VALUE(id) OVER (PARTITION BY "kind", "botToken", "chatId", "webhookUrl" ORDER BY id) AS keep
+  FROM "notification_target"
+)
+DELETE FROM "notification_target" t USING ranked r WHERE t.id = r.id AND r.id <> r.keep;
+
+CREATE UNIQUE INDEX "notification_target_botToken_chatId_key" ON "notification_target"("botToken", "chatId");
+CREATE UNIQUE INDEX "notification_target_webhookUrl_key" ON "notification_target"("webhookUrl");
+
+-- The same document twice in one screening is one row: later copies go (their
+-- verdicts cascade), the first stays with its number.
+DELETE FROM "applicant" a USING "applicant" b
+WHERE a."screeningId" = b."screeningId" AND a."textHash" = b."textHash" AND a.id > b.id;
+
+CREATE UNIQUE INDEX "applicant_screeningId_textHash_key" ON "applicant"("screeningId", "textHash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -234,6 +234,11 @@ model Job {
   screenings    Screening[]
 
   @@unique([companyId, externalId])
+  // Postgres does not index the referencing side of a foreign key: without
+  // these, every job delete scans job for cross-listings and every resume
+  // delete scans job for applications (audit 2026-09-10, DATA-2).
+  @@index([crossListedOfJobId])
+  @@index([appliedResumeId])
   @@index([status, fetchedAt])
   // Delivery reads the held rows on every heartbeat; almost always none.
   @@index([alertHeldAt])
@@ -421,6 +426,12 @@ model NotificationTarget {
   lastUsed   DateTime?
   profiles   Profile[]
 
+  // One row per destination (ADR 0053): the same bot and chat, or the same
+  // webhook, added twice used to be two active rows and every alert twice.
+  // NULLs are distinct to Postgres, so a Telegram row never collides with a
+  // Discord one.
+  @@unique([botToken, chatId])
+  @@unique([webhookUrl])
   @@map("notification_target")
 }
 
@@ -661,6 +672,7 @@ model CoverLetter {
   createdAt        DateTime @default(now())
 
   @@index([jobId, createdAt])
+  @@index([resumeId])
   @@map("cover_letter")
 }
 
@@ -760,6 +772,7 @@ model Screening {
   comparisons ScreeningComparison[]
 
   @@index([retainUntil])
+  @@index([jobId])
   @@map("screening")
 }
 
@@ -814,6 +827,9 @@ model Applicant {
   verdicts ScreeningVerdict[]
 
   @@unique([screeningId, number])
+  // The same document twice is one row (ADR 0053): the request-time check
+  // reads a snapshot, and two uploads at once both missed it.
+  @@unique([screeningId, textHash])
   @@index([screeningId, parseStatus])
   @@map("applicant")
 }

--- a/src/jobs/manual-job.ts
+++ b/src/jobs/manual-job.ts
@@ -1,4 +1,4 @@
-import { AtsType, JobStatus } from '@prisma/client';
+import { AtsType, JobStatus, Prisma } from '@prisma/client';
 import type { Job } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../db';
@@ -52,39 +52,55 @@ export async function createManualJob(
   // ("&nbsp;", "&amp;") — decode them so the stored text reads clean.
   const description = decodeHtmlEntities(f.description).trim();
   const atsToken = slugify(f.companyName);
-  const company = await prisma.company.upsert({
-    where: { atsType_atsToken: { atsType: AtsType.MANUAL, atsToken } },
-    update: {},
-    create: { name: f.companyName, atsType: AtsType.MANUAL, atsToken, active: false },
-  });
   const externalId = `manual-${hashShortId(`${f.title}\n${description}`)}`;
-  const existing = await prisma.job.findUnique({
-    where: { companyId_externalId: { companyId: company.id, externalId } },
-  });
-  if (existing) return { kind: 'existing', job: existing };
-
   // A pasted posting has no structured fields: the parser reads the string
   // the user typed (ADR 0031), and nothing here rewrites that string.
   const place = parseLocation(f.location);
-  const job = await prisma.job.create({
-    data: {
-      companyId: company.id,
-      externalId,
-      title: f.title,
-      url: f.url,
-      location: f.location,
-      workplace: place.workplace,
-      countries: place.countries,
-      regions: place.regions,
-      locationSource: place.source,
-      description,
-      salaryMin: f.salaryMin ?? null,
-      salaryMax: f.salaryMax ?? null,
-      postedAt: new Date(),
-      status: JobStatus.SAVED,
-    },
-    include: { company: { select: { name: true, atsType: true } } },
+  const jobInclude = { company: { select: { name: true, atsType: true } } } as const;
+  // One transaction: the company row and the job row appear together or not
+  // at all, and the same paste from two tabs at once (/jobs/new and
+  // /screen/new both land here) is settled by the unique key, not by a read
+  // that the other tab can outrun (audit 2026-09-10, DATA-10).
+  const found = await prisma.$transaction(async (tx) => {
+    const company = await tx.company.upsert({
+      where: { atsType_atsToken: { atsType: AtsType.MANUAL, atsToken } },
+      update: {},
+      create: { name: f.companyName, atsType: AtsType.MANUAL, atsToken, active: false },
+    });
+    const where = { companyId_externalId: { companyId: company.id, externalId } };
+    const existing = await tx.job.findUnique({ where, include: jobInclude });
+    if (existing) return { kind: 'existing' as const, job: existing, company };
+    try {
+      const job = await tx.job.create({
+        data: {
+          companyId: company.id,
+          externalId,
+          title: f.title,
+          url: f.url,
+          location: f.location,
+          workplace: place.workplace,
+          countries: place.countries,
+          regions: place.regions,
+          locationSource: place.source,
+          description,
+          salaryMin: f.salaryMin ?? null,
+          salaryMax: f.salaryMax ?? null,
+          postedAt: new Date(),
+          status: JobStatus.SAVED,
+        },
+        include: jobInclude,
+      });
+      return { kind: 'created' as const, job, company };
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        const raced = await tx.job.findUnique({ where, include: jobInclude });
+        if (raced) return { kind: 'existing' as const, job: raced, company };
+      }
+      throw err;
+    }
   });
+  if (found.kind === 'existing') return { kind: 'existing', job: found.job };
+  const { job, company } = found;
   const classified =
     opts.classify === false ? false : await classifyExistingJob(job, { keepStatus: true });
   logger.info({ jobId: job.id, company: company.name, classified }, 'web: manual job saved');

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -284,6 +284,13 @@ export async function processNormalizedJobs(
       continue;
     }
 
+    // Whether the alert is skipped (issue #50) or held for the window is known
+    // before the row exists, so the held stamp is written WITH the row: a
+    // second statement could leave a NEW match with no stamp, which nothing
+    // would ever send (audit 2026-09-10, DATA-3).
+    const skipsAlert =
+      finalClassification.red_flags.includes(NO_PROFILE_STACK_FLAG) && !alertsEveryPosting(item.watch);
+    const alertHeldAt = !skipsAlert && !mayAlert ? new Date() : null;
     const stored = await persistJob(
       placed,
       finalClassification,
@@ -291,6 +298,7 @@ export async function processNormalizedJobs(
       winner.priorityRulesApplied,
       batch,
       verdicts,
+      alertHeldAt,
     );
     if (!stored) continue;
     const { created, crossListing } = stored;
@@ -303,15 +311,13 @@ export async function processNormalizedJobs(
     // A watched company on "every posting" is the exception: that flag is a
     // statement about the SCORE, and this alert makes no claim about the
     // score — it says a company the user chose has put something up.
-    if (finalClassification.red_flags.includes(NO_PROFILE_STACK_FLAG) && !alertsEveryPosting(item.watch)) {
-      continue;
-    }
+    if (skipsAlert) continue;
 
-    // Outside the alert window the match is kept, not dropped: the row stays
-    // NEW with its verdicts already stored, and the next heartbeat inside the
-    // window sends it in one grouped message instead of twelve at 03:00.
-    if (!mayAlert) {
-      await prisma.job.update({ where: { id: created.id }, data: { alertHeldAt: new Date() } });
+    // Outside the alert window the match is kept, not dropped: the row is NEW
+    // with its verdicts and its held stamp already stored, and the next
+    // heartbeat inside the window sends it in one grouped message instead of
+    // twelve at 03:00.
+    if (alertHeldAt) {
       stats.alertHeld++;
       continue;
     }
@@ -433,6 +439,7 @@ async function persistJob(
   priorityRulesApplied: string[],
   { stats, recentFingerprints }: Batch,
   verdicts: ProfileVerdict[] = [],
+  alertHeldAt: Date | null = null,
 ): Promise<{ created: Job; crossListing: CrossListing } | null> {
   const fingerprint = simhash64(job.description);
   const crossListing = findCrossListing(fingerprint, job.companyId, recentFingerprints);
@@ -445,6 +452,7 @@ async function persistJob(
           descriptionSimhash: fingerprint,
           crossListedOfJobId: crossListing?.job.id ?? null,
         }),
+        alertHeldAt,
         // Every search's verdict, written with the row it belongs to — a
         // second statement could leave a scored Job with no JobScore.
         // `pasted: false` is the same invariant buildJobData relies on: a

--- a/src/screening/intake.test.ts
+++ b/src/screening/intake.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { deflateRawSync } from 'node:zlib';
-import { displayName, expandUploads, findDuplicate, fingerprintText, isAcceptedResume } from './intake';
+import { displayName, expandUploads, findDuplicate, fingerprintBytes, fingerprintText, isAcceptedResume } from './intake';
 
 /** The same in-memory zip writer zip.test.ts uses. */
 function buildZip(entries: { name: string; data: Buffer }[]): Buffer {
@@ -83,4 +83,11 @@ test('findDuplicate: the same text is a re-upload, the same person is another ve
   const edited = `Updated 2026\n${body}`;
   assert.equal(findDuplicate({ email: null, phone: null, ...fingerprintText(edited) }, known)?.kind, 'same-person', 'a re-upload with a new line on top is a version');
   assert.equal(findDuplicate({ email: 'b@y.io', phone: null, ...fingerprintText('Completely different frontend resume about React and design systems. '.repeat(8)) }, known), null);
+});
+
+test('fingerprintBytes: the same bytes are one hash, different bytes are not, and it is a 32-char hex', () => {
+  const a = fingerprintBytes(Buffer.from('%PDF-1.4 scanned'));
+  assert.equal(a, fingerprintBytes(Buffer.from('%PDF-1.4 scanned')));
+  assert.notEqual(a, fingerprintBytes(Buffer.from('%PDF-1.4 scanned ')));
+  assert.match(a, /^[0-9a-f]{32}$/);
 });

--- a/src/screening/intake.ts
+++ b/src/screening/intake.ts
@@ -97,6 +97,11 @@ export interface TextFingerprint {
 }
 
 /** Exact and near-duplicate keys of one resume's text. */
+/** A file no text came out of is known by its bytes, so the same scan twice is one row and two different scans never collide. */
+export function fingerprintBytes(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex').slice(0, 32);
+}
+
 export function fingerprintText(text: string): TextFingerprint {
   const canon = text.normalize('NFKC').toLowerCase().replace(/[^\p{L}\p{N}]+/gu, ' ').trim();
   return { hash: createHash('sha256').update(canon).digest('hex').slice(0, 32), simhash: simhash64(text) };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -385,6 +385,16 @@ export async function addNotificationTarget(input: NewTarget): Promise<Notificat
   });
 }
 
+/** The row that already names this destination — the same bot and chat, or the same webhook — if any (ADR 0053). */
+export async function findSameDestination(input: NewTarget): Promise<NotificationTarget | null> {
+  return prisma.notificationTarget.findFirst({
+    where:
+      input.kind === 'DISCORD'
+        ? { kind: 'DISCORD', webhookUrl: input.webhookUrl }
+        : { kind: 'TELEGRAM', botToken: input.botToken, chatId: input.chatId },
+  });
+}
+
 export async function toggleNotificationTarget(id: number): Promise<void> {
   const t = await prisma.notificationTarget.findUnique({ where: { id } });
   if (!t) return;

--- a/src/web/routes/screen.tsx
+++ b/src/web/routes/screen.tsx
@@ -13,7 +13,8 @@ import { briefForPosting, briefLine } from '../../resume/brief';
 import { ResumeTextError } from '../../resume/docx-text';
 import { extractResumeText } from '../../resume/resume-text';
 import { applyPreset, draftRubric, PRESETS, rubricEquals, rubricFromForm, rubricSummary, type Preset } from '../../screening/rubric';
-import { displayName, expandUploads, findDuplicate, fingerprintText, MAX_APPLICANTS_PER_SCREENING, MAX_BATCH_UPLOAD_MB } from '../../screening/intake';
+import { Prisma } from '@prisma/client';
+import { displayName, expandUploads, findDuplicate, fingerprintBytes, fingerprintText, MAX_APPLICANTS_PER_SCREENING, MAX_BATCH_UPLOAD_MB } from '../../screening/intake';
 import { findLeaks, readRedactions, redactApplicant } from '../../screening/redact';
 import { MAX_COMPARE, MIN_COMPARE, readScreenReply } from '../../screening/prompts';
 import { comparisonMarkdown, comparisonView, readStoredComparison } from '../../screening/comparison';
@@ -400,7 +401,7 @@ screenRoute.post('/screen/:id/applicants', (c, next) => batchUploadLimit(c.req.p
     // Redacted once with a placeholder number for the name and email the
     // dedupe reads; the store puts its own number on the label.
     const redacted = text ? redactApplicant(text, 0) : null;
-    const print = text ? fingerprintText(text) : { hash: `unreadable:${file.name}:${file.bytes.length}`, simhash: null };
+    const print = text ? fingerprintText(text) : { hash: fingerprintBytes(file.bytes), simhash: null };
     const dup = text ? findDuplicate({ email: redacted?.email ?? null, phone: redacted?.phone ?? null, ...print }, known) : null;
     if (dup?.kind === 'same-text') {
       // The same file again: nothing new to read, and a second row would only be scored twice.
@@ -409,23 +410,34 @@ screenRoute.post('/screen/:id/applicants', (c, next) => batchUploadLimit(c.req.p
     }
     const leaks = redacted ? findLeaks(redacted.text, redacted) : [];
     if (leaks.length > 0) leaked++;
-    const row = await createApplicant({
-      screeningId: screening.id,
-      name: redacted?.name ?? null,
-      email: redacted?.email ?? null,
-      phone: redacted?.phone ?? null,
-      sourceFilename: displayName(file),
-      mimeType: mimeOf(file.name),
-      original: file.bytes,
-      text: text ?? '',
-      redactedTextFor: (n) => redacted?.text.replaceAll('Applicant №0', `Applicant №${n}`) ?? '',
-      redactions: redacted?.redactions ?? [],
-      parseStatus: text ? 'ok' : 'unreadable',
-      parseNote: text ? null : note,
-      sameAsId: dup?.match.id ?? null,
-      textHash: print.hash,
-      simhash: print.simhash,
-    });
+    let row: Awaited<ReturnType<typeof createApplicant>>;
+    try {
+      row = await createApplicant({
+        screeningId: screening.id,
+        name: redacted?.name ?? null,
+        email: redacted?.email ?? null,
+        phone: redacted?.phone ?? null,
+        sourceFilename: displayName(file),
+        mimeType: mimeOf(file.name),
+        original: file.bytes,
+        text: text ?? '',
+        redactedTextFor: (n) => redacted?.text.replaceAll('Applicant №0', `Applicant №${n}`) ?? '',
+        redactions: redacted?.redactions ?? [],
+        parseStatus: text ? 'ok' : 'unreadable',
+        parseNote: text ? null : note,
+        sameAsId: dup?.match.id ?? null,
+        textHash: print.hash,
+        simhash: print.simhash,
+      });
+    } catch (err) {
+      // The unique on (screening, textHash) is the check `known` cannot make:
+      // another upload of the same file landed since it was read (ADR 0053).
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        repeats++;
+        continue;
+      }
+      throw err;
+    }
     if (!text) unreadable++;
     else {
       ok++;

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { logger } from '../../logger';
 import {
   addNotificationTarget,
+  findSameDestination,
   deleteNotificationTarget,
   getAiKeys,
   getSettings,
@@ -831,6 +832,9 @@ settingsRoute.post('/settings/targets', async (c) => {
     if (!parsed.success) {
       return flashRedirect(back, 'err', 'Invalid input — a name and a Discord webhook URL (https://discord.com/api/webhooks/…) are required.');
     }
+    // Before the test message, so a repeat does not post twice to the channel.
+    const same = await findSameDestination({ kind: 'DISCORD', ...parsed.data });
+    if (same) return flashRedirect(back, 'err', `That webhook is already added as "${same.name}".`);
     const test = await testDiscordWebhook(parsed.data.webhookUrl);
     if (!test.ok) return flashRedirect(back, 'err', `Validation failed: ${test.error ?? 'unknown'}`);
     await addNotificationTarget({ kind: 'DISCORD', ...parsed.data });
@@ -844,6 +848,8 @@ settingsRoute.post('/settings/targets', async (c) => {
   if (!parsed.success) {
     return flashRedirect(back, 'err', 'Invalid input — name, token, chat id required.');
   }
+  const same = await findSameDestination({ kind: 'TELEGRAM', ...parsed.data });
+  if (same) return flashRedirect(back, 'err', `That bot and chat are already added as "${same.name}".`);
   const test = await testTelegramTarget(parsed.data.botToken, parsed.data.chatId);
   if (!test.ok) {
     return flashRedirect(back, 'err', `Validation failed: ${test.error ?? 'unknown'}`);


### PR DESCRIPTION
Block `data-integrity` of TASKS §20 — DATA-2, DATA-3, DATA-7, DATA-8, DATA-10a of `docs/audit-2026-09-10.md`. Minor release 2.6.0 (one migration, ADR 0053).

**What changed**
- `alertHeldAt` is written in the same insert as the job and its verdicts (`process-jobs.ts`): whether the match is skipped (#50) or held for the alert window is known before the row exists. A crash between the old two statements left a NEW match nothing would ever send.
- `notification_target` unique on (`botToken`, `chatId`) and on `webhookUrl`; the form asks `findSameDestination` before it sends a test message. The migration collapses duplicates onto the oldest row and re-points `profile.notificationTargetId`.
- `applicant` unique on (`screeningId`, `textHash`); intake catches `P2002` as a repeat; an unreadable file is hashed by its bytes (`fingerprintBytes`), not by name + size. The migration deletes later copies (verdicts cascade).
- The pasted job is one transaction with its company row; a paste race is settled by the unique key (`P2002` → the existing row) instead of a read the other tab can outrun.
- Indexes on the referencing side of `job.crossListedOfJobId`, `job.appliedResumeId`, `screening.jobId`, `cover_letter.resumeId`.

**Verified**
- `lint:types` green; 2 183 tests (`fingerprintBytes`); `prisma validate` + `format --check`.
- On a scratch database at the previous schema: seeded two Discord rows with one webhook, two Telegram rows with one bot + chat plus a third chat, two profiles routed to the later copies, two applicants with one hash. Applied the migration: targets `1, 3, 5` remain, profiles now `1→1, 2→3`, applicants `1, 3`; all seven indexes present. `prisma migrate diff --from-url <scratch> --to-schema-datamodel` → "No difference detected". Scratch dropped.

**Left for a later pass:** DATA-9 (a stranded `pipelineStage` key), the scratch-resume / `isDefault` / `deleteProfile` races (DATA-10).

## Release notes
### What's new
- A match found outside the alert window is stamped in the same insert as its verdicts, so a crash can no longer leave a match nothing would ever send.
- One row per alert destination: the same bot and chat, or the same webhook, added twice used to be two rows and every alert twice. The form now says which row already has it; existing duplicates collapse onto the oldest at upgrade, and a search routed to a copy follows it.
- The same document twice in one screening is one row, whichever tab wins; a file no text came out of is known by its bytes.
- A pasted posting is one transaction; the same paste from two tabs is settled by the unique key.
- Indexes on four foreign keys: a job delete no longer scans the job table for cross-listings, a resume delete no longer scans it for applications.
### Schema
- `20260910130000_fk_indexes_and_unique_destinations`: four indexes, two uniques on `notification_target` (with the collapse), one unique on `applicant` (with the delete of later copies).
### Verification
- 2 183 tests; the migration run on a scratch database seeded with duplicates; `migrate diff` clean.
### References
- [ADR 0053](https://github.com/applypack/applypack/blob/main/docs/adr/0053-uniqueness-lives-in-the-database.md) · docs/audit-2026-09-10.md DATA-2/3/7/8/10 · TASKS §20 block `data-integrity`