### PR TITLE
route-hardening: one id reader, caps and a body limit, guarded double presses, honest 404s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.6.1] — 2026-09-10
+
+### Fixed
+- **Ids are read one way.** Every path, form and query id goes through one
+  reader that takes a plain integer and nothing else; `/jobs/1.5`, a form
+  without its `resumeId`, `?minFit=1.5` answered 500 from the database
+  driver and answer 400 now. A candidate that is already gone on
+  `/discovery` says so instead of failing; `/screen/:id/run` checks the
+  screening exists like every other screening route.
+- **A double press is refused, not doubled.** Re-classify, Rewrite, Fill
+  from a resume, a resume upload or replacement, the wizard's upload, a new
+  screening and a new alert target each refuse a second press while the
+  first is still running — two rows, two AI calls or two test messages
+  used to be the result.
+- **Every free text has a ceiling** — a pasted or replaced posting
+  (60 000 characters), a screening's posting, a resume draft (200 000), a
+  letter edit (20 000), application notes (10 000), a recruiter contact
+  (300), a search's notes (4 000) — and every POST that is not an upload
+  carries a 2 MB body limit; the upload routes keep their own larger ones.
+  A body past its limit answers 413 — the error handler used to flatten
+  the status into a 500 — and a status change on a job that is not there
+  answers 404.
+- With the database unreachable every route answered 500, `/health` and
+  `/static/*` included: static files are served before anything that reads
+  the database, and the sidebar's employer-mode read no longer takes the
+  request down with it — `/health` answers its 503, without the driver's
+  message (host, port, user) in the body.
+- A `WEB_BASIC_AUTH` that is not `user:password` stops the dashboard from
+  starting instead of serving open with a warning in the log.
+- A Discord webhook is checked to point at Discord when a message is sent,
+  not only when the row was added.
+- Opening the clean-render page no longer starts an AI reading of the
+  resume's shape by itself — the button on the page does. A GET that spends
+  a model call is one any page in the browser can fire with an image tag.
+
 ## [2.6.0] — 2026-09-10
 
 ### Fixed
@@ -3357,6 +3392,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.6.1]: https://github.com/applypack/applypack/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/applypack/applypack/compare/v2.5.4...v2.6.0
 [2.5.4]: https://github.com/applypack/applypack/compare/v2.5.3...v2.5.4
 [2.5.3]: https://github.com/applypack/applypack/compare/v2.5.2...v2.5.3

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2111,7 +2111,7 @@ release-discipline skill, a docs/site block does not.
       shown as "unfiled". Second pass: DATA-10 (`manual-job.ts`
       transaction + `P2002`, the scratch-row and `isDefault` races,
       `deleteProfile` under the lock).
-- [ ] **`route-hardening`** (minor) — ROUTE-2 one `idParam` (from
+- [x] **`route-hardening`** (patch) — shipped v2.6.1: ROUTE-1/2/3, SEC-7/8; ROUTE-4 (the 500s on repeat, cache headers on polled JSON, multipart → 400) and ROUTE-5 (the three handlers) left for a later pass. ROUTE-2 one `idParam` (from
       `screen.tsx:229`) for every `:id` and query id, 404 on a missing
       row (`discovery` ignore/delete, `/screen/:id/run`); ROUTE-1
       claim-before-create on `POST /resumes`, `/replace`, `/welcome/resume`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "description": "Runs locally with Docker: an AI console for the whole job search that finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 33 sources, 5 swappable AI backends, your data in your own Postgres, self-hosted on a VPS if you like.",
   "license": "MIT",

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -123,13 +123,16 @@ export async function promoteCandidate(id: number): Promise<void> {
   );
 }
 
-export async function ignoreCandidate(id: number): Promise<void> {
-  await prisma.companyCandidate.update({
+/** False when no such candidate — a missing row is an answer, not a 500 (audit 2026-09-10, ROUTE-2). */
+export async function ignoreCandidate(id: number): Promise<boolean> {
+  const { count } = await prisma.companyCandidate.updateMany({
     where: { id },
     data: { status: CandidateStatus.IGNORED },
   });
+  return count > 0;
 }
 
-export async function deleteCandidate(id: number): Promise<void> {
-  await prisma.companyCandidate.delete({ where: { id } });
+export async function deleteCandidate(id: number): Promise<boolean> {
+  const { count } = await prisma.companyCandidate.deleteMany({ where: { id } });
+  return count > 0;
 }

--- a/src/jobs/manual-job.ts
+++ b/src/jobs/manual-job.ts
@@ -15,6 +15,8 @@ import { classifyExistingJob, type ClassifiableJob } from './classify-existing';
  */
 
 export const MIN_DESCRIPTION_CHARS = 200;
+/** The most a pasted or replaced posting may run to — the model reads 30 k of it (posting-url.ts caps a fetched page there too). */
+export const MAX_POSTING_CHARS = 60_000;
 export const MAX_FIELD_CHARS = 200;
 
 /** '' and absent both mean "no salary" — hidden form fields post empty strings. */
@@ -28,7 +30,7 @@ export const ManualJobSchema = z.object({
   title: z.string().trim().min(1).max(MAX_FIELD_CHARS),
   url: z.string().trim().max(2000).default(''),
   location: z.string().trim().max(MAX_FIELD_CHARS).default(''),
-  description: z.string().trim().min(MIN_DESCRIPTION_CHARS),
+  description: z.string().trim().min(MIN_DESCRIPTION_CHARS).max(MAX_POSTING_CHARS),
   salaryMin: SalaryField,
   salaryMax: SalaryField,
 });

--- a/src/notify/discord.ts
+++ b/src/notify/discord.ts
@@ -116,6 +116,10 @@ export async function postDiscord(
 
 export async function deliverDiscord(target: Pick<NotificationTarget, 'name' | 'webhookUrl'>, content: string): Promise<void> {
   if (!target.webhookUrl) throw new Error(`Discord target [${target.name}] has no webhook URL`);
+  // Checked when the row was added and again here, because a row is a row
+  // (the feed fetcher's rule): a hand-edited URL must not turn every digest
+  // into a POST to an arbitrary host.
+  if (!isDiscordWebhookUrl(target.webhookUrl)) throw new Error(`Discord target [${target.name}] does not point at Discord`);
   const result = await postDiscord(target.webhookUrl, content);
   if (!result.ok) throw new Error(`[${target.name}] ${result.error ?? 'unknown error'}`);
 }

--- a/src/web/body-limits.test.ts
+++ b/src/web/body-limits.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { hasOwnBodyLimit } from './body-limits';
+
+test('the upload routes keep their own ceiling; everything else gets the default', () => {
+  for (const p of ['/resumes', '/resumes/3/replace', '/target', '/letter', '/jobs/7/target/reupload', '/settings/profiles/2/fill-from-resume', '/welcome/resume', '/screen', '/screen/9/applicants']) {
+    assert.equal(hasOwnBodyLimit('POST', p), true, p);
+  }
+  for (const p of ['/jobs/new', '/jobs/7/description', '/resumes/3/draft', '/screen/9/posting', '/settings/profiles/2/save', '/resumes/3']) {
+    assert.equal(hasOwnBodyLimit('POST', p), false, p);
+  }
+  assert.equal(hasOwnBodyLimit('GET', '/resumes'), false);
+});
+
+test('every route that sets its own bodyLimit is on the list', () => {
+  // The registrations that pass an upload limit as middleware, read off the source.
+  const dir = join(__dirname, 'routes');
+  const found: string[] = [];
+  for (const f of readdirSync(dir)) {
+    if (!/\.tsx?$/.test(f) || /\.test\./.test(f)) continue;
+    for (const m of readFileSync(join(dir, f), 'utf8').matchAll(/\.post\(\s*'([^']+)',\s*(?:[a-zA-Z]+UploadLimit|async \(c, next\) => [a-zA-Z]+UploadLimit)/g)) {
+      found.push(m[1]!);
+    }
+  }
+  assert.ok(found.length >= 8, `found only ${found.length} upload routes`);
+  for (const route of found) {
+    const sample = route.replace(/:\w+/g, '7');
+    assert.equal(hasOwnBodyLimit('POST', sample), true, `${route} sets its own bodyLimit but is not on the list`);
+  }
+});

--- a/src/web/body-limits.ts
+++ b/src/web/body-limits.ts
@@ -1,0 +1,26 @@
+/*
+ * One body limit for every POST that is not an upload. The upload routes set
+ * their own, larger ceilings inline (5 MB for a resume, 200 MB for a batch of
+ * applicants), and a global limit would reject those bodies before the route
+ * saw them — so it steps aside on exactly those paths (audit 2026-09-10,
+ * SEC-8). Add a route here when it gets its own bodyLimit.
+ */
+
+export const DEFAULT_BODY_BYTES = 2 * 1024 * 1024;
+
+const OWN_LIMIT = [
+  /^\/resumes$/,
+  /^\/resumes\/\d+\/replace$/,
+  /^\/target$/,
+  /^\/letter$/,
+  /^\/jobs\/\d+\/target\/reupload$/,
+  /^\/settings\/profiles\/\d+\/fill-from-resume$/,
+  /^\/welcome\/resume$/,
+  /^\/screen$/,
+  /^\/screen\/\d+\/applicants$/,
+];
+
+/** True for a POST whose route carries its own upload ceiling. */
+export function hasOwnBodyLimit(method: string, path: string): boolean {
+  return method === 'POST' && OWN_LIMIT.some((re) => re.test(path));
+}

--- a/src/web/inflight.test.ts
+++ b/src/web/inflight.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { beginOnce, endOnce, INFLIGHT_TTL_MS, once } from './inflight';
+
+test('beginOnce holds a key until endOnce or the ceiling', () => {
+  assert.equal(beginOnce('a', 1000), true);
+  assert.equal(beginOnce('a', 2000), false);
+  endOnce('a');
+  assert.equal(beginOnce('a', 3000), true);
+  assert.equal(beginOnce('a', 3000 + INFLIGHT_TTL_MS), true, 'an expired hold is not a hold');
+  endOnce('a');
+});
+
+test('once runs the work for the first caller and answers busy to the second', async () => {
+  let resolve!: () => void;
+  const gate = new Promise<void>((r) => (resolve = r));
+  const first = once('k', async () => { await gate; return 'done'; }, () => 'busy');
+  const second = once('k', async () => 'second', () => 'busy');
+  assert.equal(await second, 'busy');
+  resolve();
+  assert.equal(await first, 'done');
+  assert.equal(await once('k', async () => 'again', () => 'busy'), 'again', 'released after the work');
+});

--- a/src/web/inflight.ts
+++ b/src/web/inflight.ts
@@ -1,0 +1,33 @@
+/*
+ * A press that starts work is refused while the same work is still running
+ * in this process: the double-clicked submit and the two-tab paste both land
+ * within a second, and each used to spend a second AI call or mint a second
+ * row (audit 2026-09-10, ROUTE-1). Keys are the caller's; a key older than
+ * the ceiling is treated as finished, so a crash inside the work cannot hold
+ * the button forever.
+ */
+
+const running = new Map<string, number>();
+export const INFLIGHT_TTL_MS = 10 * 60_000;
+
+/** Claim the key; false when it is already held and not yet expired. */
+export function beginOnce(key: string, now = Date.now()): boolean {
+  const since = running.get(key);
+  if (since !== undefined && now - since < INFLIGHT_TTL_MS) return false;
+  running.set(key, now);
+  return true;
+}
+
+export function endOnce(key: string): void {
+  running.delete(key);
+}
+
+/** Run `work` once per key; the second caller gets `busy` back instead. */
+export async function once<T>(key: string, work: () => Promise<T>, busy: () => T): Promise<T> {
+  if (!beginOnce(key)) return busy();
+  try {
+    return await work();
+  } finally {
+    endOnce(key);
+  }
+}

--- a/src/web/once-guard.ts
+++ b/src/web/once-guard.ts
@@ -1,0 +1,20 @@
+import type { Context, MiddlewareHandler } from 'hono';
+import { flashRedirect } from './flash';
+import { beginOnce, endOnce } from './inflight';
+
+/**
+ * A route that starts work — an AI call, a new row, a test message — refuses
+ * a second press while the first is still in this process. The key names the
+ * work; `back` is where the refused press lands with its one-line reason.
+ */
+export function onceGuard(key: (c: Context) => string, back: (c: Context) => string): MiddlewareHandler {
+  return async (c, next) => {
+    const k = key(c);
+    if (!beginOnce(k)) return flashRedirect(back(c), 'warn', 'That is already running — give it a moment.');
+    try {
+      await next();
+    } finally {
+      endOnce(k);
+    }
+  };
+}

--- a/src/web/params.test.ts
+++ b/src/web/params.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { idParam, intQuery } from './params';
+
+test('idParam takes a plain positive integer and nothing else', () => {
+  assert.equal(idParam('12'), 12);
+  assert.equal(idParam('0'), 0);
+  for (const bad of ['1.5', '1e2', ' 12 ', '-1', '0x10', '', '1234567890', undefined, null, 12, new File([], 'x')]) {
+    assert.ok(Number.isNaN(idParam(bad)), `${String(bad)} must be NaN`);
+  }
+});
+
+test('intQuery reads a signed integer or says nothing', () => {
+  assert.equal(intQuery('70'), 70);
+  assert.equal(intQuery('-5'), -5);
+  for (const bad of ['1.5', 'abc', '', undefined]) assert.equal(intQuery(bad), null);
+});

--- a/src/web/params.ts
+++ b/src/web/params.ts
@@ -1,0 +1,16 @@
+/*
+ * Ids and numbers off the request. Prisma throws on a NaN in a where clause
+ * and on a fraction in an Int column alike, and `Number.isFinite(Number(x))`
+ * lets `1.5`, `1e2` and ` 12 ` through — 500s where a 400 or a 404 belongs
+ * (audit 2026-09-10, ROUTE-2). Every route reads ids through here.
+ */
+
+/** A path, form or query id: a positive integer of at most nine digits, else NaN. */
+export function idParam(raw: unknown): number {
+  return typeof raw === 'string' && /^\d{1,9}$/.test(raw) ? Number(raw) : NaN;
+}
+
+/** An optional integer off the query string (a score floor), or null when absent or not one. */
+export function intQuery(raw: unknown): number | null {
+  return typeof raw === 'string' && /^-?\d{1,9}$/.test(raw) ? Number(raw) : null;
+}

--- a/src/web/routes/applications.tsx
+++ b/src/web/routes/applications.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
+import { idParam } from '../params';
 import { z } from 'zod';
 import { prisma } from '../../db';
 import { getSettings } from '../../settings';
@@ -16,8 +17,8 @@ import { groupEventsByJob, stageTimeLine, type StageTimeLine } from '../stage-ti
 export const ApplicationFormSchema = z.object({
   pipelineStage: z.string().max(40).optional(),
   appliedAt: z.string().optional(),
-  recruiterContact: z.string().optional(),
-  applicationNotes: z.string().optional(),
+  recruiterContact: z.string().max(300).optional(),
+  applicationNotes: z.string().max(10_000).optional(),
   // Absent when the page had no resumes to offer — "keep what is stored"
   // rather than "erase it" (applied-resume.ts).
   appliedResumeId: z.string().optional(),
@@ -108,7 +109,7 @@ const StageMoveSchema = z.object({ toStage: z.string().min(1).max(40) });
 // The full form on /jobs/:id stays the only place that edits appliedAt /
 // recruiterContact / applicationNotes — reusing it here would null them out.
 applicationsRoute.post('/jobs/:id/stage', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const settings = await getSettings();
   if (!settings.applicationTrackingEnabled) {
@@ -147,7 +148,7 @@ applicationsRoute.post('/jobs/:id/stage', async (c) => {
 });
 
 applicationsRoute.post('/jobs/:id/application', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const settings = await getSettings();
   if (!settings.applicationTrackingEnabled) {

--- a/src/web/routes/companies.tsx
+++ b/src/web/routes/companies.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource hono/jsx */
 import { Hono, type Context } from 'hono';
+import { idParam } from '../params';
 import { AtsType, JobStatus } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../../db';
@@ -412,7 +413,7 @@ function packOrigin(value: unknown): PackOrigin {
 }
 
 companiesRoute.post('/companies/:id/toggle-active', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
 
   const current = await prisma.company.findUnique({
@@ -438,7 +439,7 @@ companiesRoute.post('/companies/:id/toggle-active', async (c) => {
  * recovered stops nagging without waiting for the next tick.
  */
 companiesRoute.post('/companies/:id/reprobe', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const company = await prisma.company.findUnique({
     where: { id },
@@ -472,7 +473,7 @@ companiesRoute.post('/companies/:id/reprobe', async (c) => {
 });
 
 companiesRoute.post('/companies/:id/delete', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const current = await prisma.company.findUnique({
     where: { id },

--- a/src/web/routes/discovery.tsx
+++ b/src/web/routes/discovery.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
+import { idParam } from '../params';
 import { CandidateStatus } from '@prisma/client';
 import { logger } from '../../logger';
 import {
@@ -80,7 +81,7 @@ discoveryRoute.post('/discovery/hn-run', (c) => {
 });
 
 discoveryRoute.post('/discovery/:id/promote', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   try {
     await promoteCandidate(id);
@@ -95,16 +96,16 @@ discoveryRoute.post('/discovery/:id/promote', async (c) => {
 });
 
 discoveryRoute.post('/discovery/:id/ignore', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
-  await ignoreCandidate(id);
+  if (!(await ignoreCandidate(id))) return flashRedirect('/discovery', 'warn', 'That candidate is no longer listed.');
   return flashRedirect('/discovery', 'ok', 'Marked as ignored.');
 });
 
 discoveryRoute.post('/discovery/:id/delete', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
-  await deleteCandidate(id);
+  if (!(await deleteCandidate(id))) return flashRedirect('/discovery', 'warn', 'That candidate is no longer listed.');
   return flashRedirect('/discovery', 'ok', 'Candidate deleted.');
 });
 

--- a/src/web/routes/health.ts
+++ b/src/web/routes/health.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { prisma } from '../../db';
+import { logger } from '../../logger';
 
 export const healthRoute = new Hono();
 
@@ -7,10 +8,9 @@ healthRoute.get('/health', async (c) => {
   try {
     await prisma.$queryRaw`SELECT 1`;
   } catch (err) {
-    return c.json(
-      { ok: false, db: 'down', error: err instanceof Error ? err.message : 'unknown' },
-      503,
-    );
+    // The driver's message names the host, port and user; the log gets it, the caller gets the fact.
+    logger.error({ err }, 'health: database unreachable');
+    return c.json({ ok: false, db: 'down' }, 503);
   }
   const lastFetch = await prisma.cronRun.findFirst({
     where: { name: 'fetch' },

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource hono/jsx */
 import { Hono, type Context } from 'hono';
+import { idParam, intQuery } from '../params';
 import { JobStatus, type Prisma } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../../db';
@@ -20,7 +21,8 @@ import { classifyExistingJob } from '../../jobs/classify-existing';
 import { locationMismatchReason } from '../../jobs/location-reason';
 import { getActiveProfile, listActiveProfiles } from '../../profiles';
 import { isBlankProfile } from '../../profile-guards';
-import { createManualJob, ManualJobSchema, MIN_DESCRIPTION_CHARS } from '../../jobs/manual-job';
+import { createManualJob, ManualJobSchema, MAX_POSTING_CHARS, MIN_DESCRIPTION_CHARS } from '../../jobs/manual-job';
+import { onceGuard } from '../once-guard';
 import { fetchPostingText } from '../../jobs/posting-url';
 import { describeRefresh, foldOps, normaliseDescription, planRefresh, refreshFlash, restoreFlash } from '../../jobs/description-diff';
 import { refreshDescription, restoreDescription } from '../../jobs/description-refresh';
@@ -160,7 +162,7 @@ jobsRoute.get('/jobs', async (c) => {
   if (status) {
     where.status = status as JobStatus;
   }
-  const minFitNum = minFit ? Number(minFit) : NaN;
+  const minFitNum = intQuery(minFit);
   // With a search selected both filters read that search's own score, not the
   // best-of — a chip that showed rows another search scored would be a lie.
   // "Open to me" reads the same per-search verdict (ADR 0033): with a search
@@ -170,12 +172,12 @@ jobsRoute.get('/jobs', async (c) => {
     where.scores = {
       some: {
         profileId: profile,
-        ...(Number.isNaN(minFitNum) ? {} : { fitScore: { gte: minFitNum } }),
+        ...(minFitNum === null ? {} : { fitScore: { gte: minFitNum } }),
         ...openOnly,
       },
     };
   } else {
-    if (!Number.isNaN(minFitNum)) where.fitScore = { gte: minFitNum };
+    if (minFitNum !== null) where.fitScore = { gte: minFitNum };
     if (open === '1') where.scores = { some: { locationMatch: true } };
   }
   if (q.trim().length > 0) {
@@ -301,7 +303,7 @@ async function orderedKeywords(
 }
 
 jobsRoute.get('/jobs/:id', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
 
   const [job, settings, resumes, matches, verifications, letters, activeProfile] = await Promise.all([
@@ -349,9 +351,9 @@ jobsRoute.get('/jobs/:id', async (c) => {
   if (!job) return c.text('Not found', 404);
 
   // ?match=<id> shows an older comparison; default is the latest. Same for ?letter.
-  const requestedMatch = Number(c.req.query('match'));
+  const requestedMatch = idParam(c.req.query('match'));
   const selected = matches.find((m) => m.id === requestedMatch) ?? matches[0] ?? null;
-  const requestedLetter = Number(c.req.query('letter'));
+  const requestedLetter = idParam(c.req.query('letter'));
   const selectedLetter = letters.find((l) => l.id === requestedLetter) ?? letters[0] ?? null;
   // The search that speaks for this posting is the one that scored it best,
   // not merely the primary (ADR 0028) — its linked resume wins the preselect.
@@ -428,7 +430,7 @@ jobsRoute.get('/jobs/:id', async (c) => {
 });
 
 jobsRoute.post('/jobs/:id/status', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
 
   const form = await c.req.parseBody();
@@ -437,6 +439,8 @@ jobsRoute.post('/jobs/:id/status', async (c) => {
     appliedResumeId: form.appliedResumeId === '' ? undefined : form.appliedResumeId,
   });
   if (!parsed.success) return c.text('Invalid status', 400);
+  // The update below throws on a row that is not there; a missing job is a 404, not a 500.
+  if (!(await prisma.job.findUnique({ where: { id }, select: { id: true } }))) return c.text('Not found', 404);
 
   const data: Prisma.JobUpdateInput = { status: parsed.data.status };
   if (parsed.data.status === 'ALERTED' || parsed.data.status === 'APPLIED') {
@@ -486,8 +490,11 @@ jobsRoute.post('/jobs/:id/status', async (c) => {
   return c.redirect(`/jobs/${id}`, 303);
 });
 
-jobsRoute.post('/jobs/:id/reclassify', async (c) => {
-  const id = Number(c.req.param('id'));
+/** A letter is a page; past this it is something else. */
+const MAX_LETTER_CHARS = 20_000;
+
+jobsRoute.post('/jobs/:id/reclassify', onceGuard((c) => `reclassify:${c.req.param('id')}`, (c) => `/jobs/${c.req.param('id')}`), async (c) => {
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const job = await prisma.job.findUnique({
     where: { id },
@@ -508,7 +515,7 @@ jobsRoute.post('/jobs/:id/reclassify', async (c) => {
  * stored text — keeping it — and re-classify.
  */
 jobsRoute.post('/jobs/:id/description/refresh', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const job = await prisma.job.findUnique({ where: { id }, include: { company: { select: { name: true } } } });
   if (!job) return c.text('Not found', 404);
@@ -537,7 +544,7 @@ jobsRoute.post('/jobs/:id/description/refresh', async (c) => {
 });
 
 jobsRoute.post('/jobs/:id/description', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const job = await prisma.job.findUnique({ where: { id }, include: { company: { select: { name: true, atsType: true } } } });
   if (!job) return c.text('Not found', 404);
@@ -546,12 +553,15 @@ jobsRoute.post('/jobs/:id/description', async (c) => {
   if (text.length < MIN_DESCRIPTION_CHARS) {
     return flashRedirect(`/jobs/${id}#verification`, 'warn', 'The listing text is too short to be a posting — nothing was replaced.');
   }
+  if (text.length > MAX_POSTING_CHARS) {
+    return flashRedirect(`/jobs/${id}#verification`, 'warn', `The listing text is longer than a posting (${MAX_POSTING_CHARS.toLocaleString()} characters at most) — nothing was replaced.`);
+  }
   const swap = await refreshDescription(job, text);
   return flashRedirect(`/jobs/${id}`, 'ok', refreshFlash(job.description.length, swap.job.description.length, swap.reclassified));
 });
 
 jobsRoute.post('/jobs/:id/description/restore', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const job = await prisma.job.findUnique({ where: { id }, include: { company: { select: { name: true, atsType: true } } } });
   if (!job) return c.text('Not found', 404);
@@ -561,7 +571,7 @@ jobsRoute.post('/jobs/:id/description/restore', async (c) => {
 });
 
 jobsRoute.post('/jobs/:id/verify', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const job = await prisma.job.findUnique({
     where: { id },
@@ -750,10 +760,10 @@ async function startComparison(c: Context, req: ComparisonRequest): Promise<Resp
 }
 
 jobsRoute.post('/jobs/:id/match', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const form = await c.req.parseBody();
-  const resumeId = Number(form.resumeId);
+  const resumeId = idParam(form.resumeId);
   if (!Number.isFinite(resumeId)) return c.text('Bad resume id', 400);
 
   const [job, resume] = await Promise.all([
@@ -785,8 +795,8 @@ jobsRoute.post('/jobs/:id/match', async (c) => {
 
 /** "Get suggestions" on a quick check: the lazy second call, the verdicts and the score untouched (ADR 0029). */
 jobsRoute.post('/jobs/:id/matches/:matchId/suggestions', async (c) => {
-  const id = Number(c.req.param('id'));
-  const matchId = Number(c.req.param('matchId'));
+  const id = idParam(c.req.param('id'));
+  const matchId = idParam(c.req.param('matchId'));
   if (!Number.isFinite(id) || !Number.isFinite(matchId)) return c.text('Bad id', 400);
   const form = await c.req.parseBody();
   const [job, match] = await Promise.all([
@@ -818,10 +828,13 @@ jobsRoute.post('/jobs/:id/matches/:matchId/suggestions', async (c) => {
  * wording goes through the same gate as the old one, so a rewrite cannot claim
  * what the first wording was refused for.
  */
-jobsRoute.post('/jobs/:id/matches/:matchId/actions/:index/rewrite', async (c) => {
-  const id = Number(c.req.param('id'));
-  const matchId = Number(c.req.param('matchId'));
-  const index = Number(c.req.param('index'));
+jobsRoute.post(
+  '/jobs/:id/matches/:matchId/actions/:index/rewrite',
+  onceGuard((c) => `rewrite:${c.req.param('matchId')}:${c.req.param('index')}`, (c) => `/jobs/${c.req.param('id')}`),
+  async (c) => {
+  const id = idParam(c.req.param('id'));
+  const matchId = idParam(c.req.param('matchId'));
+  const index = idParam(c.req.param('index'));
   if (!Number.isFinite(id) || !Number.isFinite(matchId) || !Number.isInteger(index) || index < 0) {
     return c.text('Bad id', 400);
   }
@@ -856,10 +869,10 @@ jobsRoute.post('/jobs/:id/matches/:matchId/actions/:index/rewrite', async (c) =>
 });
 
 jobsRoute.post('/jobs/:id/cover', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const form = await c.req.parseBody();
-  const resumeId = Number(form.resumeId);
+  const resumeId = idParam(form.resumeId);
   if (!Number.isFinite(resumeId)) return c.text('Bad resume id', 400);
   const tone: CoverTone = COVER_TONES.includes(form.tone as CoverTone)
     ? (form.tone as CoverTone)
@@ -926,8 +939,8 @@ jobsRoute.post('/jobs/:id/cover', async (c) => {
 
 /** Download a letter as a file; the edited text wins when one exists. */
 jobsRoute.get('/jobs/:id/cover/:letterId/file/:fmt', async (c) => {
-  const id = Number(c.req.param('id'));
-  const letterId = Number(c.req.param('letterId'));
+  const id = idParam(c.req.param('id'));
+  const letterId = idParam(c.req.param('letterId'));
   const fmt = c.req.param('fmt');
   if (!Number.isFinite(id) || !Number.isFinite(letterId)) return c.text('Bad id', 400);
   if (fmt !== 'pdf' && fmt !== 'docx') return c.text('Bad format', 400);
@@ -950,8 +963,8 @@ jobsRoute.get('/jobs/:id/cover/:letterId/file/:fmt', async (c) => {
 });
 
 jobsRoute.post('/jobs/:id/cover/:letterId', async (c) => {
-  const id = Number(c.req.param('id'));
-  const letterId = Number(c.req.param('letterId'));
+  const id = idParam(c.req.param('id'));
+  const letterId = idParam(c.req.param('letterId'));
   if (!Number.isFinite(id) || !Number.isFinite(letterId)) return c.text('Bad id', 400);
   const form = await c.req.parseBody();
   const text = typeof form.text === 'string' ? form.text.replace(/\r\n/g, '\n').trim() : '';
@@ -962,6 +975,11 @@ jobsRoute.post('/jobs/:id/cover/:letterId', async (c) => {
     return wantsJson
       ? c.json({ error: 'empty' }, 400)
       : flashRedirect(`/jobs/${id}?letter=${letterId}#cover-letter`, 'err', 'The letter cannot be empty.');
+  }
+  if (text.length > MAX_LETTER_CHARS) {
+    return wantsJson
+      ? c.json({ error: 'too long' }, 400)
+      : flashRedirect(`/jobs/${id}?letter=${letterId}#cover-letter`, 'err', `A letter is at most ${MAX_LETTER_CHARS.toLocaleString()} characters.`);
   }
 
   const letter = await getCoverLetter(letterId);
@@ -1004,7 +1022,7 @@ jobsRoute.post('/jobs/:id/cover/:letterId', async (c) => {
 });
 
 jobsRoute.get('/jobs/:id/target', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const [job, matches, verifications] = await Promise.all([
     prisma.job.findUnique({ where: { id }, include: { company: { select: { name: true } } } }),
@@ -1012,7 +1030,7 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
     listVerificationsForJob(id),
   ]);
   if (!job) return c.text('Not found', 404);
-  const requested = Number(c.req.query('match'));
+  const requested = idParam(c.req.query('match'));
   const match = matches.find((m) => m.id === requested) ?? matches[0];
   if (!match) {
     return flashRedirect(`/jobs/${id}#resume-match`, 'err', 'Run Compare once — tailoring the resume needs an AI match to work from.');
@@ -1053,10 +1071,10 @@ jobsRoute.get('/jobs/:id/target', async (c) => {
 });
 
 jobsRoute.post('/jobs/:id/target/reupload', async (c, next) => resumeUploadLimit(`/jobs/${c.req.param('id')}/target`)(c, next), async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const form = await c.req.parseBody();
-  const resumeId = Number(form.resumeId);
+  const resumeId = idParam(form.resumeId);
   if (!Number.isFinite(resumeId)) return c.text('Bad resume id', 400);
   const [job, resume] = await Promise.all([
     prisma.job.findUnique({ where: { id }, include: { company: { select: { name: true } } } }),

--- a/src/web/routes/keywords.ts
+++ b/src/web/routes/keywords.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { idParam } from '../params';
 import { z } from 'zod';
 import { prisma } from '../../db';
 import { loadKeywordMatcher } from '../../resume/keyword-matcher';
@@ -47,8 +48,8 @@ function describe(
 export const keywordsRoute = new Hono();
 
 keywordsRoute.post('/jobs/:id/matches/:matchId/keywords', async (c) => {
-  const id = Number(c.req.param('id'));
-  const matchId = Number(c.req.param('matchId'));
+  const id = idParam(c.req.param('id'));
+  const matchId = idParam(c.req.param('matchId'));
   if (!Number.isFinite(id) || !Number.isFinite(matchId)) return c.text('Bad id', 400);
   const parsed = KeywordFormSchema.safeParse(await c.req.parseBody());
   if (!parsed.success) return c.text('Bad keyword edit', 400);

--- a/src/web/routes/resume-render.tsx
+++ b/src/web/routes/resume-render.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource hono/jsx */
 import { Hono, type Context } from 'hono';
+import { idParam } from '../params';
 import { logger } from '../../logger';
 import { createResume, getResume, getResumeOriginal, versionFileName, type ResumeSummary } from '../../resume/store';
 import { readStructure, type JsonResume } from '../../resume/json-resume';
@@ -47,12 +48,10 @@ const isPdf = (filename: string) => /\.pdf$/i.test(filename);
 resumeRenderRoute.get('/resumes/:id/render', async (c) => {
   const ctx = await load(c);
   if ('response' in ctx) return ctx.response;
-  // The shape is read by its own AI call on the first visit (#184): the scan
-  // no longer carries it. `?shape=text` is where a failed reading lands — the
-  // built-in reader's shape, and a button to try the AI again.
-  if (ctx.origin === 'text' && c.req.query('shape') !== 'text') {
-    return c.redirect(`/target/runs/${startStructureRun(ctx.resume).id}`, 303);
-  }
+  // The shape is read by its own AI call (#184) — started by the button on
+  // this page, never by the visit itself: a GET that spends a model call is
+  // one any page in the browser can fire with an image tag (audit
+  // 2026-09-10, SEC-7). Until then the page shows the built-in reader's shape.
   const knobs = knobsFrom(ctx.style);
   return c.html(await page(ctx, knobs, parseFlashCookie(c.req.header('cookie'))), 200, {
     'Set-Cookie': clearFlashCookie(),
@@ -142,7 +141,7 @@ resumeRenderRoute.post('/resumes/:id/render', async (c) => {
  * the only hard failures are a bad id and a missing row.
  */
 async function load(c: Context): Promise<RenderContext | { response: Response }> {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return { response: c.text('Bad id', 400) };
   const resume = await getResume(id);
   if (!resume) return { response: c.text('Not found', 404) };

--- a/src/web/routes/resumes.tsx
+++ b/src/web/routes/resumes.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import { Hono, type Context } from 'hono';
+import { idParam } from '../params';
+import { onceGuard } from '../once-guard';
 import { logger } from '../../logger';
 import type { ResumeReview } from '@prisma/client';
 import { reviewResume } from '../../resume/review';
@@ -53,6 +55,8 @@ import {
 } from '../upload';
 
 const MIN_DRAFT_CHARS = 200;
+/** A resume runs to a few thousand characters; the model reads 30 k. Past this it is not a resume. */
+const MAX_DRAFT_CHARS = 200_000;
 
 export const resumesRoute = new Hono();
 
@@ -78,7 +82,7 @@ resumesRoute.get('/resumes', async (c) => {
   );
 });
 
-resumesRoute.post('/resumes', resumeUploadLimit('/resumes'), async (c) => {
+resumesRoute.post('/resumes', resumeUploadLimit('/resumes'), onceGuard(() => 'resumes:upload', () => '/resumes'), async (c) => {
   const form = await c.req.parseBody();
   const upload = await readResumeUpload(form);
   if ('error' in upload) return flashRedirect('/resumes', 'err', upload.error);
@@ -95,8 +99,8 @@ resumesRoute.post('/resumes', resumeUploadLimit('/resumes'), async (c) => {
   });
 });
 
-resumesRoute.post('/resumes/:id/replace', resumeUploadLimit('/resumes'), async (c) => {
-  const id = Number(c.req.param('id'));
+resumesRoute.post('/resumes/:id/replace', resumeUploadLimit('/resumes'), onceGuard((c) => `resumes:replace:${c.req.param('id')}`, (c) => `/resumes/${c.req.param('id')}`), async (c) => {
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   if (!(await getResume(id))) return c.text('Not found', 404);
   const upload = await readResumeUpload(await c.req.parseBody());
@@ -110,7 +114,7 @@ resumesRoute.post('/resumes/:id/replace', resumeUploadLimit('/resumes'), async (
 });
 
 resumesRoute.get('/resumes/:id', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const [resume, matches, review, linkedProfiles, impact] = await Promise.all([
     getResume(id),
@@ -154,7 +158,7 @@ resumesRoute.get('/resumes/:id', async (c) => {
 });
 
 resumesRoute.get('/resumes/:id/download', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const row = await getResumeOriginal(id);
   if (!row) return c.text('Not found', 404);
@@ -168,7 +172,7 @@ resumesRoute.get('/resumes/:id/download', async (c) => {
 });
 
 resumesRoute.post('/resumes/:id/draft', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const current = await getResume(id);
   if (!current) return c.text('Not found', 404);
@@ -176,6 +180,9 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
   const text = typeof form.text === 'string' ? form.text.replace(/\r\n/g, '\n').trim() : '';
   if (text.length < MIN_DRAFT_CHARS) {
     return flashRedirect(`/resumes/${id}`, 'err', 'The draft is too short to be a resume.');
+  }
+  if (text.length > MAX_DRAFT_CHARS) {
+    return flashRedirect(`/resumes/${id}`, 'err', `The draft is longer than a resume (${MAX_DRAFT_CHARS.toLocaleString()} characters at most).`);
   }
   // A one-off check from the Compare page is not a resume: its text belongs to
   // the comparison, which keeps its own snapshot of it. Saving one used to mint
@@ -188,7 +195,7 @@ resumesRoute.post('/resumes/:id/draft', async (c) => {
   // it a .docx cannot be patched (the diff would be against nothing) and the
   // save is a text version, as before ADR 0038.
   const baseText = typeof form.baseText === 'string' ? form.baseText.replace(/\r\n/g, '\n').trim() : '';
-  const jobId = Number(form.jobId);
+  const jobId = idParam(form.jobId);
   const job = Number.isFinite(jobId)
     ? await prisma.job.findUnique({ where: { id: jobId }, include: { company: { select: { name: true } } } })
     : null;
@@ -311,7 +318,7 @@ async function saveEdited(
  * Offered on click with the current values shown, never done silently.
  */
 resumesRoute.post('/resumes/:id/props', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const [resume, row] = await Promise.all([getResume(id), getResumeOriginal(id)]);
   if (!resume || !row) return c.text('Not found', 404);
@@ -327,7 +334,7 @@ resumesRoute.post('/resumes/:id/props', async (c) => {
  * showed exactly what this writes, so one press is enough (ADR 0015).
  */
 resumesRoute.post('/resumes/:id/profile', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const resume = await getResume(id);
   if (!resume || resume.hidden) return c.text('Not found', 404);
@@ -344,7 +351,7 @@ resumesRoute.post('/resumes/:id/profile', async (c) => {
 });
 
 resumesRoute.post('/resumes/:id/rescan', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const resume = await getResume(id);
   if (!resume) return c.text('Not found', 404);
@@ -378,7 +385,7 @@ function deltaFor(current: ResumeReview | null, previous: ResumeReview | null): 
  * about the resume changes, so a failure costs the user nothing but the wait.
  */
 resumesRoute.post('/resumes/:id/review', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const resume = await getResume(id);
   if (!resume) return c.text('Not found', 404);
@@ -423,7 +430,7 @@ resumesRoute.post('/resumes/:id/review', async (c) => {
  * should know which button does.
  */
 resumesRoute.post('/resumes/:id/answers', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const form = await c.req.parseBody();
   const question = typeof form.question === 'string' ? form.question : '';
@@ -454,7 +461,7 @@ resumesRoute.post('/resumes/:id/answers', async (c) => {
  * produces things like "Alex Doe Senior Backend Resume (3)".
  */
 resumesRoute.post('/resumes/:id/rename', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const form = await c.req.parseBody();
   const name = (typeof form.name === 'string' ? form.name : '').trim().slice(0, MAX_RESUME_NAME_CHARS);
@@ -467,7 +474,7 @@ resumesRoute.post('/resumes/:id/rename', async (c) => {
 });
 
 resumesRoute.post('/resumes/:id/default', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   if (!(await getResume(id))) return c.text('Not found', 404);
   await setDefaultResume(id);
@@ -475,7 +482,7 @@ resumesRoute.post('/resumes/:id/default', async (c) => {
 });
 
 resumesRoute.post('/resumes/:id/delete', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   await deleteResume(id);
   logger.info({ id }, 'resume: deleted');

--- a/src/web/routes/screen.tsx
+++ b/src/web/routes/screen.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
+import { idParam } from '../params';
 import { bodyLimit } from 'hono/body-limit';
 import { z } from 'zod';
 import { prisma } from '../../db';
@@ -8,7 +9,8 @@ import { getAiRuntime } from '../../ai-runtime';
 import { AI_PROVIDER_LABELS, PROVIDER_PAID } from '../../ai-engine';
 import { config } from '../../config';
 import { getSettings } from '../../settings';
-import { createManualJob, MAX_FIELD_CHARS, MIN_DESCRIPTION_CHARS } from '../../jobs/manual-job';
+import { createManualJob, MAX_FIELD_CHARS, MAX_POSTING_CHARS, MIN_DESCRIPTION_CHARS } from '../../jobs/manual-job';
+import { onceGuard } from '../once-guard';
 import { briefForPosting, briefLine } from '../../resume/brief';
 import { ResumeTextError } from '../../resume/docx-text';
 import { extractResumeText } from '../../resume/resume-text';
@@ -121,7 +123,7 @@ const postingUploadLimit = bodyLimit({
   onError: () => flashRedirect('/screen/new', 'err', `File too large — the limit is ${MAX_UPLOAD_MB} MB.`),
 });
 
-screenRoute.post('/screen', postingUploadLimit, async (c) => {
+screenRoute.post('/screen', postingUploadLimit, onceGuard(() => 'screen:new', () => '/screen/new'), async (c) => {
   const form = await c.req.parseBody();
   const parsed = NewScreeningSchema.safeParse(form);
   if (!parsed.success) return flashRedirect('/screen/new', 'err', 'The form could not be read.');
@@ -227,11 +229,6 @@ async function startRubricDraft(
   return c.redirect(`/target/runs/${run.id}`, 303);
 }
 
-/** A path id, or NaN — Prisma throws on a NaN where clause, so every route reads ids through this. */
-function idParam(raw: string): number {
-  return /^\d{1,9}$/.test(raw) ? Number(raw) : NaN;
-}
-
 async function loadScreening(id: number) {
   return Number.isInteger(id) ? getScreening(id) : null;
 }
@@ -304,6 +301,9 @@ screenRoute.post('/screen/:id/posting', async (c) => {
   const text = typeof form.postingText === 'string' ? form.postingText.replace(/\r\n/g, '\n').trim() : '';
   if (text.length < MIN_DESCRIPTION_CHARS) {
     return flashRedirect(`/screen/${screening.id}#position`, 'err', `The posting needs at least ${MIN_DESCRIPTION_CHARS} characters.`);
+  }
+  if (text.length > MAX_POSTING_CHARS) {
+    return flashRedirect(`/screen/${screening.id}#position`, 'err', `A posting is at most ${MAX_POSTING_CHARS.toLocaleString()} characters.`);
   }
   if (text === screening.postingText) return flashRedirect(`/screen/${screening.id}#position`, 'ok', 'Posting unchanged.');
   await savePosting(screening.id, text);
@@ -548,7 +548,9 @@ function mimeOf(filename: string): string {
 }
 
 screenRoute.post('/screen/:id/run', async (c) => {
-  const id = idParam(c.req.param('id'));
+  const screening = await loadScreening(idParam(c.req.param('id')));
+  if (!screening) return flashRedirect('/screen', 'err', 'That screening no longer exists.');
+  const id = screening.id;
   const outcome = await startScreeningRun(id);
   const back = `/screen/${id}#results`;
   switch (outcome.kind) {

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
+import { idParam } from '../params';
+import { onceGuard } from '../once-guard';
 import { AtsType } from '@prisma/client';
 import { z } from 'zod';
 import { logger } from '../../logger';
@@ -136,7 +138,7 @@ const ProfileFormSchema = z.object({
   roleTypes: z.string().optional().default(''),
   stackNiceToHave: z.string().optional().default(''),
   stackExclude: z.string().optional().default(''),
-  notes: z.string().optional().default(''),
+  notes: z.string().max(4_000).optional().default(''),
   seniority: z.union([z.string(), z.array(z.string())]).optional(),
   // ADR 0032: chips post one value each, the no-JS textarea posts a list.
   countries: z.union([z.string(), z.array(z.string())]).optional(),
@@ -340,7 +342,7 @@ settingsRoute.get('/settings', async (c) => {
   // ?profile= points the editor at a specific (possibly inactive) profile.
   // "+ New profile" lands here: new profiles are born inactive (issue #50)
   // and must be editable before activation.
-  const profileParam = Number(c.req.query('profile'));
+  const profileParam = idParam(c.req.query('profile'));
   if (Number.isFinite(profileParam)) {
     const editorProfile = await getProfile(profileParam);
     if (editorProfile) props.activeProfile = editorProfile;
@@ -824,7 +826,7 @@ settingsRoute.post('/settings/sources', async (c) => {
 });
 
 /** Both channels land here; `kind` says which form it was. A real test message goes out before the row is saved. */
-settingsRoute.post('/settings/targets', async (c) => {
+settingsRoute.post('/settings/targets', onceGuard(() => 'targets:add', () => '/settings?tab=notifications'), async (c) => {
   const form = await c.req.parseBody();
   const back = '/settings?tab=notifications';
   if (form.kind === 'discord') {
@@ -863,21 +865,21 @@ settingsRoute.post('/settings/targets', async (c) => {
 });
 
 settingsRoute.post('/settings/targets/:id/toggle', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   await toggleNotificationTarget(id);
   return flashRedirect('/settings?tab=notifications', 'ok', 'Target toggled.');
 });
 
 settingsRoute.post('/settings/targets/:id/delete', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   await deleteNotificationTarget(id);
   return flashRedirect('/settings?tab=notifications', 'ok', 'Target deleted.');
 });
 
 settingsRoute.post('/settings/targets/:id/test', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const t = await prisma.notificationTarget.findUnique({ where: { id } });
   if (!t) return flashRedirect('/settings?tab=notifications', 'err', 'Target not found.');
@@ -915,7 +917,7 @@ settingsRoute.post('/settings/profiles/new', async (c) => {
 // the hidden Run/Pause button is advisory only.
 settingsRoute.post('/settings/profiles/active', async (c) => {
   const form = await c.req.parseBody();
-  const id = Number(form.id);
+  const id = idParam(form.id);
   const want = form.active === '1';
   if (!Number.isFinite(id)) return flashRedirect('/settings?tab=profile', 'err', 'Invalid id.');
   // Server-side half of the gate (issue #50): a search with nothing to match
@@ -948,7 +950,7 @@ settingsRoute.post('/settings/profiles/active', async (c) => {
 
 settingsRoute.post('/settings/profiles/activate', async (c) => {
   const form = await c.req.parseBody();
-  const id = Number(form.id);
+  const id = idParam(form.id);
   if (!Number.isFinite(id)) return flashRedirect('/settings?tab=profile', 'err', 'Invalid id.');
   // Server-side half of the activation gate (issue #50) — the disabled
   // Activate button is advisory only.
@@ -978,7 +980,7 @@ settingsRoute.post('/settings/profiles/activate', async (c) => {
 
 settingsRoute.post('/settings/profiles/delete', async (c) => {
   const form = await c.req.parseBody();
-  const id = Number(form.id);
+  const id = idParam(form.id);
   if (!Number.isFinite(id)) return flashRedirect('/settings?tab=profile', 'err', 'Invalid id.');
   try {
     await deleteProfile(id);
@@ -993,7 +995,7 @@ settingsRoute.post('/settings/profiles/delete', async (c) => {
 });
 
 settingsRoute.post('/settings/profiles/:id/save', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const before = await getProfile(id);
   if (!before) {
@@ -1136,8 +1138,9 @@ async function sourcesWaiting(search: Profile): Promise<string> {
 settingsRoute.post(
   '/settings/profiles/:id/fill-from-resume',
   resumeUploadLimit('/settings?tab=profile'),
+  onceGuard((c) => `fill:${c.req.param('id')}`, () => '/settings?tab=profile'),
   async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const profile = await getProfile(id);
   if (!profile) return flashRedirect('/settings?tab=profile', 'err', 'Profile not found.');
@@ -1148,7 +1151,7 @@ settingsRoute.post(
     if ('error' in upload) return flashRedirect('/settings?tab=profile', 'err', upload.error);
     resume = await createResume({ name: nameFromFilename(upload.sourceFilename), ...upload });
   } else {
-    const resumeId = Number(form.resumeId);
+    const resumeId = idParam(form.resumeId);
     if (!Number.isFinite(resumeId)) {
       return flashRedirect('/settings?tab=profile', 'err', 'Pick a resume first.');
     }

--- a/src/web/routes/watchlist.tsx
+++ b/src/web/routes/watchlist.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
+import { idParam } from '../params';
 import { AtsType } from '@prisma/client';
 import { z } from 'zod';
 import { prisma } from '../../db';
@@ -165,7 +166,7 @@ const WatchSchema = z.object({
 
 /** Interval / policy from the watchlist row's own selects. */
 watchlistRoute.post('/companies/:id/watch', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const form = await c.req.parseBody();
   const parsed = WatchSchema.safeParse({ checkEvery: form.checkEvery, alertPolicy: form.alertPolicy });
@@ -189,7 +190,7 @@ watchlistRoute.post('/companies/:id/watch', async (c) => {
 
 /** "Check now": due on the next heartbeat, whatever the interval said. */
 watchlistRoute.post('/companies/:id/check-now', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const company = await prisma.company.findUnique({ where: { id }, select: { name: true } });
   if (!company) return c.text('Not found', 404);
@@ -203,7 +204,7 @@ watchlistRoute.post('/companies/:id/check-now', async (c) => {
 
 /** Drop the star, keep the company: it stays a tracked source on the normal rules. */
 watchlistRoute.post('/companies/:id/unwatch', async (c) => {
-  const id = Number(c.req.param('id'));
+  const id = idParam(c.req.param('id'));
   if (!Number.isFinite(id)) return c.text('Bad id', 400);
   const company = await prisma.company.findUnique({ where: { id }, select: { name: true } });
   if (!company) return c.text('Not found', 404);

--- a/src/web/routes/welcome.tsx
+++ b/src/web/routes/welcome.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource hono/jsx */
 import { Hono } from 'hono';
+import { idParam } from '../params';
+import { onceGuard } from '../once-guard';
 import { isRelocation } from '../../eligibility';
 import { CronRunStatus, JobStatus, type Profile } from '@prisma/client';
 import { prisma } from '../../db';
@@ -84,7 +86,7 @@ welcomeRoute.get('/welcome', async (c) => {
     profile && facts.profileReady ? countWaitingUnscored(profile) : 0,
   ]);
 
-  const resumeId = Number(c.req.query('resume'));
+  const resumeId = idParam(c.req.query('resume'));
   const asNew = c.req.query('mode') === 'new';
   const draftResume = Number.isFinite(resumeId) && profile ? await getResume(resumeId) : null;
   const draft = draftResume && profile ? draftCard(profile, draftResume, asNew) : null;
@@ -198,7 +200,7 @@ welcomeRoute.post('/welcome/ai/test', async () => {
  * default), then the scan runs on the progress page and lands back here
  * with the draft. An already-scanned resume skips straight to the draft.
  */
-welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) => {
+welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), onceGuard(() => 'welcome:resume', () => PROFILE_STEP), async (c) => {
   const form = await c.req.parseBody();
   // "A second search" (§4 stage A) drafts a new profile instead of filling
   // the active one; the flag rides through the scan run in the result URL.
@@ -209,7 +211,7 @@ welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) 
     if ('error' in upload) return flashRedirect(PROFILE_STEP, 'err', upload.error);
     resume = await createResume({ name: nameFromFilename(upload.sourceFilename), ...upload });
   } else {
-    const id = Number(form.resumeId);
+    const id = idParam(form.resumeId);
     if (Number.isFinite(id)) resume = await getResume(id);
   }
   if (!resume || resume.hidden) return flashRedirect(PROFILE_STEP, 'err', 'Pick a resume file first.');
@@ -250,7 +252,7 @@ welcomeRoute.post('/welcome/resume', resumeUploadLimit(PROFILE_STEP), async (c) 
 welcomeRoute.post('/welcome/profile/apply', async (c) => {
   const form = await c.req.parseBody();
   const { profile } = await loadWelcomeContext();
-  const resume = await getResume(Number(form.resumeId));
+  const resume = await getResume(idParam(form.resumeId));
   if (!profile) return flashRedirect(PROFILE_STEP, 'err', 'No primary search — create one in Settings → Profile.');
   if (!resume || !resume.scannedAt) return flashRedirect(PROFILE_STEP, 'err', 'That resume has not been read yet.');
   const draft = buildProfileDraft(profile, scanFields(resume));
@@ -276,7 +278,7 @@ welcomeRoute.post('/welcome/profile/apply', async (c) => {
  */
 welcomeRoute.post('/welcome/profile/create', async (c) => {
   const form = await c.req.parseBody();
-  const resume = await getResume(Number(form.resumeId));
+  const resume = await getResume(idParam(form.resumeId));
   if (!resume || resume.hidden || !resume.scannedAt) {
     return flashRedirect(PROFILE_STEP, 'err', 'That resume has not been read yet.');
   }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -2,6 +2,8 @@ import { serve } from '@hono/node-server';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { Hono } from 'hono';
 import { basicAuth } from 'hono/basic-auth';
+import { bodyLimit } from 'hono/body-limit';
+import { HTTPException } from 'hono/http-exception';
 import { secureHeaders } from 'hono/secure-headers';
 import { config } from '../config';
 import { logger } from '../logger';
@@ -26,6 +28,7 @@ import { welcomeRoute } from './routes/welcome';
 import { countriesRoute } from './routes/countries';
 import { screenRoute } from './routes/screen';
 import { ensureEmployerMode } from './employer-mode';
+import { DEFAULT_BODY_BYTES, hasOwnBodyLimit } from './body-limits';
 
 const app = new Hono();
 
@@ -60,7 +63,11 @@ if (config.WEB_BASIC_AUTH) {
     );
     logger.info({ user: username }, 'web: basic auth enabled');
   } else {
-    logger.warn('web: WEB_BASIC_AUTH set but malformed (expected user:password) — auth disabled');
+    // Fail closed: the operator asked for a lock and got the value wrong.
+    // Serving open with a warning in the log is how that goes unnoticed on
+    // a host bound to 0.0.0.0 (audit 2026-09-10, SEC-7).
+    logger.error('web: WEB_BASIC_AUTH is set but not user:password — refusing to start without the lock');
+    process.exit(1);
   }
 }
 
@@ -74,9 +81,27 @@ if (config.WEB_BASIC_AUTH) {
  */
 app.use('*', originGuard());
 
+// Static files (the browser modules of ADR 0010 among them) never touch the
+// database: served before anything that does, so an unreachable Postgres
+// cannot turn a stylesheet into a 500.
+app.use('/static/*', serveStatic({ root: './src/web/public', rewriteRequestPath: (p) => p.replace(/^\/static/, '') }));
+
+// Every POST carries a body ceiling; the upload routes bring their own,
+// larger one and are stepped around here (body-limits.ts).
+app.use('*', async (c, next) =>
+  hasOwnBodyLimit(c.req.method, c.req.path) ? next() : bodyLimit({ maxSize: DEFAULT_BODY_BYTES })(c, next),
+);
+
 // Tiny request log; also loads the employer-mode switch once, for the sidebar (ADR 0049).
 app.use('*', async (c, next) => {
-  await ensureEmployerMode();
+  // The sidebar's one switch. With the database down every route used to
+  // die here, /health included — the route decides what a missing database
+  // means for it (a 503 on /health), so the failure is logged and passed.
+  try {
+    await ensureEmployerMode();
+  } catch (err) {
+    logger.warn({ err, path: c.req.path }, 'web: employer mode unknown — database unreachable');
+  }
   const started = Date.now();
   await next();
   logger.info(
@@ -89,9 +114,6 @@ app.use('*', async (c, next) => {
     'web: request',
   );
 });
-
-// Browser-side keyword matcher for /jobs/:id/target (ADR 0010).
-app.use('/static/*', serveStatic({ root: './src/web/public', rewriteRequestPath: (p) => p.replace(/^\/static/, '') }));
 
 app.route('/', overviewRoute);
 app.route('/', welcomeRoute);
@@ -115,6 +137,9 @@ app.route('/', healthRoute);
 app.notFound((c) => c.text('Not found', 404));
 
 app.onError((err, c) => {
+  // A status hono itself raised — the 413 of a body past its limit — is the
+  // answer, not an accident to flatten into a 500.
+  if (err instanceof HTTPException) return err.getResponse();
   logger.error({ err, path: c.req.path }, 'web: unhandled error');
   return c.text('Internal server error', 500);
 });


### PR DESCRIPTION
Block `route-hardening` of TASKS §20 — ROUTE-1, ROUTE-2, ROUTE-3, SEC-7, SEC-8 of `docs/audit-2026-09-10.md`. Patch release 2.6.1.

**What changed**
- `src/web/params.ts` (pure, tested): `idParam` takes a plain integer and nothing else; every path, form and query id in `src/web/routes` reads through it (sed over 51 sites, the local copy in `screen.tsx` gone); `intQuery` for `?minFit`. `/discovery/:id/{ignore,delete}` and `/screen/:id/run` answer a missing row instead of throwing; `POST /jobs/:id/status` on a missing job answers 404 (found by the smoke).
- `src/web/inflight.ts` + `once-guard.ts` (pure core, tested): Re-classify, Rewrite, Fill from a resume, `POST /resumes`, `/resumes/:id/replace`, `/welcome/resume`, `POST /screen`, `/settings/targets` refuse a second press while the first runs.
- Ceilings: pasted / replaced posting 60 000 (`MAX_POSTING_CHARS`), screening posting the same, resume draft 200 000, letter edit 20 000, application notes 10 000, recruiter contact 300, search notes 4 000. `src/web/body-limits.ts` (tested — and a test reads the routes and fails if a route sets its own upload limit without being on the list): every other POST gets a 2 MB limit; `app.onError` hands a hono-raised status (the 413) back instead of a 500.
- `server.ts`: `/static/*` served before anything that reads the database; the employer-mode read is caught so `/health` reaches its 503; a malformed `WEB_BASIC_AUTH` refuses to start instead of serving open.
- `/health` no longer returns the driver's message; Discord's host is re-checked at send; the clean-render GET no longer starts an AI run (the button does).

**Verified**
- `lint:types` green; 2 189 tests (6 new).
- Built dashboard on the compose Postgres: `/jobs/1.5` → 400, `/resumes/1.5` → 400, `?minFit=1.5` → 200, `POST /discovery/999999/delete` → 303 with the warn flash, `POST /jobs/999999/status` → 404, a 3 MB body to `/jobs/1/status` → 413 while the same body to `/resumes` passes the body check (its own 5 MB limit), two concurrent Re-classify presses → one runs, one "already running"; six pages 200.
- Against a dead database port: `/static/target.mjs` → 200, `/health` → 503 `{"ok":false,"db":"down"}`, `/jobs` → 500.

**Left for a later pass (TASKS §20):** ROUTE-4 (the 500s on a repeated create, cache headers on polled JSON, malformed multipart → 400) and ROUTE-5 (`/letter`, `/target`, profile save into pure modules).

## Release notes
### What's new
- Every id off a path, a form or the query string is read one way: `/jobs/1.5`, a form missing its `resumeId`, `?minFit=1.5` answer 400 where the database driver used to answer 500; a missing candidate, screening or job answers 404.
- A double press is refused, not doubled: Re-classify, Rewrite, Fill from a resume, uploads, a new screening, a new alert target.
- Every free text has a ceiling and every non-upload POST a 2 MB body limit; a body past it answers 413.
- With the database unreachable, static files still serve and `/health` answers its 503 — every route used to answer 500 — and the driver's message stays out of the body.
- A malformed `WEB_BASIC_AUTH` stops the dashboard from starting instead of serving open; a Discord webhook is re-checked when a message is sent; opening the clean-render page no longer spends an AI call by itself.
### Schema
- no schema changes
### Verification
- 2 189 tests; the built dashboard smoked on the live database and on a dead port (see the PR).
### References
- docs/audit-2026-09-10.md ROUTE-1/2/3, SEC-7/8 · TASKS §20 block `route-hardening`