### PR TITLE
fetcher-dates: safeDate everywhere, an empty guid is no guid, validators on nine sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.6.2] — 2026-09-10
+
+### Fixed
+- **A posting date that does not parse no longer poisons the tick.** Seven
+  feed fetchers (LaraJobs, We Work Remotely, Golang Projects, Jobicy, DOU,
+  Djinni, HN jobs) built `postedAt` with no check, and Lever accepted any
+  number; one unreadable `pubDate` made the classifier throw on that row,
+  the row was never stored (so it came back every tick), and the tick
+  discarded its whole ETag cache. Every fetcher reads dates through one
+  `safeDate`, and the ingest checks once more for the fetcher that forgets.
+- An empty `<guid></guid>` in a feed item counted as an id and dropped the
+  item (Teamtailor) or gave every such item the same id (four RSS
+  fetchers); an empty guid is now no guid.
+- Nine single-request sources send the validator they were owed —
+  RemoteOK, Working Nomads, Recruitee, BambooHR, Landing.jobs, DOU, Djinni
+  and Rippling's list — and LaraJobs and Jobicy fetch through the
+  project's client (its User-Agent, the retry ladder, an error the health
+  rules can read) instead of the parser's own.
+- A SmartRecruiters board whose list answers in the wrong shape is a
+  failure from the first tick, not an empty board that surfaces two weeks
+  later.
+
 ## [2.6.1] — 2026-09-10
 
 ### Fixed
@@ -3392,6 +3414,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.6.2]: https://github.com/applypack/applypack/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/applypack/applypack/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/applypack/applypack/compare/v2.5.4...v2.6.0
 [2.5.4]: https://github.com/applypack/applypack/compare/v2.5.3...v2.5.4

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2124,7 +2124,7 @@ release-discipline skill, a docs/site block does not.
       polled JSON, multipart → 400) and ROUTE-5 (`/letter`, `/target`,
       profile save → pure decision modules; the reuse trichotomy in one
       place).
-- [ ] **`fetcher-dates`** (patch) — FETCH-1 a shared `safeDate` in the
+- [x] **`fetcher-dates`** (patch) — shipped v2.6.2; FETCH-5 left. FETCH-1 a shared `safeDate` in the
       seven RSS fetchers and `lever.ts`, and `classifier.ts:162` never
       throws on a date; FETCH-2 the `??` chain fixed in five fetchers
       (test: an item with an empty `<guid>`); FETCH-3 `conditionalHeaders`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "private": true,
   "description": "Runs locally with Docker: an AI console for the whole job search that finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 33 sources, 5 swappable AI backends, your data in your own Postgres, self-hosted on a VPS if you like.",
   "license": "MIT",

--- a/src/fetchers/bamboohr.ts
+++ b/src/fetchers/bamboohr.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { fetchWithRetry } from '../http';
+import { conditionalHeaders, rememberResponse } from './conditional';
 import type { NormalizedJob } from '../types';
 
 // BambooHR's public careers list: one GET, no auth, list-only by design
@@ -46,11 +47,14 @@ export interface BambooCompany {
 export async function fetchBamboo(
   company: BambooCompany,
 ): Promise<NormalizedJob[]> {
-  const resp = await fetchWithRetry(ENDPOINT_TEMPLATE(company.atsToken), {
-    init: { redirect: 'error' },
+  const url = ENDPOINT_TEMPLATE(company.atsToken);
+  const resp = await fetchWithRetry(url, {
+    init: { redirect: 'error', headers: conditionalHeaders(company.id, url) },
   });
   const raw: unknown = await resp.json();
-  return mapBambooFeed(raw, company.id, company.atsToken);
+  const jobs = mapBambooFeed(raw, company.id, company.atsToken);
+  rememberResponse(company.id, url, resp, jobs.length);
+  return jobs;
 }
 
 export function mapBambooFeed(

--- a/src/fetchers/dates.test.ts
+++ b/src/fetchers/dates.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { safeDate, validDate } from './dates';
+
+test('safeDate reads what parses and falls back on the rest', () => {
+  const fallback = new Date('2026-09-10T00:00:00Z');
+  assert.equal(safeDate('Wed, 09 Sep 2026 10:00:00 GMT', fallback).toISOString(), '2026-09-09T10:00:00.000Z');
+  assert.equal(safeDate(1757412000 * 1000, fallback).getTime(), 1757412000 * 1000);
+  for (const bad of ['garbage', '', null, undefined, Infinity, 1e18]) {
+    assert.equal(safeDate(bad as string, fallback), fallback, String(bad));
+  }
+});
+
+test('validDate keeps a real date and replaces an invalid one', () => {
+  const fallback = new Date('2026-09-10T00:00:00Z');
+  const real = new Date('2026-01-01T00:00:00Z');
+  assert.equal(validDate(real, fallback), real);
+  assert.equal(validDate(new Date('nope'), fallback), fallback);
+});

--- a/src/fetchers/dates.ts
+++ b/src/fetchers/dates.ts
@@ -1,0 +1,20 @@
+/*
+ * Dates off a feed or a vendor API. `new Date(garbage)` is an Invalid Date,
+ * and one of those in `postedAt` used to throw in the classifier's prompt
+ * line, keep the row unstored (so it came back every tick) and make the
+ * tick discard its whole ETag cache (audit 2026-09-10, FETCH-1). The
+ * fetchers read through safeDate; process-jobs checks once more on the
+ * way in, so a fetcher that forgets cannot repeat it.
+ */
+
+/** The date a feed or API gave, or `fallback` (now) when it does not parse. */
+export function safeDate(raw: string | number | null | undefined, fallback = new Date()): Date {
+  if (raw === null || raw === undefined || raw === '') return fallback;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? fallback : d;
+}
+
+/** A Date that is one; an invalid one becomes `fallback`. */
+export function validDate(d: Date, fallback = new Date()): Date {
+  return Number.isNaN(d.getTime()) ? fallback : d;
+}

--- a/src/fetchers/djinni.ts
+++ b/src/fetchers/djinni.ts
@@ -1,5 +1,7 @@
 import Parser from 'rss-parser';
+import { safeDate } from './dates';
 import { fetchWithRetry, stripHtml } from '../http';
+import { conditionalHeaders, rememberResponse } from './conditional';
 import type { LocationHints } from '../location';
 import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
@@ -68,11 +70,14 @@ export interface DjinniCompany {
 }
 
 export async function fetchDjinni(company: DjinniCompany): Promise<NormalizedJob[]> {
-  const resp = await fetchWithRetry(djinniFeedUrl(company.atsToken), { timeoutMs: TIMEOUT_MS });
+  const url = djinniFeedUrl(company.atsToken);
+  const resp = await fetchWithRetry(url, { timeoutMs: TIMEOUT_MS, init: { headers: conditionalHeaders(company.id, url) } });
   const feed = await parser.parseString(await resp.text());
   const place = djinniPlace(company.atsToken);
   const keyword = filterParams(company.atsToken).get('primary_keyword');
-  return feed.items.flatMap((item) => mapDjinniItem(item, company.id, place, keyword) ?? []);
+  const jobs = feed.items.flatMap((item) => mapDjinniItem(item, company.id, place, keyword) ?? []);
+  rememberResponse(company.id, url, resp, jobs.length);
+  return jobs;
 }
 
 /** The token as a feed URL: known keys only, values encoded. */
@@ -134,7 +139,7 @@ export function mapDjinniItem(
     location: place.location,
     // `content` is HTML; stripHtml decodes entities first (gotcha 12).
     description: stripHtml(item.content ?? item.contentSnippet ?? ''),
-    postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+    postedAt: safeDate(item.pubDate),
     locationHints: place.hints,
   } satisfies NormalizedJob;
 }

--- a/src/fetchers/dou.ts
+++ b/src/fetchers/dou.ts
@@ -1,6 +1,8 @@
 import Parser from 'rss-parser';
+import { safeDate } from './dates';
 import { findCountry } from '../countries';
 import { fetchWithRetry, stripHtml } from '../http';
+import { conditionalHeaders, rememberResponse } from './conditional';
 import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
 import { insideParens, parseDouTitle } from './dou-title';
@@ -50,9 +52,12 @@ export interface DouCompany {
 }
 
 export async function fetchDou(company: DouCompany): Promise<NormalizedJob[]> {
-  const resp = await fetchWithRetry(douFeedUrl(company.atsToken), { timeoutMs: PARSER_TIMEOUT_MS });
+  const url = douFeedUrl(company.atsToken);
+  const resp = await fetchWithRetry(url, { timeoutMs: PARSER_TIMEOUT_MS, init: { headers: conditionalHeaders(company.id, url) } });
   const feed = await parser.parseString(await resp.text());
-  return feed.items.flatMap((item) => mapDouItem(item, company.id) ?? []);
+  const jobs = feed.items.flatMap((item) => mapDouItem(item, company.id) ?? []);
+  rememberResponse(company.id, url, resp, jobs.length);
+  return jobs;
 }
 
 /** The token as a feed URL: known keys only, values encoded, `remote` kept bare as DOU writes it. */
@@ -97,7 +102,7 @@ export function mapDouItem(item: DouItem, companyId: number): NormalizedJob | nu
     url: link,
     location,
     description: header && body ? `${header}\n\n${body}` : header || body,
-    postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+    postedAt: safeDate(item.pubDate),
     locationHints: {
       workplace: parsed.remote ? 'REMOTE' : 'UNKNOWN',
       countries: parsed.places.flatMap((p) => findCountry(p)?.code ?? findCountry(insideParens(p))?.code ?? []),

--- a/src/fetchers/golangprojects.ts
+++ b/src/fetchers/golangprojects.ts
@@ -1,6 +1,7 @@
 import Parser from 'rss-parser';
+import { safeDate } from './dates';
 import { fetchWithRetry, stripHtml } from '../http';
-import { feedItemKey } from '../text-utils';
+import { feedEntryId } from '../text-utils';
 import { conditionalHeaders, rememberResponse } from './conditional';
 import type { NormalizedJob } from '../types';
 
@@ -44,7 +45,7 @@ export function mapGolangProjectsItem(
   companyId: number,
 ): NormalizedJob | null {
   const link = item.link ?? '';
-  const externalId = item.guid ?? feedItemKey(link, item.title);
+  const externalId = feedEntryId(item.guid, link, item.title);
   // Nothing identifies this row — skip it rather than hash '' and merge
   // every such row onto one shared id.
   if (!externalId) return null;
@@ -57,7 +58,7 @@ export function mapGolangProjectsItem(
     url: link,
     location: deriveLocation(item.title ?? '', link),
     description,
-    postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+    postedAt: safeDate(item.pubDate),
   } satisfies NormalizedJob;
 }
 

--- a/src/fetchers/hn-jobs.ts
+++ b/src/fetchers/hn-jobs.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { safeDate } from './dates';
 import { fetchWithRetry, stripHtml } from '../http';
 import type { NormalizedJob } from '../types';
 
@@ -80,11 +81,7 @@ export function mapHnJobHit(
     url: link,
     location: extractLocationFromTitle(title),
     description,
-    postedAt: hit.created_at_i
-      ? new Date(hit.created_at_i * 1000)
-      : hit.created_at
-        ? new Date(hit.created_at)
-        : new Date(),
+    postedAt: hit.created_at_i ? safeDate(hit.created_at_i * 1000) : safeDate(hit.created_at),
   } satisfies NormalizedJob;
 }
 

--- a/src/fetchers/jobicy.ts
+++ b/src/fetchers/jobicy.ts
@@ -1,7 +1,8 @@
 import Parser from 'rss-parser';
-import { sleep, stripHtml } from '../http';
+import { safeDate } from './dates';
+import { fetchWithRetry, sleep, stripHtml } from '../http';
 import { logger } from '../logger';
-import { feedItemKey } from '../text-utils';
+import { feedEntryId } from '../text-utils';
 import type { NormalizedJob } from '../types';
 import { type FetchContext, EMPTY_CONTEXT } from './fetch-context';
 
@@ -90,7 +91,10 @@ export async function fetchJobicy(
   const out = new Map<string, NormalizedJob>();
   for (const [i, slug] of feeds.entries()) {
     if (i > 0) await sleep(FEED_DELAY_MS);
-    const feed = await parser.parseURL(jobicyFeedUrl(category, slug));
+    // fetchWithRetry rather than parser.parseURL: the project's User-Agent and
+    // the retry ladder. No validator — one row makes several requests (ADR 0035).
+    const resp = await fetchWithRetry(jobicyFeedUrl(category, slug), { timeoutMs: PARSER_TIMEOUT_MS });
+    const feed = await parser.parseString(await resp.text());
     let added = 0;
     for (const item of feed.items) {
       const job = mapJobicyItem(item, companyId);
@@ -130,7 +134,7 @@ export function mapJobicyItem(
   companyId: number,
 ): NormalizedJob | null {
   const link = item.link ?? '';
-  const externalId = item.guid ?? feedItemKey(link, item.title);
+  const externalId = feedEntryId(item.guid, link, item.title);
   // Nothing identifies this row — skip it rather than hash '' and merge
   // every such row onto one shared id.
   if (!externalId) return null;
@@ -147,7 +151,7 @@ export function mapJobicyItem(
     url: link,
     location,
     description,
-    postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+    postedAt: safeDate(item.pubDate),
     // <job_listing:location> is a fixed vocabulary ("USA", "Europe, Norway",
     // "Anywhere") the parser reads from the string; the board is remote-only.
     locationHints: { workplace: 'REMOTE' },

--- a/src/fetchers/landingjobs.ts
+++ b/src/fetchers/landingjobs.ts
@@ -1,6 +1,7 @@
 import Parser from 'rss-parser';
 import { findCountry } from '../countries';
 import { fetchWithRetry, stripHtml } from '../http';
+import { conditionalHeaders, rememberResponse } from './conditional';
 import type { LocationHints, WorkplaceCode } from '../location';
 import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
@@ -50,9 +51,11 @@ const parser: Parser<unknown, LandingJobsItem> = new Parser({
 });
 
 export async function fetchLandingJobs(companyId: number): Promise<NormalizedJob[]> {
-  const resp = await fetchWithRetry(FEED_URL, { timeoutMs: TIMEOUT_MS });
+  const resp = await fetchWithRetry(FEED_URL, { timeoutMs: TIMEOUT_MS, init: { headers: conditionalHeaders(companyId, FEED_URL) } });
   const feed = await parser.parseString(await resp.text());
-  return feed.items.flatMap((item) => mapLandingJobsItem(item, companyId) ?? []);
+  const jobs = feed.items.flatMap((item) => mapLandingJobsItem(item, companyId) ?? []);
+  rememberResponse(companyId, FEED_URL, resp, jobs.length);
+  return jobs;
 }
 
 /** Pure mapper; the place and the arrangement come from the feed's own fields. */

--- a/src/fetchers/larajobs.test.ts
+++ b/src/fetchers/larajobs.test.ts
@@ -133,3 +133,17 @@ function mustmapLarajobsItem(...args: Parameters<typeof mapLarajobsItem>): NonNu
   assert.ok(job, 'expected the fixture to map to a job');
   return job;
 }
+
+describe('mapLarajobsItem — dates and ids the feed gets wrong (audit 2026-09-10)', () => {
+  it('a pubDate that does not parse becomes a real date, not an Invalid one', () => {
+    const job = mustmapLarajobsItem({ title: 'Dev', link: 'https://larajobs.com/job/1', pubDate: 'garbage' }, COMPANY_ID);
+    assert.equal(Number.isNaN(job.postedAt.getTime()), false);
+  });
+
+  it('an empty <guid> is no guid: the id comes from the link', () => {
+    const empty = mustmapLarajobsItem({ title: 'Dev', link: 'https://larajobs.com/job/2', guid: '' }, COMPANY_ID);
+    const none = mustmapLarajobsItem({ title: 'Dev', link: 'https://larajobs.com/job/2' }, COMPANY_ID);
+    assert.notEqual(empty.externalId, '');
+    assert.equal(empty.externalId, none.externalId);
+  });
+});

--- a/src/fetchers/larajobs.ts
+++ b/src/fetchers/larajobs.ts
@@ -1,6 +1,8 @@
 import Parser from 'rss-parser';
-import { stripHtml } from '../http';
-import { feedItemKey } from '../text-utils';
+import { safeDate } from './dates';
+import { fetchWithRetry, stripHtml } from '../http';
+import { conditionalHeaders, rememberResponse } from './conditional';
+import { feedEntryId } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
 const FEED_URL = 'https://larajobs.com/feed';
@@ -51,8 +53,14 @@ const parser: Parser<unknown, LarajobsItem> = new Parser({
 export async function fetchLarajobs(
   companyId: number,
 ): Promise<NormalizedJob[]> {
-  const feed = await parser.parseURL(FEED_URL);
-  return feed.items.flatMap((item) => mapLarajobsItem(item, companyId) ?? []);
+  // Through fetchWithRetry, not parser.parseURL: the project's User-Agent
+  // (DOU answers rss-parser's own with a 403), the retry ladder, an HttpError
+  // the health rules can read, and the validator (FETCH-3).
+  const resp = await fetchWithRetry(FEED_URL, { timeoutMs: PARSER_TIMEOUT_MS, init: { headers: conditionalHeaders(companyId, FEED_URL) } });
+  const feed = await parser.parseString(await resp.text());
+  const jobs = feed.items.flatMap((item) => mapLarajobsItem(item, companyId) ?? []);
+  rememberResponse(companyId, FEED_URL, resp, jobs.length);
+  return jobs;
 }
 
 /**
@@ -66,7 +74,7 @@ export function mapLarajobsItem(
   companyId: number,
 ): NormalizedJob | null {
   const link = item.link ?? '';
-  const externalId = item.guid ?? feedItemKey(link, item.title);
+  const externalId = feedEntryId(item.guid, link, item.title);
   // Nothing identifies this row — skip it rather than hash '' and merge
   // every such row onto one shared id.
   if (!externalId) return null;
@@ -84,7 +92,7 @@ export function mapLarajobsItem(
     url: link,
     location,
     description,
-    postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+    postedAt: safeDate(item.pubDate),
   } satisfies NormalizedJob;
 }
 

--- a/src/fetchers/lever.ts
+++ b/src/fetchers/lever.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { safeDate } from './dates';
 import { fetchWithRetry } from '../http';
 import { conditionalHeaders, rememberResponse } from './conditional';
 import { workplaceFromText } from '../location';
@@ -72,7 +73,7 @@ export function mapLeverPosting(
     url: p.hostedUrl,
     location: `${primary}${workplace}`.trim(),
     description: p.descriptionPlain ?? '',
-    postedAt: new Date(p.createdAt),
+    postedAt: safeDate(p.createdAt),
     locationHints: {
       countries: p.country ? [p.country] : [],
       workplace: workplaceFromText(p.workplaceType ?? ''),

--- a/src/fetchers/recruitee.ts
+++ b/src/fetchers/recruitee.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { fetchWithRetry, stripHtml } from '../http';
+import { conditionalHeaders, rememberResponse } from './conditional';
 import type { WorkplaceCode } from '../location';
 import type { NormalizedJob } from '../types';
 
@@ -58,9 +59,12 @@ export interface RecruiteeCompany {
 export async function fetchRecruitee(
   company: RecruiteeCompany,
 ): Promise<NormalizedJob[]> {
-  const resp = await fetchWithRetry(ENDPOINT_TEMPLATE(company.atsToken));
+  const url = ENDPOINT_TEMPLATE(company.atsToken);
+  const resp = await fetchWithRetry(url, { init: { headers: conditionalHeaders(company.id, url) } });
   const raw: unknown = await resp.json();
-  return mapRecruiteeFeed(raw, company.id, company.atsToken);
+  const jobs = mapRecruiteeFeed(raw, company.id, company.atsToken);
+  rememberResponse(company.id, url, resp, jobs.length);
+  return jobs;
 }
 
 export function mapRecruiteeFeed(

--- a/src/fetchers/remoteok.ts
+++ b/src/fetchers/remoteok.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { fetchWithRetry, stripHtml } from '../http';
+import { conditionalHeaders, rememberResponse } from './conditional';
 import { hashShortId } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
@@ -32,9 +33,11 @@ const RemoteOkJobSchema = z
 type RemoteOkJob = z.infer<typeof RemoteOkJobSchema>;
 
 export async function fetchRemoteOk(companyId: number): Promise<NormalizedJob[]> {
-  const resp = await fetchWithRetry(ENDPOINT);
+  const resp = await fetchWithRetry(ENDPOINT, { init: { headers: conditionalHeaders(companyId, ENDPOINT) } });
   const raw: unknown = await resp.json();
-  return mapRemoteokFeed(raw, companyId);
+  const jobs = mapRemoteokFeed(raw, companyId);
+  rememberResponse(companyId, ENDPOINT, resp, jobs.length);
+  return jobs;
 }
 
 /**

--- a/src/fetchers/rippling.ts
+++ b/src/fetchers/rippling.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { fetchWithRetry, sleep, stripHtml } from '../http';
+import { conditionalHeaders, rememberResponse } from './conditional';
 import { logger } from '../logger';
 import type { NormalizedJob } from '../types';
 
@@ -71,7 +72,10 @@ export interface RipplingCompany {
 export async function fetchRippling(
   company: RipplingCompany,
 ): Promise<NormalizedJob[]> {
-  const resp = await fetchWithRetry(LIST_URL(company.atsToken));
+  // The list is one request per tick and the details never change its
+  // validator — the same shape SmartRecruiters already revalidates.
+  const listUrl = LIST_URL(company.atsToken);
+  const resp = await fetchWithRetry(listUrl, { init: { headers: conditionalHeaders(company.id, listUrl) } });
   const raw: unknown = await resp.json();
   const rows = parseRipplingList(raw);
 
@@ -98,6 +102,7 @@ export async function fetchRippling(
     }
     out.push(toNormalized(row, detail, company.id));
   }
+  rememberResponse(company.id, listUrl, resp, out.length);
   return out;
 }
 

--- a/src/fetchers/smartrecruiters.ts
+++ b/src/fetchers/smartrecruiters.ts
@@ -92,11 +92,10 @@ export async function fetchSmartRecruiters(
   const raw: unknown = await resp.json();
   const list = SrListSchema.safeParse(raw);
   if (!list.success) {
-    logger.warn(
-      { errors: list.error.flatten().fieldErrors, atsToken: company.atsToken },
-      'smartrecruiters: list schema mismatch',
-    );
-    return [];
+    // Thrown, as Greenhouse / Lever / Ashby throw: an empty array here read
+    // as `empty` and took SILENT_DAYS to surface; a bad payload is a
+    // failure streak from the first tick (FETCH-4).
+    throw new Error(`SmartRecruiters list schema invalid for "${company.atsToken}": ${list.error.message}`);
   }
   // Normalise list rows
   const postings: z.infer<typeof SrPostingSchema>[] = [];

--- a/src/fetchers/teamtailor.ts
+++ b/src/fetchers/teamtailor.ts
@@ -4,7 +4,7 @@ import { stripHtml } from '../http';
 import { conditionalHeaders, rememberResponse } from './conditional';
 import { fetchPublicUrl, isPrivateHost } from '../jobs/posting-url';
 import type { LocationHints, WorkplaceCode } from '../location';
-import { feedItemKey } from '../text-utils';
+import { feedEntryId } from '../text-utils';
 import type { NormalizedJob } from '../types';
 import { firstText, nested, nestedAll } from './xml-text';
 
@@ -95,7 +95,7 @@ export function teamtailorHost(token: string): string {
 /** Pure mapper; the place words are the board's, the codes the gazetteer's, the arrangement the board's. */
 export function mapTeamtailorItem(item: TeamtailorItem, companyId: number, boardTitle?: string): NormalizedJob | null {
   const link = (item.link ?? '').trim();
-  const externalId = /\/jobs\/(\d+)(?:[-/?#]|$)/.exec(link)?.[1] ?? (item.guid ?? '').trim() ?? feedItemKey(link, item.title);
+  const externalId = /\/jobs\/(\d+)(?:[-/?#]|$)/.exec(link)?.[1] ?? feedEntryId(item.guid, link, item.title);
   if (!externalId) return null;
   const places = nestedAll(item['tt:locations'], 'tt:location').map((loc) => ({
     city: firstText(nested(loc, 'tt:city')) || firstText(nested(loc, 'tt:name')),

--- a/src/fetchers/weworkremotely.ts
+++ b/src/fetchers/weworkremotely.ts
@@ -1,8 +1,9 @@
 import Parser from 'rss-parser';
+import { safeDate } from './dates';
 import { fetchWithRetry, stripHtml } from '../http';
 import { conditionalHeaders, rememberResponse } from './conditional';
 import { parseLocation } from '../location';
-import { feedItemKey } from '../text-utils';
+import { feedEntryId } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
 const PARSER_TIMEOUT_MS = 10_000;
@@ -68,7 +69,7 @@ export async function fetchWeWorkRemotely(
  */
 export function mapWwrItem(item: WwrItem, companyId: number): NormalizedJob | null {
   const link = item.link ?? '';
-  const externalId = item.guid ?? feedItemKey(link, item.title);
+  const externalId = feedEntryId(item.guid, link, item.title);
   // Nothing identifies this row — skip it rather than hash '' and merge
   // every such row onto one shared id.
   if (!externalId) return null;
@@ -88,7 +89,7 @@ export function mapWwrItem(item: WwrItem, companyId: number): NormalizedJob | nu
     url: link,
     location: where.length > 0 ? `Remote · ${where}` : 'Remote',
     description,
-    postedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+    postedAt: safeDate(item.pubDate),
     locationHints: { workplace: 'REMOTE', countries, regions },
   } satisfies NormalizedJob;
 }

--- a/src/fetchers/workingnomads.ts
+++ b/src/fetchers/workingnomads.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { fetchWithRetry, stripHtml } from '../http';
+import { conditionalHeaders, rememberResponse } from './conditional';
 import { feedItemKey } from '../text-utils';
 import type { NormalizedJob } from '../types';
 
@@ -36,9 +37,11 @@ const WorkingNomadsResponseSchema = z.array(z.unknown());
 export async function fetchWorkingNomads(
   companyId: number,
 ): Promise<NormalizedJob[]> {
-  const resp = await fetchWithRetry(ENDPOINT);
+  const resp = await fetchWithRetry(ENDPOINT, { init: { headers: conditionalHeaders(companyId, ENDPOINT) } });
   const raw: unknown = await resp.json();
-  return mapWorkingNomadsFeed(raw, companyId);
+  const jobs = mapWorkingNomadsFeed(raw, companyId);
+  rememberResponse(companyId, ENDPOINT, resp, jobs.length);
+  return jobs;
 }
 
 export function mapWorkingNomadsFeed(

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -5,6 +5,7 @@ import { logger } from '../logger';
 import { createLimiter } from '../concurrency';
 import { passesAnyBaseFilter } from '../filter';
 import { withApplyLinkFlags } from '../apply-link';
+import { validDate } from '../fetchers/dates';
 import { parseLocation } from '../location';
 import { classifyJob, type ClassifyOutcome } from '../classifier';
 import { buildVerdicts, mergeVerdicts, type ProfileVerdict } from './verdict-merge';
@@ -141,6 +142,13 @@ export async function processNormalizedJobs(
     // The structured reading of the location string (ADR 0031): the source's
     // hints first, the parser for the rest. The filter compares its columns
     // with each search's (ADR 0032); the insert stores them as they are here.
+    // A date that is not one would throw in the prompt and again in the
+    // insert, and the row would come back every tick (FETCH-1). Every fetcher
+    // reads dates through safeDate; this is the check for the one that forgets.
+    if (Number.isNaN(item.job.postedAt.getTime())) {
+      logger.warn({ title: item.job.title, companyName: item.companyName }, 'process-jobs: posting date unreadable, using now');
+      item.job.postedAt = validDate(item.job.postedAt);
+    }
     const place = parseLocation(item.job.location, item.job.locationHints);
     // A posting is admitted when ANY active search admits it (ADR 0028).
     // Storing unscored keeps the UNFILTERED roster on purpose: the wizard's

--- a/src/text-utils.test.ts
+++ b/src/text-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   daysSince,
+  feedEntryId,
   feedItemKey,
   normalizeTextKey,
   normalizeUrlKey,
@@ -384,6 +385,13 @@ describe('url and text keys', () => {
   assert.equal(normalizeTextKey('Żółć ėė'), 'żółć ėė');
   assert.equal(normalizeTextKey('!!!'), null);
   assert.equal(normalizeTextKey(''), null);
+  });
+
+  it('feedEntryId takes a real guid and treats an empty one as absent', () => {
+    assert.equal(feedEntryId('abc-1', 'https://x/y', 'T'), 'abc-1');
+    assert.equal(feedEntryId('  ', 'https://x/y', 'T'), feedItemKey('https://x/y', 'T'));
+    assert.equal(feedEntryId(undefined, null, 'Only a title'), feedItemKey(null, 'Only a title'));
+    assert.equal(feedEntryId('', null, ''), null);
   });
 
   it('feedItemKey prefers the URL and falls back to text', () => {

--- a/src/text-utils.ts
+++ b/src/text-utils.ts
@@ -77,6 +77,20 @@ export function normalizeTextKey(input: string | null | undefined): string | nul
  * yields anything — the caller must skip the row rather than hash `''`,
  * which would merge every junk row into one.
  */
+/**
+ * A feed entry's id: its `<guid>` when the element carries one, else the
+ * URL-or-text key. `guid ?? …` let an EMPTY `<guid></guid>` through as ''
+ * (audit 2026-09-10, FETCH-2), which is nullish to nobody.
+ */
+export function feedEntryId(
+  guid: string | null | undefined,
+  url: string | null | undefined,
+  ...textParts: Array<string | null | undefined>
+): string | null {
+  const g = (guid ?? '').trim();
+  return g.length > 0 ? g : feedItemKey(url, ...textParts);
+}
+
 export function feedItemKey(
   url: string | null | undefined,
   ...textParts: Array<string | null | undefined>


### PR DESCRIPTION
Block `fetcher-dates` of TASKS §20 — FETCH-1 to FETCH-4 of `docs/audit-2026-09-10.md`. Patch release 2.6.2.

**What changed**
- `src/fetchers/dates.ts` (pure, tested): `safeDate` / `validDate`. Seven feed fetchers (LaraJobs, We Work Remotely, Golang Projects, Jobicy, DOU, Djinni, HN jobs) and Lever read their dates through it; `process-jobs.ts` checks once more on the way in and logs the row, so a fetcher that forgets cannot repeat FETCH-1 (an Invalid Date threw in the prompt line, kept the row unstored — fetched again every tick — and made `tickStoredEverything` drop the tick's ETag cache).
- `text-utils.ts:feedEntryId` (tested): an empty `<guid></guid>` is no guid. Teamtailor's `??` chain (the `feedItemKey` fallback was unreachable) and the four RSS fetchers' `item.guid ?? …` use it.
- Validators on the nine single-request sources CLAUDE.md's rule named and that skipped it: RemoteOK, Working Nomads, Recruitee, BambooHR, Landing.jobs, DOU, Djinni, Rippling's list; LaraJobs and Jobicy fetch through `fetchWithRetry` + `parser.parseString` (the project's User-Agent, the retry ladder, an `HttpError` the health rules can read) instead of `parser.parseURL`. HN jobs is left out on purpose: its URL carries a moving time window, so no validator could ever match.
- SmartRecruiters throws on a list-schema mismatch, as Greenhouse / Lever / Ashby do — a bad payload is a failure streak from the first tick instead of `empty` for `SILENT_DAYS`.

**Verified**
- `lint:types` green; 2 194 tests (5 new: `safeDate`/`validDate`, `feedEntryId`, a garbage `pubDate` and an empty guid through the LaraJobs mapper).
- Live, through `dist/`, two calls each in one process: RemoteOK 99 rows and LaraJobs 10 rows — both vendors send no ETag and no Last-Modified, so the header is the no-op the rule says it is; Landing.jobs 54 rows sends a weak ETag that changes on every request (three HEADs, three values), so a 304 is luck — the We Work Remotely pattern from gotcha 15. DOU / Djinni / Recruitee / BambooHR / Rippling were not hit live.

**Left (TASKS §20):** FETCH-5 — uncapped Rippling / HN-hiring loops, the totals Workable and SmartRecruiters parse and ignore, Adzuna's unstripped snippet, relative feed links, the HN parser's en-dash split, Himalayas' regions, 4dayweek's unknown code.

## Release notes
### What's new
- A posting date that does not parse no longer poisons the tick: the row is stored with today's date instead of being thrown away and fetched again every hour, and the tick keeps its ETag cache.
- An empty `<guid>` in a feed item no longer drops the item or gives every such item one id.
- Nine single-request sources now send the validator they were owed; LaraJobs and Jobicy fetch through the project's client.
- A SmartRecruiters board answering in the wrong shape shows as failing from the first tick, not as empty for two weeks.
### Schema
- no schema changes
### Verification
- 2 194 tests; three sources called twice live through the built code (see the PR).
### References
- docs/audit-2026-09-10.md FETCH-1…4 · TASKS §20 block `fetcher-dates`