### PR TITLE
a11y-pass: editor focus ring, live regions, table names and scopes, the spinner under reduced motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.6.4] — 2026-09-10
+
+### Fixed
+- The resume editor on the tailoring page shows a focus ring; its own
+  style suppressed the one every other control has, so the page's main
+  control had no visible focus but its caret.
+- What changes on its own is announced: the live match score (when the
+  number moves, not on every keystroke), "Unsaved changes" when the bar
+  appears, and the screening's scoring progress line. The one on the
+  dirty bar was a live region whose text never changed.
+- Tables have names and headers a screen reader can use: a hidden caption
+  on the jobs, applicants, screenings, resumes, companies, runs and
+  discovery tables; `scope` on the hand-written headers of the rubric,
+  calibration and comparison tables; the comparison matrix's row labels
+  are row headers.
+- Under "reduce motion" a spinner stops instead of looping at 0.01 ms;
+  the re-upload file field has a name; one link used the accent that
+  DESIGN.md reserves for fills.
+
 ## [2.6.3] — 2026-09-10
 
 ### Fixed
@@ -3434,6 +3453,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.6.4]: https://github.com/applypack/applypack/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/applypack/applypack/compare/v2.6.2...v2.6.3
 [2.6.2]: https://github.com/applypack/applypack/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/applypack/applypack/compare/v2.6.0...v2.6.1

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2158,7 +2158,7 @@ release-discipline skill, a docs/site block does not.
       number reserved once per upload, two integers instead of the
       screening row per applicant, DATA-6 the due filter as a `where`
       (the index exists) and the indexes the plans show are used.
-- [ ] **`a11y-pass`** (patch) — A11Y-1 a focus ring on `#editor`;
+- [x] **`a11y-pass`** (patch) — shipped v2.6.4: A11Y-1/2/3 and four A11Y-4 items (the spinner, the file label, the link accent, captions); the rest of A11Y-4 (glyph-only weights and gate marks, the toggle buttons' names, the tabs' keyboard model, the 15 %-alpha input ring, Hint inside the label) left. A11Y-1 a focus ring on `#editor`;
       A11Y-2 `aria-live` on `#run-progress`, the score announced (a
       visually-hidden live region beside the ring), the dirty bar's live
       region carrying text that changes; A11Y-3 `scope` on the five

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "private": true,
   "description": "Runs locally with Docker: an AI console for the whole job search that finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 33 sources, 5 swappable AI backends, your data in your own Postgres, self-hosted on a VPS if you like.",
   "license": "MIT",

--- a/src/web/layout.tsx
+++ b/src/web/layout.tsx
@@ -108,7 +108,9 @@ const TOKENS_CSS = `
     html[data-nav-open] .nav-backdrop { display: block; }
   }
   @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; }
+    /* iteration-count too: an infinite spinner at 0.01ms is not still, it is
+       a repaint storm (audit 2026-09-10, A11Y-4). */
+    *, *::before, *::after { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; scroll-behavior: auto !important; }
   }
 `;
 

--- a/src/web/pages/companies.tsx
+++ b/src/web/pages/companies.tsx
@@ -327,7 +327,7 @@ export const CompaniesPage: FC<CompaniesProps> = ({
       <Card flush>
         <div class="overflow-x-auto">
           <div class="min-w-[56rem]">
-            <Table
+            <Table caption="Companies and sources"
               columns={[
                 'Name',
                 'Source',

--- a/src/web/pages/discovery.tsx
+++ b/src/web/pages/discovery.tsx
@@ -125,7 +125,7 @@ const CandidateTable: FC<{ rows: CompanyCandidate[]; actions?: boolean }> = ({
   <Card flush>
     <div class="overflow-x-auto">
       <div class="min-w-[52rem]">
-        <Table
+        <Table caption="Discovered boards"
           columns={[
             'Name / token',
             'ATS',

--- a/src/web/pages/jobs-list.tsx
+++ b/src/web/pages/jobs-list.tsx
@@ -333,7 +333,7 @@ export const JobsListPage: FC<JobsListProps> = ({
             <>
               <div class="min-h-0 flex-1 overflow-auto">
                 <div class="min-w-[64rem]">
-                  <Table
+                  <Table caption="Jobs"
                     stickyHeader
                     widths={[
                       'w-[31%]',

--- a/src/web/pages/resumes.tsx
+++ b/src/web/pages/resumes.tsx
@@ -64,7 +64,7 @@ export const ResumesPage: FC<{
       <Empty>No resumes yet. Upload one below — the first becomes the default.</Empty>
     ) : (
       <Card flush class="mb-4">
-        <Table
+        <Table caption="Resumes"
           columns={[
             'Name',
             'Headline',

--- a/src/web/pages/runs.tsx
+++ b/src/web/pages/runs.tsx
@@ -42,7 +42,7 @@ export const RunsPage: FC<RunsProps> = ({ runs, fetchRun, flash }) => (
       <Card flush>
         <div class="overflow-x-auto">
           <div class="min-w-[56rem]">
-            <Table
+            <Table caption="Runs"
               columns={[
                 'Job',
                 'Started',

--- a/src/web/pages/screen-compare.tsx
+++ b/src/web/pages/screen-compare.tsx
@@ -92,19 +92,19 @@ export const ScreenComparePage: FC<ScreenCompareProps> = ({ screening, side, com
             </thead>
             <tbody class="divide-y divide-line">
               <tr>
-                <td class={label}>Relevant years</td>
+                <th scope="row" class={label}>Relevant years</th>
                 {side.columns.map((c) => (
                   <td class={`${td} tabular-nums`}>{c.years ?? '?'}</td>
                 ))}
               </tr>
               <tr>
-                <td class={label}>Level</td>
+                <th scope="row" class={label}>Level</th>
                 {side.columns.map((c) => (
                   <td class={td}>{c.level ?? '?'}</td>
                 ))}
               </tr>
               <tr>
-                <td class={label}>Career</td>
+                <th scope="row" class={label}>Career</th>
                 {side.columns.map((c) => (
                   <td class={`${td} text-ink-muted`}>{c.career ?? '—'}</td>
                 ))}
@@ -130,7 +130,7 @@ export const ScreenComparePage: FC<ScreenCompareProps> = ({ screening, side, com
                 </tr>
               ))}
               <tr>
-                <td class={label}>Stands out</td>
+                <th scope="row" class={label}>Stands out</th>
                 {side.columns.map((c) => (
                   <td class={`${td} text-ink-muted`}>
                     {c.standout.length === 0 ? '—' : (
@@ -144,7 +144,7 @@ export const ScreenComparePage: FC<ScreenCompareProps> = ({ screening, side, com
                 ))}
               </tr>
               <tr>
-                <td class={label}>Verdict</td>
+                <th scope="row" class={label}>Verdict</th>
                 {side.columns.map((c) => (
                   <td class={`${td} text-ink`}>{c.verdictLine || '—'}</td>
                 ))}
@@ -235,10 +235,10 @@ export const ScreenComparePage: FC<ScreenCompareProps> = ({ screening, side, com
               <table class="w-full text-sm">
                 <thead class="border-b border-line bg-surface-overlay/60">
                   <tr>
-                    <th class={th}>Criterion</th>
-                    <th class={th}>Reading A</th>
-                    <th class={th}>Reading B</th>
-                    <th class={th} />
+                    <th scope="col" class={th}>Criterion</th>
+                    <th scope="col" class={th}>Reading A</th>
+                    <th scope="col" class={th}>Reading B</th>
+                    <th scope="col" class={th} />
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-line">

--- a/src/web/pages/screen-detail.tsx
+++ b/src/web/pages/screen-detail.tsx
@@ -220,12 +220,12 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
               <table class="w-full text-sm">
                 <thead>
                   <tr class="text-left text-xs font-medium text-ink-muted">
-                    <th class="py-2 pr-2">Kind</th>
-                    <th class="py-2 pr-2">What</th>
-                    <th class="py-2 pr-2">Mode</th>
-                    <th class="py-2 pr-2">Weight</th>
-                    <th class="py-2 pr-2">From</th>
-                    <th class="py-2 text-right">Remove</th>
+                    <th scope="col" class="py-2 pr-2">Kind</th>
+                    <th scope="col" class="py-2 pr-2">What</th>
+                    <th scope="col" class="py-2 pr-2">Mode</th>
+                    <th scope="col" class="py-2 pr-2">Weight</th>
+                    <th scope="col" class="py-2 pr-2">From</th>
+                    <th scope="col" class="py-2 text-right">Remove</th>
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-line">
@@ -344,7 +344,7 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
               <Step n={4} />
               Results
             </SectionTitle>
-            <div class="text-[13px] text-ink-faint" id="run-progress" data-screening={screening.id} data-running={running ? '1' : undefined}>
+            <div class="text-[13px] text-ink-faint" id="run-progress" role="status" aria-live="polite" data-screening={screening.id} data-running={running ? '1' : undefined}>
               {running
                 ? progressText(run!)
                 : run && run.finishedAt !== null && run.failed > 0
@@ -407,7 +407,7 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
               Delete
             </Button>
           </div>
-          <Table
+          <Table caption="Applicants"
             columns={[
               <input type="checkbox" data-select-all aria-label="Select every applicant" class="h-4 w-4 accent-accent" />,
               '#',
@@ -504,10 +504,10 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
               <table class="mt-1 w-full text-sm">
                 <thead>
                   <tr class="text-left text-xs font-medium text-ink-muted">
-                    <th class="py-1 pr-2">Criterion</th>
-                    <th class="py-1 pr-2 text-right">To interview</th>
-                    <th class="py-1 pr-2 text-right">Declined</th>
-                    <th class="py-1 text-right">Gap</th>
+                    <th scope="col" class="py-1 pr-2">Criterion</th>
+                    <th scope="col" class="py-1 pr-2 text-right">To interview</th>
+                    <th scope="col" class="py-1 pr-2 text-right">Declined</th>
+                    <th scope="col" class="py-1 text-right">Gap</th>
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-line">

--- a/src/web/pages/screen-list.tsx
+++ b/src/web/pages/screen-list.tsx
@@ -32,7 +32,7 @@ export const ScreenListPage: FC<{ screenings: ScreeningSummary[]; flash?: FlashM
       </Empty>
     ) : (
       <Card flush>
-        <Table
+        <Table caption="Screenings"
           columns={['Screening', 'Position', 'Applicants', 'Scored', 'Created', 'Kept until', '']}
           hideBelow={['', 'md', '', '', 'lg', 'sm', '']}
         >

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -275,6 +275,10 @@ export const TargetPage: FC<TargetPageProps> = ({
                 {match.matchScore}
               </span>
             </button>
+            {/* The live number for a screen reader: the button's aria-label
+                changes with the score, and a changed label on an unfocused
+                element announces nothing (audit 2026-09-10, A11Y-2). */}
+            <span id="score-live" class="sr-only" aria-live="polite"></span>
             {/* Kept in the accessibility tree (opacity, not `hidden`) so
                 aria-describedby has something to read on focus. */}
             <div
@@ -365,6 +369,7 @@ export const TargetPage: FC<TargetPageProps> = ({
                     type="file"
                     name="file"
                     required
+                    aria-label="Resume file"
                     accept={ACCEPTED_EXTENSIONS.join(',')}
                     class="block w-full text-xs text-ink file:mr-2 file:cursor-pointer file:rounded-md file:border-0 file:bg-surface-overlay file:px-2.5 file:py-1 file:text-xs file:font-medium file:text-ink"
                   />
@@ -567,7 +572,7 @@ export const TargetPage: FC<TargetPageProps> = ({
             {cleanHref && (
               <>
                 {' '}
-                <a href={cleanHref} class="text-accent underline underline-offset-2 hover:no-underline">
+                <a href={cleanHref} class="text-accent-strong underline underline-offset-2 hover:no-underline">
                   Clean version in your typeface →
                 </a>
               </>
@@ -665,9 +670,9 @@ export const TargetPage: FC<TargetPageProps> = ({
       <div id="dirty-bar" hidden class="sticky bottom-3 z-20 mt-4">
         <div class="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border border-warn/40 bg-surface-raised px-4 py-2.5 shadow-lg">
           <div class="min-w-0">
-            <span class="text-sm font-medium text-ink" aria-live="polite">
-              Unsaved changes
-            </span>
+            <span class="text-sm font-medium text-ink">Unsaved changes</span>
+            {/* A live region whose text never changed announced nothing; this one is written when the bar appears. */}
+            <span id="dirty-live" class="sr-only" aria-live="polite"></span>
             <span class="ml-2 text-xs text-ink-faint">
               kept in this browser tab{resume.ephemeral ? ' — copy them out before you leave' : ' until you save'}
             </span>
@@ -763,6 +768,10 @@ const TARGET_CSS = `
   #backdrop { color: rgb(var(--ink)); pointer-events: none; overflow: hidden; }
   #editor { background: transparent; color: transparent; caret-color: rgb(var(--ink)); border: 0; outline: none; resize: none; }
   #editor::selection { background: rgb(var(--accent) / 0.25); }
+  /* The id selector above outranks the global :focus-visible ring, and the
+     page's main control had no visible focus but its caret (audit
+     2026-09-10, A11Y-1). */
+  #editor:focus-visible { outline: 2px solid rgb(var(--accent)); outline-offset: -2px; border-radius: 4px; }
   /* A grid item defaults to min-width:auto, so it is sized by its widest
      content — which made the keyword table's own overflow-x-auto wrapper
      497px wide inside a 375px column and pushed the page sideways. */

--- a/src/web/public/target-page.mjs
+++ b/src/web/public/target-page.mjs
@@ -79,9 +79,12 @@ export function init(data) {
   const chips = document.getElementById('missing-chips');
   const saveButtons = document.querySelectorAll('[data-save-button]');
   const dirtyBar = document.getElementById('dirty-bar');
+  const dirtyLive = document.getElementById('dirty-live');
   const ringButton = document.getElementById('score-ring');
   const ringArc = document.getElementById('score-arc');
   const ringNumber = document.getElementById('score-number');
+  const scoreLive = document.getElementById('score-live');
+  let announcedScore = null;
   // 2πr, straight off the element the server drew, so the two cannot drift.
   const ringLength = Number(ringArc.getAttribute('stroke-dasharray'));
   const panes = document.getElementById('panes');
@@ -126,6 +129,11 @@ export function init(data) {
       'transition-[stroke-dashoffset] duration-300 ' + RING_TONE[ringTone(score)],
     );
     ringButton.setAttribute('aria-label', 'Match score ' + score + ' of 100 — what this number is');
+    // Announced only when the number moves — every keystroke repaints, few change it.
+    if (scoreLive && announcedScore !== score) {
+      scoreLive.textContent = 'Match score ' + score + ' of 100';
+      announcedScore = score;
+    }
   }
 
   function render() {
@@ -211,6 +219,10 @@ export function init(data) {
     // the text is dirty — the estimate, the delta and the button to re-run.
     const dirty = text !== data.resumeText;
     dirtyBar.hidden = !dirty;
+    if (dirtyLive) {
+      const said = dirty ? 'Unsaved changes' : '';
+      if (dirtyLive.textContent !== said) dirtyLive.textContent = said;
+    }
     for (const b of saveButtons) b.disabled = !dirty;
     const saveText = document.getElementById('save-text');
     if (saveText) saveText.value = text;

--- a/src/web/ui.tsx
+++ b/src/web/ui.tsx
@@ -303,10 +303,13 @@ export const Table: FC<
     hideBelow?: HideBelow;
     /** Per-column classes on the `th` itself (alignment and the like). */
     thClasses?: string[];
+    /** What the table lists, for a screen reader's table list — no data table had a name (audit 2026-09-10, A11Y-3). */
+    caption?: string;
   }>
-> = ({ columns, stickyHeader = false, widths, hideBelow, thClasses, children }) => {
+> = ({ columns, stickyHeader = false, widths, hideBelow, thClasses, caption, children }) => {
   const table = (
     <table class={`w-full text-sm ${widths ? 'table-fixed' : ''} ${hideCellsClass(hideBelow)}`}>
+      {caption && <caption class="sr-only">{caption}</caption>}
       <thead>
         <tr class="text-left text-xs font-medium text-ink-muted">
           {columns.map((c, i) => (


### PR DESCRIPTION
Block `a11y-pass` of TASKS §20 — A11Y-1, A11Y-2, A11Y-3 and four items of A11Y-4 in `docs/audit-2026-09-10.md`. Patch release 2.6.4. Judged against DESIGN.md and the `accessible-interactions` skill.

**What changed**
- `target.tsx`: `#editor:focus-visible` ring (the id selector suppressed the global one); a hidden live region beside the score ring, written by `target-page.mjs` only when the number moves; the dirty bar's live region is a separate hidden span written when the bar appears (the old one wrapped a literal that never changed); the re-upload file field has a name; the clean-render link uses `accent-strong` as DESIGN.md says.
- `screen-detail.tsx`: `#run-progress` is `role="status" aria-live="polite"` (rewritten every 2 s by `screen.mjs`); `scope="col"` on the rubric and calibration tables. `screen-compare.tsx`: `scope="col"` on the readings table, the matrix's row labels are `<th scope="row">`.
- `ui.tsx`: `Table` takes a `caption` (rendered `sr-only`); named on the jobs, applicants, screenings, resumes, companies, runs and discovery tables.
- `layout.tsx`: the reduced-motion rule adds `animation-iteration-count: 1` and `scroll-behavior: auto` — `animate-spin` was an infinite 0.01 ms loop.

**Verified**
- `lint:types` green; 2 197 tests; the site's vendored `target.mjs` untouched (only `target-page.mjs` changed).
- The built dashboard on the compose Postgres: `/jobs`, `/screen`, `/screen/1`, `/resumes`, `/companies`, `/runs` render the captions, `/screen/1` renders `role="status" aria-live="polite"` on the progress line and `scope="col"` on the rubric table, and the reduced-motion rule carries `animation-iteration-count: 1`.

**Left (TASKS §20):** glyph-only weights and gate marks, the toggle buttons named by their state, the tabs' keyboard model, the 15 %-alpha input ring, `Field` putting the Hint inside the label.

## Release notes
### What's new
- The resume editor on the tailoring page shows a focus ring.
- What changes on its own is announced to a screen reader: the live match score when it moves, "Unsaved changes" when the bar appears, the screening's scoring progress.
- Tables have names and headers a screen reader can use; the comparison matrix's row labels are row headers.
- Under "reduce motion" a spinner stops instead of looping; the re-upload file field has a name.
### Schema
- no schema changes
### Verification
- 2 197 tests; rendered markup checked on the built dashboard.
### References
- docs/audit-2026-09-10.md A11Y-1…4 · TASKS §20 block `a11y-pass`