### PR TITLE
dead-exports: ten symbols gone, export dropped from 88, the scan as a script

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2177,7 +2177,7 @@ release-discipline skill, a docs/site block does not.
       `app.request()` over every GET route derived from the routers
       (2xx/3xx), the wizard's POSTs and one upload; not Playwright
       (TASKS §17.2 stands).
-- [ ] **`dead-exports`** (no tag) — DEAD-1 delete the ten (the cleanup
+- [x] **`dead-exports`** (no tag) — done 2026-09-10: the ten deleted, `export` dropped from 88, `npm run exports:audit` reruns the scan. DEAD-1 delete the ten (the cleanup
       job keeps its inline delete — the worker may not import
       `src/screening`), drop `export` from the 84, keep the 8 test seams;
       the scan script into `src/scripts/` so the next audit reruns it.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "variance:compare": "tsx src/scripts/match-variance-once.ts",
     "churn:compare": "tsx src/scripts/churn-once.ts",
     "keywords:audit": "tsx src/scripts/keyword-audit.ts",
+    "exports:audit": "tsx src/scripts/dead-exports.ts",
     "test:telegram": "tsx src/scripts/test-telegram.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate:deploy": "prisma migrate deploy",

--- a/src/ai-cooldown.ts
+++ b/src/ai-cooldown.ts
@@ -13,8 +13,8 @@ export interface CooldownTracker {
   blockedUntil(id: string): number | null;
 }
 
-export const COOLDOWN_FAILURE_THRESHOLD = 3;
-export const COOLDOWN_MS = 60_000;
+const COOLDOWN_FAILURE_THRESHOLD = 3;
+const COOLDOWN_MS = 60_000;
 
 export function createCooldownTracker(
   opts: { threshold?: number; cooldownMs?: number; now?: () => number } = {},

--- a/src/ai-engine.ts
+++ b/src/ai-engine.ts
@@ -51,7 +51,7 @@ export const PROVIDER_WEB_TOOLS: Record<AiProviderId, boolean> = {
  * mapped to OpenAI's tokens because that is what the setting is named for,
  * and erring toward the vendor is the direction that asks for less.
  */
-export const PROVIDER_AI_TOKENS: Record<AiProviderId, readonly string[]> = {
+const PROVIDER_AI_TOKENS: Record<AiProviderId, readonly string[]> = {
   anthropic_api: ['claudebot', 'claude-web', 'anthropic-ai'],
   claude_code: ['claudebot', 'claude-web', 'anthropic-ai'],
   gemini_cli: ['google-extended'],

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -22,7 +22,7 @@ const MAX_DESC_CHARS = 4000;
 // Bump on any material change to buildClassifyPrompt (rules, rubric, format,
 // fencing) — cross-engine quality comparisons are meaningless across versions.
 // v3: one call scores every active search (ADR 0028).
-export const CLASSIFIER_PROMPT_VERSION = 4;
+const CLASSIFIER_PROMPT_VERSION = 4;
 
 /**
  * Salary is hoisted out of the per-search entries on purpose: it is a fact of
@@ -226,7 +226,7 @@ export function parseClassifications(
   return out.size > 0 ? { results: out, location: parsed.data.location ?? null } : null;
 }
 
-export async function classifyWithClaude(
+async function classifyWithClaude(
   input: ClassifyInput,
   profiles: Profile[],
   onError?: (reason: string) => void,

--- a/src/countries.ts
+++ b/src/countries.ts
@@ -41,8 +41,6 @@ export const REGIONS: readonly Region[] = Object.entries(data.groups).map(([code
   code,
   ...g,
 }));
-export const REGION_CODES: readonly string[] = REGIONS.map((r) => r.code);
-
 /** Only these countries abbreviate subdivisions in job postings ("Austin, TX", "Toronto, ON"). */
 const ABBREVIATING_COUNTRIES = ['US', 'CA'];
 
@@ -52,20 +50,12 @@ const SHORT_ALIAS_LENGTH = 4;
 const byCode = new Map(COUNTRIES.map((c) => [c.code, c]));
 const regionByCode = new Map(REGIONS.map((r) => [r.code, r]));
 
-export function countryOf(code: string): Country | null {
-  return byCode.get(code.toUpperCase()) ?? null;
-}
-
 export function isCountryCode(s: string): boolean {
   return byCode.has(s);
 }
 
 export function isRegionCode(s: string): boolean {
   return regionByCode.has(s);
-}
-
-export function regionOf(code: string): Region | null {
-  return regionByCode.get(code) ?? null;
 }
 
 /** Members of a region; WORLDWIDE lists no members and means every country. */

--- a/src/currency.ts
+++ b/src/currency.ts
@@ -14,7 +14,7 @@
  */
 
 /** USD per one unit. Source: exchangerate-api.com, 2026-09-04. */
-export const RATES_REVIEWED_ON = '2026-09-04';
+const RATES_REVIEWED_ON = '2026-09-04';
 
 const RATES_TO_USD: Readonly<Record<string, number>> = {
   USD: 1,
@@ -47,10 +47,8 @@ const RATES_TO_USD: Readonly<Record<string, number>> = {
   ISK: 0.00826,
 };
 
-export const CURRENCY_CODES: readonly string[] = Object.keys(RATES_TO_USD);
-
 /** How the posting quotes the number. Null in the database means a year. */
-export const SALARY_PERIODS = ['year', 'month', 'week', 'day', 'hour'] as const;
+const SALARY_PERIODS = ['year', 'month', 'week', 'day', 'hour'] as const;
 
 export type SalaryPeriod = (typeof SALARY_PERIODS)[number];
 

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -17,7 +17,7 @@ export interface CandidateInput {
  * known. If it exists, leave it alone (don't overwrite a PROMOTED row
  * with a fresh PENDING signal).
  */
-export async function recordCandidate(
+async function recordCandidate(
   input: CandidateInput,
 ): Promise<CompanyCandidate | null> {
   // Don't propose candidates we already track in Company — they're already

--- a/src/fetchers/adzuna.ts
+++ b/src/fetchers/adzuna.ts
@@ -24,12 +24,12 @@ const CATEGORY = 'it-jobs';
 const TIMEOUT_MS = 15_000;
 
 /** The UTC hours a row is polled — four a day keeps ten markets under 2 500 calls a month. */
-export const ADZUNA_HOURS: readonly number[] = [0, 6, 12, 18];
+const ADZUNA_HOURS: readonly number[] = [0, 6, 12, 18];
 /** Rows beyond this are skipped with an error, whatever the user adds. */
 export const MAX_ADZUNA_ROWS = 10;
 
 /** The logo the terms name, served by the vendor's own CDN (press page, 2026-09-04). */
-export const ADZUNA_LOGO_URL = 'https://zunastatic-abf.kxcdn.com/images/global/adzuna_logo.svg';
+const ADZUNA_LOGO_URL = 'https://zunastatic-abf.kxcdn.com/images/global/adzuna_logo.svg';
 
 export interface AdzunaMarket {
   /** ISO-2 of the market, for the country hint. */

--- a/src/fetchers/arbeitnow.ts
+++ b/src/fetchers/arbeitnow.ts
@@ -16,7 +16,7 @@ const PAGE_DELAY_MS = 1_000;
  * filter — the rows carry no visa field of their own — so it is a feed of
  * its own, keyed by this token. Any other token is the plain board.
  */
-export const VISA_TOKEN = 'visa';
+const VISA_TOKEN = 'visa';
 
 const ArbeitnowJobSchema = z
   .object({

--- a/src/fetchers/francetravail-auth.ts
+++ b/src/fetchers/francetravail-auth.ts
@@ -9,8 +9,8 @@ import { redactSecrets } from '../source-keys';
  * ~1 499 s. Cached per process and refreshed a minute early; the secret is
  * scrubbed from anything this module throws.
  */
-export const TOKEN_URL = 'https://entreprise.francetravail.fr/connexion/oauth2/access_token?realm=%2Fpartenaire';
-export const OFFERS_SCOPE = 'api_offresdemploiv2 o2dsoffre';
+const TOKEN_URL = 'https://entreprise.francetravail.fr/connexion/oauth2/access_token?realm=%2Fpartenaire';
+const OFFERS_SCOPE = 'api_offresdemploiv2 o2dsoffre';
 const TIMEOUT_MS = 15_000;
 /** Refresh this long before the vendor's expiry so a call never lands on a dead token. */
 const REFRESH_MARGIN_MS = 60_000;

--- a/src/fetchers/francetravail.ts
+++ b/src/fetchers/francetravail.ts
@@ -105,7 +105,7 @@ export async function fetchFranceTravail(company: FranceTravailCompany, context:
 }
 
 /** One page of the token's search: the offers and, from `Content-Range`, how many there are in all. */
-export async function searchPage(
+async function searchPage(
   token: string,
   page: number,
   creds: FranceTravailCredentials,

--- a/src/fetchers/source-health.ts
+++ b/src/fetchers/source-health.ts
@@ -146,7 +146,7 @@ export function nextStreak(status: FetchStatus, current: number): number {
  * that a page moved and stores no Job; a MANUAL row is not fetched at all.
  * Everything else has to earn `lastOkAt` the ordinary way.
  */
-export function neverPosts(atsType: string | null | undefined): boolean {
+function neverPosts(atsType: string | null | undefined): boolean {
   // Compared as strings on purpose: importing AtsType would pull the Prisma
   // client into a module whose whole point is that it unit-tests without one.
   return atsType === 'CAREER_PAGE' || atsType === 'MANUAL';

--- a/src/jobs/fetch-pause.ts
+++ b/src/jobs/fetch-pause.ts
@@ -2,7 +2,7 @@ import { makeLatchingProbe } from '../cancellation';
 import { getSettings } from '../settings';
 
 /** How often a long-running tick re-reads the pause flag from the DB. */
-export const PAUSE_RECHECK_MS = 5_000;
+const PAUSE_RECHECK_MS = 5_000;
 
 /**
  * Probe for "did the user pause fetching while this tick was running?".

--- a/src/jobs/france-travail-sync.ts
+++ b/src/jobs/france-travail-sync.ts
@@ -36,7 +36,7 @@ import type { FetchContext } from '../fetchers/fetch-context';
  */
 
 /** Checks per tick — at one every CALL_GAP_MS that is under a minute of calls. */
-export const MAX_CHECKS_PER_TICK = 200;
+const MAX_CHECKS_PER_TICK = 200;
 const DAY_MS = 24 * 60 * 60 * 1000;
 /**
  * How long an offer may go unverified before we withdraw it ourselves. The

--- a/src/jobs/posting-url.ts
+++ b/src/jobs/posting-url.ts
@@ -17,7 +17,7 @@ const FETCH_TIMEOUT_MS = 12_000;
 const MAX_TEXT_CHARS = 30_000;
 
 /** ADR 0005: never scraped — not even one page at a time. */
-export const BLOCKED_POSTING_HOSTS = [
+const BLOCKED_POSTING_HOSTS = [
   'linkedin.com',
   'indeed.com',
   'glassdoor.com',
@@ -165,7 +165,7 @@ export function isPrivateHost(hostname: string): boolean {
 /** The addresses a name resolves to — injected so the guard is tested without the network. */
 export type Resolver = (hostname: string) => Promise<string[]>;
 
-export const lookupAddresses: Resolver = async (hostname) =>
+const lookupAddresses: Resolver = async (hostname) =>
   (await dns.lookup(hostname, { all: true })).map((a) => a.address);
 
 const PUBLIC_ONLY = 'Only public posting URLs can be fetched.';
@@ -187,7 +187,7 @@ export async function resolvesToPublic(
   return addresses.some(isPrivateIp) ? { ok: false, error: PUBLIC_ONLY } : { ok: true };
 }
 
-export const MAX_REDIRECTS = 5;
+const MAX_REDIRECTS = 5;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 /** What a hop has to say about itself: the status, and where it points next. */
@@ -234,7 +234,7 @@ export async function fetchPublicHops<T extends Hop>(
 }
 
 /** The guard said no — distinct from a network or HTTP failure, which pass through unchanged. */
-export class PublicUrlError extends Error {}
+class PublicUrlError extends Error {}
 
 /** fetchWithRetry for a user-supplied URL: the three layers, then the response that answered. */
 export async function fetchPublicUrl(raw: string, options: FetchOptions = {}): Promise<Response> {

--- a/src/location.ts
+++ b/src/location.ts
@@ -61,10 +61,10 @@ export interface ParsedLocation {
 
 // Arrangement markers, shared with filter.ts. Unicode boundaries rather than
 // \b so the Ukrainian and German spellings match as whole words too.
-export const REMOTE_RE =
+const REMOTE_RE =
   /(?<![\p{L}\p{N}])(?:remote|home[- ]?based|home ?office|work from home|wfh|віддалено|дистанційно|praca zdalna|zdalnie|t[ée]l[ée]travail)(?![\p{L}\p{N}])/iu;
-export const HYBRID_RE = /(?<![\p{L}\p{N}])hybrid(?![\p{L}\p{N}])/iu;
-export const ONSITE_RE = /(?<![\p{L}\p{N}])(?:on[-_ ]?site|in[- ]?office|in[- ]?person)(?![\p{L}\p{N}])/iu;
+const HYBRID_RE = /(?<![\p{L}\p{N}])hybrid(?![\p{L}\p{N}])/iu;
+const ONSITE_RE = /(?<![\p{L}\p{N}])(?:on[-_ ]?site|in[- ]?office|in[- ]?person)(?![\p{L}\p{N}])/iu;
 
 // One office or several: a segment is one place. Spaced hyphens and the
 // words "or" / "and" separate too; a bare hyphen does not (Cluj-Napoca).

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -58,7 +58,7 @@ export async function sendDigest(
 }
 
 /** The Telegram digest, packed under the 4096-char message limit. Pure — exported for the test. */
-export function formatTelegramDigest(jobs: readonly AlertJob[], quiet: readonly QuietSourceAlert[], title: string): string[] {
+function formatTelegramDigest(jobs: readonly AlertJob[], quiet: readonly QuietSourceAlert[], title: string): string[] {
   const healthLine = formatSourceHealthLine([...quiet]);
   if (jobs.length === 0) {
     const empty = escapeMarkdownV2('No new matches since the last digest.');

--- a/src/priority-rules.ts
+++ b/src/priority-rules.ts
@@ -12,7 +12,7 @@
 import { z } from 'zod';
 import type { ClaudeClassification } from './types';
 
-export const PriorityRuleSchema = z.object({
+const PriorityRuleSchema = z.object({
   /** Short user-facing label, shown as a badge on /jobs/:id. */
   label: z.string().min(1).max(80),
   /** ≥1 of these (case-insensitive substring) must appear in title OR description. */
@@ -25,7 +25,7 @@ export const PriorityRuleSchema = z.object({
 
 export type PriorityRule = z.infer<typeof PriorityRuleSchema>;
 
-export const PriorityRulesSchema = z.array(PriorityRuleSchema);
+const PriorityRulesSchema = z.array(PriorityRuleSchema);
 
 /**
  * Defensive parse for the JSON column on Profile. Returns [] for any
@@ -73,7 +73,7 @@ export function ruleMatches(rule: PriorityRule, job: MatchableJob): boolean {
  * boundary (any order, any positions). Empty phrase fails closed.
  * Exported for unit tests; consumers go through `ruleMatches`.
  */
-export function phraseMatches(haystack: string, phrase: string): boolean {
+function phraseMatches(haystack: string, phrase: string): boolean {
   const tokens = phrase.split(/\s+/).filter((t) => t.length > 0);
   if (tokens.length === 0) return false;
   return tokens.every((t) => tokenMatches(haystack, t));

--- a/src/resume/answers.ts
+++ b/src/resume/answers.ts
@@ -25,7 +25,7 @@ export interface ReviewAnswer {
 }
 
 /** A question is a sentence; an answer is a figure with its context, not an essay. */
-export const MAX_QUESTION_CHARS = 300;
+const MAX_QUESTION_CHARS = 300;
 export const MAX_ANSWER_CHARS = 300;
 /**
  * How many answers ride into a prompt. Six dimensions ask at most a couple of

--- a/src/resume/brief-depth.ts
+++ b/src/resume/brief-depth.ts
@@ -17,7 +17,7 @@ import type { PostingBrief } from './prompts';
  * scoring lever is the last thing a number this volatile needs. Pure.
  */
 
-export const POSTING_DEPTHS = ['high', 'medium', 'low'] as const;
+const POSTING_DEPTHS = ['high', 'medium', 'low'] as const;
 export type PostingDepth = (typeof POSTING_DEPTHS)[number];
 
 export interface DepthReport {

--- a/src/resume/brief.ts
+++ b/src/resume/brief.ts
@@ -25,7 +25,7 @@ import { createPostingBrief, getPostingBrief } from './store';
  */
 
 /** What a stored brief is keyed by: the posting text this reading was made from. */
-export function postingHashOf(job: Pick<MatchJobInput, 'title' | 'description'>): string {
+function postingHashOf(job: Pick<MatchJobInput, 'title' | 'description'>): string {
   return hashShortId(`${job.title}\n${job.description}`);
 }
 

--- a/src/resume/keyword-frame.ts
+++ b/src/resume/keyword-frame.ts
@@ -24,7 +24,7 @@
  * ADR 0029) so the card can say why a score stands on its own.
  */
 
-export const FRAME_REASONS = ['carried', 'first-run', 'rebuild', 'prompt-bump', 'posting-changed'] as const;
+const FRAME_REASONS = ['carried', 'first-run', 'rebuild', 'prompt-bump', 'posting-changed'] as const;
 export type FrameReason = (typeof FRAME_REASONS)[number];
 
 /** The latest stored analysis of this posting, as the frame decision reads it. */

--- a/src/resume/pdf-write.ts
+++ b/src/resume/pdf-write.ts
@@ -12,7 +12,7 @@ const PAGE_H = 792;
 const MARGIN = 72;
 const FONT_SIZE = 11;
 const LEADING = 16;
-export const PDF_WRAP_CHARS = 80;
+const PDF_WRAP_CHARS = 80;
 const LINES_PER_PAGE = Math.floor((PAGE_H - 2 * MARGIN) / LEADING); // 40
 
 /** Word wrap by character budget; a single overlong token is hard-broken. */

--- a/src/resume/prompts.ts
+++ b/src/resume/prompts.ts
@@ -117,7 +117,7 @@ const tagList = z
   .default([])
   .transform((arr) => [...new Set(arr.map((s) => s.trim().toLowerCase()).filter(Boolean))]);
 
-export const ScanSchema = z.object({
+const ScanSchema = z.object({
   title: nullableText,
   seniority: nullableText,
   years_experience: z.number().int().min(0).max(60).nullish().transform((v) => v ?? null),
@@ -145,7 +145,7 @@ export type ResumeScan = z.infer<typeof ScanSchema>;
 export type ResumeIssue = ResumeScan['issues'][number];
 
 /** How a requirement group is satisfied: any one option, or every option (ADR 0044). */
-export const SATISFY_MODES = ['any', 'all'] as const;
+const SATISFY_MODES = ['any', 'all'] as const;
 export type SatisfyMode = (typeof SATISFY_MODES)[number];
 
 /**
@@ -230,8 +230,8 @@ export type BriefKeyword = PostingBrief['keywords'][number];
 export type RequirementGroup = PostingBrief['requirement_groups'][number];
 
 export const ACTION_SECTIONS = ['title', 'summary', 'skills', 'experience', 'education', 'format'] as const;
-export const ACTION_PRIORITIES = ['high', 'medium', 'low'] as const;
-export const HARD_STATUSES = ['pass', 'unknown', 'fail'] as const;
+const ACTION_PRIORITIES = ['high', 'medium', 'low'] as const;
+const HARD_STATUSES = ['pass', 'unknown', 'fail'] as const;
 
 const AlignmentSchema = z.object({
   title: z.enum(ALIGNMENT_GRADES),
@@ -239,7 +239,7 @@ const AlignmentSchema = z.object({
   recent_role: z.enum(ALIGNMENT_GRADES),
 });
 
-export const MatchSchema = z.object({
+const MatchSchema = z.object({
   summary: z.string(),
   alignment: AlignmentSchema,
   strengths: z.array(z.string()).max(20).default([]),
@@ -338,7 +338,7 @@ export const MatchSchema = z.object({
 });
 export type ResumeMatchResult = z.infer<typeof MatchSchema>;
 /** What the lazy suggestions call returns — the full report minus the verdicts. */
-export const SuggestionsSchema = MatchSchema.pick({ strengths: true, cautions: true, actions: true, removals: true });
+const SuggestionsSchema = MatchSchema.pick({ strengths: true, cautions: true, actions: true, removals: true });
 export type MatchSuggestions = z.infer<typeof SuggestionsSchema>;
 export type MatchKeyword = ResumeMatchResult['keywords'][number];
 export type MatchAction = ResumeMatchResult['actions'][number];
@@ -347,7 +347,7 @@ export type MatchHardRequirement = ResumeMatchResult['hard_requirements'][number
 export type { MatchAlignment };
 
 /** One rewritten suggestion: the wording, and the two lines that describe it. */
-export const RewriteSchema = z.object({
+const RewriteSchema = z.object({
   what: z.string(),
   why: z.string(),
   replacement: z.string().min(1),
@@ -416,7 +416,7 @@ const coverList = (max: number) =>
     .default([])
     .transform((arr) => arr.map((s) => s.trim()).filter(Boolean));
 
-export const CoverSchema = z.object({
+const CoverSchema = z.object({
   letter: z
     .string()
     .transform((s) => s.trim())
@@ -464,9 +464,9 @@ export const RESUME_TIMEOUT_MS = {
  */
 export const REVIEW_PROMPT_VERSION = 3;
 
-export const REVIEW_PRIORITIES = ACTION_PRIORITIES;
+const REVIEW_PRIORITIES = ACTION_PRIORITIES;
 
-export const ReviewSchema = z.object({
+const ReviewSchema = z.object({
   /** One recruiter-voice sentence: what this resume reads as today. */
   headline: z.string(),
   grades: z

--- a/src/resume/render/knobs.ts
+++ b/src/resume/render/knobs.ts
@@ -12,7 +12,7 @@ export const SECTION_KEYS = ['summary', 'skills', 'work', 'projects', 'education
 export type SectionKey = (typeof SECTION_KEYS)[number];
 
 /** The order a US recruiter reads in, and the order the ATS checklist expects. */
-export const DEFAULT_SECTION_ORDER: SectionKey[] = [...SECTION_KEYS];
+const DEFAULT_SECTION_ORDER: SectionKey[] = [...SECTION_KEYS];
 
 export const SECTION_LABELS: Record<SectionKey, string> = {
   summary: 'Summary',
@@ -28,7 +28,7 @@ export const SECTION_LABELS: Record<SectionKey, string> = {
 /** The one bundled family (see fonts/README.md); anything else is the user's own. */
 export const BUNDLED_FAMILY = 'Liberation Sans';
 /** Families the bundled face is metric-compatible with — naming them is honest. */
-export const METRIC_TWINS = ['arial', 'helvetica', 'helvetica neue', 'liberation sans', 'arimo'];
+const METRIC_TWINS = ['arial', 'helvetica', 'helvetica neue', 'liberation sans', 'arimo'];
 
 export interface RenderKnobs {
   /** Named in the .docx and shown in the label; the PDF always embeds the bundled face. */

--- a/src/resume/zip.ts
+++ b/src/resume/zip.ts
@@ -24,7 +24,7 @@ export class ZipLimitError extends ZipError {}
 /** One part of a .docx; the largest document.xml in the corpus is under 2 MB. */
 export const MAX_INFLATED_PART_BYTES = 64 * 1024 * 1024;
 /** Everything an archive of resumes may inflate to, in total — the web process holds it all at once. */
-export const MAX_INFLATED_TOTAL_BYTES = 512 * 1024 * 1024;
+const MAX_INFLATED_TOTAL_BYTES = 512 * 1024 * 1024;
 
 export interface ZipEntry {
   name: string;

--- a/src/robots.ts
+++ b/src/robots.ts
@@ -81,8 +81,6 @@ export interface Robots {
   signals: Record<string, boolean>;
 }
 
-export const ALLOW_ALL: Robots = { groups: [], signals: {} };
-
 /**
  * Parse robots.txt into groups. Consecutive `User-agent` lines share the
  * rules that follow them; a rule line starts a new group's body, so a second

--- a/src/screening/anchor.ts
+++ b/src/screening/anchor.ts
@@ -102,7 +102,7 @@ const STACK_LABEL = /^\s*(?:[-•*]\s*)?(?:tech(?:nology|nologies)?(?:\s+stack)?
  * "Technology Stack: a, b," / "c, d." at the page width, and only the first
  * line carries the label — so the label is looked for up the wrapped run.
  */
-export function listHead(text: string, index: number): string {
+function listHead(text: string, index: number): string {
   let start = text.lastIndexOf('\n', index - 1) + 1;
   let line = lineAt(text, index).line;
   while (start > 0) {
@@ -121,7 +121,7 @@ export function listHead(text: string, index: number): string {
  * when the quote is a sentence and the model's rung stands. The list is
  * judged around the TERM's own cell, not the quote's first word.
  */
-export function listCap(text: string, quote: string, terms: { term: string; aliases: string[] }[], matcher: Matcher): EvidenceRung | null {
+function listCap(text: string, quote: string, terms: { term: string; aliases: string[] }[], matcher: Matcher): EvidenceRung | null {
   const exact = text.indexOf(quote);
   const start = exact !== -1 ? exact : (matcher.locateQuote(text, quote)?.start ?? null);
   const inQuote = terms.flatMap((t) => matcher.findTerm(quote, t.term, t.aliases))[0]?.start ?? 0;

--- a/src/screening/batch.ts
+++ b/src/screening/batch.ts
@@ -206,7 +206,7 @@ async function worker(run: Run, screening: ScreeningWithJob, runtime: Pick<AiRun
  * a verdict row. Never throws — a failure is a counted reason, and the
  * applicant stays pending for the next run.
  */
-export async function screenApplicant(
+async function screenApplicant(
   screening: ScreeningWithJob,
   rubric: Rubric,
   applicant: Pick<Applicant, 'id' | 'number' | 'redactedText'>,

--- a/src/screening/bench.ts
+++ b/src/screening/bench.ts
@@ -34,7 +34,7 @@ export function precisionAtK(human: string[], system: string[], k: number): { hi
 }
 
 export type GateWord = 'pass' | 'unknown' | 'fail';
-export const GATE_WORDS: GateWord[] = ['pass', 'unknown', 'fail'];
+const GATE_WORDS: GateWord[] = ['pass', 'unknown', 'fail'];
 
 /** Rows = what the human said, columns = what the run said; `agree` counts the diagonal. */
 export function gateConfusion(pairs: { expected: GateWord; got: GateWord }[]): { matrix: Record<GateWord, Record<GateWord, number>>; agree: number; total: number } {

--- a/src/screening/comparison.ts
+++ b/src/screening/comparison.ts
@@ -15,14 +15,14 @@ import type { Criterion, Rubric } from './rubric';
  * meeting.
  */
 
-export const ReadingSchema = z.object({
+const ReadingSchema = z.object({
   /** The applicant numbers in the order the resumes were shown. */
   shown: z.array(z.number().int()),
   reply: CompareReplySchema,
 });
 export type Reading = z.infer<typeof ReadingSchema>;
 
-export const StoredComparisonSchema = z.object({ v: z.literal(1), readings: z.tuple([ReadingSchema, ReadingSchema]) });
+const StoredComparisonSchema = z.object({ v: z.literal(1), readings: z.tuple([ReadingSchema, ReadingSchema]) });
 export type StoredComparison = z.infer<typeof StoredComparisonSchema>;
 
 export function readStoredComparison(value: unknown): StoredComparison | null {

--- a/src/screening/intake.ts
+++ b/src/screening/intake.ts
@@ -13,11 +13,11 @@ import { hamming64, MAX_HAMMING_DISTANCE, simhash64 } from '../fingerprint';
 /** A batch is a hiring round, not a talent pool (ADR 0048): the cap keeps one screening one job's applicants. */
 export const MAX_APPLICANTS_PER_SCREENING = 300;
 /** A whole folder at once — the per-screening cap is the real ceiling. */
-export const MAX_FILES_PER_UPLOAD = 300;
+const MAX_FILES_PER_UPLOAD = 300;
 /** Three hundred PDFs of a page or two. */
 export const MAX_BATCH_UPLOAD_MB = 200;
 /** One resume, inflated — the same ceiling as a single upload (upload.ts); a zip entry past it is not read. */
-export const MAX_ENTRY_BYTES = 5 * 1024 * 1024;
+const MAX_ENTRY_BYTES = 5 * 1024 * 1024;
 
 export interface UploadFile {
   name: string;

--- a/src/screening/prompts.ts
+++ b/src/screening/prompts.ts
@@ -30,7 +30,7 @@ export const SCREEN_PROMPT_VERSION = 4;
 /** The answer: one entry per criterion, the roles with dates, three stand-out facts, a few quotes and five questions. */
 export const SCREEN_MAX_TOKENS = 7_500;
 /** Stand-out facts per applicant — enough to say what the criteria missed, few enough to read in a row. */
-export const MAX_STANDOUT = 3;
+const MAX_STANDOUT = 3;
 /** About the full report's budget (RESUME_TIMEOUT_MS.full): the prompt is a rubric, a posting and a resume. */
 export const SCREEN_TIMEOUT_MS = 180_000;
 const MAX_RESUME_CHARS = 30_000;
@@ -57,14 +57,14 @@ export { EVIDENCE_RUNGS };
 export type { EvidenceRung } from './rubric';
 export { EVIDENCE_RUNG_LABELS } from './rubric';
 
-export const ANSWER_STATUSES = ['pass', 'partial', 'unknown', 'fail'] as const;
+const ANSWER_STATUSES = ['pass', 'partial', 'unknown', 'fail'] as const;
 export type AnswerStatus = (typeof ANSWER_STATUSES)[number];
 /** A gate is binary: "partial" reads as unknown there. */
-export const GATE_STATUSES = ['pass', 'unknown', 'fail'] as const;
+const GATE_STATUSES = ['pass', 'unknown', 'fail'] as const;
 export type GateStatus = (typeof GATE_STATUSES)[number];
-export const IMPACT_GRADES = ['strong', 'ok', 'weak'] as const;
+const IMPACT_GRADES = ['strong', 'ok', 'weak'] as const;
 export type ImpactGrade = (typeof IMPACT_GRADES)[number];
-export const OVERALL_GRADES = ['exceptional', 'strong', 'partial', 'weak', 'none'] as const;
+const OVERALL_GRADES = ['exceptional', 'strong', 'partial', 'weak', 'none'] as const;
 export type OverallGrade = (typeof OVERALL_GRADES)[number];
 
 const nullableText = z
@@ -97,7 +97,7 @@ export const AnswerSchema = z.object({
 });
 export type ScreenAnswer = z.infer<typeof AnswerSchema>;
 
-export const RoleSchema = z.object({
+const RoleSchema = z.object({
   position: z.string().trim().min(1),
   employer: nullableText,
   start: nullableText,
@@ -111,7 +111,7 @@ export const RoleSchema = z.object({
 export type ScreenRole = z.infer<typeof RoleSchema>;
 
 /** A fact worth knowing that no criterion asked for, with the line that carries it (plan §5). Never scored. */
-export const StandoutSchema = z.object({
+const StandoutSchema = z.object({
   fact: z.string().trim().min(1),
   quote: nullableText,
 });
@@ -191,7 +191,7 @@ export function answerShape(c: Criterion): string {
 }
 
 /** The rubric as the model reads it — one line per criterion, fenced because the draft came from the posting. */
-export function rubricLines(rubric: Rubric): string {
+function rubricLines(rubric: Rubric): string {
   if (rubric.criteria.length === 0) return '(no criteria)';
   return rubric.criteria
     .map((c) => {
@@ -207,7 +207,7 @@ export function rubricLines(rubric: Rubric): string {
     .join('\n');
 }
 
-export const CompareCriterionSchema = z.object({
+const CompareCriterionSchema = z.object({
   id: z.string().trim().min(1),
   /** Applicant numbers, strongest first; an applicant whose text says nothing about it is left out. */
   ranking: z.array(z.number().int()).default([]),

--- a/src/screening/redact.ts
+++ b/src/screening/redact.ts
@@ -18,7 +18,7 @@
  * Unicode classes — a Cyrillic field name has no \b to match.
  */
 
-export const REDACTION_KINDS = [
+const REDACTION_KINDS = [
   'name',
   'email',
   'phone',
@@ -33,7 +33,7 @@ export const REDACTION_KINDS = [
 ] as const;
 export type RedactionKind = (typeof REDACTION_KINDS)[number];
 
-export const REDACTION_LABELS: Record<RedactionKind, string> = {
+const REDACTION_LABELS: Record<RedactionKind, string> = {
   name: 'name',
   email: 'email',
   phone: 'phone',

--- a/src/screening/rubric.ts
+++ b/src/screening/rubric.ts
@@ -22,13 +22,6 @@ export const RUBRIC_VERSION = 2;
 
 export const SCREEN_LEVELS = ['junior', 'mid', 'senior', 'lead'] as const;
 export type ScreenLevel = (typeof SCREEN_LEVELS)[number];
-export const SCREEN_LEVEL_LABELS: Record<ScreenLevel, string> = {
-  junior: 'Junior',
-  mid: 'Mid-level',
-  senior: 'Senior',
-  lead: 'Lead / staff',
-};
-
 /** How strongly a text evidences a term, lowest first — the ladder the skill kinds are answered on. */
 export const EVIDENCE_RUNGS = ['absent', 'listed', 'project', 'role', 'production'] as const;
 export type EvidenceRung = (typeof EVIDENCE_RUNGS)[number];
@@ -123,7 +116,7 @@ export const KIND_ANSWER: Record<CriterionKind, 'status' | 'rung' | 'level' | 'i
   custom: 'status',
 };
 
-export const LEVEL_TOLERANCES = ['exact', 'one', 'atLeast', 'atMost'] as const;
+const LEVEL_TOLERANCES = ['exact', 'one', 'atLeast', 'atMost'] as const;
 export type LevelTolerance = (typeof LEVEL_TOLERANCES)[number];
 
 export const COMPANY_TYPES = ['product', 'agency', 'consultancy', 'startup', 'enterprise', 'public sector', 'non-profit'] as const;
@@ -172,7 +165,7 @@ export function specOf(partial: Partial<CriterionSpec> = {}): CriterionSpec {
   return SpecSchema.parse(partial);
 }
 
-export const CriterionSchema = z.object({
+const CriterionSchema = z.object({
   id: z.string().trim().min(1).max(24),
   kind: z.enum(CRITERION_KINDS),
   /** What the row says — the "What" column, written by the person or drafted from the posting. */
@@ -198,7 +191,7 @@ export function emptyRubric(): Rubric {
 
 let seq = 0;
 /** Short, unique within a rubric, stable across saves: the reply and the verdicts key on it. */
-export function newCriterionId(kind: CriterionKind, taken: Set<string> = new Set()): string {
+function newCriterionId(kind: CriterionKind, taken: Set<string> = new Set()): string {
   for (;;) {
     seq = (seq + 1) % 100_000;
     const id = `${kind.slice(0, 4)}-${Date.now().toString(36).slice(-4)}${seq.toString(36)}`;
@@ -628,9 +621,4 @@ export function rubricSummary(r: Rubric): string {
 /** The skill criteria whose terms count as the core stack — the cap's question (score.ts). */
 export function coreCriteria(r: Rubric): Criterion[] {
   return r.criteria.filter((c) => c.kind === 'skill' && c.spec.core);
-}
-
-/** Every term the rubric names, with aliases — what anchor.ts searches the text for. */
-export function rubricTerms(r: Rubric): { term: string; aliases: string[] }[] {
-  return r.criteria.flatMap((c) => (c.kind === 'skill' ? c.spec.terms : []));
 }

--- a/src/screening/score.ts
+++ b/src/screening/score.ts
@@ -16,7 +16,7 @@ import { coreCriteria, CRITERION_MODES, EVIDENCE_RUNGS, SCREEN_LEVELS, type Crit
  * is not a weak one, it is an unread one.
  */
 
-export const SCREEN_SCORING = {
+const SCREEN_SCORING = {
   version: 2,
   rungCredit: { absent: 0, listed: 0.3, project: 0.5, role: 0.8, production: 1 } as Record<EvidenceRung, number>,
   statusCredit: { pass: 1, partial: 0.5, fail: 0 } as Record<'pass' | 'partial' | 'fail', number>,
@@ -40,7 +40,6 @@ export const SCREEN_SCORING = {
 } as const;
 
 export type GateBucket = 'pass' | 'ask' | 'fail';
-export const GATE_BUCKETS: GateBucket[] = ['pass', 'ask', 'fail'];
 export const GATE_BUCKET_LABELS: Record<GateBucket, string> = {
   pass: 'Priority to talk to',
   ask: 'Ask first',

--- a/src/screening/store.ts
+++ b/src/screening/store.ts
@@ -305,8 +305,3 @@ export async function latestComparison(screeningId: number, applicantIds: number
   });
   return rows.find((r) => r.applicantIds.length === applicantIds.length) ?? null;
 }
-
-export async function deleteExpiredScreenings(now: Date): Promise<number> {
-  const r = await prisma.screening.deleteMany({ where: { retainUntil: { lt: now } } });
-  return r.count;
-}

--- a/src/scripts/dead-exports.ts
+++ b/src/scripts/dead-exports.ts
@@ -1,0 +1,61 @@
+/*
+ * Which exported symbols nobody imports. Reads src/ (tests and scripts count
+ * as readers, never as owners) and prints three lists: dead — no use
+ * anywhere, not even in its own file; over-exported — used only inside its
+ * own file, so the `export` is noise; tests-only — a seam a test reaches
+ * for, which is fine and stays. Types and interfaces are left alone: an
+ * unused type costs nothing at runtime.
+ *
+ *   npx tsx src/scripts/dead-exports.ts
+ *
+ * Hand-run: the answer is a list to read, not a gate (audit 2026-09-10,
+ * DEAD-1 found 10 dead and 84 over-exported this way).
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..');
+const SRC = join(ROOT, 'src');
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.(ts|tsx|mjs)$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+const files = walk(SRC);
+const texts = new Map(files.map((f) => [f, readFileSync(f, 'utf8')] as const));
+const EXPORT_RE = /^export\s+(?:async\s+)?(function|const|let|class|enum)\s+([A-Za-z_$][\w$]*)/gm;
+const isTest = (f: string) => /\.test\.ts$/.test(f);
+const isScript = (f: string) => /\/scripts\//.test(f);
+
+const dead: string[] = [];
+const overExported: string[] = [];
+const testsOnly: string[] = [];
+for (const [f, t] of texts) {
+  if (isTest(f) || isScript(f)) continue;
+  for (const m of t.matchAll(EXPORT_RE)) {
+    const name = m[2]!;
+    const word = new RegExp(`\\b${name.replace(/\$/g, '\\$')}\\b`, 'g');
+    const inFile = (t.match(word) ?? []).length - 1;
+    let refs = 0;
+    let tests = 0;
+    for (const [g, u] of texts) {
+      if (g === f) continue;
+      if (word.test(u)) isTest(g) ? tests++ : refs++;
+      word.lastIndex = 0;
+    }
+    const row = `${relative(ROOT, f)}: ${name}`;
+    if (refs === 0 && tests === 0 && inFile === 0) dead.push(row);
+    else if (refs === 0 && tests === 0) overExported.push(`${row} (used ${inFile}× in its file)`);
+    else if (refs === 0 && inFile === 0) testsOnly.push(row);
+  }
+}
+
+const section = (title: string, rows: string[]) => `${title} (${rows.length})\n${rows.map((r) => `  ${r}`).join('\n') || '  none'}`;
+console.log(section('DEAD — no use anywhere', dead));
+console.log(section('OVER-EXPORTED — used only in its own file', overExported));
+console.log(section('TESTS-ONLY — a seam a test reaches for; stays', testsOnly));

--- a/src/verification/liveness.ts
+++ b/src/verification/liveness.ts
@@ -266,7 +266,7 @@ function safeJson(body: string): unknown {
 // ---------------------------------------------------------------------------
 
 /** Markers of bot checkpoints — checked before any content heuristic. */
-export const BOT_CHALLENGE_RES: RegExp[] = [
+const BOT_CHALLENGE_RES: RegExp[] = [
   /just a moment/,
   /checking your browser/,
   /verify (?:that )?you are (?:a )?human/,
@@ -283,7 +283,7 @@ export const BOT_CHALLENGE_RES: RegExp[] = [
  * anchored on a posting noun so prose like "once the form has been filled
  * out" or "closing date: 31 Dec" can never match (guard-tested).
  */
-export const CLOSED_BANNER_RES: RegExp[] = [
+const CLOSED_BANNER_RES: RegExp[] = [
   /no longer accepting applications/,
   /(?:position|role|vacancy|opening|job) has been filled(?! out)/,
   /(?:position|posting|job|role|vacancy|opening|offer)[^.!?\n]{0,60}(?:is |are |was )?(?:no longer|not currently) (?:available|active|open|published|accepting)/,

--- a/src/verification/prompts.ts
+++ b/src/verification/prompts.ts
@@ -13,7 +13,7 @@ export const VERIFY_MAX_TOKENS = 6_000;
 const MAX_JOB_CHARS = 12_000;
 
 export const VERDICTS = ['legit', 'suspicious', 'fake'] as const;
-export const RECOMMENDATIONS = ['apply', 'caution', 'skip'] as const;
+const RECOMMENDATIONS = ['apply', 'caution', 'skip'] as const;
 export const EVIDENCE_CHECKS = [
   'careers_page',
   'linkedin',
@@ -24,14 +24,14 @@ export const EVIDENCE_CHECKS = [
   'posting_quality',
   'other',
 ] as const;
-export const EVIDENCE_SIGNALS = ['legit', 'ghost', 'scam', 'neutral', 'unverified'] as const;
+const EVIDENCE_SIGNALS = ['legit', 'ghost', 'scam', 'neutral', 'unverified'] as const;
 
 const nullableText = z
   .string()
   .nullish()
   .transform((v) => (v && v.trim().length > 0 ? v.trim() : null));
 
-export const VerificationSchema = z.object({
+const VerificationSchema = z.object({
   verdict: z.enum(VERDICTS),
   recommendation: z.enum(RECOMMENDATIONS),
   confidence: z.number().int().min(0).max(100),

--- a/src/watchlist/interval.ts
+++ b/src/watchlist/interval.ts
@@ -95,8 +95,6 @@ export interface WatchRules {
   alertPolicy: AlertPolicy;
 }
 
-export const NOT_WATCHED: WatchRules = { watched: false, alertPolicy: 'matches' };
-
 export function watchRules(row: { watched: boolean; alertPolicy: string }): WatchRules {
   return { watched: row.watched, alertPolicy: toAlertPolicy(row.alertPolicy) };
 }

--- a/src/watchlist/resolve.ts
+++ b/src/watchlist/resolve.ts
@@ -204,7 +204,7 @@ export async function resolveCompanyUrl(
 
 
 /** `<item>` / `<entry>` count — the emptiness test, not a parse. */
-export function countEntries(xml: string): number {
+function countEntries(xml: string): number {
   return (xml.match(/<item[\s>]|<entry[\s>]/gi) ?? []).length;
 }
 

--- a/src/watchlist/scan.ts
+++ b/src/watchlist/scan.ts
@@ -87,7 +87,7 @@ export function declaredJobFeeds(html: string, pageUrl: string): string[] {
  * WordPress every `/<anything>/feed` answers a well-formed feed and on most
  * sites `/feed` is the blog.
  */
-export const WELL_KNOWN_FEED_PATHS = ['/jobs.rss', '/jobs/feed', '/careers/feed'] as const;
+const WELL_KNOWN_FEED_PATHS = ['/jobs.rss', '/jobs/feed', '/careers/feed'] as const;
 
 export function wellKnownFeeds(pageUrl: string): string[] {
   const origin = new URL(pageUrl).origin;

--- a/src/web/employer-mode.ts
+++ b/src/web/employer-mode.ts
@@ -26,7 +26,7 @@ export function setEmployerModeCache(value: boolean): void {
   enabled = value;
 }
 
-export const SCREENING_SETTINGS_URL = '/settings?tab=screening';
+const SCREENING_SETTINGS_URL = '/settings?tab=screening';
 
 /** Every /screen route: with the mode off the section does not exist, and the settings tab says why. */
 export const requireEmployerMode: MiddlewareHandler = async (c, next) => {

--- a/src/web/job-facets.ts
+++ b/src/web/job-facets.ts
@@ -17,7 +17,7 @@ export const UNKNOWN_PLACE = 'unknown';
 export const TOP_PLACES = 8;
 
 /** `posted=` values → days back. */
-export const POSTED_WINDOWS: Record<string, number> = { '24h': 1, '7d': 7, '30d': 30 };
+const POSTED_WINDOWS: Record<string, number> = { '24h': 1, '7d': 7, '30d': 30 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 

--- a/src/web/pages/resume-match-card.tsx
+++ b/src/web/pages/resume-match-card.tsx
@@ -409,7 +409,7 @@ export const ConfirmFacts: FC<{ asks: MatchKeyword[]; unproven: MatchKeyword[]; 
     </div>
   );
 
-export const MatchReport: FC<{
+const MatchReport: FC<{
   match: MatchWithResume;
   previous: MatchWithResume | null;
   /** This match's keywords, ordered and counted by the matcher (§5). */
@@ -567,7 +567,7 @@ export const DeltaBox: FC<{ match: MatchWithResume; previous: MatchWithResume | 
 };
 
 /** Full hard-requirement list with notes — the score card shows only the digest. */
-export const HardRequirementsBlock: FC<{ hard: MatchHardRequirement[] }> = ({ hard }) =>
+const HardRequirementsBlock: FC<{ hard: MatchHardRequirement[] }> = ({ hard }) =>
   hard.length === 0 ? null : (
     <div>
       <div class={SUBHEAD}>Hard requirements — gates outside the score</div>

--- a/src/web/pages/resumes.tsx
+++ b/src/web/pages/resumes.tsx
@@ -277,7 +277,7 @@ const StrengthCell: FC<{ resume: ResumeRow }> = ({ resume }) =>
   );
 
 /** Shared by /resumes and the Settings card. Posts to /resumes and lands on the new resume. */
-export const ResumeUploadForm: FC = () => (
+const ResumeUploadForm: FC = () => (
   <form
     method="post"
     action="/resumes"

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -106,7 +106,7 @@ export interface AiStatusSummary {
  * Link-based sub-navigation (?tab=…): one route, server picks the sections.
  * POST routes redirect back to the tab their setting lives on.
  */
-export const SETTINGS_TABS = [
+const SETTINGS_TABS = [
   { id: 'general', label: 'General' },
   { id: 'profile', label: 'Profile' },
   { id: 'ai', label: 'AI engine' },
@@ -233,7 +233,7 @@ const ALERT_MODE_TITLE: Record<(typeof ALERT_MODES)[number], string> = {
   digest: 'As one digest',
 };
 
-export const ScheduleCard: FC<{ view: ScheduleView }> = ({ view }) => {
+const ScheduleCard: FC<{ view: ScheduleView }> = ({ view }) => {
   const { schedule: s, zones, nextFetch, held } = view;
   return (
     <Card>

--- a/src/web/pages/watchlist.tsx
+++ b/src/web/pages/watchlist.tsx
@@ -144,7 +144,7 @@ export const WatchlistRunPage: FC<{ run: WatchlistRun }> = ({ run }) => (
  * polls, and the watchlist section's selects submit themselves. Without JS
  * the page still works — the selects keep their <noscript> Save button.
  */
-export const WatchlistScript: FC = () => (
+const WatchlistScript: FC = () => (
   <script type="module" dangerouslySetInnerHTML={{ __html: WATCHLIST_BOOT }} />
 );
 

--- a/src/web/routes/applications.tsx
+++ b/src/web/routes/applications.tsx
@@ -14,7 +14,7 @@ import { groupEventsByJob, stageTimeLine, type StageTimeLine } from '../stage-ti
 
 // Stage keys are validated at runtime against the configured list
 // (ADR 0025) — an enum would freeze what is now user data.
-export const ApplicationFormSchema = z.object({
+const ApplicationFormSchema = z.object({
   pipelineStage: z.string().max(40).optional(),
   appliedAt: z.string().optional(),
   recruiterContact: z.string().max(300).optional(),

--- a/src/web/routes/watchlist.tsx
+++ b/src/web/routes/watchlist.tsx
@@ -216,7 +216,7 @@ watchlistRoute.post('/companies/:id/unwatch', async (c) => {
 });
 
 /** The (atsType, atsToken) a confirmed resolution becomes, or null. */
-export function sourceOf(r: ResolvedCompany): { atsType: AtsType; atsToken: string } | null {
+function sourceOf(r: ResolvedCompany): { atsType: AtsType; atsToken: string } | null {
   if (r.resolution.kind === 'ats') return { atsType: r.resolution.atsType, atsToken: r.resolution.atsToken };
   if (r.resolution.kind === 'feed') return { atsType: AtsType.FEED, atsToken: r.resolution.url };
   // The last rung: no postings, just "this page changed" (ADR 0036).

--- a/src/web/stage-config.ts
+++ b/src/web/stage-config.ts
@@ -11,7 +11,7 @@ export interface StageDef {
   label: string;
 }
 
-export const ENTRY_STAGE: StageDef = { key: 'applied', label: 'Applied' };
+const ENTRY_STAGE: StageDef = { key: 'applied', label: 'Applied' };
 export const TERMINAL_STAGES: StageDef[] = [
   { key: 'rejected', label: 'Rejected' },
   { key: 'ghosted', label: 'Ghosted' },

--- a/src/web/stage-time.ts
+++ b/src/web/stage-time.ts
@@ -7,7 +7,7 @@ import { TERMINAL_KEYS } from './stage-config';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** A non-terminal stage without movement for this long reads as stale. */
-export const STALE_DAYS = 14;
+const STALE_DAYS = 14;
 
 export interface StageTimeEvent {
   toStage: string | null;


### PR DESCRIPTION
Block `dead-exports` of TASKS §20 — DEAD-1 in `docs/audit-2026-09-10.md`. Runtime-invisible; no tag, rides with the next minor.

- Deleted, no use anywhere: `countries.ts` `REGION_CODES` / `countryOf` / `regionOf`, `currency.ts` `CURRENCY_CODES`, `robots.ts` `ALLOW_ALL`, `screening/rubric.ts` `SCREEN_LEVEL_LABELS` / `rubricTerms`, `screening/score.ts` `GATE_BUCKETS`, `screening/store.ts` `deleteExpiredScreenings` (the cleanup job deletes inline — the worker may not import `src/screening`), `watchlist/interval.ts` `NOT_WATCHED`.
- `export` dropped from 88 symbols used only inside their own file (47 files); the eight exported only for a test stay.
- `src/scripts/dead-exports.ts` (`npm run exports:audit`) is the scan, so the next audit reruns it instead of rewriting it. It now reports 0 / 0 / 8.

**Verified:** `lint:types` green, 2 200 tests; the site's vendored `score.mjs` / `target.mjs` untouched.