### PR TITLE
docs-drift: PRODUCT, DESIGN, SPEC and CLAUDE say what the code does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,9 @@
   `redact.ts`, `dates.ts`, `prompts.ts`, `anchor.ts`, `score.ts`,
   `trajectory.ts`, `comparison.ts`, `calibration.ts`, `bench.ts`,
   `intake.ts`, `export.ts`, `notice.ts` are pure (tested); `store.ts` is
-  the only file that touches Prisma; `batch.ts` and `compare.ts` run the
+  the only file in the module that touches Prisma (the worker's
+  `cleanup-job.ts` deletes expired screenings with its own query, because
+  the worker may not import this module); `batch.ts` and `compare.ts` run the
   calls; `scripts/screen-bench-once.ts` runs a gold folder through the
   same path without the database. Web-only behind
   `AppSettings.employerMode` — the worker never imports it, and nothing in

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -374,6 +374,34 @@ null renders an em dash.
 - **ToggleRow:** label + ok/neutral dot-pill beside an Enable/Disable button —
   the settings on/off idiom.
 
+### Screening (employer mode, ADR 0047–0052)
+The other side of the table reuses every primitive above; what is new is
+vocabulary, not chrome.
+- **Gate buckets:** three, in this order and these words — *Priority to talk
+  to* (ok), *Ask first* (warn), *Did not pass a gate* (danger) — never "best
+  candidate". A gate is a fact about the posting's conditions, so the danger
+  tone marks the bucket, not the person.
+- **Score cell:** tabular number; `*` after it means capped and the scorecard
+  says why; the person's adjustment reads `85 → 95` with a small `+10`, the
+  computed number kept in the tooltip and both exports. During a run the
+  cell shows the previous verdict muted and prefixed *was*, never a number
+  that looks new.
+- **Run badges:** *queued* (neutral) · *scoring…* (info) · *scored — refresh*
+  (ok), painted per row from `/screen/:id/state`; the progress line above
+  the table is a live region.
+- **Scorecard:** who / did / verdict at the top, then one row per criterion
+  with its quote from the redacted text; a quote is the evidence, an unquoted
+  answer is shown as unknown. "Stands out" is a list of facts, never a score.
+- **Criteria editor:** one row per criterion — kind, the person's words, a
+  Gate / Scored / Note choice, stars for weight, Remove — and a last row that
+  adds one. A row naming a protected characteristic is refused with the
+  lawful criterion offered in its place.
+- **Decisions:** the one write the tool never makes; the decision select is a
+  plain control, never violet (violet means AI spend). Calibration shows
+  counts beside every ratio and changes nothing by itself.
+- **The redaction line:** what was removed before the model read a word, on
+  the scorecard and at intake; the name is shown to the person only.
+
 ### Named Rules
 **The Drawn-Icon Rule.** Every icon is a drawn SVG stroke on the 24px Lucide
 grid — including the select chevron and check/x marks. Emoji, Unicode glyphs,

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -8,9 +8,12 @@ decisions lean on.
 
 A self-hosted job-search operations console for one person. A cron worker fetches
 postings from ATS boards and aggregators, an AI classifier scores them against the
-user's profile, Telegram delivers alerts, and a local web dashboard (this design's
-surface) is where everything is read and acted on: triage jobs, track applications,
-tune the profile, manage sources, compare resumes against postings.
+user's profile, Telegram or Discord delivers alerts, and a local web dashboard (this
+design's surface) is where everything is read and acted on: triage jobs, track
+applications, tune the profile, manage sources, compare resumes against postings.
+The same install has an opt-in employer mode (ADR 0049): a folder of resumes
+screened against one position, off by default, its section gone from the menu
+when it is off.
 
 ## Audience and scene
 
@@ -24,6 +27,13 @@ tune the profile, manage sources, compare resumes against postings.
 Read four numbers and the newest alerts, drill into a job, act (apply / save /
 dismiss / verify / compare resume), adjust settings rarely. Nothing on the surface
 persuades or markets; every screen serves a task.
+
+The test for a new feature: does it reduce the guessing in a job search without
+taking the decision away from the user? The model marks facts and code scores
+(ADR 0012), the text decides what a resume contains (ADR 0045), a person decides
+whom to interview (ADR 0047) and calibration never tunes the rubric by itself
+(ADR 0052). Another AI output that adds no evidence, feedback or control is not
+the priority.
 
 ## Brand commitments (standing)
 
@@ -47,5 +57,6 @@ persuades or markets; every screen serves a task.
   tones) so a second theme is a token swap, not a component rewrite.
 - Primitives live in `src/web/ui.tsx`; pages compose them and never hand-roll
   Tailwind for shared patterns.
-- Dashboard is localhost-only, single user — no marketing surfaces, no onboarding
-  funnel, no auth UI beyond optional basic-auth.
+- Dashboard is localhost-only, single user — no marketing surfaces, no auth UI
+  beyond optional basic-auth. The first run is a five-step setup (`/welcome`,
+  derived from data, skippable), not a funnel.

--- a/SPEC.md
+++ b/SPEC.md
@@ -5,9 +5,11 @@
 
 ## Goal
 
-Single-user, locally hosted job-search assistant. Pulls listings from a
-dozen public ATS / aggregator sources, classifies each through Claude
-against a **profile** that the user edits in a small dashboard, and
+Single-user, locally hosted job-search assistant. Pulls listings from
+33 kinds of public source (twelve ATS vendors, twenty aggregators, any
+RSS/Atom feed), classifies each through the AI engine chain (five
+backends, ADR 0013/0014) against every running **search profile** the
+user edits in a small dashboard, and
 fires Telegram or Discord alerts for matches. Designed to run continuously on a
 laptop or VPS without babysitting, with all configuration editable
 from the web UI (no SSH-and-restart).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2181,7 +2181,7 @@ release-discipline skill, a docs/site block does not.
       job keeps its inline delete — the worker may not import
       `src/screening`), drop `export` from the 84, keep the 8 test seams;
       the scan script into `src/scripts/` so the next audit reruns it.
-- [ ] **`docs-drift`** (no tag) — DOCS-3 PRODUCT.md (the wizard, Discord,
+- [x] **`docs-drift`** (no tag) — done 2026-09-10. DOCS-3 PRODUCT.md (the wizard, Discord,
       employer mode, the CDN line after `dashboard-self-contained`, the §30
       sentence under "The task"), DESIGN.md (the screening patterns),
       SPEC.md's goal line, the CLAUDE.md file rule on `screening/store.ts`.


### PR DESCRIPTION
Block `docs-drift` of TASKS §20 — DOCS-3 in `docs/audit-2026-09-10.md`, plan §30. Docs only, no tag.

- **PRODUCT.md**: alerts go to Telegram or Discord (ADR 0041); the install has an opt-in employer mode (ADR 0049); the first run is the five-step `/welcome`, not "no onboarding funnel"; the plan's §30 sentence under "The task" — the test for a new feature — with the ADRs that already embody it.
- **DESIGN.md**: a "Screening (employer mode)" subsection under Components — the three gate buckets and their words, the score cell (`*` for capped, `85 → 95 +10`, *was N* during a run), the run badges, the scorecard, the criteria editor, the decision select never violet, the redaction line. DESIGN.md had no word on the screening pages.
- **SPEC.md**: the goal line said "a dozen sources … through Claude"; it says 33 kinds of source through the five-engine chain against every running search — and `source-count.test.ts` now reads SPEC.md too, so the number cannot drift there.
- **CLAUDE.md**: the screening file rule says why `cleanup-job.ts` deletes expired screenings with its own query (the worker may not import `src/screening`).

**Verified:** 2 200 tests; the source-count guard passes on SPEC.md.