### PR TITLE
query-diet: pages read the columns they show, one read per tick, batched demotions, due sources in SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.7.1] — 2026-09-10
+
+### Changed
+- **Pages read the columns they show.** The jobs list carried fifty full
+  postings per page — descriptions, originals, summaries, the applied-resume
+  snapshots, 219 KB of text on the 09-04 data — for fifteen scalars; the
+  resume page's history carried every stored snapshot and five Json columns
+  per run; the screening table carried two full texts per applicant; the
+  digest, the held-alert pass and the two job pickers the same. Each now
+  selects what it renders. Measured on 1 083 jobs: no page was slow before
+  (9–33 ms), so this is bytes moved, not milliseconds — the reason no index
+  was added: every query the audit named ran under a millisecond there.
+- **One read per tick instead of one per posting.** The tick asked "is this
+  stored?" once for each fetched posting — 1 600 to 5 500 round trips on a
+  cold tick; it asks once for the batch. Re-classify writes its demotions
+  once per batch instead of one row at a time; a screening run compares
+  the rubric version instead of re-reading the whole screening twice per
+  applicant; the sources due this tick are a where clause on the index
+  that exists for it.
+- Also in this release, untagged since 2.7.0: `src/web/app.ts` split from
+  the listener with the route smoke in CI (#235), ten dead exports gone and
+  the `export` dropped from 88 (#233), the docs brought in line (#234).
+
 ## [2.7.0] — 2026-09-10
 
 ### Changed
@@ -3466,6 +3489,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.7.1]: https://github.com/applypack/applypack/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/applypack/applypack/compare/v2.6.4...v2.7.0
 [2.6.4]: https://github.com/applypack/applypack/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/applypack/applypack/compare/v2.6.2...v2.6.3

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2149,7 +2149,7 @@ release-discipline skill, a docs/site block does not.
       self-hosted from the site's woff2, the CDN and font hosts removed
       from CSP, a grep test that they never return; PRODUCT.md / DESIGN.md
       constraint line rewritten.
-- [ ] **`query-diet`** (minor; measured first) — restore a populated
+- [x] **`query-diet`** (patch; measured first) — shipped v2.7.1: DATA-1 / DATA-5 selects, DATA-4 loops, the due filter; no index added — on the 09-04 data (1 083 jobs) every named query ran under 1 ms. Left: the per-file applicant transaction, `listScreenings`' per-applicant rows, `listMatchesForJob`. Restore a populated
       database (the 09-04 dump), `EXPLAIN ANALYZE` the `/jobs` facet
       tally, the `/companies` latest-job query and the FT sync sort; then
       DATA-1 `select` on the list + the tally in SQL (or capped), DATA-5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "description": "Runs locally with Docker: an AI console for the whole job search that finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 33 sources, 5 swappable AI backends, your data in your own Postgres, self-hosted on a VPS if you like.",
   "license": "MIT",

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -51,7 +51,7 @@ import { fetchFeed } from './feed';
 import { fetchCareerPage } from './career-page';
 import { getSourceKeys } from '../settings';
 import { politeDelayMs, shuffleSources, tickSeed } from './source-order';
-import { isDue, nextCheckAfter, watchRules, type WatchRules } from '../watchlist/interval';
+import { nextCheckAfter, watchRules, type WatchRules } from '../watchlist/interval';
 import type { NormalizedJob } from '../types';
 
 export interface FetcherResult {
@@ -101,13 +101,23 @@ export async function runAllFetchers(
   }
 
   const now = new Date();
-  const companies = await prisma.company.findMany({
-    where: {
-      active: true,
-      ...(disabled.length > 0 ? { atsType: { notIn: disabled } } : {}),
-    },
-    orderBy: { id: 'asc' },
-  });
+  const rosterWhere = {
+    active: true,
+    ...(disabled.length > 0 ? { atsType: { notIn: disabled } } : {}),
+  };
+  // The due-ness is a where clause, on the index that exists for it, not a
+  // filter over every active row loaded in full (audit 2026-09-10, DATA-6).
+  // A manual run asks every row — see the note below.
+  const [companies, roster] = await Promise.all([
+    prisma.company.findMany({
+      where: {
+        ...rosterWhere,
+        ...(opts.manual ? {} : { OR: [{ nextCheckAt: null }, { nextCheckAt: { lte: now } }] }),
+      },
+      orderBy: { id: 'asc' },
+    }),
+    prisma.company.count({ where: rosterWhere }),
+  ]);
   // The watchlist's intervals ride on this tick, they do not replace it
   // (ADR 0036): the heartbeat still fires, the interval decides which rows it
   // asks. A row with no `nextCheckAt` is due, so every source behaves exactly
@@ -116,8 +126,8 @@ export async function runAllFetchers(
   // user at the screen asking now, and every attempt stamps the next check
   // an interval ahead — so within the hour after a tick the pacing would
   // otherwise answer "0 sources" to the very button that promises the tick.
-  const due = companies.filter((c) => (opts.manual || isDue(c, now)) && (opts.only?.(c) ?? true));
-  const waiting = companies.length - due.length;
+  const due = companies.filter((c) => opts.only?.(c) ?? true);
+  const waiting = roster - companies.length;
   if (waiting > 0) {
     logger.info({ due: due.length, waiting }, 'fetchers: some sources are not due yet');
   }

--- a/src/jobs/alert-delivery.ts
+++ b/src/jobs/alert-delivery.ts
@@ -33,10 +33,26 @@ export async function deliverHeldAlerts(now: Date, schedule: Schedule): Promise<
 
   const rows = await prisma.job.findMany({
     where: { alertHeldAt: { not: null }, status: JobStatus.NEW },
-    include: {
+    // The message's fields only (DATA-5).
+    select: {
+      id: true,
+      title: true,
+      location: true,
+      countries: true,
+      workplace: true,
+      url: true,
+      fitScore: true,
+      salaryMin: true,
+      salaryMax: true,
+      salaryCurrency: true,
+      salaryPeriod: true,
+      techMatch: true,
+      redFlags: true,
+      summary: true,
+      fetchedAt: true,
       company: { select: { name: true, atsType: true, atsToken: true, watched: true, alertPolicy: true } },
       scores: {
-        include: { profile: { select: { name: true, notificationTargetId: true } } },
+        select: { profile: { select: { name: true, notificationTargetId: true } } },
         orderBy: { fitScore: 'desc' },
         take: 2,
       },

--- a/src/jobs/digest-job.ts
+++ b/src/jobs/digest-job.ts
@@ -31,12 +31,28 @@ export async function runDigestJob(): Promise<{ stats: CronStats }> {
       // §16); listing it here too would show the user the same posting twice.
       alertHeldAt: null,
     },
-    include: {
-      company: true,
+    // The fields the message carries — not the description, the original or
+    // the source payload the row also holds (DATA-5).
+    select: {
+      title: true,
+      location: true,
+      countries: true,
+      workplace: true,
+      url: true,
+      fitScore: true,
+      salaryMin: true,
+      salaryMax: true,
+      salaryCurrency: true,
+      salaryPeriod: true,
+      techMatch: true,
+      redFlags: true,
+      summary: true,
+      fetchedAt: true,
+      company: { select: { name: true, atsType: true, atsToken: true } },
       // The search that scored each posting best, so a reader running several
       // can tell the hunts apart in one list (ADR 0028).
       scores: {
-        include: { profile: { select: { name: true } } },
+        select: { profile: { select: { name: true } } },
         orderBy: { fitScore: 'desc' },
         take: 2,
       },

--- a/src/jobs/process-jobs.ts
+++ b/src/jobs/process-jobs.ts
@@ -134,6 +134,10 @@ export async function processNormalizedJobs(
   // used to see it in the DB, now both copies would be classified together.
   const candidates: Candidate[] = [];
   const seen = new Set<string>();
+  // One read for the whole tick instead of one per posting: 1 600 to 5 500
+  // round trips on a cold tick were spent asking "is this stored?" one
+  // (companyId, externalId) at a time (audit 2026-09-10, DATA-4).
+  const stored = await storedKeys(items.map((i) => i.job));
   for (const item of items) {
     if (isCancelled && (await isCancelled())) {
       cancelled = true;
@@ -167,7 +171,7 @@ export async function processNormalizedJobs(
       continue;
     }
     const key = `${item.job.companyId}:${item.job.externalId}`;
-    if (seen.has(key) || (await isPersisted(item.job))) {
+    if (seen.has(key) || stored.has(pairKey(item.job))) {
       stats.duplicate++;
       continue;
     }
@@ -377,17 +381,26 @@ export async function processNormalizedJobs(
   }
 }
 
-async function isPersisted(job: NormalizedJob): Promise<boolean> {
-  const existing = await prisma.job.findUnique({
+function pairKey(job: Pick<NormalizedJob, 'companyId' | 'externalId'>): string {
+  return `${job.companyId}\u0000${job.externalId}`;
+}
+
+/**
+ * The (companyId, externalId) pairs already in the table, for a batch. The
+ * query asks for any company of the batch × any external id of the batch —
+ * a superset — and the Set holds the exact pairs, so a collision of
+ * external ids across two boards cannot mark a new posting as stored.
+ */
+async function storedKeys(jobs: Pick<NormalizedJob, 'companyId' | 'externalId'>[]): Promise<Set<string>> {
+  if (jobs.length === 0) return new Set();
+  const rows = await prisma.job.findMany({
     where: {
-      companyId_externalId: {
-        companyId: job.companyId,
-        externalId: job.externalId,
-      },
+      companyId: { in: [...new Set(jobs.map((j) => j.companyId))] },
+      externalId: { in: [...new Set(jobs.map((j) => j.externalId))] },
     },
-    select: { id: true },
+    select: { companyId: true, externalId: true },
   });
-  return existing !== null;
+  return new Set(rows.map(pairKey));
 }
 
 function buildClassifyInput(

--- a/src/jobs/reclassify-job.ts
+++ b/src/jobs/reclassify-job.ts
@@ -168,16 +168,17 @@ async function reclassify(opts: ReclassifyOptions): Promise<{ stats: CronStats }
         : null,
     }));
 
+    // Demotions are collected and written once per batch (DATA-4): a
+    // "Re-classify all" over thousands of rows was thousands of single-row
+    // updates, next to an updateMany the same file already uses above.
+    const demoteIds: number[] = [];
     for (const { job: j, outcome } of pending) {
       scanned++;
       opts.onProgress?.(scanned, total);
 
       if (outcome === null) {
         if (j.status !== JobStatus.DISMISSED) {
-          await prisma.job.update({
-            where: { id: j.id },
-            data: { status: JobStatus.DISMISSED },
-          });
+          demoteIds.push(j.id);
           demoted++;
         }
         filterRejected++;
@@ -190,10 +191,7 @@ async function reclassify(opts: ReclassifyOptions): Promise<{ stats: CronStats }
         // Reclassify treats pre-filtered jobs the same as base-filter rejects:
         // demote to DISMISSED so they leave the inbox.
         if (j.status !== JobStatus.DISMISSED) {
-          await prisma.job.update({
-            where: { id: j.id },
-            data: { status: JobStatus.DISMISSED },
-          });
+          demoteIds.push(j.id);
           demoted++;
         }
         continue;
@@ -234,6 +232,9 @@ async function reclassify(opts: ReclassifyOptions): Promise<{ stats: CronStats }
       } else {
         unchanged++;
       }
+    }
+    if (demoteIds.length > 0) {
+      await prisma.job.updateMany({ where: { id: { in: demoteIds } }, data: { status: JobStatus.DISMISSED } });
     }
   }
 

--- a/src/resume/store.ts
+++ b/src/resume/store.ts
@@ -199,10 +199,24 @@ export async function listMatchesForJob(jobId: number): Promise<MatchWithResume[
   });
 }
 
-export async function listMatchesForResume(resumeId: number): Promise<MatchWithJob[]> {
+/** One run of the resume's history: the scalars the list shows, never the snapshot or the five Json columns (DATA-5). */
+export type MatchRunSummary = Pick<ResumeMatch, 'id' | 'jobId' | 'resumeId' | 'resumeVersion' | 'draft' | 'matchScore' | 'createdAt'> & {
+  job: { id: number; title: string; company: { name: string } };
+};
+
+export async function listMatchesForResume(resumeId: number): Promise<MatchRunSummary[]> {
   return prisma.resumeMatch.findMany({
     where: { resumeId },
-    include: { job: { select: { id: true, title: true, company: { select: { name: true } } } } },
+    select: {
+      id: true,
+      jobId: true,
+      resumeId: true,
+      resumeVersion: true,
+      draft: true,
+      matchScore: true,
+      createdAt: true,
+      job: { select: { id: true, title: true, company: { select: { name: true } } } },
+    },
     orderBy: { createdAt: 'desc' },
     take: MATCH_LIST_LIMIT,
   });

--- a/src/screening/batch.ts
+++ b/src/screening/batch.ts
@@ -7,7 +7,7 @@ import { loadKeywordMatcher, type KeywordMatcher } from '../resume/keyword-match
 import { anchorScreenReply } from './anchor';
 import { buildScreenPrompt, parseScreenResponse, SCREEN_MAX_TOKENS, SCREEN_PROMPT_VERSION, SCREEN_TIMEOUT_MS } from './prompts';
 import { scoreScreening } from './score';
-import { createVerdict, getScreening, listPending, listReadable, postingOf, rubricOf, type ScreeningWithJob } from './store';
+import { createVerdict, getScreening, listPending, listReadable, postingOf, rubricOf, screeningStamp, type ScreeningWithJob } from './store';
 import type { Rubric } from './rubric';
 
 /*
@@ -174,13 +174,24 @@ async function refill(run: Run, screening: ScreeningWithJob): Promise<number> {
   );
 }
 
+/**
+ * The screening as it stands, re-read only when its rubric version moved:
+ * the whole row — posting text, rubric, job — used to be loaded twice per
+ * applicant to compare one integer (DATA-4).
+ */
+async function freshIfChanged(screening: ScreeningWithJob): Promise<ScreeningWithJob> {
+  const stamp = await screeningStamp(screening.id);
+  if (!stamp || stamp.rubricVersion === screening.rubricVersion) return screening;
+  return (await getScreening(screening.id)) ?? screening;
+}
+
 /** One worker: take the next applicant, score, repeat; refill from the database when the queue runs dry. */
 async function worker(run: Run, screening: ScreeningWithJob, runtime: Pick<AiRuntime, 'complete'>, matcher: Pick<KeywordMatcher, 'findTerm' | 'locateQuote'>): Promise<void> {
   for (;;) {
     let next = run.queue.shift();
     if (!next) {
       // The rubric may have been saved mid-run: the queue is read against the current version.
-      const current = (await getScreening(screening.id)) ?? screening;
+      const current = await freshIfChanged(screening);
       if ((await refill(run, current)) === 0) return;
       next = run.queue.shift();
       if (!next) return;
@@ -188,7 +199,8 @@ async function worker(run: Run, screening: ScreeningWithJob, runtime: Pick<AiRun
     }
     run.state.queued = run.state.queued.filter((n) => n !== next!.number);
     run.state.inFlight.push(next.number);
-    const current = (await getScreening(screening.id)) ?? screening;
+    const current = await freshIfChanged(screening);
+    screening = current;
     const outcome = await screenApplicant(current, rubricOf(current), next, runtime, matcher);
     run.state.inFlight = run.state.inFlight.filter((n) => n !== next!.number);
     run.state.finished.push(next.number);

--- a/src/screening/store.ts
+++ b/src/screening/store.ts
@@ -175,9 +175,26 @@ export async function createApplicant(input: NewApplicant): Promise<ApplicantSum
   });
 }
 
-export async function listApplicants(screeningId: number, rubricVersion: number): Promise<ApplicantWithVerdict[]> {
+/** A table row: everything but the file and the two texts — three hundred applicants twice over is what the page used to load (DATA-5). */
+export type ApplicantRow = Omit<ApplicantWithVerdict, 'text' | 'redactedText'>;
+
+export async function listApplicants(screeningId: number, rubricVersion: number): Promise<ApplicantRow[]> {
   const rows = await prisma.applicant.findMany({
     where: { screeningId },
+    orderBy: { number: 'asc' },
+    omit: { original: true, text: true, redactedText: true },
+    include: { verdicts: { orderBy: { createdAt: 'desc' }, take: 1 } },
+  });
+  return rows.map(({ verdicts, ...a }) => {
+    const verdict = verdicts[0] ?? null;
+    return { ...a, verdict, stale: verdict !== null && verdict.rubricVersion !== rubricVersion };
+  });
+}
+
+/** The shortlist with its redacted texts — what a comparison reads; never for the table. */
+export async function listApplicantsWithText(screeningId: number, rubricVersion: number, ids?: number[]): Promise<ApplicantWithVerdict[]> {
+  const rows = await prisma.applicant.findMany({
+    where: { screeningId, ...(ids ? { id: { in: ids } } : {}) },
     orderBy: { number: 'asc' },
     omit: { original: true },
     include: { verdicts: { orderBy: { createdAt: 'desc' }, take: 1 } },
@@ -186,6 +203,11 @@ export async function listApplicants(screeningId: number, rubricVersion: number)
     const verdict = verdicts[0] ?? null;
     return { ...a, verdict, stale: verdict !== null && verdict.rubricVersion !== rubricVersion };
   });
+}
+
+/** The rubric version alone — what a running batch checks between applicants (DATA-4). */
+export async function screeningStamp(id: number): Promise<{ rubricVersion: number } | null> {
+  return prisma.screening.findUnique({ where: { id }, select: { rubricVersion: true } });
 }
 
 export async function getApplicant(id: number): Promise<(ApplicantWithVerdict & { screening: ScreeningWithJob }) | null> {

--- a/src/scripts/rescore-screenings.ts
+++ b/src/scripts/rescore-screenings.ts
@@ -4,7 +4,7 @@ import { loadKeywordMatcher } from '../resume/keyword-matcher';
 import { anchorScreenReply } from '../screening/anchor';
 import { readScreenReply } from '../screening/prompts';
 import { scoreScreening } from '../screening/score';
-import { listApplicants, rubricOf, updateVerdictScore } from '../screening/store';
+import { listApplicantsWithText, rubricOf, updateVerdictScore } from '../screening/store';
 
 /*
  * Re-anchors and re-scores every current screening verdict with the rules
@@ -26,7 +26,7 @@ async function main(): Promise<void> {
   let changed = 0;
   for (const s of screenings) {
     const rubric = rubricOf(s);
-    const rows = await listApplicants(s.id, s.rubricVersion);
+    const rows = await listApplicantsWithText(s.id, s.rubricVersion);
     for (const a of rows) {
       if (!a.verdict || a.stale || a.parseStatus !== 'ok') continue;
       const reply = readScreenReply(a.verdict.facts);

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -26,7 +26,7 @@ import { MAX_UPLOAD_MB } from '../upload';
 import type { FlashMessage } from '../flash';
 import { formatDate, formatRelative } from '../format';
 import type { ResumeReview } from '@prisma/client';
-import type { MatchWithJob, ResumeSummary } from '../../resume/store';
+import type { MatchRunSummary, ResumeSummary } from '../../resume/store';
 import { ResumeReviewCard } from './resume-review-card';
 import type { ReviewAnswer } from '../../resume/answers';
 import type { ReviewDelta } from '../../resume/review-delta';
@@ -44,7 +44,7 @@ export interface ResumeDetailProps {
   structure: DocxStructure | null;
   /** Its document properties; null for anything but a .docx. */
   props: DocxProps | null;
-  matches: MatchWithJob[];
+  matches: MatchRunSummary[];
   /** The latest strength review, or null when the user has never asked for one. */
   review: ResumeReview | null;
   /** The candidate's answers to the review's questions (ADR 0030 phase 3). */

--- a/src/web/routes/jobs.tsx
+++ b/src/web/routes/jobs.tsx
@@ -212,7 +212,26 @@ jobsRoute.get('/jobs', async (c) => {
       orderBy,
       skip: (page - 1) * PAGE_SIZE,
       take: PAGE_SIZE,
-      include: {
+      // The columns the row renders and no more: with `include` every page
+      // carried fifty descriptions, the originals, the summaries and the
+      // applied-resume snapshots — 219 KB of text on the 09-04 data for
+      // fifteen scalars (audit 2026-09-10, DATA-1).
+      select: {
+        id: true,
+        title: true,
+        url: true,
+        location: true,
+        countries: true,
+        fitScore: true,
+        salaryMin: true,
+        salaryMax: true,
+        salaryCurrency: true,
+        salaryPeriod: true,
+        sourceUpdatedAt: true,
+        status: true,
+        fetchedAt: true,
+        postedAt: true,
+        techMatch: true,
         company: { select: { name: true, atsType: true, atsToken: true, watched: true } },
         verifications: {
           select: { verdict: true },
@@ -221,7 +240,7 @@ jobsRoute.get('/jobs', async (c) => {
         },
         // Only the selected search's row, so the list renders that search's
         // score in place of the best-of.
-        ...(profile && { scores: { where: { profileId: profile }, take: 1 } }),
+        ...(profile && { scores: { where: { profileId: profile }, take: 1, select: { fitScore: true } } }),
       },
     }),
     prisma.job.count({ where }),

--- a/src/web/routes/letter.tsx
+++ b/src/web/routes/letter.tsx
@@ -63,6 +63,9 @@ const LetterFormSchema = z.object({
 
 export const letterRoute = new Hono();
 
+/** A picker option, not a posting: five columns instead of the row's forty (DATA-5). */
+const PICK_SELECT = { id: true, title: true, fitScore: true, fetchedAt: true, company: { select: { name: true } } } as const;
+
 letterRoute.get('/letter', async (c) => {
   const settings = await getSettings();
   // Newest first among the jobs that clear the primary search's threshold —
@@ -79,7 +82,7 @@ letterRoute.get('/letter', async (c) => {
       where,
       orderBy: [{ fetchedAt: 'desc' }],
       take: JOB_PICK_LIMIT,
-      include: { company: { select: { name: true } } },
+      select: PICK_SELECT,
     }),
     listResumes(),
   ]);
@@ -92,7 +95,7 @@ letterRoute.get('/letter', async (c) => {
           where: { status: { in: PICKABLE } },
           orderBy: [{ fetchedAt: 'desc' }],
           take: JOB_PICK_LIMIT,
-          include: { company: { select: { name: true } } },
+          select: PICK_SELECT,
         });
   const now = Date.now();
   return c.html(

--- a/src/web/routes/screen.tsx
+++ b/src/web/routes/screen.tsx
@@ -39,6 +39,7 @@ import {
   getScreening,
   latestComparison,
   listApplicants,
+  listApplicantsWithText,
   listKnownApplicants,
   listScreenings,
   postingOf,
@@ -94,7 +95,8 @@ screenRoute.get('/screen/new', async (c) => {
     where: { status: { not: 'DISMISSED' } },
     orderBy: [{ fetchedAt: 'desc' }],
     take: JOB_PICK_LIMIT,
-    include: { company: { select: { name: true, atsType: true } } },
+    // A picker option, not a posting (DATA-5).
+    select: { id: true, title: true, fetchedAt: true, company: { select: { name: true, atsType: true } } },
   });
   const now = Date.now();
   const options = jobs
@@ -585,7 +587,8 @@ type Shortlist = { ok: true; applicants: ApplicantWithVerdict[] } | { ok: false;
 async function shortlistOf(screening: ScreeningWithJob, ids: number[]): Promise<Shortlist> {
   if (ids.length < MIN_COMPARE) return { ok: false, flash: `Tick ${MIN_COMPARE} to ${MAX_COMPARE} applicants to compare${ids.length === 1 ? ' — one on its own is a scorecard' : ''}.` };
   if (ids.length > MAX_COMPARE) return { ok: false, flash: `Narrow the shortlist first: at most ${MAX_COMPARE} applicants side by side, and you ticked ${ids.length}.` };
-  const byId = new Map((await listApplicants(screening.id, screening.rubricVersion)).map((a) => [a.id, a]));
+  // With their texts: a comparison reads them; the table never does.
+  const byId = new Map((await listApplicantsWithText(screening.id, screening.rubricVersion, ids)).map((a) => [a.id, a]));
   const applicants: ApplicantWithVerdict[] = [];
   for (const id of ids) {
     const a = byId.get(id);

--- a/src/web/screen-view.ts
+++ b/src/web/screen-view.ts
@@ -1,4 +1,4 @@
-import type { ApplicantWithVerdict } from '../screening/store';
+import type { ApplicantRow } from '../screening/store';
 import { readScreenReply, type GateStatus } from '../screening/prompts';
 import type { EvidenceRung } from '../screening/rubric';
 import { orderVerdicts, readScreenBreakdown, type CapReason, type ConfidenceBand, type GateBucket } from '../screening/score';
@@ -86,7 +86,7 @@ export function adjustedScore(score: number, adjustment: number): number {
   return Math.max(0, Math.min(100, score + adjustment));
 }
 
-export function rowView(a: ApplicantWithVerdict & { sameAsNumber?: number | null }, now = new Date()): ApplicantRowView {
+export function rowView(a: ApplicantRow & { sameAsNumber?: number | null }, now = new Date()): ApplicantRowView {
   const status = a.parseStatus === 'unreadable' ? 'unreadable' : 'ok';
   const reply = a.verdict ? readScreenReply(a.verdict.facts) : null;
   const bd = a.verdict ? readScreenBreakdown(a.verdict.breakdown) : null;
@@ -192,7 +192,7 @@ export function exportRows(rows: ApplicantRowView[]): ExportRow[] {
  * table's order with and without the person's adjustments, and every
  * criterion's credit, answer and gate status off the stored breakdown.
  */
-export function calibrationRows(applicants: ApplicantWithVerdict[], now = new Date()): CalibrationRow[] {
+export function calibrationRows(applicants: ApplicantRow[], now = new Date()): CalibrationRow[] {
   const scored = groupRows(applicants.map((a) => rowView(a, now))).scored;
   const computed = orderVerdicts(scored.map((r) => ({ id: r.id, number: r.number, gateBucket: r.verdict!.bucket, score: r.verdict!.score, confidence: r.verdict!.confidence }))).map((x) => x.id);
   const byId = new Map(applicants.map((a) => [a.id, a]));


### PR DESCRIPTION
Block `query-diet` of TASKS §20 — DATA-1, DATA-4, DATA-5, DATA-6 of `docs/audit-2026-09-10.md`, measured first as the block demanded. Patch release 2.7.1 (also carries #233–#235, untagged since 2.7.0).

**Measured first** — the 09-04 dump (`pre-wipe-2026-09-04-1634.sql`: 1 083 jobs, 118 companies, 24 matches) restored into a scratch database and migrated to HEAD:
- `EXPLAIN ANALYZE` on every query the audit named: the facet tally 0.32 ms (seq scan, 96 buffers), the fitScore sort 0.26 ms (top-N heapsort), `ILIKE` over 1 083 descriptions 0.42 ms, latest-job-per-company 6.9 ms (index scan backward, 97 loops), the due filter 0.06 ms. **No index was added** — none of them is a cost at this size, and the audit's DATA-6 rows were estimates, not measurements.
- The 50-row `/jobs` page as Prisma read it: **219 KB of text** (descriptions, originals, summaries, applied-resume snapshots, source payloads) for fifteen scalars. That is the waste this PR removes.
- Page timings before → after (median of five): `/jobs` 10.3 → 8.3 ms, `?q=` 33.3 → 33.2, `/companies` 12.7 → 12.2, `/resumes/1` 22.2 → 19.4, `/jobs/1393` 9.6 → 9.3 — within noise, as expected at 1 k rows; every rendered page is **byte-identical** to before (nine pages compared).

**What changed**
- Selects: the `/jobs` list (DATA-1), `listMatchesForResume` → `MatchRunSummary` (no snapshot, no five Json columns), `listApplicants` → `ApplicantRow` without the two texts (`listApplicantsWithText` for the comparison and the rescore script), the digest and held-alert reads, the two job pickers (DATA-5).
- Loops: `storedKeys()` — one read per tick for the (companyId, externalId) pairs instead of one `findUnique` per fetched posting (1 600–5 500 round trips on a cold tick); re-classify collects demotions and writes one `updateMany` per batch; a screening run checks `screeningStamp` (one integer) and re-reads the row only when the rubric moved (DATA-4).
- The sources due this tick are a `where` on `(active, nextCheckAt)` — the index that existed for exactly this predicate — with a `count` for the "waiting" log line (DATA-6).

**Verified**
- `lint:types` green, 2 200 tests; route smoke 39/39 on a fresh scratch database; the nine pages above on the perf database, identical bytes.

**Left (TASKS §20):** the per-file applicant transaction at intake, `listScreenings`' per-applicant rows for three counts, `listMatchesForJob` (the job page renders one of the fifty in full).

## Release notes
### What's new
- Pages read the columns they show: the jobs list no longer carries fifty full postings per page (219 KB of text on the 09-04 data for fifteen scalars), nor the resume history every stored snapshot, nor the screening table two texts per applicant; the digest, the held-alert pass and the job pickers the same.
- One read per tick instead of one per posting; re-classify writes its demotions per batch; a screening run compares the rubric version instead of re-reading the screening twice per applicant; the sources due this tick are a where clause on the index that exists for it.
- Also in this release, untagged since 2.7.0: the route smoke in CI (#235), ten dead exports gone (#233), the docs brought in line (#234).
### Schema
- no schema changes; no index added — measured, none was a cost.
### Verification
- 2 200 tests; route smoke 39/39; nine pages on the restored 09-04 data byte-identical before and after, 7–33 ms.
### References
- docs/audit-2026-09-10.md DATA-1/4/5/6 · TASKS §20 block `query-diet`