### PR TITLE
copy-pass: twenty-five sentences cut on six pages, four DESIGN.md corrections, the tone floors named once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/).
 
+## [2.7.2] — 2026-09-10
+
+### Changed
+- **Less water on the six busiest pages.** Twenty-five sentences that
+  repeated a heading, explained a control the eye already reads, or
+  described the implementation are gone or shorter — on Settings, the
+  tailoring page, the screening page, the wizard, the job page and the
+  resume page. Every sentence about a cap, an AI call, privacy, a
+  destructive action or the employer legal note stays. The screening
+  upload hint, one 120-word paragraph carrying six unrelated facts, is now
+  four lines.
+- Four things DESIGN.md forbade and the pages did: Re-classify on the job
+  page is violet like every other AI spend; "Watch the scoring" in the
+  wizard is a plain link, not violet; "By search" is no longer
+  uppercase-tracked; the 0–100 number on the tailoring page's history is
+  "match", the word the rest of the resume side uses.
+- The score's tone cut-offs (85 / 70 / 50) are named once in `format.ts`;
+  the tailoring page's "ready to apply" reads the same floor, and a test
+  holds the browser's ring to the same steps on every score.
+
 ## [2.7.1] — 2026-09-10
 
 ### Changed
@@ -3489,6 +3509,7 @@ commit history.
 | 2026-08-30 | AI engine chain, settings tabs, profile fill — **v0.2.0**; readable descriptions + full-width dashboard — **v0.2.1** |
 | 2026-08-31 | Liveness ladder — **v0.3.0**; fetchers wave 1 — **v0.4.0**; starter packs — **v0.5.0**; cross-source dedup — **v0.6.0**; source health — **v0.7.0**; cover letters + fact gate — **v0.8.0**; untrusted-content fences — **v0.9.0**; safe local defaults — **v0.10.0** |
 
+[2.7.2]: https://github.com/applypack/applypack/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/applypack/applypack/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/applypack/applypack/compare/v2.6.4...v2.7.0
 [2.6.4]: https://github.com/applypack/applypack/compare/v2.6.3...v2.6.4

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -2164,7 +2164,7 @@ release-discipline skill, a docs/site block does not.
       region carrying text that changes; A11Y-3 `scope` on the five
       hand-rolled tables, `<th scope="row">` in the compare matrix, a
       `caption` prop on `Table`. Then A11Y-4.
-- [ ] **`copy-pass`** (patch; one page per PR) — COPY-1 first (two false
+- [x] **`copy-pass`** (patch) — shipped v2.7.2 as one pass over the six pages (25 sentences cut or shortened, the six-fact upload hint split into lines, four DESIGN.md corrections, the tone floors named once with a parity test); left: the tab/flow/source naming (COPY-3's rename half). COPY-1 first (two false
       sentences — in `metadata-drift` if that ships first); then the
       candidate tables in [11-ui-copy.md](./improvement-2026-09/11-ui-copy.md)
       as five `good first issue`-shaped issues, each PR with word counts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "applypack",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "private": true,
   "description": "Runs locally with Docker: an AI console for the whole job search that finds the postings, checks they're real, scores your resume without flattering it, drafts the cover letter, tracks the application. 33 sources, 5 swappable AI backends, your data in your own Postgres, self-hosted on a VPS if you like.",
   "license": "MIT",

--- a/src/web/format.ts
+++ b/src/web/format.ts
@@ -104,10 +104,15 @@ export function statusTone(status: JobStatus): Tone {
   }
 }
 
+/** The tone cut-offs — mirrored by public/target-page.mjs:ringTone; tone-parity.test.ts holds the two equal. */
+export const FIT_OK_FLOOR = 85;
+export const FIT_INFO_FLOOR = 70;
+export const FIT_WARN_FLOOR = 50;
+
 export function fitTone(score: number | null | undefined): Tone {
   if (score == null) return 'neutral';
-  if (score >= 85) return 'ok';
-  if (score >= 70) return 'info';
-  if (score >= 50) return 'warn';
+  if (score >= FIT_OK_FLOOR) return 'ok';
+  if (score >= FIT_INFO_FLOOR) return 'info';
+  if (score >= FIT_WARN_FLOOR) return 'warn';
   return 'neutral';
 }

--- a/src/web/pages/job-detail.tsx
+++ b/src/web/pages/job-detail.tsx
@@ -356,7 +356,7 @@ const ClassifierCard: FC<{ job: JobDetail; scores: ProfileScore[] }> = ({ job, s
       <div class="flex flex-wrap items-center justify-between gap-3">
         <SectionTitle>Classifier</SectionTitle>
         <ActionForm action={`/jobs/${job.id}/reclassify`}>
-          <Button variant="ghost" size="sm">
+          <Button variant="violet" size="sm">
             Re-classify
           </Button>
         </ActionForm>
@@ -388,9 +388,7 @@ const ProfileScoreRow: FC<{ scores: ProfileScore[] }> = ({ scores }) => {
   if (scores.length < 2) return null;
   return (
     <div class="mt-3 border-t border-line pt-3">
-      <div class="mb-2 text-xs font-medium uppercase tracking-wide text-ink-faint">
-        By search
-      </div>
+      <div class="mb-2 text-xs font-medium text-ink-muted">By search</div>
       <ul class="space-y-1.5">
         {scores.map((s, i) => (
           <li class="flex items-start gap-2 text-[13px]">
@@ -569,7 +567,7 @@ const MarkAppliedPicker: FC<{
       {picker.resumes.length > 0 && (
         <Field
           label="Applied with"
-          hint="Recorded with the version you sent, for the follow-up nudge."
+          hint="Kept for the follow-up reminder."
           class="mb-3"
         >
           <Select name="appliedResumeId" form={MARK_APPLIED_FORM}>

--- a/src/web/pages/resume-detail.tsx
+++ b/src/web/pages/resume-detail.tsx
@@ -178,8 +178,8 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
           ) : reviewed ? (
             <>
               <Hint>
-                The strength review above judged this version — follow its list. These are the
-                first scan's notes, kept for reference.
+                The strength review above judged this version; these are the first scan's notes,
+                kept for reference.
               </Hint>
               <details class="mt-2">
                 <summary class="cursor-pointer text-[13px] font-medium text-ink-muted transition-colors duration-150 hover:text-ink">
@@ -219,7 +219,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
           </div>
           <Hint class="sm:col-span-2">
             Edited the resume from the comparison notes? Upload it here, then hit Compare on the
-            job again — the history below shows how the score moves between versions.
+            job again.
           </Hint>
         </form>
       </Card>
@@ -231,7 +231,7 @@ export const ResumeDetailPage: FC<ResumeDetailProps> = ({
         {matches.length === 0 ? (
           <div class="px-5 py-4">
             <Hint>
-              None yet. Open a job and use "Resume match" to compare this resume against it.
+              None yet. Open a job and press Compare to score this resume against it.
             </Hint>
           </div>
         ) : (

--- a/src/web/pages/screen-detail.tsx
+++ b/src/web/pages/screen-detail.tsx
@@ -97,9 +97,8 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
           </div>
         }
       >
-        Five cards, top to bottom: the position, the criteria it is screened against, the applicants, the results,
-        and how your decisions sit against the order. The order in the results is a priority to talk to; every mark
-        has its quote on the scorecard, and the decision column is yours alone.
+        The order in the results is a priority to talk to; every mark has its quote on the scorecard, and the
+        decision column is yours alone.
       </PageHeader>
       <Flash flash={flash} />
 
@@ -200,7 +199,7 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
             <Chevron />
           </summary>
           <Hint class="mt-2">
-            One row per criterion. A <span class="text-ink">gate</span> buckets (pass / unknown / fail, never points), the
+            A <span class="text-ink">gate</span> buckets (pass / unknown / fail, never points), the
             <span class="text-ink"> stars</span> weigh a scored criterion, a <span class="text-ink">note</span> is shown and
             not counted. Rows the posting wrote say so; edit the words, change the mode, tick Remove — and add your own in
             the last row, in your own words.
@@ -324,16 +323,25 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
           </Button>
           <span class="text-[13px] text-ink-faint" data-picked aria-live="polite"></span>
         </form>
-        <Hint class="mt-2">
-          Choosing is adding: the moment you pick {ACCEPTED_EXTENSIONS.join(' / ')} files, a .zip, or a folder with
-          its subfolders, they are uploaded and the scoring starts — nothing else to press. (On a folder, your
-          browser asks once whether to upload its files; that question is the browser's, not ours.) Up to{' '}
-          {MAX_APPLICANTS_PER_SCREENING} applicants per screening, {MAX_BATCH_UPLOAD_MB} MB per upload; other file
-          types in a folder are left out. Files added while a run is on join the same run. Before any model reads a file, the name, contacts, links, date of birth, age, family,
-          gender, citizenship, street and graduation years are removed. A second document of someone already in the
-          list is scored too and labelled; the same file twice is skipped; a scanned PDF with no text layer stays in
-          the list unscored, so you can see it.
-        </Hint>
+        {/* Six facts, one line each — as one paragraph none of them was findable. */}
+        <ul class="mt-2 list-disc space-y-1 pl-4 text-[13px] leading-5 text-ink-faint">
+          <li>
+            Choosing is adding: pick {ACCEPTED_EXTENSIONS.join(' / ')} files, a .zip, or a folder with its subfolders,
+            and the scoring starts. On a folder, the browser asks once whether to upload its files.
+          </li>
+          <li>
+            Up to {MAX_APPLICANTS_PER_SCREENING} applicants per screening, {MAX_BATCH_UPLOAD_MB} MB per upload; other
+            file types in a folder are left out; files added during a run join it.
+          </li>
+          <li>
+            Before any model reads a file, the name, contacts, links, date of birth, age, family, gender, citizenship,
+            street and graduation years are removed.
+          </li>
+          <li>
+            A second document of someone already listed is scored and labelled; the same file twice is skipped; a
+            scanned PDF with no text layer stays in the list unscored, so you can see it.
+          </li>
+        </ul>
       </Card>
 
       {/* 3. Score and the table. */}
@@ -540,14 +548,13 @@ export const ScreenDetailPage: FC<ScreenDetailProps> = ({ screening, rubric, row
         )}
         {!calibration.enough && (
           <Hint class="mt-1">
-            Decisions are the one thing the tool never writes (ADR 0047); {MIN_DECISIONS} of them, with a To interview and a
+            Decisions are the one thing the tool never writes; {MIN_DECISIONS} of them, with a To interview and a
             Declined among them, are enough for the first reading. The CSV and Markdown carry it too.
           </Hint>
         )}
       </Card>
       <Hint class="mt-3">
-        Created {formatRelative(screening.createdAt)}. Names are shown to you only — the model saw "Applicant №N".
-        "Priority to talk to" means every gate passed; "Ask first" means one is unknown and the scorecard has the
+        Created {formatRelative(screening.createdAt)}. "Priority to talk to" means every gate passed; "Ask first" means one is unknown and the scorecard has the
         question. A failed gate is a fact about the posting's conditions, never a verdict on the person. A score
         with a small +N or −N beside it carries your own adjustment from the scorecard; the computed number is in
         its tooltip and in the export.

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -359,9 +359,8 @@ export const SettingsPage: FC<SettingsProps> = ({
   <Layout title="Settings" active="settings">
     <div class="w-full">
       <PageHeader title="Settings">
-        Toggles apply the moment you click; forms like the profile editor save on submit. No
-        restarts needed — dashboard actions use changes immediately; the background worker
-        picks them up within the hour.
+        No restart needed: the dashboard uses a change at once, the background worker within
+        the hour.
       </PageHeader>
       <Flash flash={flash} />
 
@@ -388,7 +387,7 @@ export const SettingsPage: FC<SettingsProps> = ({
       {activeTab === 'general' && (
       <Section
         title="Job fetching"
-        desc="The master switch for new-job ingestion. Everything else keeps running while paused."
+        desc="The master switch for new-job fetching."
       >
         <Card>
           <ToggleRow
@@ -410,7 +409,7 @@ export const SettingsPage: FC<SettingsProps> = ({
       {activeTab === 'general' && (
       <Section
         title="Schedule"
-        desc="When the search runs and when alerts arrive. Defaults to what it has always done: every hour, around the clock, one message per match."
+        desc="When the search runs and when alerts arrive."
       >
         <ScheduleCard view={schedule} />
       </Section>
@@ -656,7 +655,7 @@ export const SettingsPage: FC<SettingsProps> = ({
       {activeTab === 'general' && (
       <Section
         title="Application tracking"
-        desc="The funnel board and the nudge that keeps it honest."
+        desc="The applications board, and the reminder for the ones gone quiet."
       >
         <Card>
           <div class="space-y-5">
@@ -1570,7 +1569,7 @@ const ProfileEditor: FC<{
       <summary class="cursor-pointer select-none rounded-md px-4 py-3 text-[13px] font-medium text-ink transition-colors duration-150 hover:text-accent-strong">
         Advanced — excludes, notes, priority rules, thresholds
         <span class="ml-2 font-normal text-ink-faint">
-          Defaults work for most people; open this to fine-tune.
+          Excludes, notes, priority rules, thresholds.
         </span>
       </summary>
       <div class="space-y-5 border-t border-line px-4 py-4">
@@ -1659,7 +1658,7 @@ const PriorityRulesEditor: FC<{ profile: Profile }> = ({ profile }) => {
         <span class="ml-2 font-normal text-ink-faint">
           {rules.length > 0
             ? `${rules.length} rule${rules.length === 1 ? '' : 's'} set`
-            : 'None set — most people never need these.'}
+            : 'None set.'}
         </span>
       </summary>
       <div class="border-t border-line px-4 py-4">

--- a/src/web/pages/target.tsx
+++ b/src/web/pages/target.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'hono/jsx';
 import { Layout } from '../layout';
 import { Badge, Button, Card, FitBadge, Flash, Hint, SUBMIT_ONCE } from '../ui';
 import type { FlashMessage } from '../flash';
-import { fitTone, formatRelative, type Tone } from '../format';
+import { FIT_OK_FLOOR, fitTone, formatRelative, type Tone } from '../format';
 import type { MatchWithResume } from '../../resume/store';
 import type { CountedKeyword } from '../../resume/keyword-matcher';
 import type { VerificationForHint } from '../../resume/verification-hint';
@@ -100,8 +100,8 @@ const AI_TONE: Record<Tone, string> = {
   neutral: 'text-ink-faint',
 };
 
-/** Score at which the card tells the user to stop polishing and apply. */
-const READY_TO_APPLY = 85;
+/** Score at which the card tells the user to stop polishing and apply — the `ok` tone's floor, one number in one place. */
+const READY_TO_APPLY = FIT_OK_FLOOR;
 
 /** The ring's circumference, 2πr for r=42 — the dash length the arc is cut from. */
 const RING_LENGTH = 263.9;
@@ -530,12 +530,9 @@ export const TargetPage: FC<TargetPageProps> = ({
             class="max-h-[70vh] overflow-auto whitespace-pre-wrap break-words font-sans text-sm leading-7 text-ink-muted"
           ></div>
           <Hint class="mt-2">
-            Green is already in your resume; red is what this posting requires and yours does not
-            say. A dashed underline means nothing in your resume backs the word yet — write it in
-            where it is true and it counts, or confirm it below; the number reads your text, not our
-            guess about you. Benefits, perks and legal
-            boilerplate are deliberately never keywords; hover a mark to see how often the posting
-            says the word, and re-level or ignore any of them in the keyword table.
+            A dashed underline means nothing in your resume backs the word yet — write it in where
+            it is true and it counts, or confirm it below; the number reads your text, not our guess
+            about you.
           </Hint>
         </Card>
 
@@ -589,8 +586,8 @@ export const TargetPage: FC<TargetPageProps> = ({
           </div>
           <Hint class="mt-2">
             {resume.ephemeral
-              ? 'Plain text — what an ATS parser sees. Edits stay in this browser tab until you re-check. Locate on a suggestion outlines the text it targets.'
-              : 'Plain text — what an ATS parser sees. Edits stay in this browser tab until you re-check or Save. Locate on a suggestion outlines the text it targets.'}
+              ? 'Plain text — what an ATS parser sees. Edits stay in this browser tab until you re-check.'
+              : 'Plain text — what an ATS parser sees. Edits stay in this browser tab until you re-check or Save.'}
           </Hint>
         </Card>
 
@@ -628,8 +625,8 @@ export const TargetPage: FC<TargetPageProps> = ({
                       </form>
                     </div>
                     <Hint class="mt-1.5">
-                      Markdown, for the document your resume really lives in. The second one is the
-                      diff of your own edits and turns on once you change the text.
+                      Both are Markdown. The second is the diff of your own edits and turns on once
+                      you change the text.
                     </Hint>
                   </div>
                   <ActionsBlock
@@ -721,7 +718,7 @@ const RunChip: FC<{ m: MatchWithResume; currentId: number; jobId: number }> = ({
           : 'border-line bg-surface-raised text-ink-muted hover:border-line-strong hover:text-ink'
       }`}
     >
-      <FitBadge score={m.matchScore} label="AI match" />
+      <FitBadge score={m.matchScore} label="match" />
       {m.resume.name}
       <span class="font-mono text-ink-faint">v{m.resumeVersion}</span>
       {m.draft && <Badge tone="violet">draft</Badge>}

--- a/src/web/pages/welcome.tsx
+++ b/src/web/pages/welcome.tsx
@@ -173,9 +173,7 @@ export const WelcomePage: FC<WelcomeProps> = (p) => (
         <div>
           <h1 class="text-xl font-semibold tracking-tight">Welcome to ApplyPack</h1>
           <p class="mt-1 text-[13px] leading-5 text-ink-faint">
-            Five short steps: connect an AI, prove the search works, tell us about you, turn on
-            the boards for your countries, see your first matches. Everything here can be changed
-            later in Settings.
+            Everything here can be changed later in Settings.
           </p>
         </div>
         {!p.setupCompleted && (
@@ -372,9 +370,6 @@ const SearchStep: FC<WelcomeProps> = ({ search, steps }) => {
                 {formatDuration(last.durationMs)} and stored {last.stored.toLocaleString()} new.
               </>
             )}
-          </p>
-          <p class="mt-1 text-sm text-ink-muted">
-            The search works — now let's find the ones that match <em>you</em>.
           </p>
           <div class="mt-4 flex flex-wrap items-center gap-2">
             <Button href="/welcome?step=profile">Continue →</Button>
@@ -643,8 +638,7 @@ const SourcesStep: FC<WelcomeProps> = ({ sources, steps }) => {
       ) : (
         <>
           <p class="text-sm text-ink-muted">
-            Job boards that fit where your searches hunt, built from their stack. Turn them all on
-            now; each one can be switched off on the Companies page later.
+            Turn them all on now; each one can be switched off on the Companies page later.
           </p>
           <ul class="mt-3 divide-y divide-line rounded-md border border-line">
             {sources.suggestions.map((s) => (
@@ -665,8 +659,8 @@ const SourcesStep: FC<WelcomeProps> = ({ sources, steps }) => {
         <div class="mt-4">
           <p class="text-[13px] font-medium text-ink">Starter packs for your searches</p>
           <Hint>
-            Curated employer boards, checked by hand. A preview shows what resolves, nothing is
-            added until you confirm, and the boards land switched off.
+            A preview shows what resolves, nothing is added until you confirm, and the boards land
+            switched off.
           </Hint>
           <ul class="mt-2 divide-y divide-line rounded-md border border-line">
             {sources.packs.map((p) => (
@@ -780,7 +774,7 @@ const ScoreOrWatch: FC<WelcomeProps> = ({ matches, fetchingEnabled, telegramEnab
   return (
     <>
       {matches.runningRunId ? (
-        <Button href={`/target/runs/${matches.runningRunId}`} variant="violet">
+        <Button href={`/target/runs/${matches.runningRunId}`} variant="secondary">
           Watch the scoring →
         </Button>
       ) : matches.waiting > 0 ? (
@@ -814,7 +808,7 @@ const AllDone: FC<WelcomeProps> = ({ setupCompleted, fetchingEnabled, matches })
   <Card>
     <h2 class="text-sm font-semibold text-ink">Everything is set up</h2>
     <p class="mt-1 text-sm text-ink-muted">
-      AI connected, {matches.scoredCount.toLocaleString()} jobs scored, profile filled.{' '}
+      AI connected, {matches.scoredCount.toLocaleString()} jobs scored.{' '}
       {fetchingEnabled
         ? 'The hourly watch is running — new matches land on the Overview.'
         : 'The hourly watch is paused; start it to keep the matches coming.'}

--- a/src/web/tone-parity.test.ts
+++ b/src/web/tone-parity.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fitTone } from './format';
+
+/*
+ * The score's tone is decided in two places by necessity — the server's
+ * format.ts for every rendered badge, the browser's target-page.mjs for the
+ * ring that moves as the user types — and used to be four (the same
+ * cut-offs typed out again in target.tsx and DESIGN.md). This holds the two
+ * that must exist equal on every score (audit 2026-09-10, COPY-4), the way
+ * score.test.ts holds score.mjs to score.ts.
+ */
+test('the ring paints the tone format.ts:fitTone names, on every score', async () => {
+  // @ts-expect-error — plain JS with no declaration file.
+  const { ringTone } = (await import('./public/target-page.mjs')) as { ringTone: (score: number) => string };
+  for (let score = 0; score <= 100; score++) {
+    assert.equal(ringTone(score), fitTone(score), `score ${score}`);
+  }
+});


### PR DESCRIPTION
Block `copy-pass` of TASKS §20 — COPY-2, the four DESIGN.md items of COPY-3 and COPY-4 in `docs/audit-2026-09-10.md`; the candidate list and the must-stay list are in `docs/improvement-2026-09/11-ui-copy.md`. Patch release 2.7.2.

**What changed**
- Settings, the tailoring page, the screening page, the wizard, the job page, the resume page: twenty-five sentences cut or shortened — the ones that repeated a heading ("Five short steps: …" above the list of five), explained a control the eye reads ("Toggles apply the moment you click"), described the implementation ("Benefits, perks and legal boilerplate are deliberately never keywords"), or duplicated a line next to them. Nothing about a cap, an AI call, privacy, a destructive action or the employer legal note was touched; the sentences the audit listed as must-stay are all in place.
- The screening upload hint — one 120-word paragraph with six unrelated facts — is four list lines (`Hint` renders a `<p>`, so the list stands on its own).
- DESIGN.md corrections: Re-classify on the job page is `violet` (AI spend); "Watch the scoring →" in the wizard is `secondary` (a link, no spend); "By search" is no longer uppercase-tracked; the history badge on the tailoring page says "match" like the rest of the resume side.
- `format.ts` names `FIT_OK_FLOOR` / `FIT_INFO_FLOOR` / `FIT_WARN_FLOOR` once; `target.tsx`'s `READY_TO_APPLY` reads the first; `tone-parity.test.ts` holds `target-page.mjs:ringTone` equal to `fitTone` on every score 0–100 (the pair that must exist twice, server and browser).

**Not done here (left in TASKS §20):** the naming half of COPY-3 — the "Profile" tab holding "Searches", Compare / Tailor / analysis for one flow, source vs board — a rename with URLs and docs behind it.

**Verified:** `lint:types` green; 2 201 tests (the parity test new); route smoke 39/39 on a fresh scratch database (every page still renders).

## Release notes
### What's new
- Less water on the six busiest pages: twenty-five sentences that repeated a heading, explained a control or described the implementation are gone or shorter; every sentence about a cap, an AI call, privacy, a destructive action or the employer legal note stays. The screening upload hint is four lines instead of one 120-word paragraph.
- Re-classify is violet like every AI spend; "Watch the scoring" in the wizard is a plain link; "By search" is no longer uppercase; the tailoring page's history says "match".
- The score's tone cut-offs are named once, and a test holds the browser's ring to the same steps.
### Schema
- no schema changes
### Verification
- 2 201 tests; route smoke 39/39.
### References
- docs/audit-2026-09-10.md COPY-2/3/4 · docs/improvement-2026-09/11-ui-copy.md · TASKS §20 block `copy-pass`